### PR TITLE
test(FULL-SYSTEMD): remove ldconfig.service from the target rootfs 

### DIFF
--- a/test/TEST-04-FULL-SYSTEMD/test.sh
+++ b/test/TEST-04-FULL-SYSTEMD/test.sh
@@ -53,7 +53,6 @@ test_setup() {
     # Create what will eventually be our root filesystem onto an overlay
     "$DRACUT" -l --keep --tmpdir "$TESTDIR" \
         -m "test-root systemd" \
-        -I "ldconfig" \
         -i ./test-init.sh /sbin/test-init \
         -i ./fstab /etc/fstab \
         -i "${PKGLIBDIR}/modules.d/99base/dracut-lib.sh" "/lib/dracut-lib.sh" \
@@ -78,6 +77,9 @@ test_setup() {
 
     # softlink mtab
     ln -fs /proc/self/mounts "$initdir"/etc/mtab
+
+    # Do not need ldconfig.service in our rootfs
+    rm -rf "$initdir"/usr/lib/systemd/system/sysinit.target.wants/ldconfig.service
 
     # install any Execs from the service files
     grep -Eho '^Exec[^ ]*=[^ ]+' "$initdir"{,/usr}/lib/systemd/system/*.service \


### PR DESCRIPTION
## Changes

This change makes sure that ldconfig.service is not included in the target rootfs that the test case is booting into. 

## Checklist
- [x] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it

Fixes #248

