### PR TITLE
Enable Differential ShellCheck

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -16,11 +16,9 @@ jobs:
       - name: shfmt
         uses: luizm/action-sh-checker@v0.6.0
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           SHFMT_OPTS: -s # arguments to shfmt.
         with:
           sh_checker_shellcheck_disable: false
-          sh_checker_comment: true
 
   differential-shellcheck:
     runs-on: ubuntu-latest

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -22,6 +22,30 @@ jobs:
           sh_checker_shellcheck_disable: false
           sh_checker_comment: true
 
+  differential-shellcheck:
+    runs-on: ubuntu-latest
+
+    permissions:
+      security-events: write
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - id: ShellCheck
+        name: Differential ShellCheck
+        uses: redhat-plumbers-in-action/differential-shellcheck@v5
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - if: ${{ always() }}
+        name: Upload artifact with ShellCheck defects in SARIF format
+        uses: actions/upload-artifact@v3
+        with:
+          name: Differential ShellCheck SARIF
+          path: ${{ steps.ShellCheck.outputs.sarif }}
+
   lint-c:
     runs-on: ubuntu-latest
 

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -18,7 +18,7 @@ jobs:
         env:
           SHFMT_OPTS: -s # arguments to shfmt.
         with:
-          sh_checker_shellcheck_disable: false
+          sh_checker_shellcheck_disable: true # disable shellcheck in favor of differential-shellcheck
 
   differential-shellcheck:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Changes

Differential ShellCheck is a GitHub action that performs differential ShellCheck scans on shell scripts changed via PR and reports results directly in PR.

It is able to produce reports in SARIF format. GitHub understands this format and is able to display it nicely as a PR comment, and on the Files Changed tab, please see below.

## Checklist
- [X] I have tested it locally
- [X] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it

This will resolve your issues with cleaning your codebase every time the new ShellCheck comes out: #2501

Differential ShellCheck only reports defects directly related to the PR/commit. So you can focus on defects caused by your changes and deal with the existing defects later.

(Cherry-picked commit from dracutdevs/dracut#2530)

CC @jamacku 