### PR TITLE
Return 1 if binary requirements are not met

### DIFF
--- a/modules.d/02caps/module-setup.sh
+++ b/modules.d/02caps/module-setup.sh
@@ -2,7 +2,7 @@
 
 # called by dracut
 check() {
-    require_binaries capsh
+    require_binaries capsh || return 1
     return 255
 }
 

--- a/modules.d/50plymouth/module-setup.sh
+++ b/modules.d/50plymouth/module-setup.sh
@@ -20,7 +20,9 @@ check() {
     [[ "$mount_needs" ]] && return 1
     [[ $(pkglib_dir) ]] || return 1
 
-    require_binaries plymouthd plymouth plymouth-set-default-theme
+    require_binaries plymouthd plymouth plymouth-set-default-theme || return 1
+
+    return 0
 }
 
 # called by dracut


### PR DESCRIPTION
This PR fixes the requirements for the caps and plymouth modules.

The dasd_mod module has the same error, but it's RH specific and apparently the binary requirements could be dropped.

(Cherry-picked commit from dracutdevs/dracut#2434)