### PR TITLE
chore(deps): bump actions/checkout to 4

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -37,7 +37,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Initialize CodeQL
         uses: github/codeql-action/init@v3

--- a/.github/workflows/container.yml
+++ b/.github/workflows/container.yml
@@ -38,7 +38,7 @@ jobs:
                     - { dockerfile: 'Dockerfile-alpine',            tag: 'alpine:latest' }
         steps:
             -   name: Check out the repo
-                uses: actions/checkout@v3
+                uses: actions/checkout@v4
             -   name: Set up Docker Buildx
                 uses: docker/setup-buildx-action@v3
             -   name: Login to GitHub Container Registry

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -35,7 +35,7 @@ jobs:
             options: "--privileged -v /dev:/dev"
         steps:
             -   name: "Checkout Repository"
-                uses: actions/checkout@v1
+                uses: actions/checkout@v4
                 with:
                     fetch-depth: 0
 
@@ -72,7 +72,7 @@ jobs:
             options: "--privileged -v /dev:/dev"
         steps:
             -   name: "Checkout Repository"
-                uses: actions/checkout@v3
+                uses: actions/checkout@v4
                 with:
                     fetch-depth: 0
 
@@ -105,7 +105,7 @@ jobs:
             options: "--privileged -v /dev:/dev"
         steps:
             -   name: "Checkout Repository"
-                uses: actions/checkout@v3
+                uses: actions/checkout@v4
                 with:
                     fetch-depth: 0
 

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: shfmt
         uses: luizm/action-sh-checker@v0.8.0
@@ -48,7 +48,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: install tools
         run: sudo apt-get install astyle

--- a/.github/workflows/manualtest.yml
+++ b/.github/workflows/manualtest.yml
@@ -37,7 +37,7 @@ jobs:
             tests: ${{ steps.set-matrix.outputs.tests }}
         steps:
             -   name: "Checkout Repository"
-                uses: actions/checkout@v1
+                uses: actions/checkout@v4
                 with:
                     fetch-depth: 0
             -   id: set-matrix
@@ -66,7 +66,7 @@ jobs:
             options: "--privileged -v /dev:/dev"
         steps:
             -   name: "Checkout Repository"
-                uses: actions/checkout@v1
+                uses: actions/checkout@v4
                 with:
                     fetch-depth: 0
             -   name: "${{ matrix.container }} ${{ matrix.test }}"

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Check-out the repo under $GITHUB_WORKSPACE
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
 
     - name: Run Commisery
       uses: tomtom-international/commisery-action@master

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,7 +18,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0
 


### PR DESCRIPTION
## Changes

https://github.com/dracut-ng/dracut-ng/pull/131 resolved the issue with Gentoo container is not compatible with actions/checkout version >=2 due to [musl](https://github.com/dracut-ng/dracut-ng/blob/main/test/container/Dockerfile-Gentoo#L1).

See https://github.com/actions/runner/issues/2115

We can finally remove the workaround and move to latest actions/checkout.