### PR TITLE
fix: network-manager should include kernel-network-modules

### DIFF
--- a/modules.d/35connman/module-setup.sh
+++ b/modules.d/35connman/module-setup.sh
@@ -10,7 +10,7 @@ check() {
 
 # called by dracut
 depends() {
-    echo dbus systemd bash net-lib
+    echo dbus systemd bash net-lib kernel-network-modules
     return 0
 }
 

--- a/modules.d/35network-legacy/module-setup.sh
+++ b/modules.d/35network-legacy/module-setup.sh
@@ -10,7 +10,7 @@ check() {
 
 # called by dracut
 depends() {
-    echo net-lib
+    echo net-lib kernel-network-modules
     return 0
 }
 

--- a/modules.d/35network-manager/module-setup.sh
+++ b/modules.d/35network-manager/module-setup.sh
@@ -10,7 +10,7 @@ check() {
 
 # called by dracut
 depends() {
-    echo dbus bash net-lib
+    echo dbus bash net-lib kernel-network-modules
     return 0
 }
 


### PR DESCRIPTION
## Changes

The systemd-networkd module already [includes](https://github.com/dracut-ng/dracut-ng/blob/main/modules.d/01systemd-networkd/module-setup.sh#L25) kernel-network-modules. Do the same for other networking related dracut modules.

## Checklist
- [X] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it
