### PR TITLE
ci: switch to ubuntu-latest

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -22,7 +22,7 @@ permissions:
 jobs:
   analyze:
     name: Analyze
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     concurrency:
       group: ${{ github.workflow }}-${{ matrix.language }}-${{ github.ref }}
       cancel-in-progress: true


### PR DESCRIPTION
## Changes

All other CI jobs run on ubuntu-latest.

https://github.com/actions/runner-images/issues/9848
