### PR TITLE
feat(dracut.sh): make initramfs-${kernel}.img filename configurable

### DIFF
--- a/dracut-initramfs-restore.sh
+++ b/dracut-initramfs-restore.sh
@@ -46,8 +46,15 @@ elif mountpoint -q /efi; then
 elif mountpoint -q /boot/efi; then
     IMG="/boot/efi/$MACHINE_ID/$KERNEL_VERSION/initrd"
 else
-    echo "No initramfs image found to restore!"
-    exit 1
+    files=("/boot/initr*${KERNEL_VERSION}*")
+    if [ "${#files[@]}" -ge 1 ] && [ -e "${files[0]}" ]; then
+        IMG="${files[0]}"
+    elif [[ -f /boot/initramfs-linux.img ]]; then
+        IMG="/boot/initramfs-linux.img"
+    else
+        echo "No initramfs image found to restore!"
+        exit 1
+    fi
 fi
 
 cd /run/initramfs

--- a/dracut.sh
+++ b/dracut.sh
@@ -1140,6 +1140,9 @@ if ! [[ $outfile ]]; then
         mkdir -p "$dracutsysrootdir$efidir/Linux"
         outfile="$dracutsysrootdir$efidir/Linux/linux-$kernel${MACHINE_ID:+-${MACHINE_ID}}${BUILD_ID:+-${BUILD_ID}}.efi"
     else
+        if ! [[ $initrdname ]]; then
+            initrdname="initramfs-${kernel}.img"
+        fi
         if [[ -d "$dracutsysrootdir"/efi/loader/entries || -L "$dracutsysrootdir"/efi/loader/entries ]] \
             && [[ $MACHINE_ID ]] \
             && [[ -d "$dracutsysrootdir"/efi/${MACHINE_ID} || -L "$dracutsysrootdir"/efi/${MACHINE_ID} ]]; then
@@ -1155,7 +1158,7 @@ if ! [[ $outfile ]]; then
         elif [[ -f "$dracutsysrootdir"/lib/modules/${kernel}/initrd ]]; then
             outfile="$dracutsysrootdir/lib/modules/${kernel}/initrd"
         elif [[ -e $dracutsysrootdir/boot/vmlinuz-${kernel} || -e $dracutsysrootdir/boot/vmlinux-${kernel} ]]; then
-            outfile="$dracutsysrootdir/boot/initramfs-${kernel}.img"
+            outfile="$dracutsysrootdir/boot/$initrdname"
         elif [[ -z $dracutsysrootdir ]] \
             && [[ $MACHINE_ID ]] \
             && mountpoint -q /efi; then
@@ -1165,7 +1168,7 @@ if ! [[ $outfile ]]; then
             && mountpoint -q /boot/efi; then
             outfile="/boot/efi/${MACHINE_ID}/${kernel}/initrd"
         else
-            outfile="$dracutsysrootdir/boot/initramfs-${kernel}.img"
+            outfile="$dracutsysrootdir/boot/$initrdname"
         fi
     fi
 fi

--- a/man/dracut.8.asc
+++ b/man/dracut.8.asc
@@ -18,13 +18,8 @@ DESCRIPTION
 
 Create an initramfs <image> for the kernel with the version <kernel version>.
 If <kernel version> is omitted, then the version of the actual running
-kernel is used. If <image> is omitted or empty, depending on bootloader
-specification, the default location can be
-_/efi/<machine-id>/<kernel-version>/initrd_,
-_/boot/<machine-id>/<kernel-version>/initrd_,
-_/boot/efi/<machine-id>/<kernel-version>/initrd_,
-_/lib/modules/<kernel-version>/initrd_ or
-_/boot/initramfs-<kernel-version>.img_.
+kernel is used. If <image> is omitted or empty, the default location will be
+determined by the local configuration or Linux distribution policy.
 
 dracut creates an initial image used by the kernel for preloading the block
 device modules (such as IDE, SCSI or RAID) which are needed to access the root

--- a/man/dracut.conf.5.asc
+++ b/man/dracut.conf.5.asc
@@ -320,6 +320,12 @@ Logging levels:
    If set to _yes_, try to execute tasks in parallel (currently only supported
    for _--regenerate-all_).
 
+*initrdname=*"_<filepattern>_"::
+    Specifies the file name for the generated initramfs if it is not set otherwise.
+    The initrdname configuration option is required to match the _initr*${kernel}*_
+    file pattern and only one file with this pattern should exists in the
+    directory where initramfs is loaded from. Defaults to _initramfs-${kernel}.img_.
+
 Files
 -----
 _/etc/dracut.conf_::

--- a/man/dracut.usage.asc
+++ b/man/dracut.usage.asc
@@ -5,13 +5,10 @@ To create a initramfs image, the most simple command is:
 
 This will generate a general purpose initramfs image, with all possible
 functionality resulting of the combination of the installed dracut modules and
-system tools. The image, depending on bootloader specification, can be
-_/efi/_++<machine-id>++_/_++<kernel-version>++_/initrd_,
-_/boot/_++<machine-id>++_/_++<kernel-version>++_/initrd_,
-_/boot/efi/_++<machine-id>++_/_++<kernel-version>++_/initrd_,
-_/lib/modules/_++<kernel-version>++_/initrd_ or
-_/boot/initramfs-_++<kernel-version>++_.img_ and contains the kernel modules of
+system tools. The image contains the kernel modules of
 the currently active kernel with version _++<kernel-version>++_.
+The default location of the image is determined by the local configuration
+or Linux distribution policy.
 
 If the initramfs image already exists, dracut will display an error message, and
 to overwrite the existing image, you have to use the --force option.

--- a/man/lsinitrd.1.asc
+++ b/man/lsinitrd.1.asc
@@ -18,11 +18,8 @@ SYNOPSIS
 DESCRIPTION
 -----------
 lsinitrd shows the contents of an initramfs image. if <image> is omitted, then
-lsinitrd uses the default image _/efi/<machine-id>/<kernel-version>/initrd_,
-_/boot/<machine-id>/<kernel-version>/initrd_,
-_/boot/efi/<machine-id>/<kernel-version>/initrd_,
-_/lib/modules/<kernel-version>/initrd_ or
-_/boot/initramfs-<kernel-version>.img_.
+lsinitrd determines the default location based on the local configuration
+or Linux distribution policy.
 
 OPTIONS
 -------


### PR DESCRIPTION
## Changes

The ambition is to propose a minimum viable patch and replace simple downstream patches like https://github.com/openSUSE/dracut/commit/1442c9d29

The `initrdname` configuration option is required to match a `initr*${kernel}*` file pattern.

Distributions are incentived but not required to follow the upcoming https://github.com/uapi-group/specifications/issues/100 standard (assuming positive resolution).

## Checklist
- [X] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it

Fixes #99


Tested with the following config file entry

```
initrdname=initrd-${kernel} 
```