### PR TITLE
revert(ci): only run C code scan if src/ directory changed

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -8,13 +8,9 @@ on:
   push:
     branches:
       - main
-    paths:
-      - 'src/**'
   pull_request:
     branches:
       - main
-    paths:
-      - 'src/**'
 
 permissions:
   contents: read


### PR DESCRIPTION
This breaks our required CI status conditions as a required check now does not always run.

This reverts commit cffcbf22717dba9fd296772673fee4b0d286f9ad.