### PR TITLE
perf(systemd): remove duplicate rules

### DIFF
--- a/modules.d/00systemd/module-setup.sh
+++ b/modules.d/00systemd/module-setup.sh
@@ -23,8 +23,6 @@ installkernel() {
 
 # called by dracut
 install() {
-    local _mods
-
     if [[ $prefix == /run/* ]]; then
         dfatal 'systemd does not work with a prefix, which contains "/run"!!'
         exit 1
@@ -39,9 +37,6 @@ install() {
         "$systemdutildir"/systemd-reply-password \
         "$systemdutildir"/systemd-fsck \
         "$systemdutildir"/systemd-udevd \
-        "$systemdutildir"/systemd-journald \
-        "$systemdutildir"/systemd-sysctl \
-        "$systemdutildir"/systemd-modules-load \
         "$systemdutildir"/systemd-vconsole-setup \
         "$systemdutildir"/systemd-volatile-root \
         "$systemdutildir"/systemd-sysroot-fstab-check \
@@ -82,17 +77,8 @@ install() {
         "$systemdsystemunitdir"/sys-kernel-config.mount \
         "$systemdsystemunitdir"/modprobe@.service \
         "$systemdsystemunitdir"/kmod-static-nodes.service \
-        "$systemdsystemunitdir"/systemd-tmpfiles-setup.service \
-        "$systemdsystemunitdir"/systemd-tmpfiles-setup-dev.service \
-        "$systemdsystemunitdir"/systemd-tmpfiles-setup-dev-early.service \
-        "$systemdsystemunitdir"/systemd-ask-password-console.path \
         "$systemdsystemunitdir"/systemd-udevd-control.socket \
         "$systemdsystemunitdir"/systemd-udevd-kernel.socket \
-        "$systemdsystemunitdir"/systemd-ask-password-plymouth.path \
-        "$systemdsystemunitdir"/systemd-journald.socket \
-        "$systemdsystemunitdir"/systemd-journald-audit.socket \
-        "$systemdsystemunitdir"/systemd-ask-password-console.service \
-        "$systemdsystemunitdir"/systemd-modules-load.service \
         "$systemdsystemunitdir"/systemd-halt.service \
         "$systemdsystemunitdir"/systemd-poweroff.service \
         "$systemdsystemunitdir"/systemd-reboot.service \
@@ -101,70 +87,28 @@ install() {
         "$systemdsystemunitdir"/systemd-udevd.service \
         "$systemdsystemunitdir"/systemd-udev-trigger.service \
         "$systemdsystemunitdir"/systemd-udev-settle.service \
-        "$systemdsystemunitdir"/systemd-ask-password-plymouth.service \
-        "$systemdsystemunitdir"/systemd-journald.service \
         "$systemdsystemunitdir"/systemd-vconsole-setup.service \
         "$systemdsystemunitdir"/systemd-volatile-root.service \
-        "$systemdsystemunitdir"/systemd-sysctl.service \
-        "$systemdsystemunitdir"/sysinit.target.wants/systemd-modules-load.service \
-        "$systemdsystemunitdir"/sysinit.target.wants/systemd-ask-password-console.path \
-        "$systemdsystemunitdir"/sysinit.target.wants/systemd-journald.service \
         "$systemdsystemunitdir"/sockets.target.wants/systemd-udevd-control.socket \
         "$systemdsystemunitdir"/sockets.target.wants/systemd-udevd-kernel.socket \
-        "$systemdsystemunitdir"/sockets.target.wants/systemd-journald.socket \
-        "$systemdsystemunitdir"/sockets.target.wants/systemd-journald-audit.socket \
-        "$systemdsystemunitdir"/sockets.target.wants/systemd-journald-dev-log.socket \
         "$systemdsystemunitdir"/sysinit.target.wants/systemd-udevd.service \
         "$systemdsystemunitdir"/sysinit.target.wants/systemd-udev-trigger.service \
         "$systemdsystemunitdir"/sysinit.target.wants/kmod-static-nodes.service \
-        "$systemdsystemunitdir"/sysinit.target.wants/systemd-tmpfiles-setup.service \
-        "$systemdsystemunitdir"/sysinit.target.wants/systemd-tmpfiles-setup-dev.service \
-        "$systemdsystemunitdir"/sysinit.target.wants/systemd-tmpfiles-setup-dev-early.service \
-        "$systemdsystemunitdir"/sysinit.target.wants/systemd-sysctl.service \
         "$systemdsystemunitdir"/ctrl-alt-del.target \
         "$systemdsystemunitdir"/syslog.socket \
         "$systemdsystemunitdir"/slices.target \
         "$systemdsystemunitdir"/system.slice \
         "$systemdsystemunitdir"/-.slice \
-        "$tmpfilesdir"/systemd.conf \
-        journalctl systemctl \
+        systemctl \
         echo swapoff \
         kmod insmod rmmod modprobe modinfo depmod lsmod \
         mount umount reboot poweroff \
         systemd-run systemd-escape \
-        systemd-cgls systemd-tmpfiles \
-        systemd-ask-password systemd-tty-ask-password-agent \
+        systemd-cgls \
         /etc/udev/udev.hwdb
-
-    inst_multiple -o \
-        /usr/lib/modules-load.d/*.conf \
-        /usr/lib/sysctl.d/*.conf
-
-    modules_load_get() {
-        local _line i
-        for i in "$dracutsysrootdir$1"/*.conf; do
-            [[ -f $i ]] || continue
-            while read -r _line || [ -n "$_line" ]; do
-                case $_line in
-                    \#*) ;;
-
-                    \;*) ;;
-
-                    *)
-                        echo "$_line"
-                        ;;
-                esac
-            done < "$i"
-        done
-    }
-
-    mapfile -t _mods < <(modules_load_get /usr/lib/modules-load.d)
-    [[ ${#_mods[@]} -gt 0 ]] && hostonly='' instmods "${_mods[@]}"
 
     if [[ $hostonly ]]; then
         inst_multiple -H -o \
-            /etc/systemd/journald.conf \
-            /etc/systemd/journald.conf.d/*.conf \
             /etc/systemd/system.conf \
             /etc/systemd/system.conf.d/*.conf \
             "$systemdsystemconfdir"/modprobe@.service \
@@ -176,13 +120,7 @@ install() {
             /etc/machine-info \
             /etc/vconsole.conf \
             /etc/locale.conf \
-            /etc/modules-load.d/*.conf \
-            /etc/sysctl.d/*.conf \
-            /etc/sysctl.conf \
             /etc/udev/udev.conf
-
-        mapfile -t _mods < <(modules_load_get /etc/modules-load.d)
-        [[ ${#_mods[@]} -gt 0 ]] && hostonly='' instmods "${_mods[@]}"
     fi
 
     if ! [[ -e "$initdir/etc/machine-id" ]]; then
@@ -190,17 +128,14 @@ install() {
         chmod 444 "$initdir/etc/machine-id"
     fi
 
-    # install adm user/group for journald
     inst_multiple nologin
     {
-        grep '^systemd-journal:' "$dracutsysrootdir"/etc/passwd 2> /dev/null
         grep '^adm:' "$dracutsysrootdir"/etc/passwd 2> /dev/null
         # we don't use systemd-networkd, but the user is in systemd.conf tmpfiles snippet
         grep '^systemd-network:' "$dracutsysrootdir"/etc/passwd 2> /dev/null
     } >> "$initdir/etc/passwd"
 
     {
-        grep '^systemd-journal:' "$dracutsysrootdir"/etc/group 2> /dev/null
         grep '^wheel:' "$dracutsysrootdir"/etc/group 2> /dev/null
         grep '^adm:' "$dracutsysrootdir"/etc/group 2> /dev/null
         grep '^utmp:' "$dracutsysrootdir"/etc/group 2> /dev/null
@@ -239,21 +174,12 @@ EOF
 
     for i in \
         emergency.target \
-        rescue.target \
-        systemd-ask-password-console.service \
-        systemd-ask-password-plymouth.service; do
+        rescue.target; do
         [[ -f "$systemdsystemunitdir"/$i ]] || continue
         $SYSTEMCTL -q --root "$initdir" add-wants "$i" systemd-vconsole-setup.service
     done
 
     mkdir -p "$initdir/etc/systemd"
-    # We must use a volatile journal, and we don't want rate-limiting
-    {
-        echo "[Journal]"
-        echo "Storage=volatile"
-        echo "RateLimitInterval=0"
-        echo "RateLimitBurst=0"
-    } >> "$initdir/etc/systemd/journald.conf"
 
     $SYSTEMCTL -q --root "$initdir" set-default multi-user.target
 

--- a/modules.d/01systemd-ask-password/module-setup.sh
+++ b/modules.d/01systemd-ask-password/module-setup.sh
@@ -35,6 +35,10 @@ install() {
         systemd-ask-password \
         systemd-tty-ask-password-agent
 
+    if [ -e "$systemdsystemunitdir"/systemd-vconsole-setup.service ]; then
+        $SYSTEMCTL -q --root "$initdir" add-wants systemd-ask-password-console.service systemd-vconsole-setup.service
+    fi
+
     # Enable the systemd type service unit for systemd-ask-password.
     $SYSTEMCTL -q --root "$initdir" enable systemd-ask-password-console.service
 
@@ -43,6 +47,10 @@ install() {
         inst_multiple -o \
             "$systemdsystemunitdir"/systemd-ask-password-plymouth.path \
             "$systemdsystemunitdir"/systemd-ask-password-plymouth.service
+
+        if [ -e "$systemdsystemunitdir"/systemd-vconsole-setup.service ]; then
+            $SYSTEMCTL -q --root "$initdir" add-wants systemd-ask-password-plymouth.service systemd-vconsole-setup.service
+        fi
 
         $SYSTEMCTL -q --root "$initdir" enable systemd-ask-password-plymouth.service
     fi

--- a/modules.d/01systemd-initrd/module-setup.sh
+++ b/modules.d/01systemd-initrd/module-setup.sh
@@ -10,7 +10,7 @@ check() {
 
 # called by dracut
 depends() {
-    echo systemd-udevd
+    echo systemd-udevd systemd-journald systemd-tmpfiles
 }
 
 installkernel() {

--- a/modules.d/01systemd-modules-load/module-setup.sh
+++ b/modules.d/01systemd-modules-load/module-setup.sh
@@ -21,6 +21,43 @@ depends() {
 
 }
 
+# Install kernel module(s).
+installkernel() {
+    local _mods
+
+    modules_load_get() {
+        local _line _i
+        for _i in "$dracutsysrootdir$1"/*.conf; do
+            [[ -f $_i ]] || continue
+            while read -r _line || [ -n "$_line" ]; do
+                case $_line in
+                    \#*) ;;
+
+                    \;*) ;;
+
+                    *)
+                        echo "$_line"
+                        ;;
+                esac
+            done < "$_i"
+        done
+    }
+
+    mapfile -t _mods < <(modules_load_get "$modulesload")
+    if [[ ${#_mods[@]} -gt 0 ]]; then
+        hostonly='' instmods "${_mods[@]}"
+    fi
+
+    if [[ $hostonly ]]; then
+        mapfile -t _mods < <(modules_load_get "$modulesloadconfdir")
+        if [[ ${#_mods[@]} -gt 0 ]]; then
+            hostonly='' instmods "${_mods[@]}"
+        fi
+    fi
+
+    return 0
+}
+
 # Install the required file(s) and directories for the module in the initramfs.
 install() {
 


### PR DESCRIPTION
## Changes

Add systemd-journald systemd-tmpfiles as dependencies for dracut-systemd modules as the services installed by dracut-systemd module depends on them directly.
    
Largely based on https://github.com/dracut-ng/dracut-ng/pull/181 with improved dracut module dependencies.

One change introduced by this PR is that systemd-ask-password dracut module will be only installed by the crypt dracut module.

The systemd dracut module no longer installs systemd-ask-password.

If this is a concern, let's discuss.

## Checklist
- [X] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it


