### PR TITLE
ci: add (back) gentoo to run the extended testsuite

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -141,6 +141,7 @@ jobs:
                         "arch",
                         "debian",
                         "fedora",
+                        "gentoo",
                         "ubuntu",
                 ]
                 test: [


### PR DESCRIPTION
## Changes

After https://github.com/dracut-ng/dracut-ng/pull/201 gentoo container is now passing all the extended tests.

## Checklist
- [X] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it

