### PR TITLE
chore: rename dracutdevs/dracut to dracut-ng/dracut-ng

### DIFF
--- a/.github/workflows/container.yml
+++ b/.github/workflows/container.yml
@@ -19,7 +19,7 @@ permissions:
 
 jobs:
     push_to_registry:
-        if: github.repository == 'dracutdevs/dracut' || vars.CONTAINER == 'enabled'
+        if: github.repository == 'dracut-ng/dracut-ng' || vars.CONTAINER == 'enabled'
         name: Build and push containers image to GitHub Packages
         runs-on: ubuntu-latest
         concurrency:

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -43,7 +43,7 @@ jobs:
                 ]
             fail-fast: false
         container:
-            image: ghcr.io/dracutdevs/${{ matrix.container }}
+            image: ghcr.io/dracut-ng/${{ matrix.container }}
             options: "--privileged -v /dev:/dev"
         steps:
             -   name: "Checkout Repository"
@@ -80,7 +80,7 @@ jobs:
                 ]
             fail-fast: false
         container:
-            image: ghcr.io/dracutdevs/${{ matrix.container }}
+            image: ghcr.io/dracut-ng/${{ matrix.container }}
             options: "--privileged -v /dev:/dev"
         steps:
             -   name: "Checkout Repository"

--- a/.github/workflows/manualtest.yml
+++ b/.github/workflows/manualtest.yml
@@ -27,7 +27,7 @@ jobs:
             matrix:
                 test: ${{ fromJSON(inputs.test) }}
         container:
-            image: ghcr.io/dracutdevs/${{ inputs.container }}
+            image: ghcr.io/dracut-ng/${{ inputs.container }}
             options: "--privileged -v /dev:/dev"
         steps:
             -   name: "Checkout Repository"

--- a/README.md
+++ b/README.md
@@ -1,11 +1,11 @@
-dracut
+dracut-ng
 ====
 
-dracut is an event driven initramfs infrastructure.
+dracut-ng is an event driven initramfs infrastructure.
 
 [![Contributor Covenant](https://img.shields.io/badge/Contributor%20Covenant-v2.0%20adopted-ff69b4.svg)](docs/CODE_OF_CONDUCT.md)
 
-dracut (the tool) is used to create an initramfs image by copying tools
+dracut-ng (the tool) is used to create an initramfs image by copying tools
 and files from an installed system and combining it with the
 dracut framework, usually found in /usr/lib/dracut/modules.d.
 
@@ -30,15 +30,15 @@ Documentation:
  - [Introduction](man/dracut.asc)
  - [User Manual](man/dracut.usage.asc)
 
-Currently dracut is developed on [github.com](https://github.com/dracutdevs/dracut).
+Currently dracut-ng is developed on [github.com](https://github.com/dracut-ng/dracut-ng).
 
-The release tarballs are [here](https://github.com/dracutdevs/dracut/releases).
+The release tarballs are [here](https://github.com/dracut-ng/dracut-ng/releases).
 
 Gitter (chat):
  - https://gitter.im/dracutdevs/Lobby
 
 See [News](NEWS.md) for information about changes in the releases and
-the [Wiki](https://github.com/dracutdevs/dracut/wiki) to share information.
+the [Wiki](https://github.com/dracut-ng/dracut-ng/wiki) to share information.
 
 See the github issue tracker for things which still need to be done and [Hacking](docs/HACKING.md)
 for some instructions on how to get started.  There is also a mailing list

--- a/docs/HACKING.md
+++ b/docs/HACKING.md
@@ -4,9 +4,9 @@ Please make sure to follow our [Contribution Guidelines](../CONTRIBUTING.md).
 
 ## git
 
-Currently dracut lives on github.com.
+Currently dracut-ng lives on github.com.
 
-* https://github.com/dracutdevs/dracut.git
+* https://github.com/dracut-ng/dracut-ng.git
 
 Pull requests should be filed preferably on github nowadays.
 
@@ -244,8 +244,8 @@ $ podman run --rm -it \
 ```
 
 with `[CONTAINER]` being one of the
-[github `dracutdevs` containers](https://github.com/orgs/dracutdevs/packages),
-e.g. `ghcr.io/dracutdevs/fedora:latest`.
+[github `dracut-ng` containers](https://github.com/orgs/dracut-ng/packages),
+e.g. `ghcr.io/dracut-ng/fedora:latest`.
 
 ### On bare metal
 

--- a/man/dracut-catimages.8.asc
+++ b/man/dracut-catimages.8.asc
@@ -51,7 +51,7 @@ Harald Hoyer
 AVAILABILITY
 ------------
 The dracut-catimages command is part of the dracut package and is available from
-link:$$https://github.com/dracutdevs/dracut$$[https://github.com/dracutdevs/dracut]
+link:$$https://github.com/dracut-ng/dracut-ng$$[https://github.com/dracut-ng/dracut-ng]
 
 SEE ALSO
 --------

--- a/man/dracut.8.asc
+++ b/man/dracut.8.asc
@@ -746,7 +746,7 @@ _/etc/cmdline.d/*.conf_::
 AVAILABILITY
 ------------
 The dracut command is part of the dracut package and is available from
-link:$$https://github.com/dracutdevs/dracut$$[https://github.com/dracutdevs/dracut]
+link:$$https://github.com/dracut-ng/dracut-ng$$[https://github.com/dracut-ng/dracut-ng]
 
 AUTHORS
 -------

--- a/man/lsinitrd.1.asc
+++ b/man/lsinitrd.1.asc
@@ -56,7 +56,7 @@ OPTIONS
 AVAILABILITY
 ------------
 The lsinitrd command is part of the dracut package and is available from
-link:$$https://github.com/dracutdevs/dracut$$[https://github.com/dracutdevs/dracut]
+link:$$https://github.com/dracut-ng/dracut-ng$$[https://github.com/dracut-ng/dracut-ng]
 
 AUTHORS
 -------


### PR DESCRIPTION
This change is required to initialize CI for dracut-ng.

