### PR TITLE
ci: enable Void Linux for basic tests with runit

### DIFF
--- a/.github/workflows/container.yml
+++ b/.github/workflows/container.yml
@@ -36,6 +36,7 @@ jobs:
                     - { dockerfile: 'Dockerfile-Gentoo',            tag: 'gentoo:latest' }
                     - { dockerfile: 'Dockerfile-Ubuntu',            tag: 'ubuntu:latest' }
                     - { dockerfile: 'Dockerfile-alpine',            tag: 'alpine:latest' }
+                    - { dockerfile: 'Dockerfile-Void',              tag: 'void:latest' }
         steps:
             -   name: Check out the repo
                 uses: actions/checkout@v4

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -25,6 +25,7 @@ jobs:
                         "gentoo",
                         "opensuse",
                         "ubuntu",
+                        "void",
                 ]
                 test: [
                         "01",

--- a/.github/workflows/manualtest.yml
+++ b/.github/workflows/manualtest.yml
@@ -19,6 +19,7 @@ on:
                     - "ubuntu"
                     - "opensuse"
                     - "gentoo"
+                    - "void"
             env:
                 description: 'Environment (optional)'
                 default: '{"DEBUGFAIL": "rd.debug"}'

--- a/test/container/Dockerfile-Void
+++ b/test/container/Dockerfile-Void
@@ -1,0 +1,44 @@
+FROM ghcr.io/void-linux/void-glibc-full
+
+RUN xbps-install -Syu xbps && xbps-install -yu \
+    asciidoc \
+    base-devel \
+    bash \
+    binutils \
+    btrfs-progs \
+    busybox \
+    cargo \
+    cpio \
+    cryptsetup \
+    curl \
+    dhclient \
+    dmraid \
+    dosfstools \
+    e2fsprogs \
+    edk2-ovmf \
+    eudev \
+    git \
+    gnupg \
+    gummiboot \
+    iputils \
+    kbd \
+    libkmod-devel \
+    linux \
+    lvm2 \
+    make \
+    mdadm \
+    mtools \
+    nbd \
+    NetworkManager \
+    ntfs-3g \
+    open-iscsi \
+    openssh \
+    parted \
+    pigz \
+    procps-ng \
+    qemu \
+    squashfs-tools \
+    sudo \
+    util-linux \
+    xz \
+    && rm -rf /var/cache/xbps


### PR DESCRIPTION
## Changes

Void is an well maintained distribution that can enable Dracut to be tested for compatibility with runit . 

Only adding the test container is required, the test is already passing on Void Linux (due to how the CI is designed we will only see the pass after the PR lands).

@classabbyamp, @zdykstra and @ahesford has been a significant supporter of Dracut both via code contributions and PR reviews. 

## Checklist
- [X] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it
