### PR TITLE
ci: remove mkfs.ntfs from openSUSE test containers

### DIFF
--- a/test/container/Dockerfile-OpenSuse-latest
+++ b/test/container/Dockerfile-OpenSuse-latest
@@ -8,6 +8,6 @@ RUN dnf -y install --setopt=install_weak_deps=False \
     strace libkmod-devel gcc bzip2 xz tar wget rpm-build make git bash-completion \
     sudo kernel dhcp-client qemu-kvm /usr/bin/qemu-system-$(uname -m) e2fsprogs \
     tcpdump iproute iputils kbd NetworkManager btrfsprogs tgt dbus-broker \
-    iscsiuio open-iscsi which ShellCheck shfmt procps pigz parted squashfs ntfsprogs \
+    iscsiuio open-iscsi which ShellCheck shfmt procps pigz parted squashfs \
     multipath-tools util-linux-systemd systemd-boot \
     && dnf -y remove dracut && dnf -y update && dnf clean all


### PR DESCRIPTION
openSUSE blacklisted ntfs3.

This PR should make test 16 green for openSUSE, but since this is a CI container change it will only take effect in subsequent PRs (this is just how CI is setup for now).

Fixes https://github.com/dracut-ng/dracut-ng/issues/28

CC @mwilck @aafeijoo-suse 