### PR TITLE
test(UEFI): run the test both hostonly and no-hostonly modes

### DIFF
--- a/modules.d/80test/module-setup.sh
+++ b/modules.d/80test/module-setup.sh
@@ -6,7 +6,7 @@ check() {
 }
 
 depends() {
-    echo "base debug"
+    echo "base debug qemu"
 }
 
 installkernel() {

--- a/test/TEST-18-UEFI/test.sh
+++ b/test/TEST-18-UEFI/test.sh
@@ -42,7 +42,16 @@ test_setup() {
     mksquashfs "$TESTDIR"/dracut.*/initramfs/ "$TESTDIR"/squashfs.img -quiet -no-progress
 
     mkdir -p "$TESTDIR"/ESP/EFI/BOOT
+
     test_dracut \
+        --modules 'rootfs-block' \
+        --kernel-cmdline 'root=/dev/disk/by-id/scsi-0QEMU_QEMU_HARDDISK_root ro rd.skipfsck rootfstype=squashfs' \
+        --drivers 'squashfs' \
+        --uefi \
+        "$TESTDIR"/ESP/EFI/BOOT/BOOTX64.efi
+
+    test_dracut \
+        --hostonly \
         --modules 'rootfs-block' \
         --kernel-cmdline 'root=/dev/disk/by-id/scsi-0QEMU_QEMU_HARDDISK_root ro rd.skipfsck rootfstype=squashfs' \
         --drivers 'squashfs' \

--- a/test/test-functions
+++ b/test/test-functions
@@ -30,9 +30,10 @@ test_dracut() {
     # shellcheck disable=SC2162
     IFS=' ' read -a TEST_DRACUT_ARGS_ARRAY <<< "$TEST_DRACUT_ARGS"
 
-    "$DRACUT" "$@" \
+    "$DRACUT" \
         --kernel-cmdline "panic=1 oops=panic softlockup_panic=1 systemd.crash_reboot quiet rd.retry=10 rd.info rd.shell=0 selinux=0 console=ttyS0,115200n81 $DEBUGFAIL" \
-        "${TEST_DRACUT_ARGS_ARRAY[@]}" || return 1
+        "${TEST_DRACUT_ARGS_ARRAY[@]}" \
+        "$@" || return 1
 }
 
 command -v test_check &> /dev/null || test_check() {


### PR DESCRIPTION
## Changes

Add at least one test in `hostonly` mode. `hostonly` mode is how most users experience dracut as a Linux distribution package. 

Needed to add `qemu` dracut module as a dependency to the `test` dracut module to make sure that kernel modules needed for a `qemu` run are loaded.

Needed to change the order of arguments to make sure that the test case can overwrite the default arguments in `test_functions`.

The `hostonly` mode triggers the following warning, which is expected, and confirms that the test is working.

```
Running in hostonly mode in a container!
```

## Checklist
- [X] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it

