### PR TITLE
fix: wait 12 hours before halt on media check fail

### DIFF
--- a/modules.d/90dmsquash-live/dmsquash-live-root.sh
+++ b/modules.d/90dmsquash-live/dmsquash-live-root.sh
@@ -76,7 +76,9 @@ if [ -n "$check" ]; then
         checkisomd5 --verbose "$check_dev"
     fi
     if [ $? -eq 1 ]; then
-        die "CD check failed!"
+        warn "Media check failed! We do not recommend using this medium. System will halt in 12 hours"
+        sleep 43200
+        die "Media check failed!"
         exit 1
     fi
     type plymouth > /dev/null 2>&1 && plymouth --show-splash


### PR DESCRIPTION
## Changes

If a modesetting driver has been loaded by the time the media check happens, halting the system (as we currently do immediately if the check fails) blanks the screen, which is confusing for the user. This adds a warning message and a 12-hour wait before the system is eventually halted, so the user can see the media check failure and (presumably) reboot and fix the medium.

It also tweaks the text of the failure message not to call it a "CD check", since it's not 1998 any more.

https://bugzilla.redhat.com/show_bug.cgi?id=2246410

This pull request changes...

## Checklist
- [X] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it
