### PR TITLE
fix(90kernel-modules): add psmouse for some Fujitsu laptops

### DIFF
--- a/modules.d/90kernel-modules/module-setup.sh
+++ b/modules.d/90kernel-modules/module-setup.sh
@@ -58,7 +58,8 @@ installkernel() {
             yenta_socket intel_lpss_pci spi_pxa2xx_platform \
             atkbd i8042 firewire-ohci pcmcia hv-vmbus \
             virtio virtio_ring virtio_pci pci_hyperv \
-            surface_aggregator_registry "=drivers/pcmcia"
+            surface_aggregator_registry psmouse \
+            "=drivers/pcmcia"
 
         if [[ ${DRACUT_ARCH:-$(uname -m)} == arm* || ${DRACUT_ARCH:-$(uname -m)} == aarch64 || ${DRACUT_ARCH:-$(uname -m)} == riscv* ]]; then
             # arm/aarch64 specific modules


### PR DESCRIPTION
## Changes
As reported on the Solus issue tracker and on the Arch forum some Fujitsu laptops apparently require the psmouse module to be loaded in order for the keyboard to be functional. At least the Fujitsu Lifebook T938 model laptop is known to require this.

## Checklist
- [x] I have tested it locally
- [x] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it

Fixes N/A
