### PR TITLE
feat(systemd-bsod): dracut module for systemd-bsod

### DIFF
--- a/modules.d/01systemd-bsod/module-setup.sh
+++ b/modules.d/01systemd-bsod/module-setup.sh
@@ -1,0 +1,30 @@
+#!/bin/bash
+# This file is part of dracut.
+# SPDX-License-Identifier: GPL-2.0-or-later
+
+# Prerequisite check(s) for module.
+check() {
+    # If the binary(s) requirements are not fulfilled the module can't be installed
+    require_binaries "$systemdutildir"/systemd-bsod || return 1
+
+    # Return 255 to only include the module, if another module requires it.
+    return 255
+}
+
+# Module dependency requirements.
+depends() {
+    # This module has external dependency on other module(s).
+    echo systemd-journald
+    # Return 0 to include the dependent module(s) in the initramfs.
+    return 0
+}
+
+# Install the required file(s) for the module in the initramfs.
+install() {
+    inst_multiple \
+        "$systemdsystemunitdir"/systemd-bsod.service \
+        "$systemdsystemunitdir"/initrd.target.wants/systemd-bsod.service \
+        "$systemdutildir"/systemd-bsod
+
+    inst_libdir_file "libqrencode.so*"
+}

--- a/test/container/Dockerfile-Arch
+++ b/test/container/Dockerfile-Arch
@@ -37,6 +37,7 @@ RUN pacman --noconfirm -Syu \
     pigz \
     plymouth \
     qemu \
+    qrencode \
     rng-tools \
     sbsigntools \
     shellcheck \

--- a/test/container/Dockerfile-Fedora-latest
+++ b/test/container/Dockerfile-Fedora-latest
@@ -3,6 +3,7 @@ FROM registry.fedoraproject.org/fedora:latest
 # Install needed packages for the dracut CI container
 RUN dnf -y install --setopt=install_weak_deps=False \
     asciidoc \
+    astyle \
     bash-completion \
     biosdevname \
     bluez \
@@ -27,6 +28,7 @@ RUN dnf -y install --setopt=install_weak_deps=False \
     iproute \
     iputils \
     iscsi-initiator-utils \
+    jq \
     kbd \
     kernel \
     kmod-devel \
@@ -49,6 +51,7 @@ RUN dnf -y install --setopt=install_weak_deps=False \
     pcsc-lite \
     pigz \
     qemu-system-x86-core \
+    qrencode \
     rng-tools \
     rpm-build \
     sbsigntools \


### PR DESCRIPTION
## Changes

Include https://www.freedesktop.org/software/systemd/man/latest/systemd-bsod.service.html

bsod depends on qrencode. Add qrencode to Arch and Fedora container to trigger testing.

While at it add astyle, jq to the Fedora container as well as it was missing for testing some of the dracut modules.

## Checklist
- [ ] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it


