### PR TITLE
fix(numlock): use the same shebang as other dracut modules

### DIFF
--- a/modules.d/90numlock/module-setup.sh
+++ b/modules.d/90numlock/module-setup.sh
@@ -1,4 +1,4 @@
-#!/usr/bin/bash
+#!/bin/bash
 # This file is part of dracut.
 # SPDX-License-Identifier: GPL-2.0-or-later
 
@@ -10,25 +10,20 @@ check() {
 
     # Return 255 to only include the module, if another module requires it.
     return 255
-
 }
 
 # Module dependency requirements.
 depends() {
-
     # This module has external dependency on other module(s).
     echo base
     # Return 0 to include the dependent module(s) in the initramfs.
     return 0
-
 }
 
 # Install the required file(s) and directories for the module in the initramfs.
 install() {
-
     inst_multiple \
         setleds
 
     inst_hook initqueue/settled 90 "$moddir/numlock.sh"
-
 }


### PR DESCRIPTION
## Changes

Fix what was pointed out at https://github.com/dracut-ng/dracut-ng/pull/226#pullrequestreview-2019137318

## Checklist
- [X] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it
