### PR TITLE
test(DRACUT-CPIO): enable building dracut-cpio when cargo is installed

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -154,3 +154,30 @@ jobs:
 
             -   name: "${{ matrix.container }} TEST-${{ matrix.test }}"
                 run: ./tools/test-github.sh "TEST-${{ matrix.test }}" ${{ matrix.test }}
+    dracut-cpio:
+        name: ${{ matrix.test }} on ${{ matrix.container }}
+        runs-on: ubuntu-latest
+        timeout-minutes: 30
+        concurrency:
+            group: ${{ github.workflow }}-${{ github.ref }}-${{ matrix.container }}-${{ matrix.test }}
+            cancel-in-progress: true
+        strategy:
+            matrix:
+                container: [
+                        "opensuse",
+                ]
+                test: [
+                        "63",
+                ]
+            fail-fast: false
+        container:
+            image: ghcr.io/dracut-ng/${{ matrix.container }}
+            options: "--privileged -v /dev:/dev"
+        steps:
+            -   name: "Checkout Repository"
+                uses: actions/checkout@v1
+                with:
+                    fetch-depth: 0
+
+            -   name: "${{ matrix.container }} TEST-${{ matrix.test }}"
+                run: ./tools/test-github.sh "TEST-${{ matrix.test }}" ${{ matrix.test }}

--- a/test/TEST-63-DRACUT-CPIO/test.sh
+++ b/test/TEST-63-DRACUT-CPIO/test.sh
@@ -21,19 +21,16 @@ test_dracut_cpio() {
 
     mkdir -p "$tdir"
 
-    # VM script to print sentinel on boot
-    # write to kmsg so that sysrq messages don't race with console output
     cat > "$tdir/init.sh" << EOF
-echo "Image with ${dracut_cpio_params[*]} booted successfully" > /dev/kmsg
-echo 1 > /proc/sys/kernel/sysrq
-echo o > /proc/sysrq-trigger
-sleep 20
+echo "Image with ${dracut_cpio_params[*]} booted successfully"
+poweroff -f
 EOF
 
-    "$DRACUT" -l --drivers "" \
+    "$DRACUT" -l --no-kernel --drivers "" \
         "${dracut_cpio_params[@]}" \
         --modules "bash base" \
         --include "$tdir/init.sh" /lib/dracut/hooks/emergency/00-init.sh \
+        --install "poweroff" \
         --no-hostonly --no-hostonly-cmdline \
         "$tdir/initramfs" \
         || return 1

--- a/test/container/Dockerfile-OpenSuse-latest
+++ b/test/container/Dockerfile-OpenSuse-latest
@@ -6,6 +6,7 @@ RUN dnf -y install --setopt=install_weak_deps=False \
     bash-completion \
     btrfsprogs \
     bzip2 \
+    cargo \
     cryptsetup \
     dash \
     dbus-broker \

--- a/tools/test-github.sh
+++ b/tools/test-github.sh
@@ -7,7 +7,12 @@ set -ex
 RUN_ID="$1"
 TESTS=$2
 
-./configure
+# if is cargo installed, let's build and test dracut-cpio
+if command -v cargo > /dev/null; then
+    ./configure --enable-dracut-cpio
+else
+    ./configure
+fi
 
 NCPU=$(getconf _NPROCESSORS_ONLN)
 


### PR DESCRIPTION
## Changes

Since the test is well written, it will be just skipped if cargo is not in the test container.
    
Add cargo to the openSUSE test container.

Fixes https://github.com/dracut-ng/dracut-ng/issues/106

CC @ddiss 