### PR TITLE
fix(cpio): eliminate compile time warning      

### DIFF
--- a/src/dracut-cpio/src/main.rs
+++ b/src/dracut-cpio/src/main.rs
@@ -286,7 +286,7 @@ fn archive_path<W: Seek + Write>(
     mut writer: W,
 ) -> std::io::Result<()> {
     let inpath = path;
-    let mut outpath = path.clone();
+    let mut outpath = path;
     let mut datalen: u32 = 0;
     let mut rmajor: u32 = 0;
     let mut rminor: u32 = 0;


### PR DESCRIPTION
Building dracut-cpio gives the following warning

```
2024-04-22T15:51:17.1254236Z    Compiling dracut-cpio v0.1.0 (/__w/dracut-ng/dracut-ng/src/dracut-cpio)
2024-04-22T15:51:17.2454252Z warning: call to `.clone()` on a reference in this situation does nothing
2024-04-22T15:51:17.2455792Z    --> src/main.rs:289:27
2024-04-22T15:51:17.2456392Z     |
2024-04-22T15:51:17.2456871Z 289 |     let mut outpath = path.clone();
2024-04-22T15:51:17.2457815Z     |                           ^^^^^^^^ help: remove this redundant call
2024-04-22T15:51:17.2458601Z     |
2024-04-22T15:51:17.2459868Z     = note: the type `Path` does not implement `Clone`, so calling `clone` on `&Path` copies the reference, which does not do anything and can be removed
2024-04-22T15:51:17.2461595Z     = note: `#[warn(noop_method_call)]` on by default
2024-04-22T15:51:17.2462221Z 
2024-04-22T15:51:17.3203460Z cc  -o src/install/dracut-install src/install/dracut-install.o src/install/hashmap.o src/install/log.o src/install/strv.o src/install/util.o  -lc -lkmod
2024-04-22T15:51:17.3782465Z ln -fs src/install/dracut-install dracut-install
2024-04-22T15:51:18.3521896Z warning: `dracut-cpio` (bin "dracut-cpio") generated 1 warning (run `cargo fix --bin "dracut-cpio"` to apply 1 suggestion)
2024-04-22T15:51:18.3522923Z     Finished release [optimized] target(s) in 1.43s
```


## Changes

run `cargo fix --bin "dracut-cpio"`




## Checklist
- [X] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it

CC @ddiss 