### PR TITLE
fix(dracut-systemd): replace `rd.udev.log-priority` with `rd.udev.log_level

### DIFF
--- a/modules.d/98dracut-systemd/dracut-cmdline.sh
+++ b/modules.d/98dracut-systemd/dracut-cmdline.sh
@@ -17,8 +17,10 @@ fi
 
 info "Using kernel command line parameters:" "$(getcmdline)"
 
-getargbool 0 rd.udev.log-priority=info -d rd.udev.info -d -n -y rdudevinfo && echo 'udev_log="info"' >> /etc/udev/udev.conf
-getargbool 0 rd.udev.log-priority=debug -d rd.udev.debug -d -n -y rdudevdebug && echo 'udev_log="debug"' >> /etc/udev/udev.conf
+getargbool 0 rd.udev.log_level=info -d rd.udev.log-priority=info -d rd.udev.info -d -y rdudevinfo \
+    && echo 'udev_log="info"' >> /etc/udev/udev.conf
+getargbool 0 rd.udev.log_level=debug -d rd.udev.log-priority=debug -d rd.udev.debug -d -y rdudevdebug \
+    && echo 'udev_log="debug"' >> /etc/udev/udev.conf
 
 source_conf /etc/conf.d
 


### PR DESCRIPTION
## Changes

`rd.udev.log-priority` is deprecated since systemd-v247 (https://github.com/systemd/systemd/commit/64a3494c)

Also, fix deprecation warning not being displayed for `rdudevinfo` and `rdudevdebug`.

