### PR TITLE
test(FULL-SYSTEMD): use poweroff to shut down test

### DIFF
--- a/test/TEST-04-FULL-SYSTEMD/test-init.sh
+++ b/test/TEST-04-FULL-SYSTEMD/test-init.sh
@@ -37,5 +37,4 @@ if getargbool 0 rd.shell; then
     setsid $CTTY sh -i
 fi
 echo "Powering down."
-systemctl --no-block poweroff
-exit 0
+poweroff -f


### PR DESCRIPTION
## Changes

Without this change the test seems to be flaky on all distributions (seen on Fedora, Debian as well).

Follow-up to https://github.com/dracut-ng/dracut-ng/pull/42

The error in the test run log:

```
2024-04-04T13:42:24.0379316Z [    3.642828] (sd-umount)[709]: Failed to unmount /usr: Device or resource busy
2024-04-04T13:42:24.0407632Z [    3.646058] systemd-shutdown[1]: Failed to finalize file systems, ignoring.
```

From the CI it looks like this resolved the flakiness. 

Here is a CI run on another PR that shows the failures - https://github.com/dracut-ng/dracut-ng/pull/97

I consider this PR to be a priority for CI and the project, so i added it to the release milestone.