### PR TITLE
fix(dracut-init.sh): do not print by default if a modules is not installed

### DIFF
--- a/dracut-init.sh
+++ b/dracut-init.sh
@@ -115,7 +115,7 @@ require_binaries() {
 
     for cmd in "$@"; do
         if ! find_binary "$cmd" &> /dev/null; then
-            dinfo "Module '${_module_name#[0-9][0-9]}' will not be installed, because command '$cmd' could not be found!"
+            ddebug "Module '${_module_name#[0-9][0-9]}' will not be installed, because command '$cmd' could not be found!"
             ((_ret++))
         fi
     done


### PR DESCRIPTION
## Changes

We are already printing out by default what modules are installed so user can check what got installed.

No need to issue warning for a normal execution of dracut. 

This is confusing users - especially new users we hope to attract - as seen e.g. https://forum.garudalinux.org/t/want-to-try-and-help-test-dracut-now-is-the-time/23994/75