### PR TITLE
feat(kernel-modules): Install SPMI modules on ARM/RISC-V

### DIFF
--- a/modules.d/90kernel-modules/module-setup.sh
+++ b/modules.d/90kernel-modules/module-setup.sh
@@ -87,6 +87,7 @@ installkernel() {
                 "=drivers/rtc" \
                 "=drivers/soc" \
                 "=drivers/spi" \
+                "=drivers/spmi" \
                 "=drivers/usb/chipidea" \
                 "=drivers/usb/dwc2" \
                 "=drivers/usb/dwc3" \


### PR DESCRIPTION
MediaTek's PCIe (pcie-mediatek-gen3) and the PHY driver depends on `spmi-mtk-pmif` which is related to power domain. Power domain relate driver `spmi-mtk-pmif` must be included in the initramfs for supporting PCIe if user want to access peripherals during boot, for example, NVMe disks.

So install all System Power Management Interface (SPMI) modules on ARM/RISC-V.

Bug-openSUSE: https://bugzilla.suse.com/show_bug.cgi?id=1216767
Bug-Ubuntu: https://launchpad.net/bugs/2038512

(Cherry-picked commit from dracutdevs/dracut#2557)