### PR TITLE
fix(systemd-initrd): systemd based initrd needs journald and tmpfiles

### DIFF
--- a/modules.d/01systemd-initrd/module-setup.sh
+++ b/modules.d/01systemd-initrd/module-setup.sh
@@ -10,7 +10,7 @@ check() {
 
 # called by dracut
 depends() {
-    echo systemd-udevd
+    echo systemd-udevd systemd-journald systemd-tmpfiles
 }
 
 installkernel() {


### PR DESCRIPTION
## Changes

Add systemd-journald systemd-tmpfiles as explicit dependencies to systemd-initrd.

This PR makes `dracut -m systemd-initrd` to generate a proper systemd based initrd.

## Checklist
- [X] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it
