### PR TITLE
fix(dmsquash-live): handle relative pathspec

### DIFF
--- a/man/dracut.cmdline.7.asc
+++ b/man/dracut.cmdline.7.asc
@@ -1183,7 +1183,7 @@ used.
 [listing]
 .Examples
 --
-rd.live.overlay=/dev/sdb1:persistent-overlay.img
+rd.live.overlay=/dev/sdb1:/persistent-overlay.img
 rd.live.overlay=UUID=99440c1f-8daa-41bf-b965-b7240a8996f4
 --
 

--- a/modules.d/90dmsquash-live/dmsquash-live-root.sh
+++ b/modules.d/90dmsquash-live/dmsquash-live-root.sh
@@ -143,6 +143,8 @@ do_live_overlay() {
 
     if [ -z "$pathspec" -o "$pathspec" = "auto" ]; then
         pathspec="/${live_dir}/overlay-$l-$u"
+    elif ! str_starts "$pathspec" "/"; then
+        pathspec=/"${pathspec}"
     fi
     devspec=${overlay%%:*}
 


### PR DESCRIPTION
## Changes

This change is required to make the following canonical example work that is mentioned in the [documentation](https://github.com/dracutdevs/dracut/blob/master/man/dracut.cmdline.7.asc):

> rd.live.overlay=/dev/sdb1:persistent-overlay.img

This example has been in the dracut documentation since [2015](https://github.com/dracutdevs/dracut/commit/a1b4efe6a722ac3754d8a48109575d11d5ccf61b).

At the same time, improve the documentation with a more specific example.

## Checklist
- [X] I have tested it locally
- [X] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it

Fixes [#579](https://github.com/dracutdevs/dracut/issues/579) (partially)

(Cherry-picked commit from dracutdevs/dracut#2253)

CC @FGrose @Conan-Kudo @fabiand
