### PR TITLE
fix(test): running tests no longer requires to be root

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -264,7 +264,6 @@ endif
 endif
 
 check: all syncheck
-	@[ "$$EUID" == "0" ] || { echo "'check' must be run as root! Please use 'sudo'."; exit 1; }
 	@$(MAKE) -C test check
 
 testimage: all

--- a/docs/HACKING.md
+++ b/docs/HACKING.md
@@ -253,27 +253,27 @@ For the testsuite to pass, you will have to install at least the software packag
 mentioned in the `test/container` Dockerfiles.
 
 ```
-$ sudo make clean check
+$ make clean check
 ```
 
 in verbose mode:
 ```
-$ sudo make V=1 clean check
+$ make V=1 clean check
 ```
 
 only specific test:
 ```
-$ sudo make TESTS="01 20 40" clean check
+$ make TESTS="01 20 40" clean check
 ```
 only runs the 01, 20 and 40 tests.
 
 debug a specific test case:
 ```
 $ cd TEST-01-BASIC
-$ sudo make clean setup run
+$ make clean setup run
 ```
 ... change some kernel parameters in `test.sh` ...
 ```
-$ sudo make run
+$ make run
 ```
 to run the test without doing the setup.

--- a/test/Makefile
+++ b/test/Makefile
@@ -1,7 +1,6 @@
 .PHONY: all check clean $(wildcard TEST-??-*)
 
 $(wildcard TEST-??-*):
-	@[ "$(shell id -u)" = 0 ] || { echo "'check' must be run as root! Please use 'sudo'."; exit 1; }
 	@{ \
 		[ -d $@ ] || exit 0; \
 		[ -f $@/Makefile ] || exit 0; \

--- a/test/container/Dockerfile-Debian
+++ b/test/container/Dockerfile-Debian
@@ -57,7 +57,6 @@ RUN apt-get update -y -qq && apt-get upgrade -y -qq && apt-get install -y -qq --
     shellcheck \
     squashfs-tools \
     strace \
-    sudo \
     systemd-boot-efi \
     tcpdump \
     tgt \

--- a/test/container/Dockerfile-Fedora-latest
+++ b/test/container/Dockerfile-Fedora-latest
@@ -58,7 +58,6 @@ RUN dnf -y install --setopt=install_weak_deps=False \
     shfmt \
     squashfs-tools \
     strace \
-    sudo \
     systemd-boot-unsigned \
     systemd-networkd \
     systemd-resolved \

--- a/test/container/Dockerfile-OpenSuse-latest
+++ b/test/container/Dockerfile-OpenSuse-latest
@@ -6,7 +6,7 @@ MAINTAINER https://github.com/dracutdevs/dracut
 RUN dnf -y install --setopt=install_weak_deps=False \
     dash asciidoc mdadm lvm2 dmraid cryptsetup nfs-utils nbd dhcp-server \
     strace libkmod-devel gcc bzip2 xz tar wget rpm-build make git bash-completion \
-    sudo kernel dhcp-client qemu-kvm /usr/bin/qemu-system-$(uname -m) e2fsprogs \
+    kernel dhcp-client qemu-kvm /usr/bin/qemu-system-$(uname -m) e2fsprogs \
     tcpdump iproute iputils kbd NetworkManager btrfsprogs tgt dbus-broker \
     iscsiuio open-iscsi which ShellCheck shfmt procps pigz parted squashfs ntfsprogs \
     multipath-tools util-linux-systemd systemd-boot \

--- a/test/test-functions
+++ b/test/test-functions
@@ -52,15 +52,6 @@ COLOR_FAILURE='\033[0;31m'
 COLOR_WARNING='\033[0;33m'
 COLOR_NORMAL='\033[0;39m'
 
-check_root() {
-    if ((EUID != 0)); then
-        SETCOLOR_FAILURE
-        echo "Tests must be run as root! Please use 'sudo'."
-        SETCOLOR_NORMAL
-        exit 1
-    fi
-}
-
 # generate qemu arguments for named raw disks
 #
 # qemu_add_drive_args <index> <args> <filename> <id-name> [<bootindex>]
@@ -122,13 +113,11 @@ test_marker_check() {
 while (($# > 0)); do
     case $1 in
         --run)
-            check_root
             echo "TEST RUN: $TEST_DESCRIPTION"
             test_check && test_run
             exit $?
             ;;
         --setup)
-            check_root
             echo "TEST SETUP: $TEST_DESCRIPTION"
             test_check && test_setup
             exit $?
@@ -141,7 +130,6 @@ while (($# > 0)); do
             exit $?
             ;;
         --all)
-            check_root
             if ! test_check 2 &> test${TEST_RUN_ID:+-$TEST_RUN_ID}.log; then
                 echo -e "TEST: $TEST_DESCRIPTION " "$COLOR_WARNING" "[SKIPPED]" "$COLOR_NORMAL"
                 exit 0


### PR DESCRIPTION
Remove sudo from test containers.

After fd9cd02, tests no longer requires to be root. Being able to run VMs to run tests is required, but that should not imply root user.

Fixes [#1147](https://github.com/dracutdevs/dracut/issues/1147) and https://bugs.gentoo.org/298014

(Cherry-picked commit from dracutdevs/dracut#2429)

Received positive signals from @thesamesam, @Flowdalic and @bdrung .

Ubuntu has been carrying this PR - https://changelogs.ubuntu.com/changelogs/pool/main/d/dracut/dracut_060+5-1ubuntu2/changelog
