### PR TITLE
fix(systemd-networkd): drop networkctl as it has a dependency on dbus

### DIFF
--- a/modules.d/01systemd-networkd/module-setup.sh
+++ b/modules.d/01systemd-networkd/module-setup.sh
@@ -7,7 +7,7 @@ check() {
     [[ $mount_needs ]] && return 1
 
     # If the binary(s) requirements are not fulfilled the module can't be installed
-    require_binaries ip networkctl \
+    require_binaries ip \
         "$systemdutildir"/systemd-networkd \
         "$systemdutildir"/systemd-network-generator \
         "$systemdutildir"/systemd-networkd-wait-online \
@@ -56,7 +56,7 @@ install() {
         "$systemdsystemunitdir"/systemd-networkd-wait-online@.service \
         "$systemdsystemunitdir"/systemd-network-generator.service \
         "$sysusers"/systemd-network.conf \
-        networkctl ip
+        ip
 
     # Enable systemd type units
     for i in \


### PR DESCRIPTION
## Changes

Follow-up to https://github.com/dracut-ng/dracut-ng/pull/218 as discussed https://github.com/dracut-ng/dracut-ng/pull/218#pullrequestreview-2019133702

## Checklist
- [X] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it


