### PR TITLE
fix(dracut): bsdcpio compatibility

### DIFF
--- a/dracut.sh
+++ b/dracut.sh
@@ -2351,9 +2351,9 @@ if [[ $create_early_cpio == yes ]]; then
         if ! (
             umask 077
             cd "$early_cpio_dir/d"
-            find . -print0 | sort -z \
-                | cpio ${CPIO_REPRODUCIBLE:+--reproducible} --null \
-                    ${cpio_owner:+-R "$cpio_owner"} -H newc -o --quiet > "${DRACUT_TMPDIR}/initramfs.img"
+            find . -print0 | sed -e 's,\./,,g' | sort -z \
+                | cpio -o ${CPIO_REPRODUCIBLE:+--reproducible} --null \
+                    ${cpio_owner:+-R "$cpio_owner"} -H newc --quiet > "${DRACUT_TMPDIR}/initramfs.img"
         ); then
             dfatal "Creation of $outfile failed"
             exit 1
@@ -2457,8 +2457,8 @@ else
     if ! (
         umask 077
         cd "$initdir"
-        find . -print0 | sort -z \
-            | cpio ${CPIO_REPRODUCIBLE:+--reproducible} --null ${cpio_owner:+-R "$cpio_owner"} -H newc -o --quiet \
+        find . -print0 | sed -e 's,\./,,g' | sort -z \
+            | cpio -o ${CPIO_REPRODUCIBLE:+--reproducible} --null ${cpio_owner:+-R "$cpio_owner"} -H newc --quiet \
             | $compress >> "${DRACUT_TMPDIR}/initramfs.img"
     ); then
         dfatal "Creation of $outfile failed"


### PR DESCRIPTION
## Changes

From https://github.com/OpenMandrivaAssociation/dracut/blob/master/dracut-044-bsdcpio-compat.patch

Make cpio invocations more compatible with bsdcpio -- the mode indicator has to be the first argument.

## Checklist
- [ ] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it

