### PR TITLE
test(UEFI): make test determinsitic

### DIFF
--- a/test/TEST-18-UEFI/test-init.sh
+++ b/test/TEST-18-UEFI/test-init.sh
@@ -19,5 +19,5 @@ grep -q '^tmpfs /run tmpfs' /proc/self/mounts \
 exec > /dev/console 2>&1
 
 echo "made it to the rootfs! Powering down."
-echo "dracut-root-block-success" | dd oflag=direct,dsync of=/dev/sdb
+echo "dracut-root-block-success" | dd oflag=direct,dsync of=/dev/disk/by-id/ata-disk_marker
 poweroff -f

--- a/test/TEST-18-UEFI/test.sh
+++ b/test/TEST-18-UEFI/test.sh
@@ -78,7 +78,7 @@ test_setup() {
     mkdir -p "$TESTDIR"/ESP/EFI/BOOT
     test_dracut \
         --modules 'rootfs-block test' \
-        --kernel-cmdline 'root=/dev/sdc ro rd.skipfsck rootfstype=squashfs' \
+        --kernel-cmdline 'root=/dev/disk/by-id/ata-disk_root ro rd.skipfsck rootfstype=squashfs' \
         --drivers 'ahci sd_mod squashfs' \
         --uefi \
         "$TESTDIR"/ESP/EFI/BOOT/BOOTX64.efi


### PR DESCRIPTION
identify the boot drive by id

## Checklist
- [X] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it

This should fix the TEST-18 failure on openSUSE for the CI.

(Cherry-picked commit from dracutdevs/dracut#2565)