### PR TITLE
ci: remove unused packages from Debian container

### DIFF
--- a/test/container/Dockerfile-Debian
+++ b/test/container/Dockerfile-Debian
@@ -17,7 +17,6 @@ RUN apt-get update -y -qq && apt-get upgrade -y -qq && apt-get install -y -qq --
     cpio \
     cryptsetup \
     curl \
-    dash \
     debhelper \
     debhelper-compat \
     dmraid \

--- a/test/container/Dockerfile-Debian
+++ b/test/container/Dockerfile-Debian
@@ -17,8 +17,6 @@ RUN apt-get update -y -qq && apt-get upgrade -y -qq && apt-get install -y -qq --
     cpio \
     cryptsetup \
     curl \
-    debhelper \
-    debhelper-compat \
     dmraid \
     docbook \
     docbook-xml \
@@ -52,7 +50,6 @@ RUN apt-get update -y -qq && apt-get upgrade -y -qq && apt-get install -y -qq --
     pkg-config \
     procps \
     qemu-system-x86 \
-    quilt \
     shellcheck \
     squashfs-tools \
     strace \

--- a/test/container/Dockerfile-Debian
+++ b/test/container/Dockerfile-Debian
@@ -49,7 +49,7 @@ RUN apt-get update -y -qq && apt-get upgrade -y -qq && apt-get install -y -qq --
     pigz \
     pkg-config \
     procps \
-    qemu-system-x86 \
+    qemu-kvm \
     shellcheck \
     squashfs-tools \
     strace \


### PR DESCRIPTION
## Changes

Improve the Debian container:

The dash package is a required that must be present on all Debian systems.
The debhelper and quilt packages are only needed for packaging dracut.
To make the list of required packages more architecture independent, replace qemu-system-x86 by qemu-kvm in the Debian Docker image.

## Checklist
- [X] I have tested it locally
- [X] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it

(Cherry-picked commit from dracutdevs/dracut#2491)