### PR TITLE
fix(dracut): link hooks directory from /lib/dracut/hooks to /var/lib/dracut/hooks

### DIFF
--- a/dracut-init.sh
+++ b/dracut-init.sh
@@ -633,7 +633,7 @@ inst_hook() {
         dfatal "No such hook type $1. Aborting initrd creation."
         exit 1
     fi
-    hook="/lib/dracut/hooks/${1}/${2}-${3##*/}"
+    hook="/var/lib/dracut/hooks/${1}/${2}-${3##*/}"
     inst_simple "$3" "$hook"
     chmod u+x "$initdir/$hook"
 }

--- a/dracut.sh
+++ b/dracut.sh
@@ -1884,7 +1884,11 @@ mkdir -p "${initdir}"/lib/dracut
 
 if [[ $kernel_only != yes ]]; then
     mkdir -p "${initdir}/etc/cmdline.d"
-    mkdir -m 0755 "${initdir}"/lib/dracut/hooks
+    mkdir -m 0755 -p "${initdir}"/var/lib/dracut/hooks
+
+    # symlink to old hooks location for compatibility
+    ln_r /var/lib/dracut/hooks /lib/dracut/hooks
+
     for _d in $hookdirs; do
         # shellcheck disable=SC2174
         mkdir -m 0755 -p "${initdir}/lib/dracut/hooks/$_d"

--- a/modules.d/99base/module-setup.sh
+++ b/modules.d/99base/module-setup.sh
@@ -45,7 +45,10 @@ install() {
 
     [ -e "${initdir}/lib" ] || mkdir -m 0755 -p "${initdir}"/lib
     mkdir -m 0755 -p "${initdir}"/lib/dracut
-    mkdir -m 0755 -p "${initdir}"/lib/dracut/hooks
+    mkdir -m 0755 -p "${initdir}"/var/lib/dracut/hooks
+
+    # symlink to old hooks location for compatibility
+    ln_r /var/lib/dracut/hooks /lib/dracut/hooks
 
     mkdir -p "${initdir}"/tmp
 

--- a/modules.d/99shutdown/module-setup.sh
+++ b/modules.d/99shutdown/module-setup.sh
@@ -17,9 +17,11 @@ install() {
     inst_multiple umount poweroff reboot halt losetup stat sleep timeout
     inst_multiple -o kexec
     inst "$moddir/shutdown.sh" "$prefix/shutdown"
-    [ -e "${initdir}/lib" ] || mkdir -m 0755 -p "${initdir}"/lib
-    mkdir -m 0755 -p "${initdir}"/lib/dracut
-    mkdir -m 0755 -p "${initdir}"/lib/dracut/hooks
+    mkdir -m 0755 -p "${initdir}"/var/lib/dracut/hooks
+
+    # symlink to old hooks location for compatibility
+    ln_r /var/lib/dracut/hooks /lib/dracut/hooks
+
     for _d in $hookdirs shutdown shutdown-emergency; do
         mkdir -m 0755 -p "${initdir}"/lib/dracut/hooks/"$_d"
     done


### PR DESCRIPTION
## Changes

Since https://github.com/systemd/systemd/commit/ffc1ec73, /usr is mounted as read-only in the initramfs by default.

Fixes https://github.com/dracutdevs/dracut/issues/2588

Minimal viable subset of https://github.com/dracut-ng/dracut-ng/pull/114 . No documentation change to maintain backward compatibility.

Code is same as https://github.com/dracut-ng/dracut-ng/pull/186, but Author changed as discussed at https://github.com/dracut-ng/dracut-ng/pull/186#issuecomment-2061184241 .