### PR TITLE
perf(dracut-init.sh): stop parsing args in dracut_instmods if --silent is found

### DIFF
--- a/dracut-init.sh
+++ b/dracut-init.sh
@@ -313,7 +313,10 @@ dracut_instmods() {
     local i
     [[ $no_kernel == yes ]] && return
     for i in "$@"; do
-        [[ $i == "--silent" ]] && _silent=1
+        if [[ $i == "--silent" ]]; then
+            _silent=1
+            break
+        fi
     done
 
     if $DRACUT_INSTALL \


### PR DESCRIPTION
## Changes

## Checklist
- [ ] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it

Fixes #
