### PR TITLE
test(RAID-DEG): make test 12 use the test dracut modules

### DIFF
--- a/modules.d/80test/hard-off.sh
+++ b/modules.d/80test/hard-off.sh
@@ -1,3 +1,3 @@
 #!/bin/sh
 getargbool 0 rd.shell || poweroff -f
-getargbool 0 failme && poweroff -f
+! getargbool 0 rd.break && getargbool 0 failme && poweroff -f

--- a/test/TEST-12-RAID-DEG/finished-false.sh
+++ b/test/TEST-12-RAID-DEG/finished-false.sh
@@ -1,2 +1,0 @@
-#!/bin/sh
-exit 1

--- a/test/TEST-12-RAID-DEG/test.sh
+++ b/test/TEST-12-RAID-DEG/test.sh
@@ -11,7 +11,6 @@ TEST_DESCRIPTION="root filesystem on an encrypted LVM PV on a degraded RAID-5"
 client_run() {
     echo "CLIENT TEST START: $*"
     declare -a disk_args=()
-    # shellcheck disable=SC2034
     declare -i disk_index=0
     qemu_add_drive_args disk_index disk_args "$TESTDIR"/marker.img marker
     # degrade the RAID
@@ -57,63 +56,30 @@ test_run() {
 
 test_setup() {
     kernel=$KVERSION
-    # Create what will eventually be our root filesystem onto an overlay
-    (
-        # shellcheck disable=SC2030
-        export initdir=$TESTDIR/overlay/source
-        # shellcheck disable=SC1090
-        . "$PKGLIBDIR"/dracut-init.sh
-        (
-            cd "$initdir" || exit
-            mkdir -p -- dev sys proc etc var/run tmp
-            mkdir -p root usr/bin usr/lib usr/lib64 usr/sbin
-        )
-        inst_multiple sh df free ls shutdown poweroff stty cat ps ln \
-            mount dmesg mkdir cp dd sync
-        for _terminfodir in /lib/terminfo /etc/terminfo /usr/share/terminfo; do
-            [ -f ${_terminfodir}/l/linux ] && break
-        done
-        inst_multiple -o ${_terminfodir}/l/linux
-
-        inst_simple "${PKGLIBDIR}/modules.d/99base/dracut-lib.sh" "/lib/dracut-lib.sh"
-        inst_simple "${PKGLIBDIR}/modules.d/99base/dracut-dev-lib.sh" "/lib/dracut-dev-lib.sh"
-        inst_binary "${PKGLIBDIR}/dracut-util" "/usr/bin/dracut-util"
-        ln -s dracut-util "${initdir}/usr/bin/dracut-getarg"
-        ln -s dracut-util "${initdir}/usr/bin/dracut-getargs"
-
-        inst_multiple grep
-        inst_simple /etc/os-release
-        inst ./test-init.sh /sbin/init
-        find_binary plymouth > /dev/null && inst_multiple plymouth
-        cp -a /etc/ld.so.conf* "$initdir"/etc
-        ldconfig -r "$initdir"
-    )
+    "$basedir"/dracut.sh -l --keep --tmpdir "$TESTDIR" \
+        -m "test-root" \
+        -i ./test-init.sh /sbin/init \
+        -i "${basedir}/modules.d/99base/dracut-lib.sh" "/lib/dracut-lib.sh" \
+        -i "${basedir}/modules.d/99base/dracut-dev-lib.sh" "/lib/dracut-dev-lib.sh" \
+        --no-hostonly --no-hostonly-cmdline --nohardlink \
+        -f "$TESTDIR"/initramfs.root "$KVERSION" || return 1
+    mkdir -p "$TESTDIR"/overlay/source && mv "$TESTDIR"/dracut.*/initramfs/* "$TESTDIR"/overlay/source && rm -rf "$TESTDIR"/dracut.*
 
     # second, install the files needed to make the root filesystem
-    (
-        # shellcheck disable=SC2030
-        # shellcheck disable=SC2031
-        export initdir=$TESTDIR/overlay
-        # shellcheck disable=SC1090
-        . "$PKGLIBDIR"/dracut-init.sh
-        inst_multiple sfdisk mkfs.ext4 poweroff cp umount dd grep sync
-        inst_hook initqueue 01 ./create-root.sh
-        inst_hook initqueue/finished 01 ./finished-false.sh
-    )
-
     # create an initramfs that will create the target root filesystem.
     # We do it this way so that we do not risk trashing the host mdraid
     # devices, volume groups, encrypted partitions, etc.
     "$DRACUT" -l -i "$TESTDIR"/overlay / \
-        -m "bash crypt lvm mdraid kernel-modules qemu" \
+        -m "test-makeroot bash crypt lvm mdraid kernel-modules" \
         -d "piix ide-gd_mod ata_piix ext4 sd_mod" \
+        -I "mkfs.ext4 grep sfdisk" \
+        -i ./create-root.sh /lib/dracut/hooks/initqueue/01-create-root.sh \
         --no-hostonly-cmdline -N \
         -f "$TESTDIR"/initramfs.makeroot "$KVERSION" || return 1
     rm -rf -- "$TESTDIR"/overlay
 
     # Create the blank files to use as a root filesystem
     declare -a disk_args=()
-    # shellcheck disable=SC2034
     declare -i disk_index=0
     qemu_add_drive_args disk_index disk_args "$TESTDIR"/marker.img marker 1
     qemu_add_drive_args disk_index disk_args "$TESTDIR"/raid-1.img raid1 40
@@ -132,26 +98,19 @@ test_setup() {
     eval "$(grep -F --binary-files=text -m 1 MD_UUID "$TESTDIR"/marker.img)"
     echo "$MD_UUID" > "$TESTDIR"/mduuid
 
-    (
-        # shellcheck disable=SC2031
-        export initdir=$TESTDIR/overlay
-        # shellcheck disable=SC1090
-        . "$PKGLIBDIR"/dracut-init.sh
-        inst_multiple poweroff shutdown dd
-        inst_hook shutdown-emergency 000 ./hard-off.sh
-        inst_hook emergency 000 ./hard-off.sh
-        inst ./cryptroot-ask.sh /sbin/cryptroot-ask
-        mkdir -p "$initdir"/etc
-        echo "ARRAY /dev/md0 level=raid5 num-devices=3 UUID=$MD_UUID" > "$initdir"/etc/mdadm.conf
-        echo "luks-$ID_FS_UUID UUID=$ID_FS_UUID /etc/key" > "$initdir"/etc/crypttab
-        echo -n test > "$initdir"/etc/key
-        chmod 0600 "$initdir"/etc/key
-    )
+    echo "ARRAY /dev/md0 level=raid5 num-devices=3 UUID=$MD_UUID" > /tmp/mdadm.conf
+    echo "luks-$ID_FS_UUID UUID=$ID_FS_UUID /etc/key" > /tmp/crypttab
+    echo -n test > /tmp/key
+    chmod 0600 /tmp/key
 
     "$DRACUT" -l -i "$TESTDIR"/overlay / \
         -o "dbus" \
-        -a "debug" \
+        -a "test" \
         -d "piix ide-gd_mod ata_piix ext4 sd_mod" \
+        -i "./cryptroot-ask.sh" "/sbin/cryptroot-ask" \
+        -i "/tmp/mdadm.conf" "/etc/mdadm.conf" \
+        -i "/tmp/crypttab" "/etc/crypttab" \
+        -i "/tmp/key" "/etc/key" \
         --no-hostonly-cmdline -N \
         -f "$TESTDIR"/initramfs.testing "$KVERSION" || return 1
 }


### PR DESCRIPTION
## Changes

Continuation of converting tests, just like https://github.com/dracut-ng/dracut-ng/pull/81 .

This PR is a refactor, it should not change how the tests are executed.

This PR removes about 70 lines of code while maintaining existing functionality.

## Checklist
- [X] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it
