### PR TITLE
fix(TEST-62-SKIPCPIO): test always skipped due to buggy `test_check`

### DIFF
--- a/test/TEST-62-SKIPCPIO/test.sh
+++ b/test/TEST-62-SKIPCPIO/test.sh
@@ -6,7 +6,7 @@
 TEST_DESCRIPTION="test skipcpio"
 
 test_check() {
-    cpio dd truncate find sort diff &> /dev/null
+    (command -v cpio && command -v find && command -v diff) &> /dev/null
 }
 
 skipcpio_simple() {


### PR DESCRIPTION
This test is always being skipped.

## Checklist
- [X] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it

Fixes https://github.com/dracutdevs/dracut/commit/4235c03

Fixes regression introduced by 4235c03

(Cherry-picked commit from dracutdevs/dracut#2486)