### PR TITLE
feat(dracut.sh): make hostonly default

### DIFF
--- a/dracut.sh
+++ b/dracut.sh
@@ -1051,6 +1051,7 @@ drivers_dir="${drivers_dir%"${drivers_dir##*[!/]}"}"
 [[ $prefix_l ]] && prefix=$prefix_l
 [[ $prefix == "/" ]] && unset prefix
 [[ $hostonly_l ]] && hostonly=$hostonly_l
+[[ $hostonly ]] || hostonly="-h"
 [[ $hostonly_cmdline_l ]] && hostonly_cmdline=$hostonly_cmdline_l
 [[ $hostonly_mode_l ]] && hostonly_mode=$hostonly_mode_l
 [[ $hostonly == "yes" ]] && ! [[ $hostonly_cmdline ]] && hostonly_cmdline="yes"

--- a/man/dracut.conf.5.asc
+++ b/man/dracut.conf.5.asc
@@ -119,7 +119,7 @@ Configuration files must have the extension .conf; other extensions are ignored.
 *hostonly=*"__{yes|no}__"::
     Host-only mode: Install only what is needed for booting the local host
     instead of a generic host and generate host-specific configuration
-    (default=no).
+    (default=yes).
 
 *hostonly_mode=*"__{sloppy|strict}__"::
     Specify the host-only mode to use (default=sloppy).


### PR DESCRIPTION
## Changes

hostonly is the recommended default configuration. It should be the default even without a configuration file.

## Checklist
- [x] I have tested it locally
- [x] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it

[Fedora](https://src.fedoraproject.org/rpms/dracut/blob/rawhide/f/dracut.spec#_253) and [openSUSE](https://github.com/openSUSE/dracut/blob/SUSE/059/suse/dracut.spec#L164) package a configuration file that makes hostonly the default for those distributions. Some other distributions (e.g. Gentoo or Arch) however do not do this (it is unknown if this is intentional or not). 

Some distributions have strong desire to NOT customize upstream - which in dracut's case could lead to software is not used in its recommended configuration by the users.

