### PR TITLE
revert(dracut-install): file created without restricting permissions

### DIFF
--- a/src/install/dracut-install.c
+++ b/src/install/dracut-install.c
@@ -687,11 +687,9 @@ void mark_hostonly(const char *path)
 
         _asprintf(&fulldstpath, "%s/lib/dracut/hostonly-files", destrootdir);
 
-        int fd = open(fulldstpath, O_RDONLY | O_APPEND, 0600);
-        if (fd != -1)
-                f = fdopen(fd, "a");
+        f = fopen(fulldstpath, "a");
 
-        if (fd == -1 || f == NULL) {
+        if (f == NULL) {
                 log_error("Could not open '%s' for writing.", fulldstpath);
                 return;
         }


### PR DESCRIPTION
Reverts dracut-ng/dracut-ng#56

Fixes #76