### PR TITLE
ci: add rng-tools package to all test containers to test rngd dracut module

### DIFF
--- a/test/container/Dockerfile-Debian
+++ b/test/container/Dockerfile-Debian
@@ -51,6 +51,7 @@ RUN apt-get update -y -qq && apt-get upgrade -y -qq && apt-get install -y -qq --
     pkg-config \
     procps \
     qemu-kvm \
+    rng-tools5 \
     shellcheck \
     squashfs-tools \
     strace \

--- a/test/container/Dockerfile-OpenSuse-latest
+++ b/test/container/Dockerfile-OpenSuse-latest
@@ -33,6 +33,7 @@ RUN dnf -y install --setopt=install_weak_deps=False \
     pigz \
     procps \
     qemu-kvm \
+    rng-tools \
     rpm-build \
     ShellCheck \
     shfmt \

--- a/test/container/Dockerfile-Ubuntu
+++ b/test/container/Dockerfile-Ubuntu
@@ -50,6 +50,7 @@ RUN apt-get update -y -qq && apt-get upgrade -y -qq && \
     pkg-config \
     procps \
     qemu-kvm \
+    rng-tools5 \
     shellcheck \
     squashfs-tools \
     strace \

--- a/test/container/Dockerfile-Void
+++ b/test/container/Dockerfile-Void
@@ -49,6 +49,7 @@ RUN xbps-install -Syu xbps && xbps-install -yu \
     pigz \
     plymouth \
     qemu \
+    rng-tools \
     shellcheck \
     shfmt \
     squashfs-tools \

--- a/test/container/Dockerfile-alpine
+++ b/test/container/Dockerfile-alpine
@@ -46,6 +46,7 @@ RUN apk add --no-cache \
     procps \
     qemu-img \
     qemu-system-x86_64 \
+    rng-tools \
     sed \
     sfdisk \
     squashfs-tools \


### PR DESCRIPTION
Allow test rngd dracut module.

Triggered by discussion at https://github.com/dracut-ng/dracut-ng/pull/290

## Checklist
- [ ] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it
