### PR TITLE
fix(dracut): move hooks directory from /usr/lib to /var/lib

### DIFF
--- a/docs/HACKING.md
+++ b/docs/HACKING.md
@@ -183,42 +183,42 @@ You are encouraged to provide a README that describes what the module is for.
 
 init has the following hook points to inject scripts:
 
-`/lib/dracut/hooks/cmdline/*.sh`
+`/var/lib/dracut/hooks/cmdline/*.sh`
    scripts for command line parsing
 
-`/lib/dracut/hooks/pre-udev/*.sh`
+`/var/lib/dracut/hooks/pre-udev/*.sh`
    scripts to run before udev is started
 
-`/lib/dracut/hooks/pre-trigger/*.sh`
+`/var/lib/dracut/hooks/pre-trigger/*.sh`
    scripts to run before the main udev trigger is pulled
 
-`/lib/dracut/hooks/initqueue/*.sh`
+`/var/lib/dracut/hooks/initqueue/*.sh`
    runs in parallel to the udev trigger
    Udev events can add scripts here with /sbin/initqueue.
    If /sbin/initqueue is called with the "--onetime" option, the script
    will be removed after it was run.
-   If /lib/dracut/hooks/initqueue/work is created and udev >= 143 then
+   If /var/lib/dracut/hooks/initqueue/work is created and udev >= 143 then
    this loop can process the jobs in parallel to the udevtrigger.
    If the udev queue is empty and no root device is found or no root
    filesystem was mounted, the user will be dropped to a shell after
    a timeout.
    Scripts can remove themselves from the initqueue by "rm $job".
 
-`/lib/dracut/hooks/pre-mount/*.sh`
+`/var/lib/dracut/hooks/pre-mount/*.sh`
    scripts to run before the root filesystem is mounted
    Network filesystems like NFS that do not use device files are an
    exception. Root can be mounted already at this point.
 
-`/lib/dracut/hooks/mount/*.sh`
+`/var/lib/dracut/hooks/mount/*.sh`
    scripts to mount the root filesystem
    If the udev queue is empty and no root device is found or no root
    filesystem was mounted, the user will be dropped to a shell after
    a timeout.
 
-`/lib/dracut/hooks/pre-pivot/*.sh`
+`/var/lib/dracut/hooks/pre-pivot/*.sh`
    scripts to run before latter initramfs cleanups
 
-`/lib/dracut/hooks/cleanup/*.sh`
+`/var/lib/dracut/hooks/cleanup/*.sh`
    scripts to run before the real init is executed and the initramfs
    disappears
    All processes started before should be killed here.

--- a/dracut-init.sh
+++ b/dracut-init.sh
@@ -630,7 +630,7 @@ inst_hook() {
         dfatal "No such hook type $1. Aborting initrd creation."
         exit 1
     fi
-    hook="/lib/dracut/hooks/${1}/${2}-${3##*/}"
+    hook="/var/lib/dracut/hooks/${1}/${2}-${3##*/}"
     inst_simple "$3" "$hook"
     chmod u+x "$initdir/$hook"
 }

--- a/dracut.sh
+++ b/dracut.sh
@@ -1883,10 +1883,10 @@ mkdir -p "${initdir}"/lib/dracut
 
 if [[ $kernel_only != yes ]]; then
     mkdir -p "${initdir}/etc/cmdline.d"
-    mkdir -m 0755 "${initdir}"/lib/dracut/hooks
+    mkdir -m 0755 -p "${initdir}"/var/lib/dracut/hooks
     for _d in $hookdirs; do
         # shellcheck disable=SC2174
-        mkdir -m 0755 -p "${initdir}/lib/dracut/hooks/$_d"
+        mkdir -m 0755 -p "${initdir}/var/lib/dracut/hooks/$_d"
     done
     if [[ $EUID == "0" ]] && ! [[ $DRACUT_NO_MKNOD ]]; then
         [[ -c ${initdir}/dev/null ]] || mknod "${initdir}"/dev/null c 1 3

--- a/modules.d/95resume/parse-resume.sh
+++ b/modules.d/95resume/parse-resume.sh
@@ -66,7 +66,7 @@ if ! getarg noresume; then
             printf -- ' cancel_wait_for_dev /dev/resume; rm -f -- "$job" "%s/initqueue/settled/resume.sh";\n' "$hookdir"
         } >> "$hookdir"/initqueue/timeout/resume.sh
 
