### PR TITLE
fix(dracut-systemd): include systemd-ask-password module

### DIFF
--- a/modules.d/98dracut-systemd/module-setup.sh
+++ b/modules.d/98dracut-systemd/module-setup.sh
@@ -9,7 +9,7 @@ check() {
 
 # called by dracut
 depends() {
-    echo "systemd-initrd"
+    echo "systemd-initrd systemd-ask-password"
     return 0
 }
 


### PR DESCRIPTION
## Changes

rd.cmdline=ask requires systemd-ask-password dracut module.

## Checklist
- [x] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it

Fixes #164
