### PR TITLE
ci: upgrade shfmt

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -14,7 +14,7 @@ jobs:
       - uses: actions/checkout@v3
 
       - name: shfmt
-        uses: luizm/action-sh-checker@v0.6.0
+        uses: luizm/action-sh-checker@v0.8.0
         env:
           SHFMT_OPTS: -s # arguments to shfmt.
         with:


### PR DESCRIPTION
## Changes

As the project gained a better solution for https://github.com/dracut-ng/dracut-ng/pull/75  we can move on for upgrading shfmt