### PR TITLE
test(UEFI): add support for OVMF_CODE_4M.fd for Ubuntu 24.04

### DIFF
--- a/test/TEST-18-UEFI/test.sh
+++ b/test/TEST-18-UEFI/test.sh
@@ -6,6 +6,7 @@ TEST_DESCRIPTION="UEFI boot"
 ovmf_code() {
     for path in \
         "/usr/share/OVMF/OVMF_CODE.fd" \
+        "/usr/share/OVMF/OVMF_CODE_4M.fd" \
         "/usr/share/edk2/x64/OVMF_CODE.fd" \
         "/usr/share/edk2-ovmf/OVMF_CODE.fd" \
         "/usr/share/qemu/ovmf-x86_64-4m.bin"; do


### PR DESCRIPTION
## Changes

Adjust test case to the latest Debian and Ubuntu ovmf package.

```
$ zcat /usr/share/doc/ovmf/NEWS.Debian.gz 
edk2 (2023.11-2) unstable; urgency=medium

  The 2MB ovmf pflash images, OVMF_CODE.*.fd and OVMF_VARS.*.fd, have now
  been removed. Users of the 2MB pflash images should migrate to their 4MB
  image counterparts:

    OVMF_CODE.fd         -> OVMF_CODE_4M.fd
    OVMF_CODE.ms.fd      -> OVMF_CODE_4M.ms.fd
    OVMF_CODE.secboot.fd -> OVMF_CODE_4M.secboot.fd
    OVMF_VARS.fd         -> OVMF_VARS_4M.fd
    OVMF_VARS.ms.fd      -> OVMF_VARS_4M.ms.fd

  2MB VAR images are not compatible with 4MB CODE images. Users must
  migrate both CODE and VARS images simultaneously.

  A migration guide is provided at:
    /usr/share/doc/ovmf/howto-2M-to-4M-migration.md.gz

 -- dann frazier <dannf@debian.org>  Wed, 27 Dec 2023 10:15:33 -0700
 
 ```

## Checklist
- [X] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it


