### PR TITLE
perf(crypt): move more rules to systemd-cryptsetup

### DIFF
--- a/modules.d/90crypt/module-setup.sh
+++ b/modules.d/90crypt/module-setup.sh
@@ -18,21 +18,7 @@ check() {
 
 # called by dracut
 depends() {
-    local deps
-    deps="dm rootfs-block"
-    if [[ $hostonly && -f "$dracutsysrootdir"/etc/crypttab ]]; then
-        if grep -q -e "fido2-device=" -e "fido2-cid=" "$dracutsysrootdir"/etc/crypttab; then
-            deps+=" fido2"
-        fi
-        if grep -q "pkcs11-uri" "$dracutsysrootdir"/etc/crypttab; then
-            deps+=" pkcs11"
-        fi
-        if grep -q "tpm2-device=" "$dracutsysrootdir"/etc/crypttab; then
-            deps+=" tpm2-tss"
-        fi
-    fi
-    echo "$deps"
-    return 0
+    echo dm rootfs-block
 }
 
 # called by dracut

--- a/modules.d/90systemd-cryptsetup/module-setup.sh
+++ b/modules.d/90systemd-cryptsetup/module-setup.sh
@@ -18,7 +18,20 @@ check() {
 
 # called by dracut
 depends() {
-    echo dm rootfs-block crypt systemd-ask-password
+    local deps
+    deps="dm rootfs-block crypt systemd-ask-password"
+    if [[ $hostonly && -f "$dracutsysrootdir"/etc/crypttab ]]; then
+        if grep -q -e "fido2-device=" -e "fido2-cid=" "$dracutsysrootdir"/etc/crypttab; then
+            deps+=" fido2"
+        fi
+        if grep -q "pkcs11-uri" "$dracutsysrootdir"/etc/crypttab; then
+            deps+=" pkcs11"
+        fi
+        if grep -q "tpm2-device=" "$dracutsysrootdir"/etc/crypttab; then
+            deps+=" tpm2-tss"
+        fi
+    fi
+    echo "$deps"
     return 0
 }
 


### PR DESCRIPTION
## Changes

In its current form, fido2, pkcs11, tpm2-tss dracut modules depend on systemd.

## Checklist
- [ ] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it

Fixes #
