### PR TITLE
ci: remove dracut package without removing its dependencies

### DIFF
--- a/test/container/Dockerfile-OpenSuse-latest
+++ b/test/container/Dockerfile-OpenSuse-latest
@@ -2,10 +2,47 @@ FROM registry.opensuse.org/opensuse/tumbleweed-dnf:latest
 
 # Install needed packages for the dracut CI container
 RUN dnf -y install --setopt=install_weak_deps=False \
-    dash asciidoc mdadm lvm2 dmraid cryptsetup nfs-utils nbd dhcp-server \
-    strace libkmod-devel gcc bzip2 xz tar wget rpm-build make git bash-completion \
-    kernel dhcp-client qemu-kvm /usr/bin/qemu-system-$(uname -m) e2fsprogs \
-    tcpdump iproute iputils kbd NetworkManager btrfsprogs tgt dbus-broker \
-    iscsiuio open-iscsi ShellCheck shfmt procps pigz parted squashfs \
-    util-linux-systemd systemd-boot \
+    asciidoc \
+    bash-completion \
+    btrfsprogs \
+    bzip2 \
+    cryptsetup \
+    dash \
+    dbus-broker \
+    dhcp-client \
+    dhcp-server \
+    dmraid \
+    e2fsprogs \
+    gcc \
+    git \
+    iproute \
+    iputils \
+    iscsiuio \
+    kbd \
+    kernel \
+    libkmod-devel \
+    lvm2 \
+    make \
+    mdadm \
+    nbd \
+    NetworkManager \
+    nfs-utils \
+    open-iscsi \
+    parted \
+    pigz \
+    procps \
+    qemu-kvm \
+    rpm-build \
+    ShellCheck \
+    shfmt \
+    squashfs \
+    strace \
+    systemd-boot \
+    tar \
+    tcpdump \
+    tgt \
+    /usr/bin/qemu-system-$(uname -m) \
+    util-linux-systemd \
+    wget \
+    xz \
     && rpm -e --nodeps dracut && dnf -y update && dnf clean all


### PR DESCRIPTION
## Changes

remove dracut package without removing its dependencies in the OpenSUSE CI container.

## Checklist
- [X] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it

Fixes #152
