### PR TITLE
test(LVM-THIN): make sure dm_thin_pool Linux kernel module is loaded

### DIFF
--- a/test/TEST-17-LVM-THIN/create-root.sh
+++ b/test/TEST-17-LVM-THIN/create-root.sh
@@ -11,6 +11,7 @@ udevadm control --reload
 udevadm settle
 
 set -ex
+modprobe dm_thin_pool
 for dev in /dev/disk/by-id/ata-disk_disk[123]; do
     lvm pvcreate -ff -y "$dev"
 done

--- a/test/TEST-17-LVM-THIN/test.sh
+++ b/test/TEST-17-LVM-THIN/test.sh
@@ -17,7 +17,7 @@ test_run() {
     test_marker_reset
     "$testdir"/run-qemu \
         "${disk_args[@]}" \
-        -append "panic=1 oops=panic softlockup_panic=1 systemd.crash_reboot root=/dev/dracut/root rw rd.auto=1 quiet rd.retry=3 rd.info console=ttyS0,115200n81 selinux=0 rd.shell=0 $DEBUGFAIL" \
+        -append "panic=1 oops=panic softlockup_panic=1 systemd.crash_reboot root=/dev/dracut/root rw rd.auto=1 rd.driver.pre=dm_thin_pool quiet rd.retry=3 rd.info console=ttyS0,115200n81 selinux=0 rd.shell=0 $DEBUGFAIL" \
         -initrd "$TESTDIR"/initramfs.testing || return 1
     test_marker_check || return 1
 }


### PR DESCRIPTION
It might be that the lvm dracut module should be improved instead of working around it in the test.

Regardless, I wanted to share what it takes to pass this test on Void.

## Checklist
- [X] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it

Fixes #173

CC @classabbyamp

