### PR TITLE
fix(udev-rules): remove legacy persistent network device name rule

### DIFF
--- a/modules.d/95udev-rules/module-setup.sh
+++ b/modules.d/95udev-rules/module-setup.sh
@@ -45,9 +45,6 @@ install() {
         "$moddir/59-persistent-storage.rules" \
         "$moddir/61-persistent-storage.rules"
 
-    # legacy persistent network device name rules
-    [[ $hostonly ]] && inst_rules 70-persistent-net.rules
-
     {
         for i in cdrom tape dialout floppy; do
             if ! grep -q "^$i:" "$initdir"/etc/group 2> /dev/null; then


### PR DESCRIPTION
## Changes

This udev rule used to be generated. It is no longer used.

See https://systemd-devel.freedesktop.narkive.com/oFRvlOTQ/70-persistent-net-rules .


This is how it used to look:

```
cat /etc/udev/rules.d/70-persistent-net.rules
# This file was automatically generated by the /lib/udev/write_net_rules
# program, run by the persistent-net-generator.rules rules file.
```

 `write_net_rules` is no longer in [debian stretch](https://packages.debian.org/stretch/amd64/udev/filelist) - see also https://github.com/systemd/systemd/issues/7840#issuecomment-356841508

(Cherry-picked commit from dracutdevs/dracut#2247)