### PR TITLE
ci: enable Fedora for arm64

### DIFF
--- a/.github/workflows/container.yml
+++ b/.github/workflows/container.yml
@@ -29,7 +29,7 @@ jobs:
             fail-fast: false
             matrix:
                 config:
-                    - { dockerfile: 'Dockerfile-Fedora-latest',     tag: 'fedora:latest',     platform: 'linux/amd64' }
+                    - { dockerfile: 'Dockerfile-Fedora-latest',     tag: 'fedora:latest',     platform: 'linux/arm64,linux/amd64' }
                     - { dockerfile: 'Dockerfile-OpenSuse-latest',   tag: 'opensuse:latest',   platform: 'linux/amd64' }
                     - { dockerfile: 'Dockerfile-Arch',              tag: 'arch:latest',       platform: 'linux/amd64' }
                     - { dockerfile: 'Dockerfile-Debian',            tag: 'debian:latest',     platform: 'linux/arm64,linux/amd64' }

--- a/test/container/Dockerfile-Fedora-latest
+++ b/test/container/Dockerfile-Fedora-latest
@@ -5,7 +5,6 @@ RUN dnf -y install --setopt=install_weak_deps=False \
     asciidoc \
     astyle \
     bash-completion \
-    biosdevname \
     bluez \
     btrfs-progs \
     busybox \
@@ -50,7 +49,7 @@ RUN dnf -y install --setopt=install_weak_deps=False \
     parted \
     pcsc-lite \
     pigz \
-    qemu-system-x86-core \
+    qemu \
     qrencode \
     rng-tools \
     rpm-build \


### PR DESCRIPTION
biosdevname is not available on arm64, remove it form the container as it is not essential for testing.

install qemu instead of qemu-system-x86-core.

## Checklist
- [x] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it
