### PR TITLE
Make /boot/initrd.img-$KVER path configurable (default still /boot/initramfs-$KVER.img)

### DIFF
--- a/configure
+++ b/configure
@@ -144,7 +144,8 @@ if test "$enable_dracut_cpio" = "yes"; then
     fi
 fi
 
-cat > Makefile.inc.$$ << EOF
+{
+    cat << EOF
 prefix ?= ${prefix}
 libdir ?= ${libdir:-${prefix}/lib}
 datadir ?= ${datadir:-${prefix}/share}
@@ -159,7 +160,6 @@ KMOD_LIBS ?= $(${PKG_CONFIG} --libs " libkmod >= 23 ")
 FTS_LIBS ?= ${FTS_LIBS}
 EOF
 
-{
     [[ $programprefix ]] && echo "programprefix ?= ${programprefix}"
     [[ $execprefix ]] && echo "execprefix ?= ${execprefix}"
     [[ $includedir ]] && echo "includedir ?= ${includedir}"
@@ -169,6 +169,5 @@ EOF
     [[ $infodir ]] && echo "infodir ?= ${infodir}"
     [[ $systemdsystemunitdir ]] && echo "systemdsystemunitdir ?= ${systemdsystemunitdir}"
     [[ $bashcompletiondir ]] && echo "bashcompletiondir ?= ${bashcompletiondir}"
-} >> Makefile.inc.$$
-
-mv Makefile.inc.$$ Makefile.inc
+} > Makefile.inc
+:

--- a/configure
+++ b/configure
@@ -8,6 +8,9 @@ prefix=/usr
 enable_documentation=yes
 enable_dracut_cpio=no
 
+initrdprefix=initramfs-
+initrdsuffix=.img
+
 CC="${CC:-cc}"
 PKG_CONFIG="${PKG_CONFIG:-pkg-config}"
 
@@ -50,6 +53,8 @@ while (($# > 0)); do
         --systemdsystemunitdir) read_arg systemdsystemunitdir "$@" || shift ;;
         --bashcompletiondir) read_arg bashcompletiondir "$@" || shift ;;
         --enable-dracut-cpio) enable_dracut_cpio=yes ;;
+        --initrd-prefix) read_arg initrdprefix "$@" || shift ;;
+        --initrd-suffix) read_arg initrdsuffix "$@" || shift ;;
         *) echo "Ignoring unknown option '$1'" ;;
     esac
     shift
@@ -154,6 +159,8 @@ sbindir ?= ${sbindir:-${prefix}/sbin}
 mandir ?= ${mandir:-${prefix}/share/man}
 enable_documentation ?= ${enable_documentation:-yes}
 enable_dracut_cpio ?= ${enable_dracut_cpio}
+initrdprefix ?= ${initrdprefix}
+initrdsuffix ?= ${initrdsuffix}
 bindir ?= ${bindir:-${prefix}/bin}
 KMOD_CFLAGS ?= $(${PKG_CONFIG} --cflags " libkmod >= 23 ")
 KMOD_LIBS ?= $(${PKG_CONFIG} --libs " libkmod >= 23 ")

--- a/dracut-initramfs-restore.sh.in
+++ b/dracut-initramfs-restore.sh.in
@@ -39,8 +39,8 @@ elif [[ -d /boot/efi/loader/entries || -L /boot/efi/loader/entries ]] \
     IMG="/boot/efi/$MACHINE_ID/$KERNEL_VERSION/initrd"
 elif [[ -f /lib/modules/${KERNEL_VERSION}/initrd ]]; then
     IMG="/lib/modules/${KERNEL_VERSION}/initrd"
-elif [[ -f /boot/initramfs-${KERNEL_VERSION}.img ]]; then
-    IMG="/boot/initramfs-${KERNEL_VERSION}.img"
+elif [[ -f /boot/@INITRDPREFIX@${KERNEL_VERSION}@INITRDSUFFIX@ ]]; then
+    IMG="/boot/@INITRDPREFIX@${KERNEL_VERSION}@INITRDSUFFIX@"
 elif mountpoint -q /efi; then
     IMG="/efi/$MACHINE_ID/$KERNEL_VERSION/initrd"
 elif mountpoint -q /boot/efi; then

