### PR TITLE
perf(systemd): remove duplicate rules

### DIFF
--- a/modules.d/00systemd/module-setup.sh
+++ b/modules.d/00systemd/module-setup.sh
@@ -36,7 +36,6 @@ install() {
         "$systemdutildir"/systemd-shutdown \
         "$systemdutildir"/systemd-reply-password \
         "$systemdutildir"/systemd-fsck \
-        "$systemdutildir"/systemd-sysctl \
         "$systemdutildir"/systemd-vconsole-setup \
         "$systemdutildir"/systemd-volatile-root \
         "$systemdutildir"/systemd-sysroot-fstab-check \
@@ -82,8 +81,6 @@ install() {
         "$systemdsystemunitdir"/systemd-fsck@.service \
         "$systemdsystemunitdir"/systemd-vconsole-setup.service \
         "$systemdsystemunitdir"/systemd-volatile-root.service \
-        "$systemdsystemunitdir"/systemd-sysctl.service \
-        "$systemdsystemunitdir"/sysinit.target.wants/systemd-sysctl.service \
         "$systemdsystemunitdir"/ctrl-alt-del.target \
         "$systemdsystemunitdir"/syslog.socket \
         "$systemdsystemunitdir"/slices.target \
@@ -95,9 +92,6 @@ install() {
         systemd-run systemd-escape \
         systemd-cgls
 
-    inst_multiple -o \
-        /usr/lib/sysctl.d/*.conf
-
     if [[ $hostonly ]]; then
         inst_multiple -H -o \
             /etc/systemd/system.conf \
@@ -108,9 +102,7 @@ install() {
             /etc/machine-id \
             /etc/machine-info \
             /etc/vconsole.conf \
-            /etc/locale.conf \
-            /etc/sysctl.d/*.conf \
-            /etc/sysctl.conf
+            /etc/locale.conf
     fi
 
     if ! [[ -e "$initdir/etc/machine-id" ]]; then

--- a/modules.d/01systemd-sysctl/module-setup.sh
+++ b/modules.d/01systemd-sysctl/module-setup.sh
@@ -10,7 +10,6 @@ check() {
 
     # Return 255 to only include the module, if another module requires it.
     return 255
-
 }
 
 # Module dependency requirements.
@@ -20,13 +19,13 @@ depends() {
     echo systemd-modules-load
     # Return 0 to include the dependent module(s) in the initramfs.
     return 0
-
 }
 
 # Install the required file(s) for the module in the initramfs.
 install() {
 
     inst_multiple -o \
+        /usr/lib/sysctl.d/*.conf \
         "$sysctld/*.conf" \
         "$systemdsystemunitdir"/systemd-sysctl.service \
         "$systemdsystemunitdir"/sysinit.target.wants/systemd-sysctl.service \
@@ -36,6 +35,7 @@ install() {
     if [[ $hostonly ]]; then
         inst_multiple -H -o \
             /etc/sysctl.conf \
+            /etc/sysctl.d/*.conf \
             "$sysctlconfdir/*.conf" \
             "$systemdsystemconfdir"/systemd-sysctl.service \
             "$systemdsystemconfdir/systemd-sysctl.service.d/*.conf"
@@ -43,5 +43,4 @@ install() {
 
     # Enable the systemd type service unit for sysctl.
     $SYSTEMCTL -q --root "$initdir" enable systemd-sysctl.service
-
 }


### PR DESCRIPTION
## Changes

Consolidate systemd-sysctl logic into the systemd-sysctl module.

dracut-systemd module depends indirectly on systemd-sysctl. 
(via systemd-initrd --> systemd-udevd --> systemd-sysctl).

## Checklist
- [x] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it
