### PR TITLE
fix(dracut.sh): make uki's reproducible

### DIFF
--- a/dracut.sh
+++ b/dracut.sh
@@ -2562,6 +2562,7 @@ if [[ $uefi == yes ]]; then
     objcopy --remove-section .sbat "$tmp_uefi_stub" &> /dev/null
 
     if objcopy \
+        ${DRACUT_REPRODUCIBLE:+--enable-deterministic-archives --preserve-dates} \
         ${uefi_osrelease:+--add-section .osrel="$uefi_osrelease" --change-section-vma .osrel=$(printf 0x%x "$uefi_osrelease_offs")} \
         ${uefi_cmdline:+--add-section .cmdline="$uefi_cmdline" --change-section-vma .cmdline=$(printf 0x%x "$uefi_cmdline_offs")} \
         ${uefi_splash_image:+--add-section .splash="$uefi_splash_image" --change-section-vma .splash=$(printf 0x%x "$uefi_splash_offs")} \


### PR DESCRIPTION
## Changes

If the user asks for the dracut output to be reproducible, we should ensure objcopy produces a reproducible uki to.

## Checklist
- [X] I have tested it locally
- [X] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it

(cherry picked from dracutdevs/dracut#2400)

CC @glance-
