### PR TITLE
fix(i18n): silence spurious setfont stderr warning

### DIFF
--- a/modules.d/10i18n/console_init.sh
+++ b/modules.d/10i18n/console_init.sh
@@ -49,7 +49,7 @@ set_font() {
     setfont "${FONT-${DEFAULT_FONT}}" \
         -C "${1}" \
         ${FONT_MAP:+-m "${FONT_MAP}"} \
-        ${FONT_UNIMAP:+-u "${FONT_UNIMAP}"}
+        ${FONT_UNIMAP:+-u "${FONT_UNIMAP}"} 2> /dev/null
 }
 
 dev_close() {


### PR DESCRIPTION
## Changes

This error has been here for years, but unreported by setfont. Not actionable error message.

(Cherry-picked commit from dracutdevs/dracut#2622)

CC @zdykstra