### PR TITLE
ci: disable test 20

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -71,7 +71,7 @@ jobs:
                         #"connman",
                 ]
                 test: [
-                        "20",
+                        #"20", # unstable
                         "30",
                         "35",
                         "40",


### PR DESCRIPTION
20 seems to be unstable and running a very long time. Once the CI is green, we will revisit this test.

