### PR TITLE
fix(dracut.sh): include efi mountpoint for hostonly

### DIFF
--- a/dracut.sh
+++ b/dracut.sh
@@ -1664,7 +1664,8 @@ if [[ $hostonly ]] && [[ $hostonly_default_device != "no" ]]; then
         "/usr/lib64" \
         "/boot" \
         "/boot/efi" \
-        "/boot/zipl"; do
+        "/boot/zipl" \
+        "/efi"; do
         mp=$(readlink -f "$dracutsysrootdir$mp")
         mountpoint "$mp" > /dev/null 2>&1 || continue
         _dev=$(find_block_device "$mp")


### PR DESCRIPTION
When the ESP is mounted at /efi on it's own device, support for the underlying device is excluded from the initramfs.

Since /efi is an increasingly common location for the ESP to be mounted, it should probably be included here.

## Changes
Adds /efi to the list of mountpoints to check for block devices when using `hostonly`

## Checklist
- [x] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it


