### PR TITLE
ci: add more packages to the Arch container to enable more testing

### DIFF
--- a/test/container/Dockerfile-Arch
+++ b/test/container/Dockerfile-Arch
@@ -4,17 +4,25 @@ RUN pacman --noconfirm -Syu \
     asciidoc \
     astyle \
     base-devel \
+    bluez \
     btrfs-progs \
+    busybox \
+    cargo \
+    cifs-utils \
     connman \
     cpio \
     dash \
     dhclient \
     dhcp \
     dmraid \
+    elfutils \
+    f2fs-tools \
     git \
     glibc \
+    jq \
     linux \
     lvm2 \
+    lzop \
     mdadm \
     multipath-tools \
     nbd \
@@ -22,15 +30,21 @@ RUN pacman --noconfirm -Syu \
     nfsidmap \
     nfs-utils \
     ntfs-3g \
+    nvme-cli \
     open-iscsi \
+    openssh \
     parted \
     pigz \
+    plymouth \
     qemu \
+    rng-tools \
+    sbsigntools \
     shellcheck \
     shfmt \
     squashfs-tools \
     strace \
     tcpdump \
     tgt \
+    tpm2-tools \
     vi \
     && yes | pacman -Scc


### PR DESCRIPTION
## Changes

Install tgt with pacman, instead of managing tgt dependencies (such us perl-config-general) ourselves.

Install new packages that can help with testing - such as tpm2-tools, busybox, nvme-cli