### PR TITLE
fix(memstrack): move the console warning to be a comment

### DIFF
--- a/modules.d/99memstrack/module-setup.sh
+++ b/modules.d/99memstrack/module-setup.sh
@@ -1,11 +1,12 @@
 #!/bin/bash
 
 check() {
-    if ! require_binaries pgrep pkill memstrack; then
-        dinfo "memstrack is not available"
-        dinfo "If you need to use rd.memdebug>=4, please install memstrack and procps-ng"
-        return 1
-    fi
+    # If you need to use rd.memdebug>=4, please install all the required binary dependencies
+    require_binaries \
+        pgrep \
+        pkill \
+        memstrack \
+        || return 1
 
     return 0
 }


### PR DESCRIPTION
## Changes

memstrack is debugging tool and it is typically not installed. 

The package name procps-ng is distribution specific and confusing to print out in the console in a non-verbose mode.

## Checklist
- [x] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it
