### PR TITLE
  test: make more use of the test dracut modules

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -57,7 +57,6 @@ jobs:
                 test: [
                         "20",
                         "30",
-                        "35",
                         "40",
                         "50",
                         "60",
@@ -89,7 +88,6 @@ jobs:
                 test: [
                         "20",
                         "30",
-                        "35",
                         "40",
                 ]
             fail-fast: false
@@ -102,11 +100,11 @@ jobs:
             -   name: "${{ matrix.container }} TEST-${{ matrix.test }}"
                 run: USE_NETWORK=${{ matrix.network }} ./tools/test-github.sh "TEST-${{ matrix.test }}" ${{ matrix.test }}
     systemd-networkd:
-        name: systemd-networkd-${{ matrix.test }} on ${{ matrix.container }} using ${{ matrix.network }}
+        name: ${{ matrix.test }} on ${{ matrix.container }} using ${{ matrix.network }}
         runs-on: ubuntu-latest
         timeout-minutes: 45
         concurrency:
-            group: ${{ github.workflow }}-${{ github.ref }}-${{ matrix.container }}-${{ matrix.test }}-${{ matrix.network }}
+            group: systemd-networkd-${{ github.workflow }}-${{ github.ref }}-${{ matrix.container }}-${{ matrix.test }}-${{ matrix.network }}
             cancel-in-progress: true
         strategy:
             matrix:
@@ -117,6 +115,7 @@ jobs:
                         "systemd-networkd",
                 ]
                 test: [
+                        "35",
                         "40",
                 ]
             fail-fast: false

