### PR TITLE
fix(rngd): install system service file

### DIFF
--- a/modules.d/06rngd/module-setup.sh
+++ b/modules.d/06rngd/module-setup.sh
@@ -32,7 +32,12 @@ depends() {
 
 install() {
     inst rngd
-    inst_simple "${moddir}/rngd.service" "${systemdsystemunitdir}/rngd.service"
+    inst_simple "${systemdsystemunitdir}/rngd.service"
+
+    if [ -r /etc/sysconfig/rngd ]; then
+        inst_simple "${moddir}/sysconfig" "/etc/sysconfig/rngd"
+    fi
+
     # make sure dependent libs are installed too
     inst_libdir_file opensc-pkcs11.so
 

--- a/modules.d/06rngd/rngd.service
+++ b/modules.d/06rngd/rngd.service
@@ -1,8 +1,0 @@
-[Unit]
-Description=Hardware RNG Entropy Gatherer Daemon
-DefaultDependencies=no
-Before=systemd-udevd.service
-ConditionVirtualization=!container
-
-[Service]
-ExecStart=/usr/sbin/rngd -f

--- a/modules.d/06rngd/sysconfig
+++ b/modules.d/06rngd/sysconfig
@@ -1,0 +1,1 @@
+RNGD_ARGS="-x pkcs11 -x nist"


### PR DESCRIPTION
Note: this is dependent Fedora / RH rngd service file containing

`ExecStart=/usr/sbin/rngd -f $RNGD_ARGS`

## Changes

Use system service file, but ship modified args to drop the user change.
There's no reason to keep a copy of `rngd.service`; there shouldn't be any modifications.

In case there are args stored in a separate file (Fedora and alike), it needs to be supplied too, but without the option to change the user.

## Checklist
- [ ] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it
