### PR TITLE
feat: only install network modules in non-hostonly mode if requested

### DIFF
--- a/modules.d/95cifs/module-setup.sh
+++ b/modules.d/95cifs/module-setup.sh
@@ -12,7 +12,7 @@ check() {
         return 255
     }
 
-    return 0
+    return 255
 }
 
 # called by dracut

--- a/modules.d/95fcoe/module-setup.sh
+++ b/modules.d/95fcoe/module-setup.sh
@@ -11,7 +11,7 @@ check() {
     }
 
     require_binaries dcbtool fipvlan lldpad ip readlink fcoemon fcoeadm tr || return 1
-    return 0
+    return 255
 }
 
 # called by dracut

--- a/modules.d/95iscsi/module-setup.sh
+++ b/modules.d/95iscsi/module-setup.sh
@@ -15,7 +15,7 @@ check() {
         popd > /dev/null || exit
         [[ $_is_iscsi == 0 ]] || return 255
     }
-    return 0
+    return 255
 }
 
 get_ibft_mod() {

--- a/modules.d/95nbd/module-setup.sh
+++ b/modules.d/95nbd/module-setup.sh
@@ -13,7 +13,7 @@ check() {
     }
     require_binaries nbd-client || return 1
 
-    return 0
+    return 255
 }
 
 # called by dracut

--- a/modules.d/95nfs/module-setup.sh
+++ b/modules.d/95nfs/module-setup.sh
@@ -27,7 +27,7 @@ check() {
         [[ "$(get_nfs_type)" ]] && return 0
         return 255
     }
-    return 0
+    return 255
 }
 
 # called by dracut

--- a/modules.d/95nvmf/module-setup.sh
+++ b/modules.d/95nvmf/module-setup.sh
@@ -48,7 +48,7 @@ check() {
             return 255
         fi
     }
-    return 0
+    return 255
 }
 
 # called by dracut

--- a/test/TEST-12-RAID-DEG/test.sh
+++ b/test/TEST-12-RAID-DEG/test.sh
@@ -97,7 +97,6 @@ test_setup() {
     chmod 0600 /tmp/key
 
     test_dracut \
-        -o "dbus" \
         -i "./cryptroot-ask.sh" "/sbin/cryptroot-ask" \
         -i "/tmp/mdadm.conf" "/etc/mdadm.conf" \
         -i "/tmp/crypttab" "/etc/crypttab" \

--- a/test/TEST-20-NFS/test.sh
+++ b/test/TEST-20-NFS/test.sh
@@ -404,7 +404,7 @@ test_setup() {
 
     # Make client's dracut image
     test_dracut \
-        -a "dmsquash-live watchdog ${USE_NETWORK}" \
+        -a "dmsquash-live watchdog ${USE_NETWORK} nfs" \
         "$TESTDIR"/initramfs.testing
 
     (

--- a/test/TEST-30-ISCSI/test.sh
+++ b/test/TEST-30-ISCSI/test.sh
@@ -223,7 +223,7 @@ test_setup() {
 
     # Make client's dracut image
     test_dracut \
-        --add "$USE_NETWORK" \
+        --add "$USE_NETWORK iscsi" \
         --include "./client.link" "/etc/systemd/network/01-client.link" \
         --kernel-cmdline "rw rd.auto rd.retry=50" \
         "$TESTDIR"/initramfs.testing

--- a/test/TEST-35-ISCSI-MULTI/test.sh
+++ b/test/TEST-35-ISCSI-MULTI/test.sh
@@ -228,7 +228,7 @@ test_setup() {
 
     # Make client's dracut image
     test_dracut \
-        --add "$USE_NETWORK" \
+        --add "$USE_NETWORK iscsi" \
         -i "./client.link" "/etc/systemd/network/01-client.link" \
         "$TESTDIR"/initramfs.testing
 

--- a/test/TEST-50-MULTINIC/test.sh
+++ b/test/TEST-50-MULTINIC/test.sh
@@ -343,7 +343,7 @@ test_setup() {
     )
     # Make client's dracut image
     test_dracut \
-        -a "debug watchdog ${USE_NETWORK}" \
+        -a "debug watchdog ${USE_NETWORK} nfs" \
         "$TESTDIR"/initramfs.testing
 
     (

--- a/test/TEST-60-BONDBRIDGEVLAN/test.sh
+++ b/test/TEST-60-BONDBRIDGEVLAN/test.sh
@@ -369,7 +369,7 @@ test_setup() {
     )
     # Make client's dracut image
     test_dracut \
-        -a "debug ${USE_NETWORK} ifcfg" \
+        -a "debug ${USE_NETWORK} ifcfg nfs" \
         "$TESTDIR"/initramfs.testing
 
     (


### PR DESCRIPTION
## Changes

In most setups, network and related modules are not needed and only introduce potential extra problems (example https://github.com/dracut-ng/dracut-ng/issues/132). If you need the network modules in non-hostonly mode, just include it explicitly (you probably already include it explicitly, eg for live iso use-case).

Some network dependent modules (such as [ssh-client](https://github.com/dracut-ng/dracut-ng/blob/main/modules.d/95ssh-client/module-setup.sh#L19)) always had this policy. This PR align this policy to all network modules.

In hostonly mode dracut will detect and pull in the required dracut modules to boot - including networking modules.

**This PR intentionally breaks backwards compatibility with the rational, that it improves performance for most users at the expense of a few setups needing extra configuration with a one-time migration.**

An example of "improves performance".
On Arch (or any other distro where the default is no-hostonly), I install cifs package to my rootfs as I need to access some data from a remote cifs server. cifs however is not needed to boot the system. Just by installing cifs, next time a regenerate initrd, now my intird includes all the networking infrastructure and cifs, even though this is not required, resulting in increased initrd size and slower boot.

## Checklist
- [ ] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it

Fixes #132

CC @berolinux