### PR TITLE
test: remove dead code regarding building rpm

### DIFF
--- a/tools/test-github.sh
+++ b/tools/test-github.sh
@@ -12,16 +12,7 @@ TESTS=$2
 NCPU=$(getconf _NPROCESSORS_ONLN)
 
 if ! [[ $TESTS ]]; then
-    # GitHub workflows fetch a clone of the dracut repository which doesn't
-    # contain git tags, thus "breaking" the RPM build in certain situations
-    # i.e.:
-    # DRACUT_MAIN_VERSION in Makefile is defined as an output of `git describe`,
-    # which in full git clone returns a tag with a numeric version. However,
-    # without tags it returns SHA of the last commit, which later propagates into
-    # `Provides:` attribute of the built RPM and can break dependency tree when
-    # installed
-    [[ -d .git ]] && git fetch --tags && git describe --tags
-    make -j "$NCPU" all syncheck rpm logtee
+    make -j "$NCPU" all syncheck logtee
 else
     make -j "$NCPU" enable_documentation=no all logtee
 


### PR DESCRIPTION
## Changes

Remove test infrastructure code that no longer runs and no longer used.

(Cherry-picked commit from dracutdevs/dracut#2209)