### PR TITLE
fix(install): handle new -Walloc-size for GCC 14

### DIFF
--- a/src/install/util.h
+++ b/src/install/util.h
@@ -113,7 +113,7 @@ bool streq_ptr(const char *a, const char *b);
 
 #define newdup(t, p, n) ((t*) memdup(p, sizeof(t)*(n)))
 
-#define malloc0(n) (calloc((n), 1))
+#define malloc0(n) (calloc(1, (n)))
 
 static inline const char *yes_no(bool b)
 {


### PR DESCRIPTION
GCC 14 introduces a new -Walloc-size included in -Wextra which gives:
```
src/install/hashmap.c: In function ‘hashmap_new’:
src/install/hashmap.c:83:11: warning: allocation of insufficient size ‘1’ for type ‘Hashmap’ with size ‘40’ [-Walloc-size]
   83 |         h = malloc0(size);
      |           ^
```

malloc0 is a macro deifned by Dracut (and systemd, see below):
```
malloc0(n) (calloc((n), 1))
```

The calloc prototype is:
```
void *calloc(size_t nmemb, size_t size);
```

So, just swap the number of members and size arguments to match the prototype, as we're initialising 1 struct of size `sizeof(...)`. GCC then sees we're not doing anything wrong.

This was fixed upstream in systemd in commit f80bb1f7eaf31476a44c2093d3ee02aba817a0b0 [0].

[0] https://github.com/systemd/systemd/commit/f80bb1f7eaf31476a44c2093d3ee02aba817a0b0

This pull request changes...

## Changes

## Checklist
- [X] I have tested it locally
- [X] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it

(Cherry-picked commit from dracutdevs/dracut#2553)
