### PR TITLE
ci: add tpm2-tools package to all test containers to test tpm2-tss dracut module

### DIFF
--- a/test/container/Dockerfile-Debian
+++ b/test/container/Dockerfile-Debian
@@ -59,6 +59,7 @@ RUN apt-get update -y -qq && apt-get upgrade -y -qq && apt-get install -y -qq --
     tcpdump \
     tgt \
     thin-provisioning-tools \
+    tpm2-tools \
     vim \
     wget \
     && apt-get clean && dpkg -P --force-depends dracut dracut-core initramfs-tools-core

--- a/test/container/Dockerfile-OpenSuse-latest
+++ b/test/container/Dockerfile-OpenSuse-latest
@@ -43,6 +43,7 @@ RUN dnf -y install --setopt=install_weak_deps=False \
     tar \
     tcpdump \
     tgt \
+    tpm2.0-tools \
     /usr/bin/qemu-system-$(uname -m) \
     util-linux-systemd \
     wget \

--- a/test/container/Dockerfile-Ubuntu
+++ b/test/container/Dockerfile-Ubuntu
@@ -58,6 +58,7 @@ RUN apt-get update -y -qq && apt-get upgrade -y -qq && \
     tcpdump \
     tgt \
     thin-provisioning-tools \
+    tpm2-tools \
     vim \
     wget \
     && apt-get clean \


### PR DESCRIPTION
## Changes

Noted in the following line during running tests in some of the test containers that indicates lack of test coverage. This PR resolves that.

```
dracut[E]: Module 'systemd-pcrphase' depends on 'tpm2-tss', which can't be installed
```

## Checklist
- [ ] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it
