### PR TITLE
test(NFS): enable NFSv4 tests

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -71,7 +71,7 @@ jobs:
                         #"connman",
                 ]
                 test: [
-                        #"20", # unstable
+                        "20",
                         "30",
                         "35",
                         "40",
@@ -106,6 +106,7 @@ jobs:
                         "network-legacy",
                 ]
                 test: [
+                        "20",
                         "30",
                         "35",
                         "40",

--- a/test/TEST-20-NFS/test.sh
+++ b/test/TEST-20-NFS/test.sh
@@ -3,6 +3,10 @@
 # shellcheck disable=SC2034
 TEST_DESCRIPTION="root filesystem on NFS with $USE_NETWORK"
 
+test_check() {
+    command -v exportfs &> /dev/null
+}
+
 # Uncomment this to debug failures
 #DEBUGFAIL="rd.debug loglevel=7 rd.break=initqueue rd.shell"
 SERVER_DEBUG="rd.debug loglevel=7"
@@ -213,8 +217,9 @@ test_run() {
         return 1
     fi
 
-    test_nfsv3 \
-        && test_nfsv4
+    # focus on NFSv4 testing, disable NFSv3 tests
+    #test_nfsv3
+    test_nfsv4
 
     ret=$?
 


### PR DESCRIPTION
## Changes

In addition make, sure that exportfs is available before attempting to run the tests.

Incorporated  commit from dracutdevs/dracut#2570.

If we do not run NFSv3 tests, the test is much more stable and does not time out.
