### PR TITLE
ci: adopt Gentoo container to run the test suite

### DIFF
--- a/test/container/Dockerfile-Gentoo
+++ b/test/container/Dockerfile-Gentoo
@@ -17,6 +17,7 @@ FROM docker.io/gentoo/stage3:$TAG as kernel
 COPY --from=portage /var/db/repos/gentoo /var/db/repos/gentoo
 # disable initramfs generation, only need the kernel image itself
 RUN echo 'sys-kernel/gentoo-kernel-bin -initramfs' > /etc/portage/package.use/kernel
+RUN echo 'sys-kernel/installkernel -systemd' >> /etc/portage/package.use/kernel
 RUN emerge -qv sys-kernel/gentoo-kernel-bin
 
 FROM docker.io/gentoo/stage3:$TAG

--- a/test/run-qemu
+++ b/test/run-qemu
@@ -58,6 +58,8 @@ if ! [ -f "$VMLINUZ" ]; then
         VMLINUZ="/boot/vmlinuz-${KVERSION}"
     elif [ -f "/boot/vmlinux-${KVERSION}" ]; then
         VMLINUZ="/boot/vmlinux-${KVERSION}"
+    elif [ -f "/boot/kernel-${KVERSION}" ]; then
+        VMLINUZ="/boot/kernel-${KVERSION}"
     else
         echo "Could not find a Linux kernel version $KVERSION to test with!" >&2
         echo "Please install linux." >&2


### PR DESCRIPTION
## Changes

Tell the installkernel package to use Debians installkernel rather then systemd's kernel-instal

Fixes: #135

Remaining test failures (04, 10, 12, 13, 18) should recover after the PR lands and test runs will pick up the new container version