### PR TITLE
refactor(crypt,fido2,pkcs11): improve modularity

### DIFF
--- a/modules.d/90crypt/module-setup.sh
+++ b/modules.d/90crypt/module-setup.sh
@@ -21,12 +21,6 @@ depends() {
     local deps
     deps="dm rootfs-block"
     if [[ $hostonly && -f "$dracutsysrootdir"/etc/crypttab ]]; then
-        if grep -q -e "fido2-device=" -e "fido2-cid=" "$dracutsysrootdir"/etc/crypttab; then
-            deps+=" fido2"
-        fi
-        if grep -q "pkcs11-uri" "$dracutsysrootdir"/etc/crypttab; then
-            deps+=" pkcs11"
-        fi
         if grep -q "tpm2-device=" "$dracutsysrootdir"/etc/crypttab; then
             deps+=" tpm2-tss"
         fi

--- a/modules.d/91fido2/module-setup.sh
+++ b/modules.d/91fido2/module-setup.sh
@@ -10,8 +10,15 @@ check() {
 
 # Module dependency requirements.
 depends() {
+    local deps
     # This module has external dependency on other module(s).
-    echo systemd-udevd
+    deps="systemd-udevd"
+    if dracut_module_included "crypt"; then
+        if [[ $hostonly && -f "$dracutsysrootdir"/etc/crypttab ]] && grep -q -e "fido2-device=" -e "fido2-cid=" "$dracutsysrootdir"/etc/crypttab; then
+            deps+=" fido2"
+        fi
+    fi
+    echo "$deps"
     # Return 0 to include the dependent module(s) in the initramfs.
     return 0
 }

--- a/modules.d/91pkcs11/module-setup.sh
+++ b/modules.d/91pkcs11/module-setup.sh
@@ -12,12 +12,17 @@ check() {
 
 # Module dependency requirements.
 depends() {
-
+    local deps
     # This module has external dependency on other module(s).
-    echo systemd-udevd
+    deps="systemd-udevd"
+    if dracut_module_included "crypt"; then
+        if [[ $hostonly && -f "$dracutsysrootdir"/etc/crypttab ]] && grep -q "pkcs11-uri" "$dracutsysrootdir"/etc/crypttab; then
+            deps+=" pkcs11"
+        fi
+    fi
+    echo "$deps"
     # Return 0 to include the dependent module(s) in the initramfs.
     return 0
-
 }
 
 # Install the required file(s) and directories for the module in the initramfs.


### PR DESCRIPTION
## Changes

Consolidate the conditions of installing fido2 module into the fido2 dracut module and move it out from the crypt module. Do the same for the pkcs11 module.

I was exploring how to solve https://github.com/dracut-ng/dracut-ng/issues/255 and realized that first we should improve modularity between dracut modules.

## Checklist
- [ ] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it
