### PR TITLE
fix(base): install /etc/udev/udev.conf in hostonly mode only

### DIFF
--- a/modules.d/01systemd-udevd/module-setup.sh
+++ b/modules.d/01systemd-udevd/module-setup.sh
@@ -73,9 +73,7 @@ install() {
     # Install the hosts local user configurations if enabled.
     if [[ $hostonly ]]; then
         inst_multiple -H -o \
-            /etc/udev/udev.conf \
             "$udevconfdir"/hwdb.bin \
-            "$udevconfdir"/udev.conf \
             "$udevrulesconfdir/*.rules" \
             "$systemdutilconfdir"/hwdb/hwdb.bin \
             "$systemdsystemconfdir"/systemd-udevd.service \

--- a/modules.d/95udev-rules/module-setup.sh
+++ b/modules.d/95udev-rules/module-setup.sh
@@ -8,8 +8,6 @@ install() {
     # ultimately, /lib/initramfs/rules.d or somesuch which includes links/copies
     # of the rules we want so that we just copy those in would be best
     inst_multiple udevadm cat uname blkid
-    inst_dir /etc/udev
-    inst_multiple -o /etc/udev/udev.conf
 
     [[ -d ${initdir}/$systemdutildir ]] || mkdir -p "${initdir}/$systemdutildir"
     for _i in "${systemdutildir}"/systemd-udevd "${udevdir}"/udevd /sbin/udevd; do
@@ -77,4 +75,10 @@ install() {
 
     inst_libdir_file "libnss_files*"
 
+    # Install the hosts local user configurations if enabled.
+    if [[ $hostonly ]]; then
+        inst_dir /etc/udev
+        inst_multiple -H -o \
+            /etc/udev/udev.conf
+    fi
 }


### PR DESCRIPTION
## Changes

Remove duplicated rule from systemd-udevd.

This pull request changes...

## Checklist
- [ ] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it
