### PR TITLE
refactor(systemd): remove duplicate entries in inst_multiple

### DIFF
--- a/modules.d/00systemd/module-setup.sh
+++ b/modules.d/00systemd/module-setup.sh
@@ -122,8 +122,6 @@ install() {
         "$systemdsystemunitdir"/sysinit.target.wants/systemd-tmpfiles-setup-dev-early.service \
         "$systemdsystemunitdir"/sysinit.target.wants/systemd-sysctl.service \
         "$systemdsystemunitdir"/ctrl-alt-del.target \
-        "$systemdsystemunitdir"/reboot.target \
-        "$systemdsystemunitdir"/systemd-reboot.service \
         "$systemdsystemunitdir"/syslog.socket \
         "$systemdsystemunitdir"/slices.target \
         "$systemdsystemunitdir"/system.slice \


### PR DESCRIPTION
Fixes 28eae10b7007c6a2b64876244e976eb4788e95b1

## Checklist
- [X] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it

(Cherry-picked commit from dracutdevs/dracut#2602)