### PR TITLE
ci: add systemd-boot-efi package to Ubuntu container for UEFI stub

### DIFF
--- a/test/container/Dockerfile-Ubuntu
+++ b/test/container/Dockerfile-Ubuntu
@@ -53,7 +53,7 @@ RUN apt-get update -y -qq && apt-get upgrade -y -qq && \
     shellcheck \
     squashfs-tools \
     strace \
-    systemd \
+    systemd-boot-efi \
     tcpdump \
     tgt \
     thin-provisioning-tools \


### PR DESCRIPTION
## Changes

Without this package UEFI test would fail with the following error

```
dracut[F]: Can't find a uefi stub '/usr/lib/systemd/boot/efi/linuxx64.efi.stub' \ to create a UEFI executable
```

Removed explicit systemd as it is already installed by other packages to align it with the Debian container to ease maintenance.

## Checklist
- [X] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it

