### PR TITLE
ci: gummiboot-stub no longer supports UEFI image with latest kernel

### DIFF
--- a/test/container/Dockerfile-Ubuntu
+++ b/test/container/Dockerfile-Ubuntu
@@ -50,7 +50,6 @@ RUN apt-get update -y -qq && apt-get upgrade -y -qq && \
     shellcheck \
     squashfs-tools \
     strace \
-    sudo \
     systemd \
     tcpdump \
     tgt \

--- a/test/container/Dockerfile-Void
+++ b/test/container/Dockerfile-Void
@@ -19,7 +19,6 @@ RUN xbps-install -Syu xbps && xbps-install -yu \
     eudev \
     git \
     gnupg \
-    gummiboot \
     iputils \
     kbd \
     libkmod-devel \
@@ -35,10 +34,8 @@ RUN xbps-install -Syu xbps && xbps-install -yu \
     openssh \
     parted \
     pigz \
-    procps-ng \
     qemu \
     squashfs-tools \
-    sudo \
-    util-linux \
+    systemd-boot-efistub \
     xz \
     && rm -rf /var/cache/xbps

--- a/test/container/Dockerfile-alpine
+++ b/test/container/Dockerfile-alpine
@@ -24,7 +24,6 @@ RUN apk add --no-cache \
     git \
     gpg \
     grep \
-    gummiboot \
     iputils \
     kbd \
     kmod-dev \
@@ -40,7 +39,6 @@ RUN apk add --no-cache \
     ntfs-3g-progs \
     open-iscsi \
     openssh \
-    ovmf \
     parted \
     partx \
     pigz \


### PR DESCRIPTION
## Changes

Remove ovmf from Alpine container to explicitly skip UEFI test.
Replace gummiboot with systemd-boot-efistub in the Void container.
Be consistent and remove sudo from all test containers.

## Checklist
- [X] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it

Fixes #139

CC @classabbyamp