### PR TITLE
fix(dracut.sh): recognize kernel file in /boot named vmlinux too

### DIFF
--- a/dracut.sh
+++ b/dracut.sh
@@ -1154,7 +1154,7 @@ if ! [[ $outfile ]]; then
             outfile="$dracutsysrootdir/boot/efi/${MACHINE_ID}/${kernel}/initrd"
         elif [[ -f "$dracutsysrootdir"/lib/modules/${kernel}/initrd ]]; then
             outfile="$dracutsysrootdir/lib/modules/${kernel}/initrd"
-        elif [[ -e $dracutsysrootdir/boot/vmlinuz-${kernel} ]]; then
+        elif [[ -e $dracutsysrootdir/boot/vmlinuz-${kernel} || -e $dracutsysrootdir/boot/vmlinux-${kernel} ]]; then
             outfile="$dracutsysrootdir/boot/initramfs-${kernel}.img"
         elif [[ -z $dracutsysrootdir ]] \
             && [[ $MACHINE_ID ]] \


### PR DESCRIPTION
## Changes

The kernel file, at least in AOSC OS, is named vmlinux instead of vmlinuz if uncompressed.

(Cherry-picked commit from dracutdevs/dracut#2626)

CC @Icenowy
