### PR TITLE
fix(multipath): explicitly check if `hostonly_cmdline` is `yes`

### DIFF
--- a/modules.d/90multipath/module-setup.sh
+++ b/modules.d/90multipath/module-setup.sh
@@ -126,7 +126,7 @@ install() {
     inst_libdir_file "libmultipath*" "multipath/*"
     inst_libdir_file 'libgcc_s.so*'
 
-    if [[ $hostonly_cmdline ]]; then
+    if [[ $hostonly_cmdline == "yes" ]]; then
         local _conf
         _conf=$(cmdline)
         [[ $_conf ]] && echo "$_conf" >> "${initdir}/etc/cmdline.d/90multipath.conf"


### PR DESCRIPTION
## Changes

`hostonly_cmdline` can be `no`, so the current check is invalid.

## Checklist
- [X] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it

https://github.com/dracutdevs/dracut/pull/2404