### PR TITLE
ci: add more packages to Debian and Ubuntu container to enable more testing

### DIFF
--- a/test/container/Dockerfile-Debian
+++ b/test/container/Dockerfile-Debian
@@ -7,6 +7,7 @@ RUN apt-get update -y -qq && apt-get upgrade -y -qq && apt-get install -y -qq --
     DEBIAN_FRONTEND=noninteractive apt-get install -y -qq --no-install-recommends -o Dpkg::Use-Pty=0 \
     asciidoc \
     astyle \
+    bluez \
     btrfs-progs \
     busybox-static \
     bzip2 \
@@ -28,6 +29,7 @@ RUN apt-get update -y -qq && apt-get upgrade -y -qq && apt-get install -y -qq --
     iputils-ping \
     isc-dhcp-client \
     isc-dhcp-server \
+    iscsiuio \
     kmod \
     less \
     libdmraid-dev \

--- a/test/container/Dockerfile-Ubuntu
+++ b/test/container/Dockerfile-Ubuntu
@@ -6,6 +6,7 @@ RUN apt-get update -y -qq && apt-get upgrade -y -qq && \
     DEBIAN_FRONTEND=noninteractive apt-get install -y -qq --no-install-recommends -o Dpkg::Use-Pty=0 \
     asciidoc \
     astyle \
+    bluez \
     btrfs-progs \
     busybox-static \
     bzip2 \
@@ -27,6 +28,7 @@ RUN apt-get update -y -qq && apt-get upgrade -y -qq && \
     iputils-ping \
     isc-dhcp-client \
     isc-dhcp-server \
+    iscsiuio \
     kmod \
     less \
     libdmraid-dev \


### PR DESCRIPTION
## Changes

`bluez` is required to test `bluetooth` dracut module.
`iscsiuio` is required to test `iscsi` dracut module.

## Checklist
- [X] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it
