### PR TITLE
fix(dracut-install): release memory allocated for regular expressions

### DIFF
--- a/src/install/dracut-install.c
+++ b/src/install/dracut-install.c
@@ -2275,6 +2275,17 @@ finish2:
         hashmap_free(modules_suppliers);
         hashmap_free(processed_suppliers);
 
+        if (arg_mod_filter_path)
+                regfree(&mod_filter_path);
+        if (arg_mod_filter_nopath)
+                regfree(&mod_filter_nopath);
+        if (arg_mod_filter_symbol)
+                regfree(&mod_filter_symbol);
+        if (arg_mod_filter_nosymbol)
+                regfree(&mod_filter_nosymbol);
+        if (arg_mod_filter_noname)
+                regfree(&mod_filter_noname);
+
         strv_free(firmwaredirs);
         strv_free(pathdirs);
         return r;


### PR DESCRIPTION
## Changes

Use `regfree` to free memory allocated by `regcomp`. Quoting [1]:

"If the preg argument to regexec() or regfree() is not a compiled regular expression returned by regcomp(), the result is undefined."

Therefore, `regfree` must only be called if `regcomp` succeeded.

[1] https://pubs.opengroup.org/onlinepubs/9699919799/functions/regcomp.html

## Checklist
- [X] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it


