### PR TITLE
ci: drop maintainer entry from container descriptor files

### DIFF
--- a/test/container/Dockerfile-Arch
+++ b/test/container/Dockerfile-Arch
@@ -1,7 +1,5 @@
 FROM docker.io/archlinux
 
-MAINTAINER https://github.com/dracutdevs/dracut
-
 # Install needed packages for the dracut CI container
 RUN pacman --noconfirm -Syu \
     linux dash strace dhclient asciidoc cpio pigz squashfs-tools \

--- a/test/container/Dockerfile-Debian
+++ b/test/container/Dockerfile-Debian
@@ -1,7 +1,5 @@
 FROM docker.io/debian:latest
 
-MAINTAINER https://github.com/dracutdevs/dracut
-
 # Install needed packages for the dracut CI container
 # Install dracut as a linux-initramfs-tool provider so that the default initramfs-tool package does not get installed
 # Uninstall initramfs-tools-core as a workaround for https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=994492

--- a/test/container/Dockerfile-Fedora-latest
+++ b/test/container/Dockerfile-Fedora-latest
@@ -1,7 +1,5 @@
 FROM registry.fedoraproject.org/fedora:latest
 
-MAINTAINER https://github.com/dracutdevs/dracut
-
 # Install needed packages for the dracut CI container
 RUN dnf -y install --setopt=install_weak_deps=False \
     asciidoc \

--- a/test/container/Dockerfile-Gentoo
+++ b/test/container/Dockerfile-Gentoo
@@ -23,8 +23,6 @@ COPY --from=kernel /lib/modules /lib/modules
 COPY --from=efistub /usr/lib/systemd/boot/efi /usr/lib/systemd/boot/efi
 ARG TAG
 
-MAINTAINER https://github.com/dracutdevs/dracut
-
 # required by sys-fs/dmraid
 RUN echo 'sys-fs/lvm2 lvm thin' > /etc/portage/package.use/lvm2
 

--- a/test/container/Dockerfile-OpenSuse-latest
+++ b/test/container/Dockerfile-OpenSuse-latest
@@ -1,7 +1,5 @@
 FROM registry.opensuse.org/opensuse/tumbleweed-dnf:latest
 
-MAINTAINER https://github.com/dracutdevs/dracut
-
 # Install needed packages for the dracut CI container
 RUN dnf -y install --setopt=install_weak_deps=False \
     dash asciidoc mdadm lvm2 dmraid cryptsetup nfs-utils nbd dhcp-server \

--- a/test/container/Dockerfile-Ubuntu
+++ b/test/container/Dockerfile-Ubuntu
@@ -1,7 +1,5 @@
 FROM docker.io/ubuntu:latest
 
-MAINTAINER https://github.com/dracutdevs/dracut
-
 # Install needed packages for the dracut CI container
 # The Linux kernel is only readable by root. See https://launchpad.net/bugs/759725
 RUN apt-get update -y -qq && apt-get upgrade -y -qq && \


### PR DESCRIPTION
## Changes

These Dockerfiles are only used in the context of this repo, no need to point back to the github url.

This should help finalizing repo url changes and the churn in test containers. 