-        mv /lib/dracut/resume.sh /lib/dracut/hooks/pre-mount/10-resume.sh
+        mv /lib/dracut/resume.sh /var/lib/dracut/hooks/pre-mount/10-resume.sh
     else
         {
             if [ -x /usr/sbin/resume ]; then

--- a/modules.d/98dracut-systemd/dracut-cmdline.service
+++ b/modules.d/98dracut-systemd/dracut-cmdline.service
@@ -9,7 +9,7 @@ After=systemd-journald.socket
 Wants=systemd-journald.socket
 ConditionPathExists=/usr/lib/initrd-release
 ConditionPathExistsGlob=|/etc/cmdline.d/*.conf
-ConditionDirectoryNotEmpty=|/lib/dracut/hooks/cmdline
+ConditionDirectoryNotEmpty=|/var/lib/dracut/hooks/cmdline
 ConditionKernelCommandLine=|rd.break=cmdline
 ConditionKernelCommandLine=|resume
 ConditionKernelCommandLine=|noresume

--- a/modules.d/98dracut-systemd/dracut-mount.service
+++ b/modules.d/98dracut-systemd/dracut-mount.service
@@ -6,7 +6,7 @@ Documentation=man:dracut-mount.service(8) man:dracut.bootup(7)
 After=initrd-root-fs.target initrd-parse-etc.service
 After=dracut-initqueue.service dracut-pre-mount.service
 ConditionPathExists=/usr/lib/initrd-release
-ConditionDirectoryNotEmpty=|/lib/dracut/hooks/mount
+ConditionDirectoryNotEmpty=|/var/lib/dracut/hooks/mount
 ConditionKernelCommandLine=|rd.break=mount
 DefaultDependencies=no
 Conflicts=shutdown.target emergency.target

--- a/modules.d/98dracut-systemd/dracut-pre-mount.service
+++ b/modules.d/98dracut-systemd/dracut-pre-mount.service
@@ -7,7 +7,7 @@ DefaultDependencies=no
 Before=initrd-root-fs.target sysroot.mount systemd-fsck-root.service
 After=dracut-initqueue.service cryptsetup.target
 ConditionPathExists=/usr/lib/initrd-release
-ConditionDirectoryNotEmpty=|/lib/dracut/hooks/pre-mount
+ConditionDirectoryNotEmpty=|/var/lib/dracut/hooks/pre-mount
 ConditionKernelCommandLine=|rd.break=pre-mount
 Conflicts=shutdown.target emergency.target
 

--- a/modules.d/98dracut-systemd/dracut-pre-pivot.service
+++ b/modules.d/98dracut-systemd/dracut-pre-pivot.service
@@ -10,8 +10,8 @@ Before=initrd-cleanup.service
 Wants=remote-fs.target
 After=remote-fs.target
 ConditionPathExists=/usr/lib/initrd-release
-ConditionDirectoryNotEmpty=|/lib/dracut/hooks/pre-pivot
-ConditionDirectoryNotEmpty=|/lib/dracut/hooks/cleanup
+ConditionDirectoryNotEmpty=|/var/lib/dracut/hooks/pre-pivot
+ConditionDirectoryNotEmpty=|/var/lib/dracut/hooks/cleanup
 ConditionKernelCommandLine=|rd.break=pre-pivot
 ConditionKernelCommandLine=|rd.break=cleanup
 ConditionKernelCommandLine=|rd.break

--- a/modules.d/98dracut-systemd/dracut-pre-trigger.service
+++ b/modules.d/98dracut-systemd/dracut-pre-trigger.service
@@ -8,7 +8,7 @@ Before=systemd-udev-trigger.service dracut-initqueue.service
 After=dracut-pre-udev.service systemd-udevd.service systemd-tmpfiles-setup-dev.service
 Wants=dracut-pre-udev.service systemd-udevd.service
 ConditionPathExists=/usr/lib/initrd-release
-ConditionDirectoryNotEmpty=|/lib/dracut/hooks/pre-trigger
+ConditionDirectoryNotEmpty=|/var/lib/dracut/hooks/pre-trigger
 ConditionKernelCommandLine=|rd.break=pre-trigger
 Conflicts=shutdown.target emergency.target
 

--- a/modules.d/98dracut-systemd/dracut-pre-udev.service
+++ b/modules.d/98dracut-systemd/dracut-pre-udev.service
@@ -8,7 +8,7 @@ Before=systemd-udevd.service dracut-pre-trigger.service
 After=dracut-cmdline.service
 Wants=dracut-cmdline.service
 ConditionPathExists=/usr/lib/initrd-release
-ConditionDirectoryNotEmpty=|/lib/dracut/hooks/pre-udev
+ConditionDirectoryNotEmpty=|/var/lib/dracut/hooks/pre-udev
 ConditionKernelCommandLine=|rd.break=pre-udev
 ConditionKernelCommandLine=|rd.driver.blacklist
 ConditionKernelCommandLine=|rd.driver.pre

--- a/modules.d/99base/dracut-lib.sh
+++ b/modules.d/99base/dracut-lib.sh
@@ -399,14 +399,14 @@ source_all() {
     done
 }
 
-hookdir=/lib/dracut/hooks
+hookdir=/var/lib/dracut/hooks
 export hookdir
 
 source_hook() {
     local _dir
     _dir=$1
     shift
-    source_all "/lib/dracut/hooks/$_dir" "$@"
+    source_all "/var/lib/dracut/hooks/$_dir" "$@"
 }
 
 check_finished() {

--- a/modules.d/99base/module-setup.sh
+++ b/modules.d/99base/module-setup.sh
@@ -45,7 +45,10 @@ install() {
 
     [ -e "${initdir}/lib" ] || mkdir -m 0755 -p "${initdir}"/lib
     mkdir -m 0755 -p "${initdir}"/lib/dracut
-    mkdir -m 0755 -p "${initdir}"/lib/dracut/hooks
+    mkdir -m 0755 -p "${initdir}"/var/lib/dracut/hooks
+
+    # symlink to old hooks location for compatibility
+    ln_r /var/lib/dracut/hooks /lib/dracut/hooks
 
     mkdir -p "${initdir}"/tmp
 
@@ -116,7 +119,7 @@ install() {
                     export DRACUT_SYSTEMD=1
                 fi
                 export PREFIX="$initdir"
-                export hookdir=/lib/dracut/hooks
+                export hookdir=/var/lib/dracut/hooks
 
                 # shellcheck source=dracut-dev-lib.sh
                 . "$moddir/dracut-dev-lib.sh"

--- a/modules.d/99shutdown/module-setup.sh
+++ b/modules.d/99shutdown/module-setup.sh
@@ -17,10 +17,8 @@ install() {
     inst_multiple umount poweroff reboot halt losetup stat sleep timeout
     inst_multiple -o kexec
     inst "$moddir/shutdown.sh" "$prefix/shutdown"
-    [ -e "${initdir}/lib" ] || mkdir -m 0755 -p "${initdir}"/lib
-    mkdir -m 0755 -p "${initdir}"/lib/dracut
-    mkdir -m 0755 -p "${initdir}"/lib/dracut/hooks
+    mkdir -m 0755 -p "${initdir}"/var/lib/dracut/hooks
     for _d in $hookdirs shutdown shutdown-emergency; do
-        mkdir -m 0755 -p "${initdir}"/lib/dracut/hooks/"$_d"
+        mkdir -m 0755 -p "${initdir}"/var/lib/dracut/hooks/"$_d"
     done
 }

--- a/test/TEST-01-BASIC/test.sh
+++ b/test/TEST-01-BASIC/test.sh
@@ -39,7 +39,7 @@ test_setup() {
     "$DRACUT" -l -i "$TESTDIR"/overlay / \
         -m "test-makeroot" \
         -I "mkfs.ext4" \
-        -i ./create-root.sh /lib/dracut/hooks/initqueue/01-create-root.sh \
+        -i ./create-root.sh /var/lib/dracut/hooks/initqueue/01-create-root.sh \
         --nomdadmconf \
         --no-hostonly-cmdline -N \
         -f "$TESTDIR"/initramfs.makeroot "$KVERSION" || return 1

--- a/test/TEST-02-SYSTEMD/test.sh
+++ b/test/TEST-02-SYSTEMD/test.sh
@@ -41,7 +41,7 @@ test_setup() {
     "$DRACUT" -l -i "$TESTDIR"/overlay / \
         -m "test-makeroot" \
         -I "mkfs.ext4" \
-        -i ./create-root.sh /lib/dracut/hooks/initqueue/01-create-root.sh \
+        -i ./create-root.sh /var/lib/dracut/hooks/initqueue/01-create-root.sh \
         --nomdadmconf \
         --no-hostonly-cmdline -N \
         -f "$TESTDIR"/initramfs.makeroot "$KVERSION" || return 1
@@ -66,7 +66,7 @@ test_setup() {
         -a "test systemd" \
         -o "network kernel-network-modules" \
         -d "piix ide-gd_mod ata_piix ext4 sd_mod" \
-        -i ./systemd-analyze.sh /lib/dracut/hooks/pre-pivot/00-systemd-analyze.sh \
+        -i ./systemd-analyze.sh /var/lib/dracut/hooks/pre-pivot/00-systemd-analyze.sh \
         -i "/bin/true" "/usr/bin/man" \
         --no-hostonly-cmdline -N \
         -f "$TESTDIR"/initramfs.testing "$KVERSION" || return 1

--- a/test/TEST-03-USR-MOUNT/test.sh
+++ b/test/TEST-03-USR-MOUNT/test.sh
@@ -58,7 +58,7 @@ test_setup() {
     "$DRACUT" -l -i "$TESTDIR"/overlay / \
         -m "test-makeroot" \
         -I "mkfs.btrfs" \
-        -i ./create-root.sh /lib/dracut/hooks/initqueue/01-create-root.sh \
+        -i ./create-root.sh /var/lib/dracut/hooks/initqueue/01-create-root.sh \
         --nomdadmconf \
         --nohardlink \
         --no-hostonly-cmdline -N \

--- a/test/TEST-04-FULL-SYSTEMD/test.sh
+++ b/test/TEST-04-FULL-SYSTEMD/test.sh
@@ -119,7 +119,7 @@ EOF
     "$DRACUT" -l -i "$TESTDIR"/overlay / \
         -m "test-makeroot bash btrfs" \
         -I "mkfs.btrfs" \
-        -i ./create-root.sh /lib/dracut/hooks/initqueue/01-create-root.sh \
+        -i ./create-root.sh /var/lib/dracut/hooks/initqueue/01-create-root.sh \
         --nomdadmconf \
         --nohardlink \
         --no-hostonly-cmdline -N \

--- a/test/TEST-16-DMSQUASH/test.sh
+++ b/test/TEST-16-DMSQUASH/test.sh
@@ -98,7 +98,7 @@ test_setup() {
         --modules "test-makeroot" \
         --install "sfdisk mkfs.ext4 mkfs.ntfs mksquashfs" \
         --drivers "ntfs3" \
-        --include ./create-root.sh /lib/dracut/hooks/initqueue/01-create-root.sh \
+        --include ./create-root.sh /var/lib/dracut/hooks/initqueue/01-create-root.sh \
         --no-hostonly --no-hostonly-cmdline --no-early-microcode --nofscks --nomdadmconf --nohardlink --nostrip \
         --force "$TESTDIR"/initramfs.makeroot "$KVERSION" || return 1
     rm -rf -- "$TESTDIR"/overlay

--- a/test/TEST-30-ISCSI/test.sh
+++ b/test/TEST-30-ISCSI/test.sh
@@ -148,7 +148,7 @@ test_setup() {
     "$DRACUT" -l -i "$TESTDIR"/overlay / \
         -m "test-makeroot crypt lvm mdraid" \
         -I "mkfs.ext4 setsid blockdev" \
-        -i ./create-client-root.sh /lib/dracut/hooks/initqueue/01-create-client-root.sh \
+        -i ./create-client-root.sh /var/lib/dracut/hooks/initqueue/01-create-client-root.sh \
         --no-hostonly-cmdline -N \
         -f "$TESTDIR"/initramfs.makeroot "$KVERSION" || return 1
     rm -rf -- "$TESTDIR"/overlay
@@ -192,7 +192,7 @@ test_setup() {
     "$DRACUT" -l -i "$TESTDIR"/overlay / \
         -m "test-makeroot" \
         -I "mkfs.ext4" \
-        -i ./create-server-root.sh /lib/dracut/hooks/initqueue/01-create-server-root.sh \
+        -i ./create-server-root.sh /var/lib/dracut/hooks/initqueue/01-create-server-root.sh \
         --nomdadmconf \
         --no-hostonly-cmdline -N \
         -f "$TESTDIR"/initramfs.makeroot "$KVERSION" || return 1
@@ -217,7 +217,7 @@ test_setup() {
         -a "dash rootfs-block test kernel-modules network network-legacy" \
         -d "piix ide-gd_mod ata_piix ext4 sd_mod e1000 drbg" \
         -i "./server.link" "/etc/systemd/network/01-server.link" \
-        -i ./wait-if-server.sh /lib/dracut/hooks/pre-mount/99-wait-if-server.sh \
+        -i ./wait-if-server.sh /var/lib/dracut/hooks/pre-mount/99-wait-if-server.sh \
         --no-hostonly-cmdline -N \
         -f "$TESTDIR"/initramfs.server "$KVERSION" || return 1
 

--- a/test/TEST-63-DRACUT-CPIO/test.sh
+++ b/test/TEST-63-DRACUT-CPIO/test.sh
@@ -33,7 +33,7 @@ EOF
     "$DRACUT" -l --drivers "" \
         "${dracut_cpio_params[@]}" \
         --modules "bash base" \
-        --include "$tdir/init.sh" /lib/dracut/hooks/emergency/00-init.sh \
+        --include "$tdir/init.sh" /var/lib/dracut/hooks/emergency/00-init.sh \
         --no-hostonly --no-hostonly-cmdline \
         "$tdir/initramfs" \
         || return 1


### PR DESCRIPTION
## Changes

Since https://github.com/systemd/systemd/commit/ffc1ec73, /usr is mounted as read-only in the initramfs by default.

Fixes https://github.com/dracutdevs/dracut/issues/2588

(cherry picked from dracutdevs/dracut#2591)

CC @aafeijoo-suse 