### PR TITLE
fix(90multipath): drop unneeded dependencies from configure service

### DIFF
--- a/modules.d/90multipath/multipathd-configure.service
+++ b/modules.d/90multipath/multipathd-configure.service
@@ -1,8 +1,8 @@
 [Unit]
 Description=Device-Mapper Multipath Default Configuration
-Before=iscsi.service iscsid.service lvm2-activation-early.service
-Wants=systemd-udev-trigger.service systemd-udev-settle.service local-fs-pre.target
-After=systemd-udev-trigger.service systemd-udev-settle.service
+Before=lvm2-activation-early.service
+Wants=local-fs-pre.target
+After=systemd-journald.socket
 Before=local-fs-pre.target multipathd.service
 DefaultDependencies=no
 Conflicts=shutdown.target


### PR DESCRIPTION
multipathd-configure.service previously had the same "After" dependencies as the multipathd.service, with the idea of running immediately before it. Multipathd now supports being started much earlier, but the dependencies in multipathd-configure.service stop it from being able to.

Since all multipathd-configure.service does is write out a configuration file, it doesn't need any of its "After" udev dependencies. Remove them, and clean up some other unneeded dependencies.

(Cherry-picked commit from dracutdevs/dracut#2609)

Positive feedback on this PR from @jlebon and @mwilck 