### PR TITLE
fix(systemd-networkd): dbus is not a mandatory dependency

### DIFF
--- a/modules.d/01systemd-networkd/module-setup.sh
+++ b/modules.d/01systemd-networkd/module-setup.sh
@@ -22,7 +22,7 @@ check() {
 depends() {
 
     # This module has external dependency on other module(s).
-    echo dbus kernel-network-modules systemd-sysusers
+    echo kernel-network-modules systemd-sysusers
     # Return 0 to include the dependent module(s) in the initramfs.
     return 0
 


### PR DESCRIPTION
## Changes

systemd-networkd does not require dbus, see https://github.com/dracutdevs/dracut/issues/2378#issuecomment-1668136681 .

Now that the project has a systemd-networkd [test case](https://github.com/dracut-ng/dracut-ng/pull/147), it is observable that dropping dbus from the generated initrd does not break the test case.

## Checklist
- [x] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it

Fixes (partially): #60 https://github.com/dracutdevs/dracut/issues/2378
