### PR TITLE
perf(systemd-udevd): remove duplicate rules

### DIFF
--- a/modules.d/01systemd-udevd/module-setup.sh
+++ b/modules.d/01systemd-udevd/module-setup.sh
@@ -20,7 +20,7 @@ check() {
 depends() {
 
     # This module has external dependency on other module(s).
-    echo systemd systemd-sysctl
+    echo udev-rules systemd systemd-sysctl
     # Return 0 to include the dependent module(s) in the initramfs.
     return 0
 
@@ -31,19 +31,12 @@ install() {
 
     inst_multiple -o \
         "$udevdir"/hwdb.bin \
-        "$udevdir"/udev.conf \
-        "$udevdir"/ata_id \
-        "$udevdir"/cdrom_id \
         "$udevdir"/dmi_memory_id \
         "$udevdir"/fido_id \
         "$udevdir"/mtd_probe \
         "$udevdir"/mtp-probe \
-        "$udevdir"/scsi_id \
         "$udevdir"/v4l_id \
-        "$udevrulesdir"/50-udev-default.rules \
         "$udevrulesdir"/60-autosuspend.rules \
-        "$udevrulesdir"/60-block.rules \
-        "$udevrulesdir"/60-cdrom_id.rules \
         "$udevrulesdir"/60-drm.rules \
         "$udevrulesdir"/60-evdev.rules \
         "$udevrulesdir"/60-fido-id.rules \
@@ -51,20 +44,15 @@ install() {
         "$udevrulesdir"/60-persistent-alsa.rules \
         "$udevrulesdir"/60-persistent-input.rules \
         "$udevrulesdir"/60-persistent-storage-tape.rules \
-        "$udevrulesdir"/60-persistent-storage.rules \
         "$udevrulesdir"/60-persistent-v4l.rules \
         "$udevrulesdir"/60-sensor.rules \
         "$udevrulesdir"/60-serial.rules \
-        "$udevrulesdir"/64-btrfs.rules \
         "$udevrulesdir"/70-joystick.rules \
         "$udevrulesdir"/70-memory.rules \
         "$udevrulesdir"/70-mouse.rules \
         "$udevrulesdir"/70-touchpad.rules \
-        "$udevrulesdir"/75-net-description.rules \
         "$udevrulesdir"/75-probe_mtd.rules \
         "$udevrulesdir"/78-sound-card.rules \
-        "$udevrulesdir"/80-drivers.rules \
-        "$udevrulesdir"/80-net-setup-link.rules \
         "$udevrulesdir"/81-net-dhcp.rules \
         "$udevrulesdir"/99-systemd.rules \
         "$systemdutildir"/systemd-udevd \
@@ -79,8 +67,7 @@ install() {
         "$systemdsystemunitdir"/sockets.target.wants/systemd-udevd-control.socket \
         "$systemdsystemunitdir"/sockets.target.wants/systemd-udevd-kernel.socket \
         "$systemdsystemunitdir"/sysinit.target.wants/systemd-udevd.service \
-        "$systemdsystemunitdir"/sysinit.target.wants/systemd-udev-trigger.service \
-        udevadm
+        "$systemdsystemunitdir"/sysinit.target.wants/systemd-udev-trigger.service
 
     # Install the hosts local user configurations if enabled.
     if [[ $hostonly ]]; then


### PR DESCRIPTION
## Changes

During a typical systemd-enabled initrd generation both [udev-rules](https://github.com/dracut-ng/dracut-ng/blob/main/modules.d/95udev-rules/module-setup.sh) and systemd-udevd gets installed. This leads to duplicate file copying, that can be easily avoided just by removing the duplicate rules.

The performance benefit of this PR is negligent. More importantly this PR makes it easier to read, reason and maintain the code.

Added explicit dependency to make sure there is no regression for the `dracut -m systemd-udevd` invocation.

## Checklist
- [x] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it
