### PR TITLE
test: switch to virtio for the QEMU drive

### DIFF
--- a/modules.d/80test/module-setup.sh
+++ b/modules.d/80test/module-setup.sh
@@ -9,6 +9,13 @@ depends() {
     echo "debug"
 }
 
+installkernel() {
+    instmods \
+        sd_mod \
+        virtio_pci \
+        virtio_scsi
+}
+
 install() {
     inst poweroff
     inst_hook shutdown-emergency 000 "$moddir/hard-off.sh"

--- a/test/TEST-01-BASIC/create-root.sh
+++ b/test/TEST-01-BASIC/create-root.sh
@@ -12,11 +12,11 @@ udevadm settle
 
 set -ex
 
-mkfs.ext4 -L '  rdinit=/bin/sh' /dev/disk/by-id/ata-disk_root
+mkfs.ext4 -L '  rdinit=/bin/sh' /dev/disk/by-id/scsi-0QEMU_QEMU_HARDDISK_root
 mkdir -p /root
-mount -t ext4 /dev/disk/by-id/ata-disk_root /root
+mount -t ext4 /dev/disk/by-id/scsi-0QEMU_QEMU_HARDDISK_root /root
 cp -a -t /root /source/*
 mkdir -p /root/run
 umount /root
-echo "dracut-root-block-created" | dd oflag=direct,dsync of=/dev/disk/by-id/ata-disk_marker
+echo "dracut-root-block-created" | dd oflag=direct,dsync of=/dev/disk/by-id/scsi-0QEMU_QEMU_HARDDISK_marker
 poweroff -f

--- a/test/TEST-01-BASIC/test-init.sh
+++ b/test/TEST-01-BASIC/test-init.sh
@@ -7,7 +7,7 @@ export PATH=/usr/sbin:/usr/bin:/sbin:/bin
 command -v plymouth > /dev/null 2>&1 && plymouth --quit
 exec > /dev/console 2>&1
 
-echo "dracut-root-block-success" | dd oflag=direct,dsync of=/dev/disk/by-id/ata-disk_marker
+echo "dracut-root-block-success" | dd oflag=direct,dsync of=/dev/disk/by-id/scsi-0QEMU_QEMU_HARDDISK_marker
 
 export TERM=linux
 export PS1='initramfs-test:\w\$ '

--- a/test/TEST-01-BASIC/test.sh
+++ b/test/TEST-01-BASIC/test.sh
@@ -8,8 +8,8 @@ TEST_DESCRIPTION="root filesystem on a ext4 filesystem"
 test_run() {
     declare -a disk_args=()
     declare -i disk_index=0
-    qemu_add_drive_args disk_index disk_args "$TESTDIR"/marker.img marker
-    qemu_add_drive_args disk_index disk_args "$TESTDIR"/root.img root
+    qemu_add_drive disk_index disk_args "$TESTDIR"/marker.img marker
+    qemu_add_drive disk_index disk_args "$TESTDIR"/root.img root
 
     test_marker_reset
     "$testdir"/run-qemu \
@@ -47,13 +47,13 @@ test_setup() {
 
     declare -a disk_args=()
     declare -i disk_index=0
-    qemu_add_drive_args disk_index disk_args "$TESTDIR"/marker.img marker 1
-    qemu_add_drive_args disk_index disk_args "$TESTDIR"/root.img root 80
+    qemu_add_drive disk_index disk_args "$TESTDIR"/marker.img marker 1
+    qemu_add_drive disk_index disk_args "$TESTDIR"/root.img root 80
 
     # Invoke KVM and/or QEMU to actually create the target filesystem.
     "$testdir"/run-qemu \
         "${disk_args[@]}" \
-        -append "root=/dev/dracut/root rw rootfstype=ext4 quiet console=ttyS0,115200n81 selinux=0" \
+        -append "root=/dev/dracut/root rw rootfstype=ext4 console=ttyS0,115200n81 selinux=0" \
         -initrd "$TESTDIR"/initramfs.makeroot || return 1
     test_marker_check dracut-root-block-created || return 1
     rm -- "$TESTDIR"/marker.img
@@ -61,7 +61,7 @@ test_setup() {
     # make sure --omit-drivers does not filter out drivers using regexp to test for an earlier regression (assuming there is no one letter linux kernel module needed to run the test)
     "$DRACUT" -l -i "$TESTDIR"/overlay / \
         -a "test watchdog" \
-        -d "piix ide-gd_mod ata_piix ext4 sd_mod i6300esb" \
+        -d "piix ide-gd_mod ata_piix ext4 i6300esb" \
         --omit-drivers 'a b c d e f g h i j k l m n o p q r s t u v w x y z' \
         --no-hostonly-cmdline -N \
         -f "$TESTDIR"/initramfs.testing "$KVERSION" || return 1

--- a/test/TEST-02-SYSTEMD/create-root.sh
+++ b/test/TEST-02-SYSTEMD/create-root.sh
@@ -11,11 +11,11 @@ udevadm control --reload
 set -e
 
 udevadm settle
-mkfs.ext4 -L dracut /dev/disk/by-id/ata-disk_root
+mkfs.ext4 -L dracut /dev/disk/by-id/scsi-0QEMU_QEMU_HARDDISK_root
 mkdir -p /root
-mount -t ext4 /dev/disk/by-id/ata-disk_root /root
+mount -t ext4 /dev/disk/by-id/scsi-0QEMU_QEMU_HARDDISK_root /root
 cp -a -t /root /source/*
 mkdir -p /root/run
 umount /root
-echo "dracut-root-block-created" | dd oflag=direct,dsync of=/dev/disk/by-id/ata-disk_marker
+echo "dracut-root-block-created" | dd oflag=direct,dsync of=/dev/disk/by-id/scsi-0QEMU_QEMU_HARDDISK_marker
 poweroff -f

--- a/test/TEST-02-SYSTEMD/test-init.sh
+++ b/test/TEST-02-SYSTEMD/test-init.sh
@@ -7,7 +7,7 @@ export PATH=/usr/sbin:/usr/bin:/sbin:/bin
 command -v plymouth > /dev/null 2>&1 && plymouth --quit
 exec > /dev/console 2>&1
 
-echo "dracut-root-block-success" | dd oflag=direct,dsync of=/dev/disk/by-id/ata-disk_marker
+echo "dracut-root-block-success" | dd oflag=direct,dsync of=/dev/disk/by-id/scsi-0QEMU_QEMU_HARDDISK_marker
 
 export TERM=linux
 export PS1='initramfs-test:\w\$ '

--- a/test/TEST-02-SYSTEMD/test.sh
+++ b/test/TEST-02-SYSTEMD/test.sh
@@ -11,8 +11,8 @@ test_check() {
 test_run() {
     declare -a disk_args=()
     declare -i disk_index=0
-    qemu_add_drive_args disk_index disk_args "$TESTDIR"/marker.img marker
-    qemu_add_drive_args disk_index disk_args "$TESTDIR"/root.img root
+    qemu_add_drive disk_index disk_args "$TESTDIR"/marker.img marker
+    qemu_add_drive disk_index disk_args "$TESTDIR"/root.img root
 
     test_marker_reset
     "$testdir"/run-qemu \
@@ -49,8 +49,8 @@ test_setup() {
 
     declare -a disk_args=()
     declare -i disk_index=0
-    qemu_add_drive_args disk_index disk_args "$TESTDIR"/marker.img marker 1
-    qemu_add_drive_args disk_index disk_args "$TESTDIR"/root.img root 80
+    qemu_add_drive disk_index disk_args "$TESTDIR"/marker.img marker 1
+    qemu_add_drive disk_index disk_args "$TESTDIR"/root.img root 80
 
     # Invoke KVM and/or QEMU to actually create the target filesystem.
     "$testdir"/run-qemu \
@@ -64,7 +64,7 @@ test_setup() {
     # make the man command succeed always
     "$DRACUT" -l -i "$TESTDIR"/overlay / \
         -a "test systemd" \
-        -d "piix ide-gd_mod ata_piix ext4 sd_mod" \
+        -d "piix ide-gd_mod ata_piix ext4" \
         -i ./systemd-analyze.sh /lib/dracut/hooks/pre-pivot/00-systemd-analyze.sh \
         -i "/bin/true" "/usr/bin/man" \
         --no-hostonly-cmdline -N \

--- a/test/TEST-03-USR-MOUNT/create-root.sh
+++ b/test/TEST-03-USR-MOUNT/create-root.sh
@@ -12,22 +12,22 @@ set -e
 
 udevadm settle
 modprobe btrfs || :
-mkfs.btrfs -L dracut /dev/disk/by-id/ata-disk_root
-mkfs.btrfs -L dracutusr /dev/disk/by-id/ata-disk_usr
-btrfs device scan /dev/disk/by-id/ata-disk_root
-btrfs device scan /dev/disk/by-id/ata-disk_usr
+mkfs.btrfs -L dracut /dev/disk/by-id/scsi-0QEMU_QEMU_HARDDISK_root
+mkfs.btrfs -L dracutusr /dev/disk/by-id/scsi-0QEMU_QEMU_HARDDISK_usr
+btrfs device scan /dev/disk/by-id/scsi-0QEMU_QEMU_HARDDISK_root
+btrfs device scan /dev/disk/by-id/scsi-0QEMU_QEMU_HARDDISK_usr
 mkdir -p /root
-mount -t btrfs /dev/disk/by-id/ata-disk_root /root
+mount -t btrfs /dev/disk/by-id/scsi-0QEMU_QEMU_HARDDISK_root /root
 [ -d /root/usr ] || mkdir -p /root/usr
-mount -t btrfs /dev/disk/by-id/ata-disk_usr /root/usr
+mount -t btrfs /dev/disk/by-id/scsi-0QEMU_QEMU_HARDDISK_usr /root/usr
 btrfs subvolume create /root/usr/usr
 umount /root/usr
-mount -t btrfs -o subvol=usr /dev/disk/by-id/ata-disk_usr /root/usr
+mount -t btrfs -o subvol=usr /dev/disk/by-id/scsi-0QEMU_QEMU_HARDDISK_usr /root/usr
 cp -a -t /root /source/*
 mkdir -p /root/run
 btrfs filesystem sync /root/usr
 btrfs filesystem sync /root
 umount /root/usr
 umount /root
-echo "dracut-root-block-created" | dd oflag=direct,dsync of=/dev/disk/by-id/ata-disk_marker
+echo "dracut-root-block-created" | dd oflag=direct,dsync of=/dev/disk/by-id/scsi-0QEMU_QEMU_HARDDISK_marker
 poweroff -f

--- a/test/TEST-03-USR-MOUNT/fstab
+++ b/test/TEST-03-USR-MOUNT/fstab
@@ -1,2 +1,2 @@
-/dev/disk/by-id/ata-disk_root	/                       btrfs   defaults         0 0
-/dev/disk/by-id/ata-disk_usr	/usr                    btrfs   subvol=usr,ro    0 0
+/dev/disk/by-id/scsi-0QEMU_QEMU_HARDDISK_root	/                       btrfs   defaults         0 0
+/dev/disk/by-id/scsi-0QEMU_QEMU_HARDDISK_usr	/usr                    btrfs   subvol=usr,ro    0 0

--- a/test/TEST-03-USR-MOUNT/test-init.sh
+++ b/test/TEST-03-USR-MOUNT/test-init.sh
@@ -7,7 +7,7 @@ export PATH=/usr/sbin:/usr/bin:/sbin:/bin
 command -v plymouth > /dev/null 2>&1 && plymouth --quit
 exec > /dev/console 2>&1
 
-echo "dracut-root-block-success" | dd oflag=direct,dsync of=/dev/disk/by-id/ata-disk_marker
+echo "dracut-root-block-success" | dd oflag=direct,dsync of=/dev/disk/by-id/scsi-0QEMU_QEMU_HARDDISK_marker
 
 export TERM=linux
 export PS1='initramfs-test:\w\$ '

--- a/test/TEST-03-USR-MOUNT/test.sh
+++ b/test/TEST-03-USR-MOUNT/test.sh
@@ -15,9 +15,9 @@ client_run() {
 
     declare -a disk_args=()
     declare -i disk_index=0
-    qemu_add_drive_args disk_index disk_args "$TESTDIR"/marker.img marker
-    qemu_add_drive_args disk_index disk_args "$TESTDIR"/root.btrfs root
-    qemu_add_drive_args disk_index disk_args "$TESTDIR"/usr.btrfs usr
+    qemu_add_drive disk_index disk_args "$TESTDIR"/marker.img marker
+    qemu_add_drive disk_index disk_args "$TESTDIR"/root.btrfs root
+    qemu_add_drive disk_index disk_args "$TESTDIR"/usr.btrfs usr
 
     test_marker_reset
     "$testdir"/run-qemu \
@@ -68,9 +68,9 @@ test_setup() {
     # Create the blank file to use as a root filesystem
     declare -a disk_args=()
     declare -i disk_index=0
-    qemu_add_drive_args disk_index disk_args "$TESTDIR"/marker.img marker 1
-    qemu_add_drive_args disk_index disk_args "$TESTDIR"/root.btrfs root 160
-    qemu_add_drive_args disk_index disk_args "$TESTDIR"/usr.btrfs usr 160
+    qemu_add_drive disk_index disk_args "$TESTDIR"/marker.img marker 1
+    qemu_add_drive disk_index disk_args "$TESTDIR"/root.btrfs root 160
+    qemu_add_drive disk_index disk_args "$TESTDIR"/usr.btrfs usr 160
 
     # Invoke KVM and/or QEMU to actually create the target filesystem.
     "$testdir"/run-qemu \
@@ -85,7 +85,7 @@ test_setup() {
 
     "$DRACUT" -l -i "$TESTDIR"/overlay / \
         -a "test watchdog" \
-        -d "piix ide-gd_mod ata_piix btrfs sd_mod i6300esb" \
+        -d "piix ide-gd_mod ata_piix btrfs i6300esb" \
         --no-hostonly-cmdline -N \
         -f "$TESTDIR"/initramfs.testing "$KVERSION" || return 1
     rm -rf -- "$TESTDIR"/overlay

--- a/test/TEST-04-FULL-SYSTEMD/create-root.sh
+++ b/test/TEST-04-FULL-SYSTEMD/create-root.sh
@@ -12,22 +12,22 @@ set -e
 
 udevadm settle
 modprobe btrfs || :
-mkfs.btrfs -L dracut /dev/disk/by-id/ata-disk_root
-mkfs.btrfs -L dracutusr /dev/disk/by-id/ata-disk_usr
-btrfs device scan /dev/disk/by-id/ata-disk_root
-btrfs device scan /dev/disk/by-id/ata-disk_usr
+mkfs.btrfs -L dracut /dev/disk/by-id/scsi-0QEMU_QEMU_HARDDISK_root
+mkfs.btrfs -L dracutusr /dev/disk/by-id/scsi-0QEMU_QEMU_HARDDISK_usr
+btrfs device scan /dev/disk/by-id/scsi-0QEMU_QEMU_HARDDISK_root
+btrfs device scan /dev/disk/by-id/scsi-0QEMU_QEMU_HARDDISK_usr
 mkdir -p /root
-mount -t btrfs /dev/disk/by-id/ata-disk_root /root
+mount -t btrfs /dev/disk/by-id/scsi-0QEMU_QEMU_HARDDISK_root /root
 [ -d /root/usr ] || mkdir -p /root/usr
-mount -t btrfs /dev/disk/by-id/ata-disk_usr /root/usr
+mount -t btrfs /dev/disk/by-id/scsi-0QEMU_QEMU_HARDDISK_usr /root/usr
 btrfs subvolume create /root/usr/usr
 umount /root/usr
-mount -t btrfs -o subvol=usr /dev/disk/by-id/ata-disk_usr /root/usr
+mount -t btrfs -o subvol=usr /dev/disk/by-id/scsi-0QEMU_QEMU_HARDDISK_usr /root/usr
 cp -a -t /root /source/*
 mkdir -p /root/run
 btrfs filesystem sync /root/usr
 btrfs filesystem sync /root
 umount /root/usr
 umount /root
-echo "dracut-root-block-created" | dd oflag=direct,dsync of=/dev/disk/by-id/ata-disk_marker
+echo "dracut-root-block-created" | dd oflag=direct,dsync of=/dev/disk/by-id/scsi-0QEMU_QEMU_HARDDISK_marker
 poweroff -f

--- a/test/TEST-04-FULL-SYSTEMD/fstab
+++ b/test/TEST-04-FULL-SYSTEMD/fstab
@@ -1,2 +1,2 @@
-/dev/disk/by-id/ata-disk_root	/                       btrfs   defaults         0 0
-/dev/disk/by-id/ata-disk_usr	/usr                    btrfs   subvol=usr,ro    0 0
+/dev/disk/by-id/scsi-0QEMU_QEMU_HARDDISK_root	/                       btrfs   defaults         0 0
+/dev/disk/by-id/scsi-0QEMU_QEMU_HARDDISK_usr	/usr                    btrfs   subvol=usr,ro    0 0

--- a/test/TEST-04-FULL-SYSTEMD/test-init.sh
+++ b/test/TEST-04-FULL-SYSTEMD/test-init.sh
@@ -21,7 +21,7 @@ else
         echo "**************************FAILED**************************"
 
     else
-        echo "dracut-root-block-success" | dd oflag=direct,dsync of=/dev/disk/by-id/ata-disk_marker
+        echo "dracut-root-block-success" | dd oflag=direct,dsync of=/dev/disk/by-id/scsi-0QEMU_QEMU_HARDDISK_marker
         echo "All OK"
     fi
 fi

--- a/test/TEST-04-FULL-SYSTEMD/test.sh
+++ b/test/TEST-04-FULL-SYSTEMD/test.sh
@@ -20,9 +20,9 @@ client_run() {
 
     declare -a disk_args=()
     declare -i disk_index=0
-    qemu_add_drive_args disk_index disk_args "$TESTDIR"/marker.img marker
-    qemu_add_drive_args disk_index disk_args "$TESTDIR"/root.btrfs root
-    qemu_add_drive_args disk_index disk_args "$TESTDIR"/usr.btrfs usr
+    qemu_add_drive disk_index disk_args "$TESTDIR"/marker.img marker
+    qemu_add_drive disk_index disk_args "$TESTDIR"/root.btrfs root
+    qemu_add_drive disk_index disk_args "$TESTDIR"/usr.btrfs usr
 
     test_marker_reset
     "$testdir"/run-qemu \
@@ -132,9 +132,9 @@ EOF
     declare -a disk_args=()
     # shellcheck disable=SC2034
     declare -i disk_index=0
-    qemu_add_drive_args disk_index disk_args "$TESTDIR"/marker.img marker 1
-    qemu_add_drive_args disk_index disk_args "$TESTDIR"/root.btrfs root 160
-    qemu_add_drive_args disk_index disk_args "$TESTDIR"/usr.btrfs usr 160
+    qemu_add_drive disk_index disk_args "$TESTDIR"/marker.img marker 1
+    qemu_add_drive disk_index disk_args "$TESTDIR"/root.btrfs root 160
+    qemu_add_drive disk_index disk_args "$TESTDIR"/usr.btrfs usr 160
 
     # Invoke KVM and/or QEMU to actually create the target filesystem.
     "$testdir"/run-qemu \
@@ -153,7 +153,7 @@ EOF
     "$DRACUT" -l -i "$TESTDIR"/overlay / \
         -a "test systemd i18n qemu" \
         ${EXTRA_MACHINE:+-I "$EXTRA_MACHINE"} \
-        -d "piix ide-gd_mod ata_piix btrfs sd_mod i6300esb" \
+        -d "piix ide-gd_mod ata_piix btrfs i6300esb" \
         --no-hostonly-cmdline -N \
         -f "$TESTDIR"/initramfs.testing "$KVERSION" || return 1
 

--- a/test/TEST-10-RAID/create-root.sh
+++ b/test/TEST-10-RAID/create-root.sh
@@ -10,7 +10,7 @@ rm -f -- /etc/lvm/lvm.conf
 udevadm control --reload
 udevadm settle
 set -ex
-mdadm --create /dev/md0 --run --auto=yes --level=5 --raid-devices=3 /dev/disk/by-id/ata-disk_raid[123]
+mdadm --create /dev/md0 --run --auto=yes --level=5 --raid-devices=3 /dev/disk/by-id/scsi-0QEMU_QEMU_HARDDISK_raid[123]
 # wait for the array to finish initializing, otherwise this sometimes fails
 # randomly.
 mdadm -W /dev/md0 || :
@@ -42,6 +42,6 @@ eval "$(udevadm info --query=property --name=/dev/md0 | while read -r line || [ 
     echo "dracut-root-block-created"
     echo MD_UUID="$MD_UUID"
     echo "ID_FS_UUID=$ID_FS_UUID"
-} | dd oflag=direct,dsync of=/dev/disk/by-id/ata-disk_marker
+} | dd oflag=direct,dsync of=/dev/disk/by-id/scsi-0QEMU_QEMU_HARDDISK_marker
 sync
 poweroff -f

--- a/test/TEST-10-RAID/test-init.sh
+++ b/test/TEST-10-RAID/test-init.sh
@@ -7,7 +7,7 @@ export PATH=/usr/sbin:/usr/bin:/sbin:/bin
 command -v plymouth > /dev/null 2>&1 && plymouth --quit
 exec > /dev/console 2>&1
 
-echo "dracut-root-block-success" | dd oflag=direct,dsync of=/dev/disk/by-id/ata-disk_marker
+echo "dracut-root-block-success" | dd oflag=direct,dsync of=/dev/disk/by-id/scsi-0QEMU_QEMU_HARDDISK_marker
 
 export TERM=linux
 export PS1='initramfs-test:\w\$ '

--- a/test/TEST-10-RAID/test.sh
+++ b/test/TEST-10-RAID/test.sh
@@ -8,10 +8,10 @@ TEST_DESCRIPTION="root filesystem on an encrypted LVM PV on a RAID-5"
 test_run() {
     declare -a disk_args=()
     declare -i disk_index=0
-    qemu_add_drive_args disk_index disk_args "$TESTDIR"/marker.img marker
-    qemu_add_drive_args disk_index disk_args "$TESTDIR"/raid-1.img raid1
-    qemu_add_drive_args disk_index disk_args "$TESTDIR"/raid-2.img raid2
-    qemu_add_drive_args disk_index disk_args "$TESTDIR"/raid-3.img raid3
+    qemu_add_drive disk_index disk_args "$TESTDIR"/marker.img marker
+    qemu_add_drive disk_index disk_args "$TESTDIR"/raid-1.img raid1
+    qemu_add_drive disk_index disk_args "$TESTDIR"/raid-2.img raid2
+    qemu_add_drive disk_index disk_args "$TESTDIR"/raid-3.img raid3
 
     test_marker_reset
     "$testdir"/run-qemu \
@@ -49,10 +49,10 @@ test_setup() {
     # Create the blank files to use as a root filesystem
     declare -a disk_args=()
     declare -i disk_index=0
-    qemu_add_drive_args disk_index disk_args "$TESTDIR"/marker.img marker 1
-    qemu_add_drive_args disk_index disk_args "$TESTDIR"/raid-1.img raid1 40
-    qemu_add_drive_args disk_index disk_args "$TESTDIR"/raid-2.img raid2 40
-    qemu_add_drive_args disk_index disk_args "$TESTDIR"/raid-3.img raid3 40
+    qemu_add_drive disk_index disk_args "$TESTDIR"/marker.img marker 1
+    qemu_add_drive disk_index disk_args "$TESTDIR"/raid-1.img raid1 40
+    qemu_add_drive disk_index disk_args "$TESTDIR"/raid-2.img raid2 40
+    qemu_add_drive disk_index disk_args "$TESTDIR"/raid-3.img raid3 40
 
     "$testdir"/run-qemu \
         "${disk_args[@]}" \
@@ -66,7 +66,7 @@ test_setup() {
 
     "$DRACUT" -l -i "$TESTDIR"/overlay / \
         -a "test" \
-        -d "piix ide-gd_mod ata_piix ext4 sd_mod" \
+        -d "piix ide-gd_mod ata_piix ext4" \
         --no-hostonly-cmdline -N \
         -i "./cryptroot-ask.sh" "/sbin/cryptroot-ask" \
         -i "/tmp/crypttab" "/etc/crypttab" \

--- a/test/TEST-11-LVM/create-root.sh
+++ b/test/TEST-11-LVM/create-root.sh
@@ -11,11 +11,11 @@ udevadm control --reload
 udevadm settle
 
 set -ex
-for dev in /dev/disk/by-id/ata-disk_disk[123]; do
+for dev in /dev/disk/by-id/scsi-0QEMU_QEMU_HARDDISK_disk[123]; do
     lvm pvcreate -ff -y "$dev"
 done
 
-lvm vgcreate dracut /dev/disk/by-id/ata-disk_disk[123]
+lvm vgcreate dracut /dev/disk/by-id/scsi-0QEMU_QEMU_HARDDISK_disk[123]
 lvm lvcreate -l 100%FREE -n root dracut
 lvm vgchange -ay
 mkfs.ext4 /dev/dracut/root
@@ -24,5 +24,5 @@ mount -t ext4 /dev/dracut/root /sysroot
 cp -a -t /sysroot /source/*
 umount /sysroot
 lvm lvchange -a n /dev/dracut/root
-echo "dracut-root-block-created" | dd oflag=direct,dsync of=/dev/disk/by-id/ata-disk_marker
+echo "dracut-root-block-created" | dd oflag=direct,dsync of=/dev/disk/by-id/scsi-0QEMU_QEMU_HARDDISK_marker
 poweroff -f

--- a/test/TEST-11-LVM/test-init.sh
+++ b/test/TEST-11-LVM/test-init.sh
@@ -7,7 +7,7 @@ export PATH=/usr/sbin:/usr/bin:/sbin:/bin
 command -v plymouth > /dev/null 2>&1 && plymouth --quit
 exec > /dev/console 2>&1
 
-echo "dracut-root-block-success" | dd oflag=direct,dsync of=/dev/disk/by-id/ata-disk_marker
+echo "dracut-root-block-success" | dd oflag=direct,dsync of=/dev/disk/by-id/scsi-0QEMU_QEMU_HARDDISK_marker
 
 export TERM=linux
 export PS1='initramfs-test:\w\$ '

--- a/test/TEST-11-LVM/test.sh
+++ b/test/TEST-11-LVM/test.sh
@@ -9,10 +9,10 @@ TEST_DESCRIPTION="root filesystem on LVM PV"
 test_run() {
     declare -a disk_args=()
     declare -i disk_index=0
-    qemu_add_drive_args disk_index disk_args "$TESTDIR"/marker.img marker
-    qemu_add_drive_args disk_index disk_args "$TESTDIR"/disk-1.img disk1
-    qemu_add_drive_args disk_index disk_args "$TESTDIR"/disk-2.img disk2
-    qemu_add_drive_args disk_index disk_args "$TESTDIR"/disk-3.img disk3
+    qemu_add_drive disk_index disk_args "$TESTDIR"/marker.img marker
+    qemu_add_drive disk_index disk_args "$TESTDIR"/disk-1.img disk1
+    qemu_add_drive disk_index disk_args "$TESTDIR"/disk-2.img disk2
+    qemu_add_drive disk_index disk_args "$TESTDIR"/disk-3.img disk3
 
     test_marker_reset
     "$testdir"/run-qemu \
@@ -51,10 +51,10 @@ test_setup() {
     declare -a disk_args=()
     # shellcheck disable=SC2034
     declare -i disk_index=0
-    qemu_add_drive_args disk_index disk_args "$TESTDIR"/marker.img marker 1
-    qemu_add_drive_args disk_index disk_args "$TESTDIR"/disk-1.img disk1 40
-    qemu_add_drive_args disk_index disk_args "$TESTDIR"/disk-2.img disk2 40
-    qemu_add_drive_args disk_index disk_args "$TESTDIR"/disk-3.img disk3 40
+    qemu_add_drive disk_index disk_args "$TESTDIR"/marker.img marker 1
+    qemu_add_drive disk_index disk_args "$TESTDIR"/disk-1.img disk1 40
+    qemu_add_drive disk_index disk_args "$TESTDIR"/disk-2.img disk2 40
+    qemu_add_drive disk_index disk_args "$TESTDIR"/disk-3.img disk3 40
 
     "$testdir"/run-qemu \
         "${disk_args[@]}" \
@@ -64,7 +64,7 @@ test_setup() {
 
     "$DRACUT" -l -i "$TESTDIR"/overlay / \
         -a "test" \
-        -d "piix ide-gd_mod ata_piix ext4 sd_mod" \
+        -d "piix ide-gd_mod ata_piix ext4" \
         --no-hostonly-cmdline -N \
         -f "$TESTDIR"/initramfs.testing "$KVERSION" || return 1
 }

--- a/test/TEST-12-RAID-DEG/create-root.sh
+++ b/test/TEST-12-RAID-DEG/create-root.sh
@@ -10,7 +10,7 @@ rm -f -- /etc/lvm/lvm.conf
 udevadm control --reload
 udevadm settle
 set -ex
-mdadm --create /dev/md0 --run --auto=yes --level=5 --raid-devices=3 /dev/disk/by-id/ata-disk_raid[123]
+mdadm --create /dev/md0 --run --auto=yes --level=5 --raid-devices=3 /dev/disk/by-id/scsi-0QEMU_QEMU_HARDDISK_raid[123]
 # wait for the array to finish initializing, otherwise this sometimes fails
 # randomly.
 mdadm -W /dev/md0 || :
@@ -42,6 +42,6 @@ eval "$(udevadm info --query=property --name=/dev/md0 | while read -r line || [ 
     echo "dracut-root-block-created"
     echo MD_UUID="$MD_UUID"
     echo "ID_FS_UUID=$ID_FS_UUID"
-} | dd oflag=direct,dsync of=/dev/disk/by-id/ata-disk_marker
+} | dd oflag=direct,dsync of=/dev/disk/by-id/scsi-0QEMU_QEMU_HARDDISK_marker
 sync
 poweroff -f

--- a/test/TEST-12-RAID-DEG/test-init.sh
+++ b/test/TEST-12-RAID-DEG/test-init.sh
@@ -7,7 +7,7 @@ export PATH=/usr/sbin:/usr/bin:/sbin:/bin
 command -v plymouth > /dev/null 2>&1 && plymouth --quit
 exec > /dev/console 2>&1
 
-echo "dracut-root-block-success" | dd oflag=direct,dsync of=/dev/disk/by-id/ata-disk_marker
+echo "dracut-root-block-success" | dd oflag=direct,dsync of=/dev/disk/by-id/scsi-0QEMU_QEMU_HARDDISK_marker
 
 export TERM=linux
 export PS1='initramfs-test:\w\$ '

--- a/test/TEST-12-RAID-DEG/test.sh
+++ b/test/TEST-12-RAID-DEG/test.sh
@@ -12,11 +12,11 @@ client_run() {
     echo "CLIENT TEST START: $*"
     declare -a disk_args=()
     declare -i disk_index=0
-    qemu_add_drive_args disk_index disk_args "$TESTDIR"/marker.img marker
+    qemu_add_drive disk_index disk_args "$TESTDIR"/marker.img marker
     # degrade the RAID
-    # qemu_add_drive_args disk_index disk_args "$TESTDIR"/raid-1.img raid1
-    qemu_add_drive_args disk_index disk_args "$TESTDIR"/raid-2.img raid2
-    qemu_add_drive_args disk_index disk_args "$TESTDIR"/raid-3.img raid3
+    # qemu_add_drive disk_index disk_args "$TESTDIR"/raid-1.img raid1
+    qemu_add_drive disk_index disk_args "$TESTDIR"/raid-2.img raid2
+    qemu_add_drive disk_index disk_args "$TESTDIR"/raid-3.img raid3
 
     test_marker_reset
     "$testdir"/run-qemu \
@@ -81,10 +81,10 @@ test_setup() {
     # Create the blank files to use as a root filesystem
     declare -a disk_args=()
     declare -i disk_index=0
-    qemu_add_drive_args disk_index disk_args "$TESTDIR"/marker.img marker 1
-    qemu_add_drive_args disk_index disk_args "$TESTDIR"/raid-1.img raid1 40
-    qemu_add_drive_args disk_index disk_args "$TESTDIR"/raid-2.img raid2 40
-    qemu_add_drive_args disk_index disk_args "$TESTDIR"/raid-3.img raid3 40
+    qemu_add_drive disk_index disk_args "$TESTDIR"/marker.img marker 1
+    qemu_add_drive disk_index disk_args "$TESTDIR"/raid-1.img raid1 40
+    qemu_add_drive disk_index disk_args "$TESTDIR"/raid-2.img raid2 40
+    qemu_add_drive disk_index disk_args "$TESTDIR"/raid-3.img raid3 40
 
     "$testdir"/run-qemu \
         "${disk_args[@]}" \
@@ -106,7 +106,7 @@ test_setup() {
     "$DRACUT" -l -i "$TESTDIR"/overlay / \
         -o "dbus" \
         -a "test" \
-        -d "piix ide-gd_mod ata_piix ext4 sd_mod" \
+        -d "piix ide-gd_mod ata_piix ext4" \
         -i "./cryptroot-ask.sh" "/sbin/cryptroot-ask" \
         -i "/tmp/mdadm.conf" "/etc/mdadm.conf" \
         -i "/tmp/crypttab" "/etc/crypttab" \

--- a/test/TEST-14-IMSM/create-root.sh
+++ b/test/TEST-14-IMSM/create-root.sh
@@ -12,7 +12,7 @@ udevadm control --reload
 udevadm settle
 
 # dmraid does not want symlinks in --disk "..."
-echo y | dmraid -f isw -C Test0 --type 1 --disk "$(realpath /dev/disk/by-id/ata-disk_disk1) $(realpath /dev/disk/by-id/ata-disk_disk2)"
+echo y | dmraid -f isw -C Test0 --type 1 --disk "$(realpath /dev/disk/by-id/scsi-0QEMU_QEMU_HARDDISK_disk1) $(realpath /dev/disk/by-id/scsi-0QEMU_QEMU_HARDDISK_disk2)"
 udevadm settle
 
 SETS=$(dmraid -c -s)
@@ -72,7 +72,7 @@ echo "MD_UUID=$MD_UUID"
 {
     echo "dracut-root-block-created"
     echo MD_UUID="$MD_UUID"
-} | dd oflag=direct,dsync of=/dev/disk/by-id/ata-disk_marker
+} | dd oflag=direct,dsync of=/dev/disk/by-id/scsi-0QEMU_QEMU_HARDDISK_marker
 mdadm --wait-clean /dev/md0
 sync
 poweroff -f

--- a/test/TEST-14-IMSM/test-init.sh
+++ b/test/TEST-14-IMSM/test-init.sh
@@ -7,7 +7,7 @@ export PATH=/usr/sbin:/usr/bin:/sbin:/bin
 command -v plymouth > /dev/null 2>&1 && plymouth --quit
 exec > /dev/console 2>&1
 
-echo "dracut-root-block-success" | dd oflag=direct,dsync of=/dev/disk/by-id/ata-disk_marker
+echo "dracut-root-block-success" | dd oflag=direct,dsync of=/dev/disk/by-id/scsi-0QEMU_QEMU_HARDDISK_marker
 
 export TERM=linux
 export PS1='initramfs-test:\w\$ '

--- a/test/TEST-14-IMSM/test.sh
+++ b/test/TEST-14-IMSM/test.sh
@@ -11,9 +11,9 @@ client_run() {
 
     declare -a disk_args=()
     declare -i disk_index=0
-    qemu_add_drive_args disk_index disk_args "$TESTDIR"/marker.img marker
-    qemu_add_drive_args disk_index disk_args "$TESTDIR"/disk-1.img disk1
-    qemu_add_drive_args disk_index disk_args "$TESTDIR"/disk-2.img disk2
+    qemu_add_drive disk_index disk_args "$TESTDIR"/marker.img marker
+    qemu_add_drive disk_index disk_args "$TESTDIR"/disk-1.img disk1
+    qemu_add_drive disk_index disk_args "$TESTDIR"/disk-2.img disk2
 
     test_marker_reset
     "$testdir"/run-qemu \
@@ -77,9 +77,9 @@ test_setup() {
     # Create the blank files to use as a root filesystem
     declare -a disk_args=()
     declare -i disk_index=0
-    qemu_add_drive_args disk_index disk_args "$TESTDIR"/marker.img marker 1
-    qemu_add_drive_args disk_index disk_args "$TESTDIR"/disk-1.img disk1 200
-    qemu_add_drive_args disk_index disk_args "$TESTDIR"/disk-2.img disk2 200
+    qemu_add_drive disk_index disk_args "$TESTDIR"/marker.img marker 1
+    qemu_add_drive disk_index disk_args "$TESTDIR"/disk-1.img disk1 200
+    qemu_add_drive disk_index disk_args "$TESTDIR"/disk-2.img disk2 200
 
     # Invoke KVM and/or QEMU to actually create the target filesystem.
     "$testdir"/run-qemu \
@@ -97,7 +97,7 @@ test_setup() {
     echo "$MD_UUID" > "$TESTDIR"/mduuid
     "$DRACUT" -l -i "$TESTDIR"/overlay / \
         -a "test" \
-        -d "piix ide-gd_mod ata_piix ext4 sd_mod" \
+        -d "piix ide-gd_mod ata_piix ext4" \
         --no-hostonly-cmdline -N \
         -f "$TESTDIR"/initramfs.testing "$KVERSION" || return 1
 }

--- a/test/TEST-15-BTRFSRAID/create-root.sh
+++ b/test/TEST-15-BTRFSRAID/create-root.sh
@@ -12,17 +12,17 @@ udevadm settle
 
 set -e
 
-mkfs.btrfs -draid10 -mraid10 -L root /dev/disk/by-id/ata-disk_raid[1234]
+mkfs.btrfs -draid10 -mraid10 -L root /dev/disk/by-id/scsi-0QEMU_QEMU_HARDDISK_raid[1234]
 udevadm settle
 
 btrfs device scan
 udevadm settle
 
 mkdir -p /sysroot
-mount -t btrfs /dev/disk/by-id/ata-disk_raid4 /sysroot
+mount -t btrfs /dev/disk/by-id/scsi-0QEMU_QEMU_HARDDISK_raid4 /sysroot
 cp -a -t /sysroot /source/*
 umount /sysroot
 
-echo "dracut-root-block-created" | dd oflag=direct,dsync of=/dev/disk/by-id/ata-disk_marker
+echo "dracut-root-block-created" | dd oflag=direct,dsync of=/dev/disk/by-id/scsi-0QEMU_QEMU_HARDDISK_marker
 sync
 poweroff -f

--- a/test/TEST-15-BTRFSRAID/test-init.sh
+++ b/test/TEST-15-BTRFSRAID/test-init.sh
@@ -7,7 +7,7 @@ export PATH=/usr/sbin:/usr/bin:/sbin:/bin
 command -v plymouth > /dev/null 2>&1 && plymouth --quit
 exec > /dev/console 2>&1
 
-echo "dracut-root-block-success" | dd oflag=direct,dsync of=/dev/disk/by-id/ata-disk_marker
+echo "dracut-root-block-success" | dd oflag=direct,dsync of=/dev/disk/by-id/scsi-0QEMU_QEMU_HARDDISK_marker
 
 export TERM=linux
 export PS1='initramfs-test:\w\$ '

--- a/test/TEST-15-BTRFSRAID/test.sh
+++ b/test/TEST-15-BTRFSRAID/test.sh
@@ -7,11 +7,11 @@ TEST_DESCRIPTION="root filesystem on multiple device btrfs"
 test_run() {
     declare -a disk_args=()
     declare -i disk_index=0
-    qemu_add_drive_args disk_index disk_args "$TESTDIR"/marker.img marker
-    qemu_add_drive_args disk_index disk_args "$TESTDIR"/raid-1.img raid1
-    qemu_add_drive_args disk_index disk_args "$TESTDIR"/raid-2.img raid2
-    qemu_add_drive_args disk_index disk_args "$TESTDIR"/raid-3.img raid3
-    qemu_add_drive_args disk_index disk_args "$TESTDIR"/raid-4.img raid4
+    qemu_add_drive disk_index disk_args "$TESTDIR"/marker.img marker
+    qemu_add_drive disk_index disk_args "$TESTDIR"/raid-1.img raid1
+    qemu_add_drive disk_index disk_args "$TESTDIR"/raid-2.img raid2
+    qemu_add_drive disk_index disk_args "$TESTDIR"/raid-3.img raid3
+    qemu_add_drive disk_index disk_args "$TESTDIR"/raid-4.img raid4
 
     test_marker_reset
     "$testdir"/run-qemu \
@@ -55,11 +55,11 @@ test_setup() {
     declare -a disk_args=()
     # shellcheck disable=SC2034
     declare -i disk_index=0
-    qemu_add_drive_args disk_index disk_args "$TESTDIR"/marker.img marker 1
-    qemu_add_drive_args disk_index disk_args "$TESTDIR"/raid-1.img raid1 150
-    qemu_add_drive_args disk_index disk_args "$TESTDIR"/raid-2.img raid2 150
-    qemu_add_drive_args disk_index disk_args "$TESTDIR"/raid-3.img raid3 150
-    qemu_add_drive_args disk_index disk_args "$TESTDIR"/raid-4.img raid4 150
+    qemu_add_drive disk_index disk_args "$TESTDIR"/marker.img marker 1
+    qemu_add_drive disk_index disk_args "$TESTDIR"/raid-1.img raid1 150
+    qemu_add_drive disk_index disk_args "$TESTDIR"/raid-2.img raid2 150
+    qemu_add_drive disk_index disk_args "$TESTDIR"/raid-3.img raid3 150
+    qemu_add_drive disk_index disk_args "$TESTDIR"/raid-4.img raid4 150
 
     "$testdir"/run-qemu \
         "${disk_args[@]}" \
@@ -70,7 +70,7 @@ test_setup() {
 
     "$DRACUT" -l -i "$TESTDIR"/overlay / \
         -a "test" \
-        -d "piix ide-gd_mod ata_piix btrfs sd_mod" \
+        -d "piix ide-gd_mod ata_piix btrfs" \
         --no-hostonly-cmdline -N \
         -f "$TESTDIR"/initramfs.testing "$KVERSION" || return 1
 }

--- a/test/TEST-16-DMSQUASH/create-root.sh
+++ b/test/TEST-16-DMSQUASH/create-root.sh
@@ -13,29 +13,29 @@ set -e
 udevadm settle
 
 # create a single partition using 50% of the capacity of the image file created by test_setup() in test.sh
-sfdisk /dev/disk/by-id/ata-disk_root << EOF
+sfdisk /dev/disk/by-id/scsi-0QEMU_QEMU_HARDDISK_root << EOF
 2048,161792
 EOF
 
 udevadm settle
 
-mkfs.ext4 -q -L dracut /dev/disk/by-id/ata-disk_root-part1
+mkfs.ext4 -q -L dracut /dev/disk/by-id/scsi-0QEMU_QEMU_HARDDISK_root-part1
 mkdir -p /root
-mount -t ext4 /dev/disk/by-id/ata-disk_root-part1 /root
+mount -t ext4 /dev/disk/by-id/scsi-0QEMU_QEMU_HARDDISK_root-part1 /root
 mkdir -p /root/run /root/testdir
 cp -a -t /root /source/*
 echo "Creating squashfs"
 mksquashfs /source /root/testdir/rootfs.img -quiet
 
 # Copy rootfs.img to the NTFS drive if exists
-if [ -e "/dev/disk/by-id/ata-disk_root_ntfs" ]; then
-    mkfs.ntfs -F -L dracut_ntfs /dev/disk/by-id/ata-disk_root_ntfs
+if [ -e "/dev/disk/by-id/scsi-0QEMU_QEMU_HARDDISK_root_ntfs" ]; then
+    mkfs.ntfs -F -L dracut_ntfs /dev/disk/by-id/scsi-0QEMU_QEMU_HARDDISK_root_ntfs
     mkdir -p /root_ntfs
-    mount -t ntfs3 /dev/disk/by-id/ata-disk_root_ntfs /root_ntfs
+    mount -t ntfs3 /dev/disk/by-id/scsi-0QEMU_QEMU_HARDDISK_root_ntfs /root_ntfs
     mkdir -p /root_ntfs/run /root_ntfs/testdir
     cp /root/testdir/rootfs.img /root_ntfs/testdir/rootfs.img
 fi
 
 umount /root
-echo "dracut-root-block-created" | dd oflag=direct,dsync of=/dev/disk/by-id/ata-disk_marker
+echo "dracut-root-block-created" | dd oflag=direct,dsync of=/dev/disk/by-id/scsi-0QEMU_QEMU_HARDDISK_marker
 poweroff -f

--- a/test/TEST-16-DMSQUASH/test-init.sh
+++ b/test/TEST-16-DMSQUASH/test-init.sh
@@ -7,7 +7,7 @@ export PATH=/usr/sbin:/usr/bin:/sbin:/bin
 command -v plymouth > /dev/null 2>&1 && plymouth --quit
 exec > /dev/console 2>&1
 
-echo "dracut-root-block-success" | dd oflag=direct,dsync of=/dev/disk/by-id/ata-disk_marker
+echo "dracut-root-block-success" | dd oflag=direct,dsync of=/dev/disk/by-id/scsi-0QEMU_QEMU_HARDDISK_marker
 
 if grep -qF ' rd.live.overlay=LABEL=persist ' /proc/cmdline; then
     # Writing to a file in the root filesystem lets test_run() verify that the autooverlay module successfully created

--- a/test/TEST-16-DMSQUASH/test.sh
+++ b/test/TEST-16-DMSQUASH/test.sh
@@ -9,12 +9,12 @@ TEST_DESCRIPTION="live root on a squash filesystem"
 test_run() {
     declare -a disk_args=()
     declare -i disk_index=0
-    qemu_add_drive_args disk_index disk_args "$TESTDIR"/marker.img marker
-    qemu_add_drive_args disk_index disk_args "$TESTDIR"/root.img root
+    qemu_add_drive disk_index disk_args "$TESTDIR"/marker.img marker
+    qemu_add_drive disk_index disk_args "$TESTDIR"/root.img root
 
     # NTFS drive
     if modprobe --dry-run ntfs3 &> /dev/null && command -v mkfs.ntfs &> /dev/null; then
-        qemu_add_drive_args disk_index disk_args "$TESTDIR"/root_ntfs.img root_ntfs
+        qemu_add_drive disk_index disk_args "$TESTDIR"/root_ntfs.img root_ntfs
     fi
 
     test_marker_reset
@@ -106,13 +106,13 @@ test_setup() {
     # Create the blank file to use as a root filesystem
     declare -a disk_args=()
     declare -i disk_index=0
-    qemu_add_drive_args disk_index disk_args "$TESTDIR"/marker.img marker 1
-    qemu_add_drive_args disk_index disk_args "$TESTDIR"/root.img root 160
+    qemu_add_drive disk_index disk_args "$TESTDIR"/marker.img marker 1
+    qemu_add_drive disk_index disk_args "$TESTDIR"/root.img root 160
 
     # NTFS drive
     if modprobe --dry-run ntfs3 &> /dev/null && command -v mkfs.ntfs &> /dev/null; then
         dd if=/dev/zero of="$TESTDIR"/root_ntfs.img bs=1MiB count=160
-        qemu_add_drive_args disk_index disk_args "$TESTDIR"/root_ntfs.img root_ntfs
+        qemu_add_drive disk_index disk_args "$TESTDIR"/root_ntfs.img root_ntfs
     fi
 
     # Invoke KVM and/or QEMU to actually create the target filesystem.
@@ -141,7 +141,7 @@ EOF
 
     "$DRACUT" -l -i "$TESTDIR"/overlay / \
         --modules "test dmsquash-live-autooverlay qemu" \
-        --drivers "ext4 sd_mod" \
+        --drivers "ext4" \
         --install "mkfs.ext4" \
         --no-hostonly --no-hostonly-cmdline \
         --force "$TESTDIR"/initramfs.testing-autooverlay "$KVERSION" || return 1

--- a/test/TEST-18-UEFI/test-init.sh
+++ b/test/TEST-18-UEFI/test-init.sh
@@ -19,5 +19,5 @@ grep -q '^tmpfs /run tmpfs' /proc/self/mounts \
 exec > /dev/console 2>&1
 
 echo "made it to the rootfs! Powering down."
-echo "dracut-root-block-success" | dd oflag=direct,dsync of=/dev/disk/by-id/ata-disk_marker
+echo "dracut-root-block-success" | dd oflag=direct,dsync of=/dev/disk/by-id/scsi-0QEMU_QEMU_HARDDISK_marker
 poweroff -f

--- a/test/TEST-18-UEFI/test.sh
+++ b/test/TEST-18-UEFI/test.sh
@@ -49,8 +49,8 @@ test_dracut() {
 test_run() {
     declare -a disk_args=()
     declare -i disk_index=1
-    qemu_add_drive_args disk_index disk_args "$TESTDIR"/marker.img marker
-    qemu_add_drive_args disk_index disk_args "$TESTDIR"/squashfs.img root
+    qemu_add_drive disk_index disk_args "$TESTDIR"/marker.img marker
+    qemu_add_drive disk_index disk_args "$TESTDIR"/squashfs.img root
 
     test_marker_reset
     "$testdir"/run-qemu "${disk_args[@]}" -net none \
@@ -78,8 +78,8 @@ test_setup() {
     mkdir -p "$TESTDIR"/ESP/EFI/BOOT
     test_dracut \
         --modules 'rootfs-block test' \
-        --kernel-cmdline 'root=/dev/disk/by-id/ata-disk_root ro rd.skipfsck rootfstype=squashfs' \
-        --drivers 'ahci sd_mod squashfs' \
+        --kernel-cmdline 'root=/dev/disk/by-id/scsi-0QEMU_QEMU_HARDDISK_root ro rd.skipfsck rootfstype=squashfs' \
+        --drivers 'squashfs' \
         --uefi \
         "$TESTDIR"/ESP/EFI/BOOT/BOOTX64.efi
 }

--- a/test/test-functions
+++ b/test/test-functions
@@ -52,9 +52,30 @@ COLOR_FAILURE='\033[0;31m'
 COLOR_WARNING='\033[0;33m'
 COLOR_NORMAL='\033[0;39m'
 
+# obsolete - use qemu_add_drive
+qemu_add_drive_args() {
+    local index=${!1}
+    local file=$3
+    local name=${4:-$index}
+    local size=${5:-0}
+    local bootindex=$6
+
+    if [ "${size}" -ne 0 ]; then
+        dd if=/dev/zero of="${file}" bs=1MiB count="${size}"
+    fi
+
+    eval "${2}"'+=(' \
+        -drive "if=none,format=raw,file=${file},id=drive-sata${index}" \
+        -device "ide-hd,bus=ide.${index},drive=drive-sata${index},id=sata${index},${bootindex:+bootindex=$bootindex,}model=disk,serial=${name}" \
+        ')'
+
+    # shellcheck disable=SC2219
+    let "${1}++"
+}
+
 # generate qemu arguments for named raw disks
 #
-# qemu_add_drive_args <index> <args> <filename> <id-name> [<bootindex>]
+# qemu_add_drive <index> <args> <filename> <id-name> [<bootindex>]
 #
 # index: name of the index variable (set to 0 at start)
 # args: name of the argument array variable (set to () at start)
@@ -72,13 +93,13 @@ COLOR_NORMAL='\033[0;39m'
 # ```
 #   declare -a disk_args=()
 #   declare -i disk_index=0
-#   qemu_add_drive_args disk_index disk_args "$TESTDIR"/root.ext3 root 0 1
-#   qemu_add_drive_args disk_index disk_args "$TESTDIR"/client.img client
-#   qemu_add_drive_args disk_index disk_args "$TESTDIR"/iscsidisk2.img iscsidisk2
-#   qemu_add_drive_args disk_index disk_args "$TESTDIR"/iscsidisk3.img iscsidisk3
+#   qemu_add_drive disk_index disk_args "$TESTDIR"/root.ext3 root 0 1
+#   qemu_add_drive disk_index disk_args "$TESTDIR"/client.img client
+#   qemu_add_drive disk_index disk_args "$TESTDIR"/iscsidisk2.img iscsidisk2
+#   qemu_add_drive disk_index disk_args "$TESTDIR"/iscsidisk3.img iscsidisk3
 #   qemu "${disk_args[@]}"
 # ```
-qemu_add_drive_args() {
+qemu_add_drive() {
     local index=${!1}
     local file=$3
     local name=${4:-$index}
@@ -90,8 +111,9 @@ qemu_add_drive_args() {
     fi
 
     eval "${2}"'+=(' \
-        -drive "if=none,format=raw,file=${file},id=drive-sata${index}" \
-        -device "ide-hd,bus=ide.${index},drive=drive-sata${index},id=sata${index},${bootindex:+bootindex=$bootindex,}model=disk,serial=${name}" \
+        -device "virtio-scsi-pci,id=scsi${index}" \
+        -drive "if=none,format=raw,file=${file},id=drive-data${index}" \
+        -device "scsi-hd,bus=scsi${index}.0,drive=drive-data${index},id=data${index},${bootindex:+bootindex=$bootindex,}serial=${name}" \
         ')'
 
     # shellcheck disable=SC2219


### PR DESCRIPTION
## Changes

The IDE device needs to be replaced by virtio for arm64 support. See dracutdevs/dracut#2493  and https://github.com/dracut-ng/dracut-ng/pull/169 .

Once one test is working reliably, will migrate more tests.  Once migration is finished, remove the obsolete qemu_add_drive_args function.

## Checklist
- [X] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it
