### PR TITLE
fix(base): correct handling of quiet in loginit

### DIFF
--- a/modules.d/99base/loginit.sh
+++ b/modules.d/99base/loginit.sh
@@ -18,6 +18,6 @@ while read -r line || [ -n "$line" ]; do
     fi
     echo "<31>dracut: $line" >&5
     # if "quiet" is specified we output to /dev/console
-    [ -n "$QUIET" ] || echo "dracut: $line"
+    [ "$QUIET" = "yes" ] || echo "dracut: $line"
     echo "$line" >&6
 done


### PR DESCRIPTION
dracut-lib.sh sets DRACUT_QUIET=no
and passes this to loginit

## Checklist
- [X] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it

(Cherry-picked commit from dracutdevs/dracut#2451)