--- a/dracut.sh.in
+++ b/dracut.sh.in
@@ -1155,7 +1155,7 @@ if ! [[ $outfile ]]; then
         elif [[ -f "$dracutsysrootdir"/lib/modules/${kernel}/initrd ]]; then
             outfile="$dracutsysrootdir/lib/modules/${kernel}/initrd"
         elif [[ -e $dracutsysrootdir/boot/vmlinuz-${kernel} || -e $dracutsysrootdir/boot/vmlinux-${kernel} ]]; then
-            outfile="$dracutsysrootdir/boot/initramfs-${kernel}.img"
+            outfile="$dracutsysrootdir/boot/@INITRDPREFIX@${kernel}@INITRDSUFFIX@"
         elif [[ -z $dracutsysrootdir ]] \
             && [[ $MACHINE_ID ]] \
             && mountpoint -q /efi; then
@@ -1165,7 +1165,7 @@ if ! [[ $outfile ]]; then
             && mountpoint -q /boot/efi; then
             outfile="/boot/efi/${MACHINE_ID}/${kernel}/initrd"
         else
-            outfile="$dracutsysrootdir/boot/initramfs-${kernel}.img"
+            outfile="$dracutsysrootdir/boot/@INITRDPREFIX@${kernel}@INITRDSUFFIX@"
         fi
     fi
 fi

--- a/lsinitrd.sh.in
+++ b/lsinitrd.sh.in
@@ -134,8 +134,8 @@ else
         image="/lib/modules/${KERNEL_VERSION}/initrd"
     elif [[ -f /lib/modules/${KERNEL_VERSION}/initramfs.img ]]; then
         image="/lib/modules/${KERNEL_VERSION}/initramfs.img"
-    elif [[ -f /boot/initramfs-${KERNEL_VERSION}.img ]]; then
-        image="/boot/initramfs-${KERNEL_VERSION}.img"
+    elif [[ -f /boot/@INITRDPREFIX@${KERNEL_VERSION}@INITRDSUFFIX@ ]]; then
+        image="/boot/@INITRDPREFIX@${KERNEL_VERSION}@INITRDSUFFIX@"
     elif [[ $MACHINE_ID ]] \
         && mountpoint -q /efi; then
         image="/efi/${MACHINE_ID}/${KERNEL_VERSION}/initrd"

--- a/man/dracut.8.asc
+++ b/man/dracut.8.asc
@@ -24,7 +24,7 @@ _/efi/<machine-id>/<kernel-version>/initrd_,
 _/boot/<machine-id>/<kernel-version>/initrd_,
 _/boot/efi/<machine-id>/<kernel-version>/initrd_,
 _/lib/modules/<kernel-version>/initrd_ or
-_/boot/initramfs-<kernel-version>.img_.
+_/boot/{initrdprefix}<kernel-version>{initrdsuffix}_.
 
 dracut creates an initial image used by the kernel for preloading the block
 device modules (such as IDE, SCSI or RAID) which are needed to access the root

--- a/man/dracut.usage.asc
+++ b/man/dracut.usage.asc
@@ -10,7 +10,7 @@ _/efi/_++<machine-id>++_/_++<kernel-version>++_/initrd_,
 _/boot/_++<machine-id>++_/_++<kernel-version>++_/initrd_,
 _/boot/efi/_++<machine-id>++_/_++<kernel-version>++_/initrd_,
 _/lib/modules/_++<kernel-version>++_/initrd_ or
-_/boot/initramfs-_++<kernel-version>++_.img_ and contains the kernel modules of
+_/boot/{initrdprefix}_++<kernel-version>++_{initrdsuffix}_ and contains the kernel modules of
 the currently active kernel with version _++<kernel-version>++_.
 
 If the initramfs image already exists, dracut will display an error message, and

--- a/man/lsinitrd.1.asc
+++ b/man/lsinitrd.1.asc
@@ -22,7 +22,7 @@ lsinitrd uses the default image _/efi/<machine-id>/<kernel-version>/initrd_,
 _/boot/<machine-id>/<kernel-version>/initrd_,
 _/boot/efi/<machine-id>/<kernel-version>/initrd_,
 _/lib/modules/<kernel-version>/initrd_ or
-_/boot/initramfs-<kernel-version>.img_.
+_/boot/{initrdprefix}<kernel-version>{initrdsuffix}_.
 
 OPTIONS
 -------


### PR DESCRIPTION
To get the correct setup, run `./configure --initrd-prefix initrd.img --initrd-suffix ""`

## Checklist
- [x] I have tested it locally
- [x] I have reviewed and updated any documentation if relevant
- [x] I am providing new code and test(s) for it

Fixes #99