### PR TITLE
fix(rootfs-block): remove support for [no]readonlyroot and fastboot

### DIFF
--- a/modules.d/95rootfs-block/mount-root.sh
+++ b/modules.d/95rootfs-block/mount-root.sh
@@ -30,22 +30,13 @@ mount_root() {
         fsck_ask_err
     done
 
-    READONLY=
     fsckoptions=
     if [ -f "$NEWROOT"/etc/sysconfig/readonly-root ]; then
         # shellcheck disable=SC1090
         . "$NEWROOT"/etc/sysconfig/readonly-root
     fi
 
-    if getargbool 0 "readonlyroot=" -y readonlyroot; then
-        READONLY=yes
-    fi
-
-    if getarg noreadonlyroot; then
-        READONLY=no
-    fi
-
-    if [ -f "$NEWROOT"/fastboot ] || getargbool 0 fastboot; then
+    if [ -f "$NEWROOT"/fastboot ]; then
         fastboot=yes
     fi
 
@@ -106,8 +97,8 @@ mount_root() {
     # esc_root=$(echo ${root#block:} | sed 's,\\,\\\\,g')
     # printf '%s %s %s %s 1 1 \n' "$esc_root" "$NEWROOT" "$rootfs" "$rflags" >/etc/fstab
 
-    if fsck_able "$rootfs" \
-        && [ "$rootfsck" != "0" -a -z "$fastboot" -a "$READONLY" != "yes" ] \
+    if ! getargbool 0 ro && fsck_able "$rootfs" \
+        && [ "$rootfsck" != "0" -a -z "$fastboot" ] \
         && ! strstr "${rflags}" _netdev \
         && ! getargbool 0 rd.skipfsck; then
         umount "$NEWROOT"


### PR DESCRIPTION
## Changes

This PR removes a command line option for a core dracut module.

"readonlyroot" and "noreadonlyroot" command line option are no longer supported (not sure if they actually ever fully worked). 

Use "ro" or "rw" instead.

I am open to keep these arguments and document them instead of removing them, but since there is a much more prevalent command line alternative, I do not think these are used."

Original commit from 2010: https://github.com/dracutdevs/dracut/commit/3871942d13b9175b8143f1ebbd48a211a007c7d2

Fixes [#1948](https://github.com/dracutdevs/dracut/issues/1948) (partially)

(Cherry-picked commit from dracutdevs/dracut#2264)