### PR TITLE
ci: don't validate the pull request title

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -15,5 +15,6 @@ jobs:
       uses: tomtom-international/commisery-action@master
       with:
         token: ${{ secrets.GITHUB_TOKEN }}
-        pull_request: ${{ github.event.number }}
-
+        # don't validate the pull request title
+        validate-pull-request: false
+        validate-pull-request-title-bump: false


### PR DESCRIPTION
Let's try to make commisery-action not very intrusive and disable some feature we do not need. If commisery-action is too intrusive, I do not mind turning it off completely, but lets see first if this helps. 
