### PR TITLE
test: add /sbin/init script to the test-root dracut module

### DIFF
--- a/modules.d/80test-root/module-setup.sh
+++ b/modules.d/80test-root/module-setup.sh
@@ -26,5 +26,7 @@ install() {
     inst_script "${dracutbasedir}/modules.d/99base/dracut-lib.sh" "/lib/dracut-lib.sh"
     inst_script "${dracutbasedir}/modules.d/99base/dracut-dev-lib.sh" "/lib/dracut-dev-lib.sh"
 
+    inst_script "$moddir/test-init.sh" "/test-init.sh"
+
     inst_multiple -o plymouth
 }

--- a/modules.d/80test-root/module-setup.sh
+++ b/modules.d/80test-root/module-setup.sh
@@ -26,7 +26,7 @@ install() {
     inst_script "${dracutbasedir}/modules.d/99base/dracut-lib.sh" "/lib/dracut-lib.sh"
     inst_script "${dracutbasedir}/modules.d/99base/dracut-dev-lib.sh" "/lib/dracut-dev-lib.sh"
 
-    inst_script "$moddir/test-init.sh" "/test-init.sh"
+    inst_script "$moddir/test-init.sh" "/sbin/init"
 
     inst_multiple -o plymouth
 }

--- a/modules.d/80test-root/module-setup.sh
+++ b/modules.d/80test-root/module-setup.sh
@@ -23,5 +23,8 @@ install() {
     ln -s dracut-util "${initdir}/usr/bin/dracut-getarg"
     ln -s dracut-util "${initdir}/usr/bin/dracut-getargs"
 
+    inst_script "${dracutbasedir}/modules.d/99base/dracut-lib.sh" "/lib/dracut-lib.sh"
+    inst_script "${dracutbasedir}/modules.d/99base/dracut-dev-lib.sh" "/lib/dracut-dev-lib.sh"
+
     inst_multiple -o plymouth
 }

--- a/modules.d/80test-root/test-init.sh
+++ b/modules.d/80test-root/test-init.sh
@@ -1,0 +1,50 @@
+#!/bin/sh
+
+export PATH=/usr/sbin:/usr/bin:/sbin:/bin
+
+[ -e /proc/self/mounts ] \
+    || (mkdir -p /proc && mount -t proc -o nosuid,noexec,nodev proc /proc)
+
+grep -q '^sysfs /sys sysfs' /proc/self/mounts \
+    || (mkdir -p /sys && mount -t sysfs -o nosuid,noexec,nodev sysfs /sys)
+
+grep -q '^devtmpfs /dev devtmpfs' /proc/self/mounts \
+    || (mkdir -p /dev && mount -t devtmpfs -o mode=755,noexec,nosuid,strictatime devtmpfs /dev)
+
+grep -q '^tmpfs /run tmpfs' /proc/self/mounts \
+    || (mkdir -p /run && mount -t tmpfs -o mode=755,noexec,nosuid,strictatime tmpfs /run)
+
+: > /dev/watchdog
+
+exec > /dev/console 2>&1
+
+if [ -s /failed ]; then
+    echo "**************************FAILED**************************"
+    cat /failed
+    echo "**************************FAILED**************************"
+else
+    echo "dracut-root-block-success" | dd oflag=direct,dsync of=/dev/disk/by-id/scsi-0QEMU_QEMU_HARDDISK_marker
+    echo "All OK"
+fi
+
+export TERM=linux
+export PS1='initramfs-test:\w\$ '
+[ -f /etc/mtab ] || ln -sfn /proc/mounts /etc/mtab
+[ -f /etc/fstab ] || ln -sfn /proc/mounts /etc/fstab
+stty sane
+echo "made it to the rootfs!"
+
+. /lib/dracut-lib.sh
+
+if getargbool 0 rd.shell; then
+    strstr "$(setsid --help)" "control" && CTTY="-c"
+    # shellcheck disable=SC2086
+    setsid $CTTY sh -i
+fi
+
+echo "Powering down."
+mount -n -o remount,ro /
+if [ -d /run/initramfs/etc ]; then
+    echo " rd.debug=0 " >> /run/initramfs/etc/cmdline
+fi
+poweroff -f

--- a/test/TEST-01-BASIC/test-init.sh
+++ b/test/TEST-01-BASIC/test-init.sh
@@ -1,3 +1,0 @@
-#!/bin/sh
-
-. /test-init.sh

--- a/test/TEST-01-BASIC/test-init.sh
+++ b/test/TEST-01-BASIC/test-init.sh
@@ -1,24 +1,3 @@
 #!/bin/sh
-: > /dev/watchdog
 
-. /lib/dracut-lib.sh
-
-export PATH=/usr/sbin:/usr/bin:/sbin:/bin
-command -v plymouth > /dev/null 2>&1 && plymouth --quit
-exec > /dev/console 2>&1
-
-echo "dracut-root-block-success" | dd oflag=direct,dsync of=/dev/disk/by-id/scsi-0QEMU_QEMU_HARDDISK_marker
-
-export TERM=linux
-export PS1='initramfs-test:\w\$ '
-[ -f /etc/mtab ] || ln -sfn /proc/mounts /etc/mtab
-[ -f /etc/fstab ] || ln -sfn /proc/mounts /etc/fstab
-stty sane
-echo "made it to the rootfs!"
-if getargbool 0 rd.shell; then
-    strstr "$(setsid --help)" "control" && CTTY="-c"
-    setsid $CTTY sh -i
-fi
-echo "Powering down."
-mount -n -o remount,ro /
-poweroff -f
+. /test-init.sh

