### PR TITLE
perf(dracut-systemd): check for systemd binary

### DIFF
--- a/modules.d/98dracut-systemd/module-setup.sh
+++ b/modules.d/98dracut-systemd/module-setup.sh
@@ -4,6 +4,9 @@
 check() {
     [[ $mount_needs ]] && return 1
 
+    # If the binary(s) requirements are not fulfilled the module can't be installed
+    require_binaries "$systemdutildir"/systemd || return 1
+
     return 0
 }
 


### PR DESCRIPTION
## Changes

dracut-systemd is the "top" level dracut module that pulls in all the systemd dependent modules.

For non-systemd based distributions this check makes the initrd generation faster as it skips all the other the processing of systemd-initrd and systemd-udevd dracut modules.

## Checklist
- [ ] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it
