### PR TITLE
fix(systemd-255): handle systemd-pcr{phase -> extend} rename

### DIFF
--- a/modules.d/01systemd-pcrphase/module-setup.sh
+++ b/modules.d/01systemd-pcrphase/module-setup.sh
@@ -6,7 +6,11 @@
 check() {
 
     # If the binary(s) requirements are not fulfilled the module can't be installed.
-    require_binaries "$systemdutildir"/systemd-pcrphase || return 1
+    # systemd-255 renamed the binary, check for old and new location.
+    if ! require_binaries "$systemdutildir"/systemd-pcrphase \
+        && ! require_binaries "$systemdutildir"/systemd-pcrextend; then
+        return 1
+    fi
 
     # Return 255 to only include the module, if another module requires it.
     return 255
@@ -28,6 +32,7 @@ install() {
 
     inst_multiple -o \
         "$systemdutildir"/systemd-pcrphase \
+        "$systemdutildir"/systemd-pcrextend \
         "$systemdsystemunitdir"/systemd-pcrphase-initrd.service \
         "$systemdsystemunitdir/systemd-pcrphase-initrd.service.d/*.conf" \
         "$systemdsystemunitdir"/initrd.target.wants/systemd-pcrphase-initrd.service


### PR DESCRIPTION
The binary systemd-pcrphase was renamed to systemd-pcrextend in systemd 255, but the backing units were all left named systemd-pcrphase.

Fixes: [#2583](https://github.com/dracutdevs/dracut/issues/2583)

(Cherry-picked commit from dracutdevs/dracut#2610)

Received positive feedback from @dtardon
