### PR TITLE
fix(systemd-initrd): add systemd-udevd dependency

### DIFF
--- a/modules.d/01systemd-initrd/module-setup.sh
+++ b/modules.d/01systemd-initrd/module-setup.sh
@@ -9,7 +9,7 @@ check() {
 
 # called by dracut
 depends() {
-    echo "systemd"
+    echo systemd-udevd
 }
 
 installkernel() {


### PR DESCRIPTION
 'dracut -m dracut-systemd' does NOT includes `systemd-udevd` dracut module into the generated initrd.

This PR fixes this obvious dependency issue.

`systemd-udevd` dracut module already depends on `systemd` dracut module, so no need to directly depend on it here.
