### PR TITLE
ci: improve Gentoo container

### DIFF
--- a/.github/workflows/container.yml
+++ b/.github/workflows/container.yml
@@ -35,6 +35,7 @@ jobs:
                     - { dockerfile: 'Dockerfile-Debian',            tag: 'debian:latest' }
                     - { dockerfile: 'Dockerfile-Gentoo',            tag: 'gentoo:latest' }
                     - { dockerfile: 'Dockerfile-Ubuntu',            tag: 'ubuntu:latest' }
+                    - { dockerfile: 'Dockerfile-alpine',            tag: 'alpine:latest' }
         steps:
             -   name: Check out the repo
                 uses: actions/checkout@v3

--- a/test/container/Dockerfile-Gentoo
+++ b/test/container/Dockerfile-Gentoo
@@ -1,4 +1,7 @@
-ARG TAG=musl
+# ARG TAG=musl # to enable musl instead of glibc
+
+ARG TAG=systemd
+
 FROM docker.io/gentoo/portage:latest as portage
 
 # uefi stub in a separate builder

--- a/test/container/Dockerfile-alpine
+++ b/test/container/Dockerfile-alpine
@@ -1,0 +1,62 @@
+FROM docker.io/alpine:latest
+
+RUN apk add --no-cache \
+    alpine-sdk \
+    asciidoc \
+    bash \
+    binutils \
+    blkid \
+    btrfs-progs \
+    busybox \
+    bzip2 \
+    coreutils \
+    cpio \
+    cryptsetup \
+    curl \
+    dash \
+    dhclient \
+    dmraid \
+    dosfstools \
+    e2fsprogs \
+    eudev \
+    findmnt \
+    gawk \
+    git \
+    gpg \
+    grep \
+    gummiboot \
+    iputils \
+    kbd \
+    kmod-dev \
+    linux-virt \
+    losetup \
+    lvm2 \
+    make \
+    mdadm \
+    mtools \
+    multipath-tools \
+    musl-fts-dev \
+    nbd \
+    ntfs-3g-progs \
+    open-iscsi \
+    openssh \
+    ovmf \
+    parted \
+    partx \
+    pigz \
+    procps \
+    qemu-img \
+    qemu-system-x86_64 \
+    sed \
+    sfdisk \
+    squashfs-tools \
+    sudo \
+    util-linux-misc \
+    xz
+
+RUN \
+  cp /usr/lib/udev/rules.d/* /lib/udev/rules.d/ && \
+  ln -sf /sbin/poweroff /sbin/shutdown && \
+  ln -sf /usr/bin/dash /bin/dash && \
+  ln -sf /bin/sh /usr/bin/sh && \
+  ln -sf /boot/vmlinuz-virt /boot/vmlinuz-$(cd /lib/modules; ls -1 | tail -1)


### PR DESCRIPTION
## Changes

Switch from musl and OpenRC to glibc and systemd for Gentoo.
Use Alpine instead for musl and OpenRC testing.

Gentoo musl container is not compatible with actions/checkout version >=2 due to musl. Alpine container (with musl) does not have this issue, so this PR would allow us to remove the actions/checkout@1 workarounds as seen on https://github.com/dracut-ng/dracut-ng/pull/129 .

This PR does not enable yet any testing on the new Alpine container, so for now the Manualtest Action needs to be used for that.