### PR TITLE
fix(network-manager,dbus): improve dependency checking

### DIFF
--- a/modules.d/06dbus-broker/module-setup.sh
+++ b/modules.d/06dbus-broker/module-setup.sh
@@ -6,7 +6,6 @@
 check() {
 
     # If the binary(s) requirements are not fulfilled the module can't be installed
-    require_binaries busctl || return 1
     require_binaries dbus-broker || return 1
     require_binaries dbus-broker-launch || return 1
 

--- a/modules.d/06dbus-daemon/module-setup.sh
+++ b/modules.d/06dbus-daemon/module-setup.sh
@@ -6,7 +6,6 @@
 check() {
 
     # If the binary(s) requirements are not fulfilled the module can't be installed
-    require_binaries busctl || return 1
     require_binaries dbus-daemon || return 1
     require_binaries dbus-send || return 1
 

--- a/modules.d/35network-manager/module-setup.sh
+++ b/modules.d/35network-manager/module-setup.sh
@@ -3,6 +3,7 @@
 # called by dracut
 check() {
     require_binaries sed grep NetworkManager || return 1
+    require_binaries busctl || return 1
 
     # do not add this module by default
     return 255


### PR DESCRIPTION
## Changes

Only network-manager requires busctl. Some distributions do not package busctl as part of dbus package.

This allows dbus dracut module to be installed even if busctl is not available to satisfy e.g. bluetooth module installation requirements.

## Checklist
- [X] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it
