### PR TITLE
feat(systemd-pcrphase): include systemd-pcrphase if dependencies are met

### DIFF
--- a/modules.d/01systemd-pcrphase/module-setup.sh
+++ b/modules.d/01systemd-pcrphase/module-setup.sh
@@ -12,8 +12,7 @@ check() {
         return 1
     fi
 
-    # Return 255 to only include the module, if another module requires it.
-    return 255
+    return 0
 
 }
 


### PR DESCRIPTION
## Changes

If systemd and tpm2-tss dracut modules can be installed (e.g. they are not omitted and dependencies are met) than automatically include them into initrd. 

## Checklist
- [ ] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it

Fixes #92 #255 (partially)

CC @ossimoi @DanWin @adrelanos
