### PR TITLE
Skip creating the dracut initrd when initrd is provided or a different initrd generator is configured

### DIFF
--- a/install.d/50-dracut.install
+++ b/install.d/50-dracut.install
@@ -6,38 +6,19 @@ BOOT_DIR_ABS="$3"
 KERNEL_IMAGE="$4"
 
 # If KERNEL_INSTALL_MACHINE_ID is defined but empty, BOOT_DIR_ABS is a fake directory.
-# So, let's skip to create initrd.
+# In this case, do not create the initrd.
 if ! [[ ${KERNEL_INSTALL_MACHINE_ID-x} ]]; then
     exit 0
 fi
 
-# Do not attempt to create initramfs if the supplied image is already a UKI
-if [[ "$KERNEL_INSTALL_IMAGE_TYPE" = "uki" ]]; then
+# Skip this plugin if we're using a different generator. If nothing is specified,
+# assume we're wanted since we're installed.
+if [ "${KERNEL_INSTALL_INITRD_GENERATOR:-dracut}" != "dracut" ]; then
     exit 0
 fi
 
-# Mismatching the install layout and the --uefi/--no-uefi opts just creates a mess.
-if [[ $KERNEL_INSTALL_LAYOUT == "uki" && -n $KERNEL_INSTALL_STAGING_AREA ]]; then
-    BOOT_DIR_ABS="$KERNEL_INSTALL_STAGING_AREA"
-    if [[ -z $KERNEL_INSTALL_UKI_GENERATOR || $KERNEL_INSTALL_UKI_GENERATOR == "dracut" ]]; then
-        # No uki generator preference set or we have been chosen
-        IMAGE="uki.efi"
-        UEFI_OPTS="--uefi"
-    elif [[ -z $KERNEL_INSTALL_INITRD_GENERATOR || $KERNEL_INSTALL_INITRD_GENERATOR == "dracut" ]]; then
-        # We aren't the uki generator, but we have been requested to make the initrd
-        IMAGE="initrd"
-        UEFI_OPTS="--no-uefi"
-    else
-        exit 0
-    fi
-elif [[ $KERNEL_INSTALL_LAYOUT == "bls" && -n $KERNEL_INSTALL_STAGING_AREA ]]; then
-    BOOT_DIR_ABS="$KERNEL_INSTALL_STAGING_AREA"
-    if [[ -z $KERNEL_INSTALL_INITRD_GENERATOR || $KERNEL_INSTALL_INITRD_GENERATOR == "dracut" ]]; then
-        IMAGE="initrd"
-        UEFI_OPTS="--no-uefi"
-    else
-        exit 0
-    fi
+if [[ -d "$BOOT_DIR_ABS" ]]; then
+    INITRD="initrd"
 else
     # No layout information, use users --uefi/--no-uefi preference
     UEFI_OPTS=""

--- a/install.d/50-dracut.install
+++ b/install.d/50-dracut.install
@@ -4,6 +4,7 @@ COMMAND="$1"
 KERNEL_VERSION="$2"
 BOOT_DIR_ABS="$3"
 KERNEL_IMAGE="$4"
+INITRD_OPTIONS_SHIFT=4
 
 # If KERNEL_INSTALL_MACHINE_ID is defined but empty, BOOT_DIR_ABS is a fake directory.
 # In this case, do not create the initrd.
@@ -34,6 +35,9 @@ ret=0
 
 case "$COMMAND" in
     add)
+        # If the initrd was provided on the kernel command line, we shouldn't generate our own.
+        [ "$#" -gt "$INITRD_OPTIONS_SHIFT" ] && exit 0
+
         if [[ $IMAGE == "uki.efi" ]]; then
             IMAGE_PREGENERATED=${KERNEL_IMAGE%/*}/uki.efi
         else

--- a/install.d/51-dracut-rescue.install
+++ b/install.d/51-dracut-rescue.install
@@ -7,9 +7,15 @@ KERNEL_VERSION="$2"
 BOOT_DIR_ABS="${3%/*}/0-rescue"
 KERNEL_IMAGE="$4"
 
-dropindirs_sort() {
-    suffix=$1
-    shift
+# Skip this plugin if we're using a different generator. If nothing is specified,
+# assume we're wanted since we're installed.
+if [ "${KERNEL_INSTALL_INITRD_GENERATOR:-dracut}" != "dracut" ]; then
+    exit 0
+fi
+
+dropindirs_sort()
+{
+    suffix=$1; shift
     args=("$@")
     files=$(
         while (($# > 0)); do


### PR DESCRIPTION
This pull request changes...

## Changes

`kernel-install` respects the `KERNEL_INSTALL_INITRD_GENERATOR` to select initramfs generators, especially now to not invoke dracut at all if unwanted.

## Checklist
- [x] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it

Rebased version of https://github.com/dracutdevs/dracut/pull/1825 by @keszybz pulled from Fedora dracut patchset.
