### PR TITLE
fix(dracut): add support for RISC-V EFI

### DIFF
--- a/dracut.sh
+++ b/dracut.sh
@@ -1528,6 +1528,9 @@ if [[ ! $print_cmdline ]]; then
             aarch64)
                 EFI_MACHINE_TYPE_NAME=aa64
                 ;;
+            riscv64)
+                EFI_MACHINE_TYPE_NAME=riscv64
+                ;;
             *)
                 dfatal "Architecture '${DRACUT_ARCH:-$(uname -m)}' not supported to create a UEFI executable"
                 exit 1


### PR DESCRIPTION
## Changes

From: https://gitlab.com/freedesktop-sdk/freedesktop-sdk/-/blob/master/patches/dracut/dracut-riscv64-efi.patch

## Checklist
- [ ] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it

CC @valentindavid