### PR TITLE
fix(base): add support for rd.udev.log_level

### DIFF
--- a/man/dracut.cmdline.7.asc
+++ b/man/dracut.cmdline.7.asc
@@ -224,11 +224,8 @@ It should be attached to any report about dracut problems.
     drop to a shell before the defined breakpoint starts.
     This parameter can be specified multiple times.
 
-**rd.udev.info**::
-    set udev to loglevel info
-
-**rd.udev.debug**::
-    set udev to loglevel debug
+**rd.udev.log_level=**__{err|info|debug}__::
+    set udev log level. The default is 'err'.
 
 I18N
 ~~~~
@@ -1392,8 +1389,7 @@ ecryptfskey=/etc/keys/ecryptfs-trusted.blob
 
 Deprecated, renamed Options
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~
-Here is a list of options, which were used in dracut prior to version 008, and
-their new replacement.
+Here is a list of options and their new replacement.
 
 rdbreak:: rd.break
 
@@ -1494,9 +1490,13 @@ rdshell:: rd.shell
 
 rd_NO_SPLASH:: rd.splash
 
-rdudevdebug:: rd.udev.debug
+rdudevdebug:: rd.udev.udev_log=debug
 
-rdudevinfo:: rd.udev.info
+rdudevinfo:: rd.udev.udev_log=info
+
+rd.udev.debug:: rd.udev.udev_log=debug
+
+rd.udev.info:: rd.udev.udev_log=info
 
 rd_NO_ZFCPCONF:: rd.zfcp.conf=0
 

--- a/modules.d/99base/init.sh
+++ b/modules.d/99base/init.sh
@@ -137,8 +137,10 @@ getargs 'rd.break=pre-udev' -d 'rdbreak=pre-udev' && emergency_shell -n pre-udev
 source_hook pre-udev
 
 UDEV_LOG=err
-getargbool 0 rd.udev.info -d -y rdudevinfo && UDEV_LOG=info
-getargbool 0 rd.udev.debug -d -y rdudevdebug && UDEV_LOG=debug
+getargbool 0 rd.udev.log_level=info -d rd.udev.log-priority=info -d rd.udev.info -d -y rdudevinfo \
+    && UDEV_LOG=info
+getargbool 0 rd.udev.log_level=debug -d rd.udev.log-priority=debug -d rd.udev.debug -d -y rdudevdebug \
+    && UDEV_LOG=debug
 
 # start up udev and trigger cold plugs
 UDEV_LOG=$UDEV_LOG "$systemdutildir"/systemd-udevd --daemon --resolve-names=never


### PR DESCRIPTION
## Changes

Follow-up to https://github.com/dracut-ng/dracut-ng/pull/124  .

`rd.udev.log-priority` is deprecated since systemd-v247 (https://github.com/systemd/systemd/commit/64a3494c)

Fixed documentation.

## Checklist
- [ ] I have tested it locally
- [X] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it


