### PR TITLE
test(FULL SYSTEMD): no need to include dbus to the target rootfs

### DIFF
--- a/test/TEST-04-FULL-SYSTEMD/test.sh
+++ b/test/TEST-04-FULL-SYSTEMD/test.sh
@@ -52,7 +52,7 @@ test_setup() {
 
     # Create what will eventually be our root filesystem onto an overlay
     "$DRACUT" -l --keep --tmpdir "$TESTDIR" \
-        -m "test-root dbus" \
+        -m "test-root systemd" \
         -I "ldconfig" \
         -i ./test-init.sh /sbin/test-init \
         -i ./fstab /etc/fstab \


### PR DESCRIPTION
systemd does not depend on dbus.

## Checklist
- [X] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it

(Cherry-picked commit from dracutdevs/dracut#2549)

Ubuntu has been carrying this PR - https://changelogs.ubuntu.com/changelogs/pool/main/d/dracut/dracut_060+5-1ubuntu2/changelog

Debian just landed it - https://salsa.debian.org/debian/dracut/-/commit/700f2c9b75fd3486425fe941192790f4be505076