--- a/test/TEST-01-BASIC/test.sh
+++ b/test/TEST-01-BASIC/test.sh
@@ -26,8 +26,6 @@ test_setup() {
     "$DRACUT" -l --keep --tmpdir "$TESTDIR" \
         -m "test-root" \
         -i ./test-init.sh /sbin/init \
-        -i "${PKGLIBDIR}/modules.d/99base/dracut-lib.sh" "/lib/dracut-lib.sh" \
-        -i "${PKGLIBDIR}/modules.d/99base/dracut-dev-lib.sh" "/lib/dracut-dev-lib.sh" \
         --no-hostonly --no-hostonly-cmdline --nomdadmconf --nohardlink \
         -f "$TESTDIR"/initramfs.root "$KVERSION" || return 1
     mkdir -p "$TESTDIR"/overlay/source && mv "$TESTDIR"/dracut.*/initramfs/* "$TESTDIR"/overlay/source && rm -rf "$TESTDIR"/dracut.*

--- a/test/TEST-01-BASIC/test.sh
+++ b/test/TEST-01-BASIC/test.sh
@@ -25,7 +25,6 @@ test_setup() {
     # Create what will eventually be our root filesystem onto an overlay
     "$DRACUT" -l --keep --tmpdir "$TESTDIR" \
         -m "test-root" \
-        -i ./test-init.sh /sbin/init \
         --no-hostonly --no-hostonly-cmdline --nomdadmconf --nohardlink \
         -f "$TESTDIR"/initramfs.root "$KVERSION" || return 1
     mkdir -p "$TESTDIR"/overlay/source && mv "$TESTDIR"/dracut.*/initramfs/* "$TESTDIR"/overlay/source && rm -rf "$TESTDIR"/dracut.*

--- a/test/TEST-02-SYSTEMD/test-init.sh
+++ b/test/TEST-02-SYSTEMD/test-init.sh
@@ -1,3 +1,0 @@
-#!/bin/sh
-
-. /test-init.sh

--- a/test/TEST-02-SYSTEMD/test-init.sh
+++ b/test/TEST-02-SYSTEMD/test-init.sh
@@ -1,24 +1,3 @@
 #!/bin/sh
-: > /dev/watchdog
 
-. /lib/dracut-lib.sh
-
-export PATH=/usr/sbin:/usr/bin:/sbin:/bin
-command -v plymouth > /dev/null 2>&1 && plymouth --quit
-exec > /dev/console 2>&1
-
-echo "dracut-root-block-success" | dd oflag=direct,dsync of=/dev/disk/by-id/scsi-0QEMU_QEMU_HARDDISK_marker
-
-export TERM=linux
-export PS1='initramfs-test:\w\$ '
-[ -f /etc/mtab ] || ln -sfn /proc/mounts /etc/mtab
-[ -f /etc/fstab ] || ln -sfn /proc/mounts /etc/fstab
-stty sane
-echo "made it to the rootfs!"
-if getargbool 0 rd.shell; then
-    strstr "$(setsid --help)" "control" && CTTY="-c"
-    setsid $CTTY sh -i
-fi
-echo "Powering down."
-mount -n -o remount,ro /
-poweroff -f
+. /test-init.sh

--- a/test/TEST-02-SYSTEMD/test.sh
+++ b/test/TEST-02-SYSTEMD/test.sh
@@ -27,7 +27,6 @@ test_setup() {
     # Create what will eventually be our root filesystem onto an overlay
     "$DRACUT" -l --keep --tmpdir "$TESTDIR" \
         -m "test-root" \
-        -i ./test-init.sh /sbin/init \
         --no-hostonly --no-hostonly-cmdline --nomdadmconf --nohardlink \
         -f "$TESTDIR"/initramfs.root "$KVERSION" || return 1
     mkdir -p "$TESTDIR"/overlay/source && mv "$TESTDIR"/dracut.*/initramfs/* "$TESTDIR"/overlay/source && rm -rf "$TESTDIR"/dracut.*

--- a/test/TEST-02-SYSTEMD/test.sh
+++ b/test/TEST-02-SYSTEMD/test.sh
@@ -28,8 +28,6 @@ test_setup() {
     "$DRACUT" -l --keep --tmpdir "$TESTDIR" \
         -m "test-root" \
         -i ./test-init.sh /sbin/init \
-        -i "${PKGLIBDIR}/modules.d/99base/dracut-lib.sh" "/lib/dracut-lib.sh" \
-        -i "${PKGLIBDIR}/modules.d/99base/dracut-dev-lib.sh" "/lib/dracut-dev-lib.sh" \
         --no-hostonly --no-hostonly-cmdline --nomdadmconf --nohardlink \
         -f "$TESTDIR"/initramfs.root "$KVERSION" || return 1
     mkdir -p "$TESTDIR"/overlay/source && mv "$TESTDIR"/dracut.*/initramfs/* "$TESTDIR"/overlay/source && rm -rf "$TESTDIR"/dracut.*

--- a/test/TEST-03-USR-MOUNT/test-init.sh
+++ b/test/TEST-03-USR-MOUNT/test-init.sh
@@ -1,3 +1,0 @@
-#!/bin/sh
-
-. /test-init.sh

--- a/test/TEST-03-USR-MOUNT/test-init.sh
+++ b/test/TEST-03-USR-MOUNT/test-init.sh
@@ -1,24 +1,3 @@
 #!/bin/sh
-: > /dev/watchdog
 
-. /lib/dracut-lib.sh
-
-export PATH=/usr/sbin:/usr/bin:/sbin:/bin
-command -v plymouth > /dev/null 2>&1 && plymouth --quit
-exec > /dev/console 2>&1
-
-echo "dracut-root-block-success" | dd oflag=direct,dsync of=/dev/disk/by-id/scsi-0QEMU_QEMU_HARDDISK_marker
-
-export TERM=linux
-export PS1='initramfs-test:\w\$ '
-[ -f /etc/mtab ] || ln -sfn /proc/mounts /etc/mtab
-[ -f /etc/fstab ] || ln -sfn /proc/mounts /etc/fstab
-stty sane
-echo "made it to the rootfs!"
-if getargbool 0 rd.shell; then
-    strstr "$(setsid --help)" "control" && CTTY="-c"
-    setsid $CTTY sh -i
-fi
-echo "Powering down."
-mount -n -o remount,ro /
-poweroff -f
+. /test-init.sh

--- a/test/TEST-03-USR-MOUNT/test.sh
+++ b/test/TEST-03-USR-MOUNT/test.sh
@@ -43,7 +43,6 @@ test_setup() {
     # Create what will eventually be our root filesystem onto an overlay
     "$DRACUT" -l --keep --tmpdir "$TESTDIR" \
         -m "test-root" \
-        -i ./test-init.sh /sbin/init \
         -i ./fstab /etc/fstab \
         --no-hostonly --no-hostonly-cmdline --nomdadmconf --nohardlink \
         -f "$TESTDIR"/initramfs.root "$KVERSION" || return 1

--- a/test/TEST-03-USR-MOUNT/test.sh
+++ b/test/TEST-03-USR-MOUNT/test.sh
@@ -45,8 +45,6 @@ test_setup() {
         -m "test-root" \
         -i ./test-init.sh /sbin/init \
         -i ./fstab /etc/fstab \
-        -i "${PKGLIBDIR}/modules.d/99base/dracut-lib.sh" "/lib/dracut-lib.sh" \
-        -i "${PKGLIBDIR}/modules.d/99base/dracut-dev-lib.sh" "/lib/dracut-dev-lib.sh" \
         --no-hostonly --no-hostonly-cmdline --nomdadmconf --nohardlink \
         -f "$TESTDIR"/initramfs.root "$KVERSION" || return 1
     mkdir -p "$TESTDIR"/overlay/source && mv "$TESTDIR"/dracut.*/initramfs/* "$TESTDIR"/overlay/source && rm -rf "$TESTDIR"/dracut.*

--- a/test/TEST-04-FULL-SYSTEMD/test-init.sh
+++ b/test/TEST-04-FULL-SYSTEMD/test-init.sh
@@ -1,40 +1,21 @@
 #!/bin/sh
 : > /dev/watchdog
 
-. /lib/dracut-lib.sh
-
 export PATH=/usr/sbin:/usr/bin:/sbin:/bin
 command -v plymouth > /dev/null 2>&1 && plymouth --quit
 exec > /dev/console 2>&1
 
 systemctl --failed --no-legend --no-pager > /failed
 
+ismounted() {
+    findmnt "$1" > /dev/null 2>&1
+}
+
 if ! ismounted /usr; then
     echo "**************************FAILED**************************"
     echo "/usr not mounted!!"
-    cat /proc/mounts
+    cat /proc/mounts >> /failed
     echo "**************************FAILED**************************"
-else
-    if [ -s /failed ]; then
-        echo "**************************FAILED**************************"
-        cat /failed
-        echo "**************************FAILED**************************"
-
-    else
-        echo "dracut-root-block-success" | dd oflag=direct,dsync of=/dev/disk/by-id/scsi-0QEMU_QEMU_HARDDISK_marker
-        echo "All OK"
-    fi
 fi
 
-export TERM=linux
-export PS1='initramfs-test:\w\$ '
-[ -f /etc/mtab ] || ln -sfn /proc/mounts /etc/mtab
-[ -f /etc/fstab ] || ln -sfn /proc/mounts /etc/fstab
-stty sane
-echo "made it to the rootfs!"
-if getargbool 0 rd.shell; then
-    strstr "$(setsid --help)" "control" && CTTY="-c"
-    setsid $CTTY sh -i
-fi
-echo "Powering down."
-poweroff -f
+. /test-init.sh

--- a/test/TEST-04-FULL-SYSTEMD/test-init.sh
+++ b/test/TEST-04-FULL-SYSTEMD/test-init.sh
@@ -18,4 +18,4 @@ if ! ismounted /usr; then
     echo "**************************FAILED**************************"
 fi
 
-. /test-init.sh
+. /sbin/test-init.sh

--- a/test/TEST-04-FULL-SYSTEMD/test.sh
+++ b/test/TEST-04-FULL-SYSTEMD/test.sh
@@ -55,8 +55,6 @@ test_setup() {
         -m "test-root systemd" \
         -i ./test-init.sh /sbin/test-init \
         -i ./fstab /etc/fstab \
-        -i "${PKGLIBDIR}/modules.d/99base/dracut-lib.sh" "/lib/dracut-lib.sh" \
-        -i "${PKGLIBDIR}/modules.d/99base/dracut-dev-lib.sh" "/lib/dracut-dev-lib.sh" \
         --no-hostonly --no-hostonly-cmdline --nomdadmconf --nohardlink \
         -f "$TESTDIR"/initramfs.root "$KVERSION" || return 1
 

--- a/test/TEST-04-FULL-SYSTEMD/test.sh
+++ b/test/TEST-04-FULL-SYSTEMD/test.sh
@@ -54,6 +54,7 @@ test_setup() {
     "$DRACUT" -l --keep --tmpdir "$TESTDIR" \
         -m "test-root systemd" \
         -i ./test-init.sh /sbin/test-init \
+        -I "findmnt" \
         -i ./fstab /etc/fstab \
         --no-hostonly --no-hostonly-cmdline --nomdadmconf --nohardlink \
         -f "$TESTDIR"/initramfs.root "$KVERSION" || return 1

--- a/test/TEST-04-FULL-SYSTEMD/test.sh
+++ b/test/TEST-04-FULL-SYSTEMD/test.sh
@@ -53,6 +53,7 @@ test_setup() {
     # Create what will eventually be our root filesystem onto an overlay
     "$DRACUT" -l --keep --tmpdir "$TESTDIR" \
         -m "test-root systemd" \
+        -i "${PKGLIBDIR}/modules.d/80test-root/test-init.sh" "/sbin/test-init.sh" \
         -i ./test-init.sh /sbin/test-init \
         -I "findmnt" \
         -i ./fstab /etc/fstab \

--- a/test/TEST-10-RAID/test-init.sh
+++ b/test/TEST-10-RAID/test-init.sh
@@ -1,3 +1,0 @@
-#!/bin/sh
-
-. /test-init.sh

--- a/test/TEST-10-RAID/test-init.sh
+++ b/test/TEST-10-RAID/test-init.sh
@@ -1,24 +1,3 @@
 #!/bin/sh
-: > /dev/watchdog
 
-. /lib/dracut-lib.sh
-
-export PATH=/usr/sbin:/usr/bin:/sbin:/bin
-command -v plymouth > /dev/null 2>&1 && plymouth --quit
-exec > /dev/console 2>&1
-
-echo "dracut-root-block-success" | dd oflag=direct,dsync of=/dev/disk/by-id/scsi-0QEMU_QEMU_HARDDISK_marker
-
-export TERM=linux
-export PS1='initramfs-test:\w\$ '
-[ -f /etc/mtab ] || ln -sfn /proc/mounts /etc/mtab
-[ -f /etc/fstab ] || ln -sfn /proc/mounts /etc/fstab
-stty sane
-echo "made it to the rootfs!"
-if getargbool 0 rd.shell; then
-    strstr "$(setsid --help)" "control" && CTTY="-c"
-    setsid $CTTY sh -i
-fi
-echo "Powering down."
-mount -n -o remount,ro /
-poweroff -f
+. /test-init.sh

--- a/test/TEST-10-RAID/test.sh
+++ b/test/TEST-10-RAID/test.sh
@@ -27,8 +27,6 @@ test_setup() {
     "$DRACUT" -l --keep --tmpdir "$TESTDIR" \
         -m "test-root" \
         -i ./test-init.sh /sbin/init \
-        -i "${PKGLIBDIR}/modules.d/99base/dracut-lib.sh" "/lib/dracut-lib.sh" \
-        -i "${PKGLIBDIR}/modules.d/99base/dracut-dev-lib.sh" "/lib/dracut-dev-lib.sh" \
         --no-hostonly --no-hostonly-cmdline --nohardlink \
         -f "$TESTDIR"/initramfs.root "$KVERSION" || return 1
     mkdir -p "$TESTDIR"/overlay/source && mv "$TESTDIR"/dracut.*/initramfs/* "$TESTDIR"/overlay/source && rm -rf "$TESTDIR"/dracut.*

--- a/test/TEST-10-RAID/test.sh
+++ b/test/TEST-10-RAID/test.sh
@@ -26,7 +26,6 @@ test_setup() {
     # Create what will eventually be our root filesystem onto an overlay
     "$DRACUT" -l --keep --tmpdir "$TESTDIR" \
         -m "test-root" \
-        -i ./test-init.sh /sbin/init \
         --no-hostonly --no-hostonly-cmdline --nohardlink \
         -f "$TESTDIR"/initramfs.root "$KVERSION" || return 1
     mkdir -p "$TESTDIR"/overlay/source && mv "$TESTDIR"/dracut.*/initramfs/* "$TESTDIR"/overlay/source && rm -rf "$TESTDIR"/dracut.*

--- a/test/TEST-11-LVM/test-init.sh
+++ b/test/TEST-11-LVM/test-init.sh
@@ -1,3 +1,0 @@
-#!/bin/sh
-
-. /test-init.sh

--- a/test/TEST-11-LVM/test-init.sh
+++ b/test/TEST-11-LVM/test-init.sh
@@ -1,24 +1,3 @@
 #!/bin/sh
-: > /dev/watchdog
 
-. /lib/dracut-lib.sh
-
-export PATH=/usr/sbin:/usr/bin:/sbin:/bin
-command -v plymouth > /dev/null 2>&1 && plymouth --quit
-exec > /dev/console 2>&1
-
-echo "dracut-root-block-success" | dd oflag=direct,dsync of=/dev/disk/by-id/scsi-0QEMU_QEMU_HARDDISK_marker
-
-export TERM=linux
-export PS1='initramfs-test:\w\$ '
-[ -f /etc/mtab ] || ln -sfn /proc/mounts /etc/mtab
-[ -f /etc/fstab ] || ln -sfn /proc/mounts /etc/fstab
-stty sane
-echo "made it to the rootfs!"
-if getargbool 0 rd.shell; then
-    strstr "$(setsid --help)" "control" && CTTY="-c"
-    setsid $CTTY sh -i
-fi
-echo "Powering down."
-mount -n -o remount,ro /
-poweroff -f
+. /test-init.sh

--- a/test/TEST-11-LVM/test.sh
+++ b/test/TEST-11-LVM/test.sh
@@ -28,8 +28,6 @@ test_setup() {
     "$DRACUT" -l --keep --tmpdir "$TESTDIR" \
         -m "test-root" \
         -i ./test-init.sh /sbin/init \
-        -i "${basedir}/modules.d/99base/dracut-lib.sh" "/lib/dracut-lib.sh" \
-        -i "${basedir}/modules.d/99base/dracut-dev-lib.sh" "/lib/dracut-dev-lib.sh" \
         --no-hostonly --no-hostonly-cmdline --nohardlink \
         -f "$TESTDIR"/initramfs.root "$KVERSION" || return 1
     mkdir -p "$TESTDIR"/overlay/source && mv "$TESTDIR"/dracut.*/initramfs/* "$TESTDIR"/overlay/source && rm -rf "$TESTDIR"/dracut.*

--- a/test/TEST-11-LVM/test.sh
+++ b/test/TEST-11-LVM/test.sh
@@ -27,7 +27,6 @@ test_setup() {
     # Create what will eventually be our root filesystem onto an overlay
     "$DRACUT" -l --keep --tmpdir "$TESTDIR" \
         -m "test-root" \
-        -i ./test-init.sh /sbin/init \
         --no-hostonly --no-hostonly-cmdline --nohardlink \
         -f "$TESTDIR"/initramfs.root "$KVERSION" || return 1
     mkdir -p "$TESTDIR"/overlay/source && mv "$TESTDIR"/dracut.*/initramfs/* "$TESTDIR"/overlay/source && rm -rf "$TESTDIR"/dracut.*

--- a/test/TEST-12-RAID-DEG/test-init.sh
+++ b/test/TEST-12-RAID-DEG/test-init.sh
@@ -1,3 +1,0 @@
-#!/bin/sh
-
-. /test-init.sh

--- a/test/TEST-12-RAID-DEG/test-init.sh
+++ b/test/TEST-12-RAID-DEG/test-init.sh
@@ -1,27 +1,3 @@
 #!/bin/sh
-: > /dev/watchdog
 
-. /lib/dracut-lib.sh
-
-export PATH=/usr/sbin:/usr/bin:/sbin:/bin
-command -v plymouth > /dev/null 2>&1 && plymouth --quit
-exec > /dev/console 2>&1
-
-echo "dracut-root-block-success" | dd oflag=direct,dsync of=/dev/disk/by-id/scsi-0QEMU_QEMU_HARDDISK_marker
-
-export TERM=linux
-export PS1='initramfs-test:\w\$ '
-[ -f /etc/mtab ] || ln -sfn /proc/mounts /etc/mtab
-[ -f /etc/fstab ] || ln -sfn /proc/mounts /etc/fstab
-stty sane
-echo "made it to the rootfs!"
-if getargbool 0 rd.shell; then
-    strstr "$(setsid --help)" "control" && CTTY="-c"
-    setsid $CTTY sh -i
-fi
-echo "Powering down."
-mount -n -o remount,ro /
-if [ -d /run/initramfs/etc ]; then
-    echo " rd.debug=0 " >> /run/initramfs/etc/cmdline
-fi
-poweroff -f
+. /test-init.sh

--- a/test/TEST-12-RAID-DEG/test.sh
+++ b/test/TEST-12-RAID-DEG/test.sh
@@ -58,8 +58,6 @@ test_setup() {
     "$basedir"/dracut.sh -l --keep --tmpdir "$TESTDIR" \
         -m "test-root" \
         -i ./test-init.sh /sbin/init \
-        -i "${basedir}/modules.d/99base/dracut-lib.sh" "/lib/dracut-lib.sh" \
-        -i "${basedir}/modules.d/99base/dracut-dev-lib.sh" "/lib/dracut-dev-lib.sh" \
         --no-hostonly --no-hostonly-cmdline --nohardlink \
         -f "$TESTDIR"/initramfs.root "$KVERSION" || return 1
     mkdir -p "$TESTDIR"/overlay/source && mv "$TESTDIR"/dracut.*/initramfs/* "$TESTDIR"/overlay/source && rm -rf "$TESTDIR"/dracut.*

--- a/test/TEST-12-RAID-DEG/test.sh
+++ b/test/TEST-12-RAID-DEG/test.sh
@@ -57,7 +57,6 @@ test_run() {
 test_setup() {
     "$basedir"/dracut.sh -l --keep --tmpdir "$TESTDIR" \
         -m "test-root" \
-        -i ./test-init.sh /sbin/init \
         --no-hostonly --no-hostonly-cmdline --nohardlink \
         -f "$TESTDIR"/initramfs.root "$KVERSION" || return 1
     mkdir -p "$TESTDIR"/overlay/source && mv "$TESTDIR"/dracut.*/initramfs/* "$TESTDIR"/overlay/source && rm -rf "$TESTDIR"/dracut.*

--- a/test/TEST-13-ENC-RAID-LVM/test-init.sh
+++ b/test/TEST-13-ENC-RAID-LVM/test-init.sh
@@ -1,3 +1,0 @@
-#!/bin/sh
-
-. /test-init.sh

--- a/test/TEST-13-ENC-RAID-LVM/test-init.sh
+++ b/test/TEST-13-ENC-RAID-LVM/test-init.sh
@@ -1,27 +1,3 @@
 #!/bin/sh
-: > /dev/watchdog
 
-. /lib/dracut-lib.sh
-
-export PATH=/usr/sbin:/usr/bin:/sbin:/bin
-command -v plymouth > /dev/null 2>&1 && plymouth --quit
-exec > /dev/console 2>&1
-
-echo "dracut-root-block-success" | dd oflag=direct,dsync of=/dev/disk/by-id/scsi-0QEMU_QEMU_HARDDISK_marker
-
-export TERM=linux
-export PS1='initramfs-test:\w\$ '
-[ -f /etc/mtab ] || ln -sfn /proc/mounts /etc/mtab
-[ -f /etc/fstab ] || ln -sfn /proc/mounts /etc/fstab
-stty sane
-echo "made it to the rootfs!"
-if getargbool 0 rd.shell; then
-    strstr "$(setsid --help)" "control" && CTTY="-c"
-    setsid $CTTY sh -i
-fi
-echo "Powering down."
-mount -n -o remount,ro /
-if [ -d /run/initramfs/etc ]; then
-    echo " rd.debug=0 " >> /run/initramfs/etc/cmdline
-fi
-poweroff -f
+. /test-init.sh

--- a/test/TEST-13-ENC-RAID-LVM/test.sh
+++ b/test/TEST-13-ENC-RAID-LVM/test.sh
@@ -54,7 +54,6 @@ test_setup() {
     # Create what will eventually be our root filesystem onto an overlay
     "$DRACUT" -l --keep --tmpdir "$TESTDIR" \
         -m "test-root" \
-        -i ./test-init.sh /sbin/init \
         --no-hostonly --no-hostonly-cmdline --nohardlink \
         -f "$TESTDIR"/initramfs.root "$KVERSION" || return 1
     mkdir -p "$TESTDIR"/overlay/source && mv "$TESTDIR"/dracut.*/initramfs/* "$TESTDIR"/overlay/source && rm -rf "$TESTDIR"/dracut.*

--- a/test/TEST-13-ENC-RAID-LVM/test.sh
+++ b/test/TEST-13-ENC-RAID-LVM/test.sh
@@ -55,8 +55,6 @@ test_setup() {
     "$DRACUT" -l --keep --tmpdir "$TESTDIR" \
         -m "test-root" \
         -i ./test-init.sh /sbin/init \
-        -i "${basedir}/modules.d/99base/dracut-lib.sh" "/lib/dracut-lib.sh" \
-        -i "${basedir}/modules.d/99base/dracut-dev-lib.sh" "/lib/dracut-dev-lib.sh" \
         --no-hostonly --no-hostonly-cmdline --nohardlink \
         -f "$TESTDIR"/initramfs.root "$KVERSION" || return 1
     mkdir -p "$TESTDIR"/overlay/source && mv "$TESTDIR"/dracut.*/initramfs/* "$TESTDIR"/overlay/source && rm -rf "$TESTDIR"/dracut.*

--- a/test/TEST-14-IMSM/test-init.sh
+++ b/test/TEST-14-IMSM/test-init.sh
@@ -1,3 +1,0 @@
-#!/bin/sh
-
-. /test-init.sh

--- a/test/TEST-14-IMSM/test-init.sh
+++ b/test/TEST-14-IMSM/test-init.sh
@@ -1,27 +1,3 @@
 #!/bin/sh
-: > /dev/watchdog
 
-. /lib/dracut-lib.sh
-
-export PATH=/usr/sbin:/usr/bin:/sbin:/bin
-command -v plymouth > /dev/null 2>&1 && plymouth --quit
-exec > /dev/console 2>&1
-
-echo "dracut-root-block-success" | dd oflag=direct,dsync of=/dev/disk/by-id/scsi-0QEMU_QEMU_HARDDISK_marker
-
-export TERM=linux
-export PS1='initramfs-test:\w\$ '
-[ -f /etc/mtab ] || ln -sfn /proc/mounts /etc/mtab
-[ -f /etc/fstab ] || ln -sfn /proc/mounts /etc/fstab
-stty sane
-echo "made it to the rootfs!"
-if getargbool 0 rd.shell; then
-    strstr "$(setsid --help)" "control" && CTTY="-c"
-    setsid $CTTY sh -i
-fi
-echo "Powering down."
-mount -n -o remount,ro /
-if [ -d /run/initramfs/etc ]; then
-    echo " rd.debug=0 " >> /run/initramfs/etc/cmdline
-fi
-poweroff -f
+. /test-init.sh

--- a/test/TEST-14-IMSM/test.sh
+++ b/test/TEST-14-IMSM/test.sh
@@ -52,7 +52,6 @@ test_setup() {
     # Create what will eventually be our root filesystem onto an overlay
     "$DRACUT" -l --keep --tmpdir "$TESTDIR" \
         -m "test-root" \
-        -i ./test-init.sh /sbin/init \
         --no-hostonly --no-hostonly-cmdline --nohardlink \
         -f "$TESTDIR"/initramfs.root "$KVERSION" || return 1
     mkdir -p "$TESTDIR"/overlay/source && mv "$TESTDIR"/dracut.*/initramfs/* "$TESTDIR"/overlay/source && rm -rf "$TESTDIR"/dracut.*

--- a/test/TEST-14-IMSM/test.sh
+++ b/test/TEST-14-IMSM/test.sh
@@ -53,8 +53,6 @@ test_setup() {
     "$DRACUT" -l --keep --tmpdir "$TESTDIR" \
         -m "test-root" \
         -i ./test-init.sh /sbin/init \
-        -i "${basedir}/modules.d/99base/dracut-lib.sh" "/lib/dracut-lib.sh" \
-        -i "${basedir}/modules.d/99base/dracut-dev-lib.sh" "/lib/dracut-dev-lib.sh" \
         --no-hostonly --no-hostonly-cmdline --nohardlink \
         -f "$TESTDIR"/initramfs.root "$KVERSION" || return 1
     mkdir -p "$TESTDIR"/overlay/source && mv "$TESTDIR"/dracut.*/initramfs/* "$TESTDIR"/overlay/source && rm -rf "$TESTDIR"/dracut.*

--- a/test/TEST-15-BTRFSRAID/test-init.sh
+++ b/test/TEST-15-BTRFSRAID/test-init.sh
@@ -1,3 +1,0 @@
-#!/bin/sh
-
-. /test-init.sh

--- a/test/TEST-15-BTRFSRAID/test-init.sh
+++ b/test/TEST-15-BTRFSRAID/test-init.sh
@@ -1,25 +1,3 @@
 #!/bin/sh
-: > /dev/watchdog
 
-. /lib/dracut-lib.sh
-
-export PATH=/usr/sbin:/usr/bin:/sbin:/bin
-command -v plymouth > /dev/null 2>&1 && plymouth --quit
-exec > /dev/console 2>&1
-
-echo "dracut-root-block-success" | dd oflag=direct,dsync of=/dev/disk/by-id/scsi-0QEMU_QEMU_HARDDISK_marker
-
-export TERM=linux
-export PS1='initramfs-test:\w\$ '
-[ -f /etc/mtab ] || ln -sfn /proc/mounts /etc/mtab
-[ -f /etc/fstab ] || ln -sfn /proc/mounts /etc/fstab
-stty sane
-echo "made it to the rootfs!"
-if getargbool 0 rd.shell; then
-    strstr "$(setsid --help)" "control" && CTTY="-c"
-    setsid $CTTY sh -i
-fi
-echo "Powering down."
-mount -n -o remount,ro /
-
-poweroff -f
+. /test-init.sh

--- a/test/TEST-15-BTRFSRAID/test.sh
+++ b/test/TEST-15-BTRFSRAID/test.sh
@@ -30,7 +30,6 @@ test_setup() {
     # Create what will eventually be our root filesystem onto an overlay
     "$DRACUT" -l --keep --tmpdir "$TESTDIR" \
         -m "test-root" \
-        -i ./test-init.sh /sbin/init \
         --no-hostonly --no-hostonly-cmdline --nohardlink \
         -f "$TESTDIR"/initramfs.root "$KVERSION" || return 1
     mkdir -p "$TESTDIR"/overlay/source && mv "$TESTDIR"/dracut.*/initramfs/* "$TESTDIR"/overlay/source && rm -rf "$TESTDIR"/dracut.*

--- a/test/TEST-15-BTRFSRAID/test.sh
+++ b/test/TEST-15-BTRFSRAID/test.sh
@@ -31,8 +31,6 @@ test_setup() {
     "$DRACUT" -l --keep --tmpdir "$TESTDIR" \
         -m "test-root" \
         -i ./test-init.sh /sbin/init \
-        -i "${basedir}/modules.d/99base/dracut-lib.sh" "/lib/dracut-lib.sh" \
-        -i "${basedir}/modules.d/99base/dracut-dev-lib.sh" "/lib/dracut-dev-lib.sh" \
         --no-hostonly --no-hostonly-cmdline --nohardlink \
         -f "$TESTDIR"/initramfs.root "$KVERSION" || return 1
     mkdir -p "$TESTDIR"/overlay/source && mv "$TESTDIR"/dracut.*/initramfs/* "$TESTDIR"/overlay/source && rm -rf "$TESTDIR"/dracut.*

--- a/test/TEST-16-DMSQUASH/test-init.sh
+++ b/test/TEST-16-DMSQUASH/test-init.sh
@@ -6,4 +6,5 @@ if grep -qF ' rd.live.overlay=LABEL=persist ' /proc/cmdline; then
     echo "dracut-autooverlay-success" > /overlay-marker
 fi
 
-. /test-init.sh
+# call the rest of the init
+. /sbin/init

--- a/test/TEST-16-DMSQUASH/test-init.sh
+++ b/test/TEST-16-DMSQUASH/test-init.sh
@@ -1,13 +1,4 @@
 #!/bin/sh
-: > /dev/watchdog
-
-. /lib/dracut-lib.sh
-
-export PATH=/usr/sbin:/usr/bin:/sbin:/bin
-command -v plymouth > /dev/null 2>&1 && plymouth --quit
-exec > /dev/console 2>&1
-
-echo "dracut-root-block-success" | dd oflag=direct,dsync of=/dev/disk/by-id/scsi-0QEMU_QEMU_HARDDISK_marker
 
 if grep -qF ' rd.live.overlay=LABEL=persist ' /proc/cmdline; then
     # Writing to a file in the root filesystem lets test_run() verify that the autooverlay module successfully created
@@ -15,17 +6,4 @@ if grep -qF ' rd.live.overlay=LABEL=persist ' /proc/cmdline; then
     echo "dracut-autooverlay-success" > /overlay-marker
 fi
 
-export TERM=linux
-export PS1='initramfs-test:\w\$ '
-[ -f /etc/mtab ] || ln -sfn /proc/mounts /etc/mtab
-[ -f /etc/fstab ] || ln -sfn /proc/mounts /etc/fstab
-stty sane
-echo "made it to the rootfs!"
-if getargbool 0 rd.shell; then
-    strstr "$(setsid --help)" "control" && CTTY="-c"
-    setsid $CTTY sh -i
-fi
-echo "Powering down."
-mount -n -o remount,ro /
-
-poweroff -f
+. /test-init.sh

--- a/test/TEST-16-DMSQUASH/test.sh
+++ b/test/TEST-16-DMSQUASH/test.sh
@@ -84,8 +84,6 @@ test_setup() {
     "$DRACUT" -l --keep --tmpdir "$TESTDIR" \
         -m "test-root" \
         -i ./test-init.sh /sbin/init \
-        -i "${PKGLIBDIR}/modules.d/99base/dracut-lib.sh" "/lib/dracut-lib.sh" \
-        -i "${PKGLIBDIR}/modules.d/99base/dracut-dev-lib.sh" "/lib/dracut-dev-lib.sh" \
         --no-hostonly --no-hostonly-cmdline --nomdadmconf --nohardlink \
         -f "$TESTDIR"/initramfs.root "$KVERSION" || return 1
     mkdir -p "$TESTDIR"/overlay/source && mv "$TESTDIR"/dracut.*/initramfs/* "$TESTDIR"/overlay/source && rm -rf "$TESTDIR"/dracut.*

--- a/test/TEST-16-DMSQUASH/test.sh
+++ b/test/TEST-16-DMSQUASH/test.sh
@@ -63,7 +63,7 @@ test_run() {
     "$testdir"/run-qemu \
         "${disk_args[@]}" \
         -boot order=d \
-        -append "rd.live.image rd.live.overlay.overlayfs=1 rd.live.overlay=LABEL=persist rd.live.dir=testdir root=LABEL=dracut console=ttyS0,115200n81 quiet selinux=0 rd.info rd.shell=0 panic=1 oops=panic softlockup_panic=1 $DEBUGFAIL" \
+        -append "init=/sbin/init-persist rd.live.image rd.live.overlay.overlayfs=1 rd.live.overlay=LABEL=persist rd.live.dir=testdir root=LABEL=dracut console=ttyS0,115200n81 quiet selinux=0 rd.info rd.shell=0 panic=1 oops=panic softlockup_panic=1 $DEBUGFAIL" \
         -initrd "$TESTDIR"/initramfs.testing-autooverlay
 
     rootPartitions=$(sfdisk -d "$TESTDIR"/root.img | grep -c 'root\.img[0-9]')
@@ -83,7 +83,7 @@ test_setup() {
     # Create what will eventually be our root filesystem onto an overlay
     "$DRACUT" -l --keep --tmpdir "$TESTDIR" \
         -m "test-root" \
-        -i ./test-init.sh /sbin/init \
+        -i ./test-init.sh /sbin/init-persist \
         --no-hostonly --no-hostonly-cmdline --nomdadmconf --nohardlink \
         -f "$TESTDIR"/initramfs.root "$KVERSION" || return 1
     mkdir -p "$TESTDIR"/overlay/source && mv "$TESTDIR"/dracut.*/initramfs/* "$TESTDIR"/overlay/source && rm -rf "$TESTDIR"/dracut.*

--- a/test/TEST-17-LVM-THIN/test-init.sh
+++ b/test/TEST-17-LVM-THIN/test-init.sh
@@ -1,3 +1,0 @@
-#!/bin/sh
-
-. /test-init.sh

--- a/test/TEST-17-LVM-THIN/test-init.sh
+++ b/test/TEST-17-LVM-THIN/test-init.sh
@@ -1,24 +1,3 @@
 #!/bin/sh
-: > /dev/watchdog
 
-. /lib/dracut-lib.sh
-
-export PATH=/usr/sbin:/usr/bin:/sbin:/bin
-command -v plymouth > /dev/null 2>&1 && plymouth --quit
-exec > /dev/console 2>&1
-
-echo "dracut-root-block-success" | dd oflag=direct,dsync of=/dev/disk/by-id/scsi-0QEMU_QEMU_HARDDISK_marker
-
-export TERM=linux
-export PS1='initramfs-test:\w\$ '
-[ -f /etc/mtab ] || ln -sfn /proc/mounts /etc/mtab
-[ -f /etc/fstab ] || ln -sfn /proc/mounts /etc/fstab
-stty sane
-echo "made it to the rootfs!"
-if getargbool 0 rd.shell; then
-    strstr "$(setsid --help)" "control" && CTTY="-c"
-    setsid $CTTY sh -i
-fi
-echo "Powering down."
-mount -n -o remount,ro /
-poweroff -f
+. /test-init.sh

--- a/test/TEST-17-LVM-THIN/test.sh
+++ b/test/TEST-17-LVM-THIN/test.sh
@@ -27,8 +27,6 @@ test_setup() {
     "$DRACUT" -l --keep --tmpdir "$TESTDIR" \
         -m "test-root" \
         -i ./test-init.sh /sbin/init \
-        -i "${basedir}/modules.d/99base/dracut-lib.sh" "/lib/dracut-lib.sh" \
-        -i "${basedir}/modules.d/99base/dracut-dev-lib.sh" "/lib/dracut-dev-lib.sh" \
         --no-hostonly --no-hostonly-cmdline --nohardlink \
         -f "$TESTDIR"/initramfs.root "$KVERSION" || return 1
     mkdir -p "$TESTDIR"/overlay/source && mv "$TESTDIR"/dracut.*/initramfs/* "$TESTDIR"/overlay/source && rm -rf "$TESTDIR"/dracut.*

--- a/test/TEST-17-LVM-THIN/test.sh
+++ b/test/TEST-17-LVM-THIN/test.sh
@@ -26,7 +26,6 @@ test_setup() {
 
     "$DRACUT" -l --keep --tmpdir "$TESTDIR" \
         -m "test-root" \
-        -i ./test-init.sh /sbin/init \
         --no-hostonly --no-hostonly-cmdline --nohardlink \
         -f "$TESTDIR"/initramfs.root "$KVERSION" || return 1
     mkdir -p "$TESTDIR"/overlay/source && mv "$TESTDIR"/dracut.*/initramfs/* "$TESTDIR"/overlay/source && rm -rf "$TESTDIR"/dracut.*

--- a/test/TEST-18-UEFI/test-init.sh
+++ b/test/TEST-18-UEFI/test-init.sh
@@ -1,3 +1,0 @@
-#!/bin/sh
-
-. /test-init.sh

--- a/test/TEST-18-UEFI/test-init.sh
+++ b/test/TEST-18-UEFI/test-init.sh
@@ -1,23 +1,3 @@
 #!/bin/sh
 
-export PATH=/usr/sbin:/usr/bin:/sbin:/bin
-
-[ -e /proc/self/mounts ] \
-    || (mkdir -p /proc && mount -t proc -o nosuid,noexec,nodev proc /proc)
-
-grep -q '^sysfs /sys sysfs' /proc/self/mounts \
-    || (mkdir -p /sys && mount -t sysfs -o nosuid,noexec,nodev sysfs /sys)
-
-grep -q '^devtmpfs /dev devtmpfs' /proc/self/mounts \
-    || (mkdir -p /dev && mount -t devtmpfs -o mode=755,noexec,nosuid,strictatime devtmpfs /dev)
-
-grep -q '^tmpfs /run tmpfs' /proc/self/mounts \
-    || (mkdir -p /run && mount -t tmpfs -o mode=755,noexec,nosuid,strictatime tmpfs /run)
-
-: > /dev/watchdog
-
-exec > /dev/console 2>&1
-
-echo "made it to the rootfs! Powering down."
-echo "dracut-root-block-success" | dd oflag=direct,dsync of=/dev/disk/by-id/scsi-0QEMU_QEMU_HARDDISK_marker
-poweroff -f
+. /test-init.sh

--- a/test/TEST-18-UEFI/test.sh
+++ b/test/TEST-18-UEFI/test.sh
@@ -35,7 +35,7 @@ test_run() {
 test_setup() {
     # Create what will eventually be our root filesystem
     "$DRACUT" --local --no-hostonly --no-early-microcode --nofscks \
-        --tmpdir "$TESTDIR" --keep --modules "test-root" --include ./test-init.sh /sbin/init \
+        --tmpdir "$TESTDIR" --keep --modules "test-root" \
         "$TESTDIR"/tmp-initramfs.root "$KVERSION" || return 1
 
     mkdir -p "$TESTDIR"/dracut.*/initramfs/proc

--- a/test/TEST-30-ISCSI/test.sh
+++ b/test/TEST-30-ISCSI/test.sh
@@ -136,7 +136,6 @@ test_setup() {
     # Create what will eventually be the client root filesystem onto an overlay
     "$DRACUT" -l --keep --tmpdir "$TESTDIR" \
         -m "test-root" \
-        -i ./client-init.sh /sbin/init \
         -I "ip grep setsid" \
         -i "${PKGLIBDIR}/modules.d/99base/dracut-lib.sh" "/lib/dracut-lib.sh" \
         -i "${PKGLIBDIR}/modules.d/99base/dracut-dev-lib.sh" "/lib/dracut-dev-lib.sh" \
@@ -145,6 +144,7 @@ test_setup() {
     mkdir -p "$TESTDIR"/overlay/source && mv "$TESTDIR"/dracut.*/initramfs/* "$TESTDIR"/overlay/source && rm -rf "$TESTDIR"/dracut.*
 
     mkdir -p -- "$TESTDIR"/overlay/source/var/lib/nfs/rpc_pipefs
+    cp ./client-init.sh "$TESTDIR"/overlay/source/sbin/init
 
     # create an initramfs that will create the target root filesystem.
     # We do it this way so that we do not risk trashing the host mdraid
@@ -176,7 +176,6 @@ test_setup() {
     "$DRACUT" -l --keep --tmpdir "$TESTDIR" \
         -m "test-root network network-legacy" \
         -d "iscsi_tcp crc32c ipv6" \
-        -i ./server-init.sh /sbin/init \
         -i "${PKGLIBDIR}/modules.d/99base/dracut-lib.sh" "/lib/dracut-lib.sh" \
         -i "${PKGLIBDIR}/modules.d/99base/dracut-dev-lib.sh" "/lib/dracut-dev-lib.sh" \
         -I "modprobe chmod ip tcpdump setsid pidof tgtd tgtadm /etc/passwd" \
@@ -188,6 +187,7 @@ test_setup() {
     mkdir -p "$TESTDIR"/overlay/source && mv "$TESTDIR"/dracut.*/initramfs/* "$TESTDIR"/overlay/source && rm -rf "$TESTDIR"/dracut.*
 
     mkdir -p "$TESTDIR"/overlay/source/var/lib/dhcpd
+    cp ./server-init.sh "$TESTDIR"/overlay/source/sbin/init
 
     # second, install the files needed to make the root filesystem
     # create an initramfs that will create the target root filesystem.

--- a/test/TEST-35-ISCSI-MULTI/test.sh
+++ b/test/TEST-35-ISCSI-MULTI/test.sh
@@ -149,7 +149,6 @@ test_setup() {
     rm -rf -- "$TESTDIR"/overlay
     "$DRACUT" -l --keep --tmpdir "$TESTDIR" \
         -m "test-root" \
-        -i ./client-init.sh /sbin/init \
         -I "ip grep setsid" \
         -i "${basedir}/modules.d/99base/dracut-lib.sh" "/lib/dracut-lib.sh" \
         -i "${basedir}/modules.d/99base/dracut-dev-lib.sh" "/lib/dracut-dev-lib.sh" \
@@ -157,6 +156,7 @@ test_setup() {
         -f "$TESTDIR"/initramfs.root "$KVERSION" || return 1
     mkdir -p "$TESTDIR"/overlay/source && mv "$TESTDIR"/dracut.*/initramfs/* "$TESTDIR"/overlay/source && rm -rf "$TESTDIR"/dracut.*
     mkdir -p -- "$TESTDIR"/overlay/source/var/lib/nfs/rpc_pipefs
+    cp ./client-init.sh "$TESTDIR"/overlay/source/sbin/init
 
     # second, install the files needed to make the root filesystem
     # create an initramfs that will create the target root filesystem.
@@ -189,7 +189,6 @@ test_setup() {
     "$DRACUT" -l --keep --tmpdir "$TESTDIR" \
         -m "test-root network network-legacy iscsi" \
         -d "iscsi_tcp crc32c ipv6 af_packet" \
-        -i ./server-init.sh /sbin/init \
         -I "ip grep sleep setsid chmod modprobe pidof tgtd tgtadm" \
         -i "${basedir}/modules.d/99base/dracut-lib.sh" "/lib/dracut-lib.sh" \
         -i "${basedir}/modules.d/99base/dracut-dev-lib.sh" "/lib/dracut-dev-lib.sh" \
@@ -202,6 +201,7 @@ test_setup() {
     mkdir -p "$TESTDIR"/overlay/source && mv "$TESTDIR"/dracut.*/initramfs/* "$TESTDIR"/overlay/source && rm -rf "$TESTDIR"/dracut.*
 
     mkdir -p -- "$TESTDIR"/overlay/source/var/lib/dhcpd "$TESTDIR"/overlay/source/etc/iscsi
+    cp ./server-init.sh "$TESTDIR"/overlay/source/sbin/init
 
     # second, install the files needed to make the root filesystem
     # create an initramfs that will create the target root filesystem.

--- a/test/TEST-40-NBD/test.sh
+++ b/test/TEST-40-NBD/test.sh
@@ -190,13 +190,13 @@ make_encrypted_root() {
     # Create what will eventually be our root filesystem onto an overlay
     "$DRACUT" -l --keep --tmpdir "$TESTDIR" \
         -m "test-root" \
-        -i ./client-init.sh /sbin/init \
         -I "ip grep" \
         -i "${basedir}/modules.d/99base/dracut-lib.sh" "/lib/dracut-lib.sh" \
         -i "${basedir}/modules.d/99base/dracut-dev-lib.sh" "/lib/dracut-dev-lib.sh" \
         --no-hostonly --no-hostonly-cmdline --nohardlink \
         -f "$TESTDIR"/initramfs.root "$KVERSION" || return 1
     mkdir -p "$TESTDIR"/overlay/source && mv "$TESTDIR"/dracut.*/initramfs/* "$TESTDIR"/overlay/source && rm -rf "$TESTDIR"/dracut.*
+    cp ./client-init.sh "$TESTDIR"/overlay/source/sbin/init
 
     # second, install the files needed to make the root filesystem
     # create an initramfs that will create the target root filesystem.
@@ -228,13 +228,13 @@ make_client_root() {
     rm -fr "$TESTDIR"/overlay
     "$DRACUT" -l --keep --tmpdir "$TESTDIR" \
         -m "test-root" \
-        -i ./client-init.sh /sbin/init \
         -I "ip" \
         -i "${basedir}/modules.d/99base/dracut-lib.sh" "/lib/dracut-lib.sh" \
         -i "${basedir}/modules.d/99base/dracut-dev-lib.sh" "/lib/dracut-dev-lib.sh" \
         --no-hostonly --no-hostonly-cmdline --nohardlink \
         -f "$TESTDIR"/initramfs.root "$KVERSION" || return 1
     mkdir -p "$TESTDIR"/overlay/source && mv "$TESTDIR"/dracut.*/initramfs/* "$TESTDIR"/overlay/source && rm -rf "$TESTDIR"/dracut.*
+    cp ./client-init.sh "$TESTDIR"/overlay/source/sbin/init
 
     # second, install the files needed to make the root filesystem
     # create an initramfs that will create the target root filesystem.
@@ -280,7 +280,6 @@ EOF
     "$DRACUT" -l --keep --tmpdir "$TESTDIR" \
         -m "test-root network network-legacy" \
         -d "nfsd sunrpc ipv6 lockd af_packet 8021q ipvlan macvlan" \
-        -i ./server-init.sh /sbin/init \
         -I "ip grep sleep nbd-server chmod modprobe vi pidof" \
         -i "${basedir}/modules.d/99base/dracut-lib.sh" "/lib/dracut-lib.sh" \
         -i "${basedir}/modules.d/99base/dracut-dev-lib.sh" "/lib/dracut-dev-lib.sh" \
@@ -293,6 +292,7 @@ EOF
     mkdir -p "$TESTDIR"/overlay/source && mv "$TESTDIR"/dracut.*/initramfs/* "$TESTDIR"/overlay/source && rm -rf "$TESTDIR"/dracut.*
 
     mkdir -p -- "$TESTDIR"/overlay/source/var/lib/dhcpd "$TESTDIR"/overlay/source/etc/nbd-server
+    cp ./server-init.sh "$TESTDIR"/overlay/source/sbin/init
 
     # second, install the files needed to make the root filesystem
     # create an initramfs that will create the target root filesystem.


### PR DESCRIPTION
This PR removes 300+ lines of "repeating yourself" boilerplate from the test CI.

It consolidates the `/sbin/init` script (called `test-init.sh`) for the rootfs that test cases are booting into.

## Checklist
- [X] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it