--- a/modules.d/80test-root/module-setup.sh
+++ b/modules.d/80test-root/module-setup.sh
@@ -6,7 +6,7 @@ check() {
 }
 
 depends() {
-    echo "debug"
+    echo debug
 }
 
 install() {

--- a/modules.d/80test/module-setup.sh
+++ b/modules.d/80test/module-setup.sh
@@ -6,7 +6,7 @@ check() {
 }
 
 depends() {
-    echo "debug"
+    echo "base debug"
 }
 
 installkernel() {

--- a/test/TEST-10-RAID/test.sh
+++ b/test/TEST-10-RAID/test.sh
@@ -38,7 +38,6 @@ test_setup() {
     # devices, volume groups, encrypted partitions, etc.
     "$DRACUT" -l -i "$TESTDIR"/overlay / \
         -m "test-makeroot bash crypt lvm mdraid kernel-modules" \
-        -d "piix ide-gd_mod ata_piix ext4 sd_mod" \
         --nomdadmconf \
         -I "mkfs.ext4 grep" \
         -i ./create-root.sh /lib/dracut/hooks/initqueue/01-create-root.sh \

--- a/test/TEST-11-LVM/test.sh
+++ b/test/TEST-11-LVM/test.sh
@@ -40,7 +40,6 @@ test_setup() {
     # devices, volume groups, encrypted partitions, etc.
     "$DRACUT" -l -i "$TESTDIR"/overlay / \
         -m "test-makeroot bash lvm mdraid kernel-modules" \
-        -d "piix ide-gd_mod ata_piix ext4 sd_mod" \
         -I "mkfs.ext4" \
         -i ./create-root.sh /lib/dracut/hooks/initqueue/01-create-root.sh \
         --no-hostonly-cmdline -N \

--- a/test/TEST-12-RAID-DEG/hard-off.sh
+++ b/test/TEST-12-RAID-DEG/hard-off.sh
@@ -1,4 +1,0 @@
-#!/bin/sh
-sleep 5
-getargbool 0 rd.shell || poweroff -f
-! getargbool 0 rd.break && getargbool 0 failme && poweroff -f

--- a/test/TEST-12-RAID-DEG/test.sh
+++ b/test/TEST-12-RAID-DEG/test.sh
@@ -55,7 +55,6 @@ test_run() {
 }
 
 test_setup() {
-    kernel=$KVERSION
     "$basedir"/dracut.sh -l --keep --tmpdir "$TESTDIR" \
         -m "test-root" \
         -i ./test-init.sh /sbin/init \

--- a/test/TEST-12-RAID-DEG/test.sh
+++ b/test/TEST-12-RAID-DEG/test.sh
@@ -70,7 +70,6 @@ test_setup() {
     # devices, volume groups, encrypted partitions, etc.
     "$DRACUT" -l -i "$TESTDIR"/overlay / \
         -m "test-makeroot bash crypt lvm mdraid kernel-modules" \
-        -d "piix ide-gd_mod ata_piix ext4 sd_mod" \
         -I "mkfs.ext4 grep sfdisk" \
         -i ./create-root.sh /lib/dracut/hooks/initqueue/01-create-root.sh \
         --no-hostonly-cmdline -N \

--- a/test/TEST-13-ENC-RAID-LVM/test.sh
+++ b/test/TEST-13-ENC-RAID-LVM/test.sh
@@ -68,7 +68,6 @@ test_setup() {
     # devices, volume groups, encrypted partitions, etc.
     "$DRACUT" -l -i "$TESTDIR"/overlay / \
         -m "test-makeroot bash crypt lvm mdraid kernel-modules" \
-        -d "piix ide-gd_mod ata_piix ext4 sd_mod" \
         -I "mkfs.ext4 grep" \
         -i ./create-root.sh /lib/dracut/hooks/initqueue/01-create-root.sh \
         --no-hostonly-cmdline -N \

--- a/test/TEST-14-IMSM/test.sh
+++ b/test/TEST-14-IMSM/test.sh
@@ -49,7 +49,6 @@ test_run() {
 }
 
 test_setup() {
-    kernel=$KVERSION
     # Create what will eventually be our root filesystem onto an overlay
     "$DRACUT" -l --keep --tmpdir "$TESTDIR" \
         -m "test-root" \
@@ -61,7 +60,6 @@ test_setup() {
     mkdir -p "$TESTDIR"/overlay/source && mv "$TESTDIR"/dracut.*/initramfs/* "$TESTDIR"/overlay/source && rm -rf "$TESTDIR"/dracut.*
 
     # second, install the files needed to make the root filesystem
-
     # create an initramfs that will create the target root filesystem.
     # We do it this way so that we do not risk trashing the host mdraid
     # devices, volume groups, encrypted partitions, etc.

--- a/test/TEST-17-LVM-THIN/test.sh
+++ b/test/TEST-17-LVM-THIN/test.sh
@@ -40,7 +40,6 @@ test_setup() {
     # devices, volume groups, encrypted partitions, etc.
     "$DRACUT" -l -i "$TESTDIR"/overlay / \
         -m "test-makeroot bash lvm mdraid kernel-modules" \
-        -d "piix ide-gd_mod ata_piix ext4 sd_mod" \
         -I "mkfs.ext4 grep" \
         -i ./create-root.sh /lib/dracut/hooks/initqueue/01-create-root.sh \
         --no-hostonly-cmdline -N \

--- a/test/TEST-18-UEFI/test.sh
+++ b/test/TEST-18-UEFI/test.sh
@@ -70,12 +70,6 @@ test_setup() {
     mksquashfs "$TESTDIR"/dracut.*/initramfs/ "$TESTDIR"/squashfs.img -quiet -no-progress
 
     mkdir -p "$TESTDIR"/ESP/EFI/BOOT
-
-    if [ -f "/usr/lib/gummiboot/linuxx64.efi.stub" ]; then
-        TEST_DRACUT_ARGS+=" --uefi-stub /usr/lib/gummiboot/linuxx64.efi.stub "
-    fi
-
-    mkdir -p "$TESTDIR"/ESP/EFI/BOOT
     test_dracut \
         --modules 'rootfs-block test' \
         --kernel-cmdline 'root=/dev/disk/by-id/scsi-0QEMU_QEMU_HARDDISK_root ro rd.skipfsck rootfstype=squashfs' \

--- a/test/TEST-18-UEFI/test.sh
+++ b/test/TEST-18-UEFI/test.sh
@@ -3,13 +3,6 @@
 # shellcheck disable=SC2034
 TEST_DESCRIPTION="UEFI boot"
 
-# Linux kernel requirements
-# CONFIG_BLK_DEV_INITRD for initramfs
-# CONFIG_EFI_HANDOVER_PROTOCOL for ovmf (Open Virtual Machine Firmware)
-# CONFIG_SATA_AHCI for ahci.ko
-# CONFIG_BLK_DEV_SD for sd_mod.ko
-# CONFIG_SQUASHFS_ZLIB for squashfs.ko
-
 ovmf_code() {
     for path in \
         "/usr/share/OVMF/OVMF_CODE.fd" \
@@ -22,28 +15,6 @@ ovmf_code() {
 
 test_check() {
     [[ -n "$(ovmf_code)" ]]
-}
-
-KVERSION="${KVERSION-$(uname -r)}"
-
-test_marker_reset() {
-    dd if=/dev/zero of="$TESTDIR"/marker.img bs=1MiB count=1
-}
-
-test_marker_check() {
-    grep -U --binary-files=binary -F -m 1 -q dracut-root-block-success -- "$TESTDIR"/marker.img
-    return $?
-}
-
-test_dracut() {
-    TEST_DRACUT_ARGS+=" --local --no-hostonly --no-early-microcode --add test --kver $KVERSION"
-
-    # shellcheck disable=SC2162
-    IFS=' ' read -a TEST_DRACUT_ARGS_ARRAY <<< "$TEST_DRACUT_ARGS"
-
-    "$DRACUT" "$@" \
-        --kernel-cmdline "panic=1 oops=panic softlockup_panic=1 systemd.crash_reboot selinux=0 console=ttyS0,115200n81 $DEBUGFAIL" \
-        "${TEST_DRACUT_ARGS_ARRAY[@]}" || return 1
 }
 
 test_run() {

--- a/test/TEST-20-NFS/test.sh
+++ b/test/TEST-20-NFS/test.sh
@@ -252,7 +252,7 @@ test_setup() {
         )
 
         inst_multiple sh ls shutdown poweroff stty cat ps ln ip \
-            dmesg mkdir cp ping exportfs \
+            dmesg mkdir cp exportfs \
             modprobe rpc.nfsd rpc.mountd showmount tcpdump \
             sleep mount chmod rm
         for _terminfodir in /lib/terminfo /etc/terminfo /usr/share/terminfo; do
@@ -312,7 +312,7 @@ test_setup() {
         )
 
         inst_multiple sh shutdown poweroff stty cat ps ln ip dd \
-            mount dmesg mkdir cp ping grep setsid ls vi less cat sync
+            mount dmesg mkdir cp grep setsid ls vi less cat sync
         for _terminfodir in /lib/terminfo /etc/terminfo /usr/share/terminfo; do
             if [ -f "${_terminfodir}"/l/linux ]; then
                 inst_multiple -o "${_terminfodir}"/l/linux

--- a/test/TEST-30-ISCSI/test.sh
+++ b/test/TEST-30-ISCSI/test.sh
@@ -133,7 +133,7 @@ test_setup() {
     "$DRACUT" -l --keep --tmpdir "$TESTDIR" \
         -m "test-root" \
         -i ./client-init.sh /sbin/init \
-        -I "ip ping grep setsid" \
+        -I "ip grep setsid" \
         -i "${PKGLIBDIR}/modules.d/99base/dracut-lib.sh" "/lib/dracut-lib.sh" \
         -i "${PKGLIBDIR}/modules.d/99base/dracut-dev-lib.sh" "/lib/dracut-dev-lib.sh" \
         --no-hostonly --no-hostonly-cmdline --nohardlink \
@@ -175,7 +175,7 @@ test_setup() {
         -i ./server-init.sh /sbin/init \
         -i "${PKGLIBDIR}/modules.d/99base/dracut-lib.sh" "/lib/dracut-lib.sh" \
         -i "${PKGLIBDIR}/modules.d/99base/dracut-dev-lib.sh" "/lib/dracut-dev-lib.sh" \
-        -I "modprobe chmod ip ping tcpdump setsid pidof tgtd tgtadm /etc/passwd" \
+        -I "modprobe chmod ip tcpdump setsid pidof tgtd tgtadm /etc/passwd" \
         --install-optional "/etc/netconfig dhcpd /etc/group /etc/nsswitch.conf /etc/rpc /etc/protocols /etc/services /usr/etc/nsswitch.conf /usr/etc/rpc /usr/etc/protocols /usr/etc/services" \
         -i "./hosts" "/etc/hosts" \
         -i "./dhcpd.conf" "/etc/dhcpd.conf" \

--- a/test/TEST-30-ISCSI/test.sh
+++ b/test/TEST-30-ISCSI/test.sh
@@ -126,6 +126,10 @@ test_check() {
         echo "Need tgtd and tgtadm from scsi-target-utils"
         return 1
     fi
+    if ! [ -f /lib/systemd/system/iscsiuio.socket ]; then
+        echo "Need iscsiuio.socket to run this test"
+        return 1
+    fi
 }
 
 test_setup() {

--- a/test/TEST-35-ISCSI-MULTI/finished-false.sh
+++ b/test/TEST-35-ISCSI-MULTI/finished-false.sh
@@ -1,2 +1,0 @@
-#!/bin/sh
-exit 1

--- a/test/TEST-35-ISCSI-MULTI/hard-off.sh
+++ b/test/TEST-35-ISCSI-MULTI/hard-off.sh
@@ -1,3 +1,0 @@
-#!/bin/sh
-getargbool 0 rd.shell || poweroff -f
-getargbool 0 failme && poweroff -f

--- a/test/TEST-35-ISCSI-MULTI/test.sh
+++ b/test/TEST-35-ISCSI-MULTI/test.sh
@@ -155,7 +155,7 @@ test_setup() {
             mkdir -p -- var/lib/nfs/rpc_pipefs
         )
         inst_multiple sh shutdown poweroff stty cat ps ln ip \
-            mount dmesg mkdir cp ping grep setsid dd sync
+            mount dmesg mkdir cp grep setsid dd sync
         for _terminfodir in /lib/terminfo /etc/terminfo /usr/share/terminfo; do
             [ -f ${_terminfodir}/l/linux ] && break
         done
@@ -224,7 +224,7 @@ test_setup() {
         )
         inst /etc/passwd /etc/passwd
         inst_multiple sh ls shutdown poweroff stty cat ps ln ip \
-            dmesg mkdir cp ping modprobe tcpdump setsid \
+            dmesg mkdir cp modprobe tcpdump setsid \
             sleep mount chmod pidof
         inst_multiple tgtd tgtadm
         for _terminfodir in /lib/terminfo /etc/terminfo /usr/share/terminfo; do

--- a/test/TEST-35-ISCSI-MULTI/test.sh
+++ b/test/TEST-35-ISCSI-MULTI/test.sh
@@ -138,6 +138,10 @@ test_check() {
         echo "Need tgtd and tgtadm from scsi-target-utils"
         return 1
     fi
+    if ! [ -f /lib/systemd/system/iscsiuio.socket ]; then
+        echo "Need iscsiuio.socket to run this test"
+        return 1
+    fi
 }
 
 test_setup() {

--- a/test/TEST-35-ISCSI-MULTI/test.sh
+++ b/test/TEST-35-ISCSI-MULTI/test.sh
@@ -141,7 +141,6 @@ test_check() {
 }
 
 test_setup() {
-    kernel=$KVERSION
     # Create what will eventually be our root filesystem onto an overlay
     rm -rf -- "$TESTDIR"/overlay
     (
@@ -211,8 +210,6 @@ test_setup() {
     test_marker_check dracut-root-block-created || return 1
     rm -- "$TESTDIR"/marker.img
 
-    # shellcheck disable=SC2031
-    export kernel=$KVERSION
     rm -rf -- "$TESTDIR"/overlay
     (
         mkdir -p "$TESTDIR"/overlay/source

--- a/test/TEST-40-NBD/finished-false.sh
+++ b/test/TEST-40-NBD/finished-false.sh
@@ -1,2 +1,0 @@
-#!/bin/sh
-exit 1

--- a/test/TEST-40-NBD/hard-off.sh
+++ b/test/TEST-40-NBD/hard-off.sh
@@ -1,3 +1,0 @@
-#!/bin/sh
-getargbool 0 rd.shell || poweroff -f
-getargbool 0 failme && poweroff -f

--- a/test/TEST-40-NBD/test.sh
+++ b/test/TEST-40-NBD/test.sh
@@ -204,7 +204,6 @@ make_encrypted_root() {
     # devices, volume groups, encrypted partitions, etc.
     "$DRACUT" -l -i "$TESTDIR"/overlay / \
         -m "test-makeroot" \
-        -d "piix ide-gd_mod ata_piix ext4 sd_mod" \
         -i ./create-server-root.sh /lib/dracut/hooks/initqueue/01-create-encrypted-root.sh \
         -I "mkfs.ext4" \
         --no-hostonly-cmdline -N \
@@ -243,7 +242,6 @@ make_client_root() {
     # devices, volume groups, encrypted partitions, etc.
     "$DRACUT" -l -i "$TESTDIR"/overlay / \
         -m "test-makeroot" \
-        -d "piix ide-gd_mod ata_piix ext4 sd_mod" \
         -I "mkfs.ext4" \
         -i ./create-client-root.sh /lib/dracut/hooks/initqueue/01-create-client-root.sh \
         --nomdadmconf \
@@ -302,7 +300,6 @@ EOF
     # devices, volume groups, encrypted partitions, etc.
     "$DRACUT" -l -i "$TESTDIR"/overlay / \
         -m "test-makeroot" \
-        -d "piix ide-gd_mod ata_piix ext4 sd_mod" \
         -i ./create-server-root.sh /lib/dracut/hooks/initqueue/01-create-server-root.sh \
         -I "mkfs.ext4" \
         --nomdadmconf \

--- a/test/TEST-40-NBD/test.sh
+++ b/test/TEST-40-NBD/test.sh
@@ -188,7 +188,6 @@ client_run() {
 
 make_encrypted_root() {
     rm -fr "$TESTDIR"/overlay
-    kernel=$KVERSION
     # Create what will eventually be our root filesystem onto an overlay
     (
         # shellcheck disable=SC2030
@@ -267,7 +266,6 @@ make_encrypted_root() {
 
 make_client_root() {
     rm -fr "$TESTDIR"/overlay
-    kernel=$KVERSION
     (
         mkdir -p "$TESTDIR"/overlay/source
         # shellcheck disable=SC2030
@@ -345,8 +343,6 @@ make_client_root() {
 
 make_server_root() {
     rm -fr "$TESTDIR"/overlay
-    # shellcheck disable=SC2031
-    export kernel=$KVERSION
     (
         mkdir -p "$TESTDIR"/overlay/source
         # shellcheck disable=SC2030

--- a/test/TEST-40-NBD/test.sh
+++ b/test/TEST-40-NBD/test.sh
@@ -203,8 +203,8 @@ make_encrypted_root() {
     # We do it this way so that we do not risk trashing the host mdraid
     # devices, volume groups, encrypted partitions, etc.
     "$DRACUT" -l -i "$TESTDIR"/overlay / \
-        -m "test-makeroot" \
-        -i ./create-server-root.sh /lib/dracut/hooks/initqueue/01-create-encrypted-root.sh \
+        -m "test-makeroot crypt lvm mdraid" \
+        -i ./create-encrypted-root.sh /lib/dracut/hooks/initqueue/01-create-encrypted-root.sh \
         -I "mkfs.ext4" \
         --no-hostonly-cmdline -N \
         -f "$TESTDIR"/initramfs.makeroot "$KVERSION" || return 1

--- a/test/TEST-40-NBD/test.sh
+++ b/test/TEST-40-NBD/test.sh
@@ -191,7 +191,7 @@ make_encrypted_root() {
     "$DRACUT" -l --keep --tmpdir "$TESTDIR" \
         -m "test-root" \
         -i ./client-init.sh /sbin/init \
-        -I "ip ping grep" \
+        -I "ip grep" \
         -i "${basedir}/modules.d/99base/dracut-lib.sh" "/lib/dracut-lib.sh" \
         -i "${basedir}/modules.d/99base/dracut-dev-lib.sh" "/lib/dracut-dev-lib.sh" \
         --no-hostonly --no-hostonly-cmdline --nohardlink \
@@ -229,7 +229,7 @@ make_client_root() {
     "$DRACUT" -l --keep --tmpdir "$TESTDIR" \
         -m "test-root" \
         -i ./client-init.sh /sbin/init \
-        -I "ip ping" \
+        -I "ip" \
         -i "${basedir}/modules.d/99base/dracut-lib.sh" "/lib/dracut-lib.sh" \
         -i "${basedir}/modules.d/99base/dracut-dev-lib.sh" "/lib/dracut-dev-lib.sh" \
         --no-hostonly --no-hostonly-cmdline --nohardlink \
@@ -281,7 +281,7 @@ EOF
         -m "test-root network network-legacy" \
         -d "nfsd sunrpc ipv6 lockd af_packet 8021q ipvlan macvlan" \
         -i ./server-init.sh /sbin/init \
-        -I "ip ping grep sleep nbd-server chmod modprobe vi pidof" \
+        -I "ip grep sleep nbd-server chmod modprobe vi pidof" \
         -i "${basedir}/modules.d/99base/dracut-lib.sh" "/lib/dracut-lib.sh" \
         -i "${basedir}/modules.d/99base/dracut-dev-lib.sh" "/lib/dracut-dev-lib.sh" \
         --install-optional "/etc/netconfig dhcpd /etc/group /etc/nsswitch.conf /etc/rpc /etc/protocols /etc/services /usr/etc/nsswitch.conf /usr/etc/rpc /usr/etc/protocols /usr/etc/services" \

--- a/test/TEST-40-NBD/test.sh
+++ b/test/TEST-40-NBD/test.sh
@@ -27,7 +27,6 @@ run_server() {
     echo "NBD TEST SETUP: Starting DHCP/NBD server"
 
     declare -a disk_args=()
-    # shellcheck disable=SC2034
     declare -i disk_index=0
     qemu_add_drive disk_index disk_args "$TESTDIR"/unencrypted.img unencrypted
     qemu_add_drive disk_index disk_args "$TESTDIR"/encrypted.img encrypted
@@ -165,7 +164,7 @@ client_run() {
 
     # Encrypted root handling via LVM/LUKS over NBD
 
-    # shellcheck disable=SC1090
+    # shellcheck source=$TESTDIR/luks.uuid
     . "$TESTDIR"/luks.uuid
 
     client_test "NBD root=LABEL=dracut netroot=nbd:IP:port" \
@@ -189,68 +188,30 @@ client_run() {
 make_encrypted_root() {
     rm -fr "$TESTDIR"/overlay
     # Create what will eventually be our root filesystem onto an overlay
-    (
-        # shellcheck disable=SC2030
-        export initdir=$TESTDIR/overlay/source
-        # shellcheck disable=SC1090
-        . "$PKGLIBDIR"/dracut-init.sh
-        mkdir -p "$initdir"
-        (
-            cd "$initdir" || exit
-            mkdir -p dev sys proc etc run var/run tmp
-        )
-
-        inst_multiple sh df free ls shutdown poweroff stty cat ps ln ip \
-            mount dmesg mkdir cp ping dd sync
-        for _terminfodir in /lib/terminfo /etc/terminfo /usr/share/terminfo; do
-            [ -f ${_terminfodir}/l/linux ] && break
-        done
-        inst_multiple -o ${_terminfodir}/l/linux
-
-        inst_simple "${PKGLIBDIR}/modules.d/99base/dracut-lib.sh" "/lib/dracut-lib.sh"
-        inst_simple "${PKGLIBDIR}/modules.d/99base/dracut-dev-lib.sh" "/lib/dracut-dev-lib.sh"
-        inst_binary "${PKGLIBDIR}/dracut-util" "/usr/bin/dracut-util"
-        ln -s dracut-util "${initdir}/usr/bin/dracut-getarg"
-        ln -s dracut-util "${initdir}/usr/bin/dracut-getargs"
-
-        inst ./client-init.sh /sbin/init
-        inst_simple /etc/os-release
-        find_binary plymouth > /dev/null && inst_multiple plymouth
-        cp -a /etc/ld.so.conf* "$initdir"/etc
-        ldconfig -r "$initdir"
-    )
+    "$DRACUT" -l --keep --tmpdir "$TESTDIR" \
+        -m "test-root" \
+        -i ./client-init.sh /sbin/init \
+        -I "ip ping grep" \
+        -i "${basedir}/modules.d/99base/dracut-lib.sh" "/lib/dracut-lib.sh" \
+        -i "${basedir}/modules.d/99base/dracut-dev-lib.sh" "/lib/dracut-dev-lib.sh" \
+        --no-hostonly --no-hostonly-cmdline --nohardlink \
+        -f "$TESTDIR"/initramfs.root "$KVERSION" || return 1
+    mkdir -p "$TESTDIR"/overlay/source && mv "$TESTDIR"/dracut.*/initramfs/* "$TESTDIR"/overlay/source && rm -rf "$TESTDIR"/dracut.*
 
     # second, install the files needed to make the root filesystem
-    (
-        # shellcheck disable=SC2030
-        # shellcheck disable=SC2031
-        export initdir=$TESTDIR/overlay
-        # shellcheck disable=SC1090
-        . "$PKGLIBDIR"/dracut-init.sh
-        (
-            cd "$initdir" || exit
-            mkdir -p dev sys proc etc tmp var run root
-            ln -s ../run var/run
-        )
-        inst_multiple mkfs.ext4 poweroff cp umount dd sync
-        inst_hook shutdown-emergency 000 ./hard-off.sh
-        inst_hook emergency 000 ./hard-off.sh
-        inst_hook initqueue 01 ./create-encrypted-root.sh
-        inst_hook initqueue/finished 01 ./finished-false.sh
-    )
-
     # create an initramfs that will create the target root filesystem.
     # We do it this way so that we do not risk trashing the host mdraid
     # devices, volume groups, encrypted partitions, etc.
     "$DRACUT" -l -i "$TESTDIR"/overlay / \
-        -m "dash crypt lvm mdraid kernel-modules qemu" \
+        -m "test-makeroot" \
         -d "piix ide-gd_mod ata_piix ext4 sd_mod" \
+        -i ./create-server-root.sh /lib/dracut/hooks/initqueue/01-create-encrypted-root.sh \
+        -I "mkfs.ext4" \
         --no-hostonly-cmdline -N \
         -f "$TESTDIR"/initramfs.makeroot "$KVERSION" || return 1
     rm -rf -- "$TESTDIR"/overlay
 
     declare -a disk_args=()
-    # shellcheck disable=SC2034
     declare -i disk_index=0
     qemu_add_drive disk_index disk_args "$TESTDIR"/marker.img marker 1
     qemu_add_drive disk_index disk_args "$TESTDIR"/encrypted.img root 120
@@ -266,68 +227,30 @@ make_encrypted_root() {
 
 make_client_root() {
     rm -fr "$TESTDIR"/overlay
-    (
-        mkdir -p "$TESTDIR"/overlay/source
-        # shellcheck disable=SC2030
-        # shellcheck disable=SC2031
-        export initdir=$TESTDIR/overlay/source
-        # shellcheck disable=SC1090
-        . "$PKGLIBDIR"/dracut-init.sh
-        mkdir -p "$initdir"
-        (
-            cd "$initdir" || exit
-            mkdir -p dev sys proc etc run var/run tmp
-        )
-        inst_multiple sh ls shutdown poweroff stty cat ps ln ip \
-            dmesg mkdir cp ping dd mount sync
-        for _terminfodir in /lib/terminfo /etc/terminfo /usr/share/terminfo; do
-            [ -f ${_terminfodir}/l/linux ] && break
-        done
-        inst_multiple -o ${_terminfodir}/l/linux
-
-        inst_simple "${PKGLIBDIR}/modules.d/99base/dracut-lib.sh" "/lib/dracut-lib.sh"
-        inst_simple "${PKGLIBDIR}/modules.d/99base/dracut-dev-lib.sh" "/lib/dracut-dev-lib.sh"
-        inst_binary "${PKGLIBDIR}/dracut-util" "/usr/bin/dracut-util"
-        ln -s dracut-util "${initdir}/usr/bin/dracut-getarg"
-        ln -s dracut-util "${initdir}/usr/bin/dracut-getargs"
-
-        inst ./client-init.sh /sbin/init
-        inst_simple /etc/os-release
-        inst_multiple -o {,/usr}/etc/nsswitch.conf
-        inst /etc/passwd /etc/passwd
-        inst /etc/group /etc/group
-        for i in /usr/lib*/libnss_files* /lib*/libnss_files*; do
-            [ -e "$i" ] || continue
-            inst "$i"
-        done
-        cp -a /etc/ld.so.conf* "$initdir"/etc
-        ldconfig -r "$initdir"
-    )
+    "$DRACUT" -l --keep --tmpdir "$TESTDIR" \
+        -m "test-root" \
+        -i ./client-init.sh /sbin/init \
+        -I "ip ping" \
+        -i "${basedir}/modules.d/99base/dracut-lib.sh" "/lib/dracut-lib.sh" \
+        -i "${basedir}/modules.d/99base/dracut-dev-lib.sh" "/lib/dracut-dev-lib.sh" \
+        --no-hostonly --no-hostonly-cmdline --nohardlink \
+        -f "$TESTDIR"/initramfs.root "$KVERSION" || return 1
+    mkdir -p "$TESTDIR"/overlay/source && mv "$TESTDIR"/dracut.*/initramfs/* "$TESTDIR"/overlay/source && rm -rf "$TESTDIR"/dracut.*
 
     # second, install the files needed to make the root filesystem
-    (
-        # shellcheck disable=SC2030
-        # shellcheck disable=SC2031
-        export initdir=$TESTDIR/overlay
-        # shellcheck disable=SC1090
-        . "$PKGLIBDIR"/dracut-init.sh
-        inst_multiple sfdisk mkfs.ext4 poweroff cp umount sync dd
-        inst_hook initqueue 01 ./create-client-root.sh
-        inst_hook initqueue/finished 01 ./finished-false.sh
-    )
-
     # create an initramfs that will create the target root filesystem.
     # We do it this way so that we do not risk trashing the host mdraid
     # devices, volume groups, encrypted partitions, etc.
     "$DRACUT" -l -i "$TESTDIR"/overlay / \
-        -m "dash rootfs-block kernel-modules qemu" \
+        -m "test-makeroot" \
         -d "piix ide-gd_mod ata_piix ext4 sd_mod" \
+        -I "mkfs.ext4" \
+        -i ./create-client-root.sh /lib/dracut/hooks/initqueue/01-create-client-root.sh \
         --nomdadmconf \
         --no-hostonly-cmdline -N \
         -f "$TESTDIR"/initramfs.makeroot "$KVERSION" || return 1
 
     declare -a disk_args=()
-    # shellcheck disable=SC2034
     declare -i disk_index=0
     qemu_add_drive disk_index disk_args "$TESTDIR"/marker.img marker 1
     qemu_add_drive disk_index disk_args "$TESTDIR"/unencrypted.img root 120
@@ -343,20 +266,8 @@ make_client_root() {
 
 make_server_root() {
     rm -fr "$TESTDIR"/overlay
-    (
-        mkdir -p "$TESTDIR"/overlay/source
-        # shellcheck disable=SC2030
-        # shellcheck disable=SC2031
-        export initdir=$TESTDIR/overlay/source
-        # shellcheck disable=SC1090
-        . "$PKGLIBDIR"/dracut-init.sh
-        mkdir -p "$initdir"
-        (
-            cd "$initdir" || exit
-            mkdir -p run dev sys proc etc var var/lib/dhcpd tmp etc/nbd-server
-            ln -s ../run var/run
-        )
-        cat > "$initdir/etc/nbd-server/config" << EOF
+
+    cat > /tmp/config << EOF
 [generic]
 [raw]
 exportname = /dev/disk/by-id/scsi-0QEMU_QEMU_HARDDISK_unencrypted
@@ -367,64 +278,41 @@ exportname = /dev/disk/by-id/scsi-0QEMU_QEMU_HARDDISK_encrypted
 port = 2001
 bs = 4096
 EOF
-        inst_multiple sh ls shutdown poweroff stty cat ps ln ip \
-            dmesg mkdir cp ping grep \
-            sleep nbd-server chmod modprobe vi pidof
-        for _terminfodir in /lib/terminfo /etc/terminfo /usr/share/terminfo; do
-            [ -f ${_terminfodir}/l/linux ] && break
-        done
-        inst_multiple -o ${_terminfodir}/l/linux
-        instmods nfsd sunrpc ipv6 lockd af_packet 8021q ipvlan macvlan
-        type -P dhcpd > /dev/null && inst_multiple dhcpd
-        inst ./server-init.sh /sbin/init
-        inst_simple /etc/os-release
-        inst ./hosts /etc/hosts
-        inst ./dhcpd.conf /etc/dhcpd.conf
-        inst_multiple -o {,/usr}/etc/nsswitch.conf
-        inst /etc/passwd /etc/passwd
-        inst /etc/group /etc/group
-        _nsslibs=$(
-            cat "$dracutsysrootdir"/{,usr/}etc/nsswitch.conf 2> /dev/null \
-                | sed -e '/^#/d' -e 's/^.*://' -e 's/\[NOTFOUND=return\]//' \
-                | tr -s '[:space:]' '\n' | sort -u | tr -s '[:space:]' '|'
-        )
-        _nsslibs=${_nsslibs#|}
-        _nsslibs=${_nsslibs%|}
 
-        inst_libdir_file -n "$_nsslibs" 'libnss_*.so*'
+    "$DRACUT" -l --keep --tmpdir "$TESTDIR" \
+        -m "test-root network network-legacy" \
+        -d "nfsd sunrpc ipv6 lockd af_packet 8021q ipvlan macvlan" \
+        -i ./server-init.sh /sbin/init \
+        -I "ip ping grep sleep nbd-server chmod modprobe vi pidof" \
+        -i "${basedir}/modules.d/99base/dracut-lib.sh" "/lib/dracut-lib.sh" \
+        -i "${basedir}/modules.d/99base/dracut-dev-lib.sh" "/lib/dracut-dev-lib.sh" \
+        --install-optional "/etc/netconfig dhcpd /etc/group /etc/nsswitch.conf /etc/rpc /etc/protocols /etc/services /usr/etc/nsswitch.conf /usr/etc/rpc /usr/etc/protocols /usr/etc/services" \
+        -i /tmp/config /etc/nbd-server/config \
+        -i "./hosts" "/etc/hosts" \
+        -i "./dhcpd.conf" "/etc/dhcpd.conf" \
+        --no-hostonly --no-hostonly-cmdline --nohardlink \
+        -f "$TESTDIR"/initramfs.root "$KVERSION" || return 1
+    mkdir -p "$TESTDIR"/overlay/source && mv "$TESTDIR"/dracut.*/initramfs/* "$TESTDIR"/overlay/source && rm -rf "$TESTDIR"/dracut.*
 
-        cp -a /etc/ld.so.conf* "$initdir"/etc
-        ldconfig -r "$initdir"
-        dracut_kernel_post
-    )
+    mkdir -p -- "$TESTDIR"/overlay/source/var/lib/dhcpd "$TESTDIR"/overlay/source/etc/nbd-server
 
     # second, install the files needed to make the root filesystem
-    (
-        # shellcheck disable=SC2030
-        # shellcheck disable=SC2031
-        export initdir=$TESTDIR/overlay
-        # shellcheck disable=SC1090
-        . "$PKGLIBDIR"/dracut-init.sh
-        inst_multiple sfdisk mkfs.ext4 poweroff cp umount sync dd sync
-        inst_hook initqueue 01 ./create-server-root.sh
-        inst_hook initqueue/finished 01 ./finished-false.sh
-    )
-
     # create an initramfs that will create the target root filesystem.
     # We do it this way so that we do not risk trashing the host mdraid
     # devices, volume groups, encrypted partitions, etc.
     "$DRACUT" -l -i "$TESTDIR"/overlay / \
-        -m "dash rootfs-block kernel-modules qemu" \
+        -m "test-makeroot" \
         -d "piix ide-gd_mod ata_piix ext4 sd_mod" \
+        -i ./create-server-root.sh /lib/dracut/hooks/initqueue/01-create-server-root.sh \
+        -I "mkfs.ext4" \
         --nomdadmconf \
         --no-hostonly-cmdline -N \
         -f "$TESTDIR"/initramfs.makeroot "$KVERSION" || return 1
 
     declare -a disk_args=()
-    # shellcheck disable=SC2034
     declare -i disk_index=0
     qemu_add_drive disk_index disk_args "$TESTDIR"/marker.img marker 1
-    qemu_add_drive disk_index disk_args "$TESTDIR"/server.img root 120
+    qemu_add_drive disk_index disk_args "$TESTDIR"/server.img root 240
 
     # Invoke KVM and/or QEMU to actually create the target filesystem.
     "$testdir"/run-qemu \
@@ -442,45 +330,27 @@ test_setup() {
 
     rm -fr "$TESTDIR"/overlay
     # Make the test image
-    (
-        # shellcheck disable=SC2031
-        # shellcheck disable=SC2030
-        export initdir=$TESTDIR/overlay
-        # shellcheck disable=SC1090
-        . "$PKGLIBDIR"/dracut-init.sh
-        inst_multiple poweroff shutdown dd
-        inst_hook shutdown-emergency 000 ./hard-off.sh
-        inst ./cryptroot-ask.sh /sbin/cryptroot-ask
 
-        #        inst ./debug-shell.service /lib/systemd/system/debug-shell.service
-        #        mkdir -p "${initdir}/lib/systemd/system/sysinit.target.wants"
-        #        ln -fs ../debug-shell.service "${initdir}/lib/systemd/system/sysinit.target.wants/debug-shell.service"
+    # shellcheck source=$TESTDIR/luks.uuid
+    . "$TESTDIR"/luks.uuid
 
-        # shellcheck disable=SC1090
-        . "$TESTDIR"/luks.uuid
-        mkdir -p "$initdir"/etc
-        echo "luks-$ID_FS_UUID /dev/nbd0 /etc/key" > "$initdir"/etc/crypttab
-        echo -n test > "$initdir"/etc/key
-        inst_simple ./client.link /etc/systemd/network/01-client.link
-    )
+    echo "luks-$ID_FS_UUID /dev/nbd0 /etc/key" > /tmp/crypttab
+    echo -n test > /tmp/key
 
     "$DRACUT" -l -i "$TESTDIR"/overlay / \
-        -a "debug watchdog ${USE_NETWORK}" \
+        -a "test debug watchdog ${USE_NETWORK}" \
+        -i "./cryptroot-ask.sh" "/sbin/cryptroot-ask" \
+        -i "./client.link" "/etc/systemd/network/01-client.link" \
+        -i "/tmp/crypttab" "/etc/crypttab" \
+        -i "/tmp/key" "/etc/key" \
         --no-hostonly-cmdline -N \
         -f "$TESTDIR"/initramfs.testing "$KVERSION" || return 1
 
-    (
-        # shellcheck disable=SC2031
-        export initdir="$TESTDIR"/overlay
-        # shellcheck disable=SC1090
-        . "$PKGLIBDIR"/dracut-init.sh
-        rm "$initdir"/etc/systemd/network/01-client.link
-        inst_simple ./server.link /etc/systemd/network/01-server.link
-        inst_hook pre-mount 99 ./wait-if-server.sh
-    )
     "$DRACUT" -l -i "$TESTDIR"/overlay / \
-        -a "rootfs-block debug kernel-modules network network-legacy" \
+        -a "test rootfs-block debug kernel-modules network network-legacy" \
         -d "af_packet piix ide-gd_mod ata_piix ext4 sd_mod e1000 drbg" \
+        -i "./server.link" "/etc/systemd/network/01-server.link" \
+        -i "./wait-if-server.sh" "/lib/dracut/hooks/pre-mount/99-wait-if-server.sh" \
         --no-hostonly-cmdline -N \
         -f "$TESTDIR"/initramfs.server "$KVERSION" || return 1
 

--- a/test/TEST-50-MULTINIC/test.sh
+++ b/test/TEST-50-MULTINIC/test.sh
@@ -194,7 +194,7 @@ test_setup() {
         )
 
         inst_multiple sh ls shutdown poweroff stty cat ps ln ip \
-            dmesg mkdir cp ping exportfs \
+            dmesg mkdir cp exportfs \
             modprobe rpc.nfsd rpc.mountd showmount tcpdump \
             sleep mount chmod rm
         for _terminfodir in /lib/terminfo /etc/terminfo /usr/share/terminfo; do
@@ -252,7 +252,7 @@ test_setup() {
         )
 
         inst_multiple sh shutdown poweroff stty cat ps ln ip dd \
-            mount dmesg mkdir cp ping grep setsid ls vi less cat sync
+            mount dmesg mkdir cp grep setsid ls vi less cat sync
         for _terminfodir in /lib/terminfo /etc/terminfo /usr/share/terminfo; do
             if [ -f "${_terminfodir}"/l/linux ]; then
                 inst_multiple -o "${_terminfodir}"/l/linux

--- a/test/TEST-63-DRACUT-CPIO/test.sh
+++ b/test/TEST-63-DRACUT-CPIO/test.sh
@@ -28,7 +28,7 @@ EOF
 
     "$DRACUT" -l --no-kernel --drivers "" \
         "${dracut_cpio_params[@]}" \
-        --modules "bash base" \
+        --modules "test" \
         --include "$tdir/init.sh" /lib/dracut/hooks/emergency/00-init.sh \
         --install "poweroff" \
         --no-hostonly --no-hostonly-cmdline \


### PR DESCRIPTION
## Changes
- Migrate NBD, DRACUT-CPIO and ISCSI-MULTI test to use test dracut modules
- Remove obsolete, duplicate or unused code
- Add iscsiuio.socket requirement to run the ISCSI tests
-  Switch over ISCSI-MULTI to run on systemd-networkd on the CI to have more tests coverage for systemd-networkd. The ISCSI-MULTI test itself is not specific to systemd-networkd (just as before).

This PR removes about 300 source code lines, and us such helps with readability and code maintenance. 

## Checklist
- [X] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it
