### PR TITLE
test(NFS): increase virtual disk space to accomodate Ubuntu 24.04

### DIFF
--- a/test/TEST-20-NFS/test.sh
+++ b/test/TEST-20-NFS/test.sh
@@ -379,7 +379,7 @@ test_setup() {
     # shellcheck disable=SC2034
     declare -i disk_index=0
     qemu_add_drive disk_index disk_args "$TESTDIR"/marker.img marker 1
-    qemu_add_drive disk_index disk_args "$TESTDIR"/server.img root 80
+    qemu_add_drive disk_index disk_args "$TESTDIR"/server.img root 160
 
     # Invoke KVM and/or QEMU to actually create the target filesystem.
     "$testdir"/run-qemu \


### PR DESCRIPTION
## Changes

Newer distribution versions needs more space.

Resolves the following error when running test on Ubuntu

```
++ mkdir -p /root
++ mount -t ext4 /dev/disk/by-id/scsi-0QEMU_QEMU_HARDDISK_root /root
++ cp -a -t /root /source/bin /source/dev /source/etc /source/lib /source/lib64 /source/nfs /source/proc /source/run /source/sbin /source/sys /source/tmp /source/usr /source/var
cp: error writing '/root/usr/lib/x86_64-linux-gnu/libnl-route-3.so.200.26.0': No space left on device
cp: error writing '/root/usr/lib/x86_64-linux-gnu/libpcap.so.1.10.4': No space left on device
cp: error writing '/root/usr/lib/x86_64-linux-gnu/libresolv.so.2': No space left on device
cp: error writing '/root/usr/lib/x86_64-linux-gnu/libstdc++.so.6.0.33': No space left on device
cp: error writing '/root/usr/lib/x86_64-linux-gnu/libtirpc.so.3.0.0': No space left on device
cp: error writing '/root/usr/lib/x86_64-linux-gnu/libwrap.so.0.7.6': No space left on device
cp: error writing '/root/usr/lib/x86_64-linux-gnu/libxml2.so.2.9.14': No space left on device
cp: error writing '/root/usr/lib/x86_64-linux-gnu/libcom_err.so.2.1': No space left on device
cp: error writing '/root/usr/lib/x86_64-linux-gnu/libuuid.so.1.3.0': No space left on device
cp: cannot create directory '/root/usr/lib64': No space left on device
cp: cannot create directory '/root/usr/sbin': No space left on device
cp: cannot create directory '/root/usr/share': No space left on device
cp: cannot create directory '/root/var': No space left on device
+ poweroff -f
Powering off.
```

## Checklist
- [X] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it

Fixes #
