### PR TITLE
fix(90kernel-modules): add surface_aggregator_registry for Surface Laptop 4

### DIFF
--- a/modules.d/90kernel-modules/module-setup.sh
+++ b/modules.d/90kernel-modules/module-setup.sh
@@ -58,7 +58,7 @@ installkernel() {
             yenta_socket intel_lpss_pci spi_pxa2xx_platform \
             atkbd i8042 firewire-ohci pcmcia hv-vmbus \
             virtio virtio_ring virtio_pci pci_hyperv \
-            "=drivers/pcmcia"
+            surface_aggregator_registry "=drivers/pcmcia"
 
         if [[ ${DRACUT_ARCH:-$(uname -m)} == arm* || ${DRACUT_ARCH:-$(uname -m)} == aarch64 || ${DRACUT_ARCH:-$(uname -m)} == riscv* ]]; then
             # arm/aarch64 specific modules


### PR DESCRIPTION
The help text for the kernel module `surface_aggregator_registry` says: "Device-registry for Surface System Aggregator Module (SSAM) devices. Provides a module and driver which act as a device-registry for SSAM client devices that cannot be detected automatically, e.g. via ACPI. Such devices are instead provided and managed via this registry. Devices provided via this registry are:
 - Platform profile (performance-/cooling-mode) device (5th- and later generations).
 - Battery/AC devices (7th-generation).
 - HID input devices (7th-generation)."

This kernel module is needed on the Surface Laptop 4 for the keyboard.

Bug-Ubuntu: https://launchpad.net/bugs/2007050
Bug-linux-surface: https://github.com/linux-surface/linux-surface/issues/839

(Cherry-picked commit from dracutdevs/dracut#2558)