### PR TITLE
fix(45ifcfg): mark as deprecated and strictly opt-in

### DIFF
--- a/modules.d/45ifcfg/module-setup.sh
+++ b/modules.d/45ifcfg/module-setup.sh
@@ -1,8 +1,11 @@
 #!/bin/bash
 
+# This module is deprecated. Modern replacements are NetworkManager keyfiles and
+# systemd network files. It must now be explicitly opted in by the user to be
+# added to the initrd.
+
 # called by dracut
 check() {
-    [[ -d $dracutsysrootdir/etc/sysconfig/network-scripts ]] && return 0
     return 255
 }
 

--- a/test/TEST-60-BONDBRIDGEVLAN/test.sh
+++ b/test/TEST-60-BONDBRIDGEVLAN/test.sh
@@ -367,7 +367,7 @@ test_setup() {
     "$DRACUT" -l -i "$TESTDIR"/overlay / \
         --no-early-microcode \
         -o "plymouth" \
-        -a "debug ${USE_NETWORK}" \
+        -a "debug ${USE_NETWORK} ifcfg" \
         --no-hostonly-cmdline -N \
         -f "$TESTDIR"/initramfs.testing "$KVERSION" || return 1
 


### PR DESCRIPTION
## Changes

The `45ifcfg` module should be considered deprecated now since ifcfg files themselves are deprecated. They've been replaced by e.g. NetworkManager keyfiles or systemd-networkd files.

Currently, the `45ifcfg` module checks if the `/etc/sysconfig/network- scripts` directory exists to know if to automatically get pulled in. However, on systems with NetworkManager, this directory always exists even if the functionality to read ifcfg files is disabled by default (NM kindly ships a README in there to ease migrating to keyfiles).

Since almost everyone should've already migrated to a more modern alternative, let's make this module purely opt-in now.

## Checklist
- [X] I have tested it locally
- [X] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it

(Cherry-picked commit from dracutdevs/dracut#2529)

This model is removed in some of the distro packaging already (such as Arch or Debian)

CC @pvalena @lnykryn @jlebon @aaradhak