### PR TITLE
fix: /etc/modprobe.d --> /run/modprobe.d

### DIFF
--- a/man/dracut.modules.7.asc
+++ b/man/dracut.modules.7.asc
@@ -181,7 +181,7 @@ hook _insmodpost.sh_ in the _initqueue/settled_.
 _parse-insmodpost.sh_:
 ----
 for p in $(getargs rd.driver.post=); do
-    echo "blacklist $p" >> /etc/modprobe.d/initramfsblacklist.conf
+    echo "blacklist $p" >> /run/modprobe.d/initramfsblacklist.conf
     _do_insmodpost=1
 done
 

--- a/modules.d/01fips/fips-boot.sh
+++ b/modules.d/01fips/fips-boot.sh
@@ -3,7 +3,7 @@
 type getarg > /dev/null 2>&1 || . /lib/dracut-lib.sh
 
 if ! fipsmode=$(getarg fips) || [ "$fipsmode" = "0" ]; then
-    rm -f -- /etc/modprobe.d/fips.conf > /dev/null 2>&1
+    :
 elif [ -z "$fipsmode" ]; then
     die "FIPS mode have to be enabled by 'fips=1' not just 'fips'"
 elif getarg boot= > /dev/null; then

--- a/modules.d/01fips/fips-load-crypto.sh
+++ b/modules.d/01fips/fips-load-crypto.sh
@@ -3,7 +3,7 @@
 type getarg > /dev/null 2>&1 || . /lib/dracut-lib.sh
 
 if ! fipsmode=$(getarg fips) || [ "$fipsmode" = "0" ]; then
-    rm -f -- /etc/modprobe.d/fips.conf > /dev/null 2>&1
+    :
 elif [ -z "$fipsmode" ]; then
     die "FIPS mode have to be enabled by 'fips=1' not just 'fips'"
 else

--- a/modules.d/01fips/fips-noboot.sh
+++ b/modules.d/01fips/fips-noboot.sh
@@ -3,7 +3,7 @@
 type getarg > /dev/null 2>&1 || . /lib/dracut-lib.sh
 
 if ! fipsmode=$(getarg fips) || [ "$fipsmode" = "0" ]; then
-    rm -f -- /etc/modprobe.d/fips.conf > /dev/null 2>&1
+    :
 elif [ -z "$fipsmode" ]; then
     die "FIPS mode have to be enabled by 'fips=1' not just 'fips'"
 elif ! [ -f /tmp/fipsdone ]; then

--- a/modules.d/01fips/fips.sh
+++ b/modules.d/01fips/fips.sh
@@ -97,7 +97,6 @@ fips_load_crypto() {
     read -d '' -r FIPSMODULES < /etc/fipsmodules
 
     fips_info "Loading and integrity checking all crypto modules"
-    mv /etc/modprobe.d/fips.conf /etc/modprobe.d/fips.conf.bak
     for _module in $FIPSMODULES; do
         if [ "$_module" != "tcrypt" ]; then
             if ! nonfatal_modprobe "${_module}" 2> /tmp/fips.modprobe_err; then
@@ -113,7 +112,10 @@ fips_load_crypto() {
             fi
         fi
     done
-    mv /etc/modprobe.d/fips.conf.bak /etc/modprobe.d/fips.conf
+    if [ -f /etc/fips.conf ]; then
+        mkdir -p /run/modprobe.d
+        cp /etc/fips.conf /run/modprobe.d/fips.conf
+    fi
 
     fips_info "Self testing crypto algorithms"
     modprobe tcrypt || return 1

--- a/modules.d/01fips/module-setup.sh
+++ b/modules.d/01fips/module-setup.sh
@@ -39,13 +39,10 @@ installkernel() {
         _fipsmodules+="aead cryptomgr tcrypt crypto_user "
     fi
 
-    # shellcheck disable=SC2174
-    mkdir -m 0755 -p "${initdir}/etc/modprobe.d"
-
     for _mod in $_fipsmodules; do
         if hostonly='' instmods -c -s "$_mod"; then
             echo "$_mod" >> "${initdir}/etc/fipsmodules"
-            echo "blacklist $_mod" >> "${initdir}/etc/modprobe.d/fips.conf"
+            echo "blacklist $_mod" >> "${initdir}/etc/fips.conf"
         fi
     done
 

--- a/modules.d/90kernel-modules/parse-kernel.sh
+++ b/modules.d/90kernel-modules/parse-kernel.sh
@@ -1,11 +1,7 @@
 #!/bin/sh
 
-_modprobe_d=/etc/modprobe.d
-if [ -d /usr/lib/modprobe.d ]; then
-    _modprobe_d=/usr/lib/modprobe.d
-elif [ -d /lib/modprobe.d ]; then
-    _modprobe_d=/lib/modprobe.d
-elif [ ! -d $_modprobe_d ]; then
+_modprobe_d=/run/modprobe.d
+if [ ! -d $_modprobe_d ]; then
     mkdir -p $_modprobe_d
 fi
 
@@ -17,8 +13,6 @@ for i in $(getargs rd.driver.pre -d rdloaddriver=); do
         done
     )
 done
-
-[ -d /etc/modprobe.d ] || mkdir -p /etc/modprobe.d
 
 for i in $(getargs rd.driver.blacklist -d rdblacklist=); do
     (

--- a/modules.d/95lunmask/parse-lunmask.sh
+++ b/modules.d/95lunmask/parse-lunmask.sh
@@ -32,8 +32,9 @@ for lunmask_arg in $(getargs rd.lunmask); do
         IFS="$OLDIFS"
         if [ -d /sys/module/scsi_mod ]; then
             printf "manual" > /sys/module/scsi_mod/parameters/scan
-        elif [ ! -f /etc/modprobe.d/95lunmask.conf ]; then
-            echo "options scsi_mod scan=manual" > /etc/modprobe.d/95lunmask.conf
+        elif [ ! -f /run/modprobe.d/95lunmask.conf ]; then
+            mkdir -p /run/modprobe.d
+            echo "options scsi_mod scan=manual" > /run/modprobe.d/95lunmask.conf
         fi
         create_udev_rule "$1" "$2" "$3"
     )

--- a/modules.d/98dracut-systemd/dracut-pre-udev.sh
+++ b/modules.d/98dracut-systemd/dracut-pre-udev.sh
@@ -13,12 +13,8 @@ make_trace_mem "hook pre-udev" '1:shortmem' '2+:mem' '3+:slab'
 getargs 'rd.break=pre-udev' -d 'rdbreak=pre-udev' && emergency_shell -n pre-udev "Break before pre-udev"
 source_hook pre-udev
 
-_modprobe_d=/etc/modprobe.d
-if [ -d /usr/lib/modprobe.d ]; then
-    _modprobe_d=/usr/lib/modprobe.d
-elif [ -d /lib/modprobe.d ]; then
-    _modprobe_d=/lib/modprobe.d
-elif [ ! -d $_modprobe_d ]; then
+_modprobe_d=/run/modprobe.d
+if [ ! -d $_modprobe_d ]; then
     mkdir -p $_modprobe_d
 fi
 
@@ -30,8 +26,6 @@ for i in $(getargs rd.driver.pre -d rdloaddriver=); do
         done
     )
 done
-
-[ -d /etc/modprobe.d ] || mkdir -p /etc/modprobe.d
 
 for i in $(getargs rd.driver.blacklist -d rdblacklist=); do
     (


### PR DESCRIPTION
## Changes

Change /etc/modprobe.d path to /run/modprobe.d in hooks.  

## Checklist
- [ ] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it

Fixes #253 (partially)
