### PR TITLE
ci: adapt Dockerfile-Gentoo for recent systemd-utils change

### DIFF
--- a/test/container/Dockerfile-Gentoo
+++ b/test/container/Dockerfile-Gentoo
@@ -6,7 +6,7 @@ FROM docker.io/gentoo/stage3 as efistub
 COPY --from=portage /var/db/repos/gentoo /var/db/repos/gentoo
 
 # systemd-boot
-RUN echo 'sys-apps/systemd-utils boot' > /etc/portage/package.use/systemd-utils && \
+RUN echo 'sys-apps/systemd-utils boot kernel-install' > /etc/portage/package.use/systemd-utils && \
     emerge -qv sys-apps/systemd-utils
 
 # kernel and its dependencies in a separate builder


### PR DESCRIPTION
systemd-utils can now install kernel-install independently of systemd-boot, but systemd-boot requires that option to be enabled.

Fixes: https://github.com/dracutdevs/dracut/issues/2554

(Cherry-picked commit from dracutdevs/dracut#2562)
