### PR TITLE
feat(systemd-cryptsetup): new module for systemd-cryptsetup

### DIFF
--- a/modules.d/90crypt/module-setup.sh
+++ b/modules.d/90crypt/module-setup.sh
@@ -31,9 +31,6 @@ depends() {
             deps+=" tpm2-tss"
         fi
     fi
-    if dracut_module_included "systemd"; then
-        deps+=" systemd-ask-password"
-    fi
     echo "$deps"
     return 0
 }
@@ -162,19 +159,6 @@ install() {
 
     inst_simple "$moddir/crypt-lib.sh" "/lib/dracut-crypt-lib.sh"
     inst_script "$moddir/crypt-run-generator.sh" "/sbin/crypt-run-generator"
-
-    if dracut_module_included "systemd"; then
-        # the cryptsetup targets are already pulled in by 00systemd, but not
-        # the enablement symlinks
-        inst_multiple -o \
-            "$tmpfilesdir"/cryptsetup.conf \
-            "$systemdutildir"/system-generators/systemd-cryptsetup-generator \
-            "$systemdutildir"/systemd-cryptsetup \
-            "$systemdsystemunitdir"/cryptsetup.target \
-            "$systemdsystemunitdir"/sysinit.target.wants/cryptsetup.target \
-            "$systemdsystemunitdir"/remote-cryptsetup.target \
-            "$systemdsystemunitdir"/initrd-root-device.target.wants/remote-cryptsetup.target
-    fi
 
     # Install required libraries.
     _arch=${DRACUT_ARCH:-$(uname -m)}

--- a/modules.d/90systemd-cryptsetup/module-setup.sh
+++ b/modules.d/90systemd-cryptsetup/module-setup.sh
@@ -1,0 +1,37 @@
+#!/bin/bash
+
+# called by dracut
+check() {
+    local fs
+    # if cryptsetup is not installed, then we cannot support encrypted devices.
+    require_any_binary "$systemdutildir"/systemd-cryptsetup || return 1
+
+    [[ $hostonly ]] || [[ $mount_needs ]] && {
+        for fs in "${host_fs_types[@]}"; do
+            [[ $fs == "crypto_LUKS" ]] && return 0
+        done
+        return 255
+    }
+
+    return 0
+}
+
+# called by dracut
+depends() {
+    echo dm rootfs-block crypt systemd-ask-password
+    return 0
+}
+
+# called by dracut
+install() {
+    # the cryptsetup targets are already pulled in by 00systemd, but not
+    # the enablement symlinks
+    inst_multiple -o \
+        "$tmpfilesdir"/cryptsetup.conf \
+        "$systemdutildir"/system-generators/systemd-cryptsetup-generator \
+        "$systemdutildir"/systemd-cryptsetup \
+        "$systemdsystemunitdir"/cryptsetup.target \
+        "$systemdsystemunitdir"/sysinit.target.wants/cryptsetup.target \
+        "$systemdsystemunitdir"/remote-cryptsetup.target \
+        "$systemdsystemunitdir"/initrd-root-device.target.wants/remote-cryptsetup.target
+}


### PR DESCRIPTION
Separate out systemd dependent part of crypt into it's own module.

This new `systemd-cryptsetup` module is dependent on the `crypt` module, so it inherits all the `check()` and `install()` etc functionality, that we do not need to duplicate.

## Checklist
- [ ] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it


