### PR TITLE
fix(numlock): use the same shebang as other dracut modules

### DIFF
--- a/modules.d/90numlock/numlock.sh
+++ b/modules.d/90numlock/numlock.sh
@@ -1,4 +1,4 @@
-#!/usr/bin/sh
+#!/bin/sh
 i=1
 # 6 is the default value of the NAutoVTs option of the systemd login manager
 while [ "${i}" -le 6 ]; do


### PR DESCRIPTION
## Changes

Fix what was pointed out at https://github.com/dracut-ng/dracut-ng/pull/235#pullrequestreview-2020112273

## Checklist
- [X] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it
