### PR TITLE
fix: clean Makefile rule

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -228,7 +228,7 @@ clean:
 	$(RM) dracut-install src/install/dracut-install $(DRACUT_INSTALL_OBJECTS)
 	$(RM) skipcpio/skipcpio $(SKIPCPIO_OBJECTS)
 	$(RM) dracut-util util/util $(UTIL_OBJECTS)
-	$(RM) $(manpages) dracut.html
+	$(RM) $(manpages)
 	$(RM) dracut.pc
 	$(RM) dracut-cpio src/dracut-cpio/target/release/dracut-cpio*
 	$(MAKE) -C test clean


### PR DESCRIPTION
## Changes

dracut.html is now checked in, 'make clean' should no longer remove it

Follow-up fix to https://github.com/dracut-ng/dracut-ng/pull/104

## Checklist
- [X] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it
