### PR TITLE
ci: disable running flaky tests on openSUSE

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -22,7 +22,6 @@ jobs:
                         "debian",
                         "fedora",
                         "gentoo",
-                        "opensuse",
                         "ubuntu",
                 ]
                 test: [


### PR DESCRIPTION
Tests-04 is flaky (sometimes passes sometimes fails on a seemingly same environment) on openSUSE CI container. The tests is satbel on all other distros.

Flaky tests tent to confuse contributors and slow down the project - https://github.com/dracut-ng/dracut-ng/pull/67#issuecomment-2030868270 .

openSUSE CI container (and only this one) struggled with some other tests recently as well, see https://github.com/dracut-ng/dracut-ng/pull/29 and https://github.com/dracut-ng/dracut-ng/pull/23 .

Now that we use the openSUSE CI container to test network-legacy (https://github.com/dracut-ng/dracut-ng/pull/47), we can remove openSUSE from the non-networking tests and still get some CI coverage on openSUSE.