### PR TITLE
test: when DRACUT_SKIP_TEST_CHECK is set skip running test_check

### DIFF
--- a/test/test-functions
+++ b/test/test-functions
@@ -36,9 +36,16 @@ test_dracut() {
         "$@" || return 1
 }
 
-command -v test_check &> /dev/null || test_check() {
-    :
-}
+if [ -n "$DRACUT_SKIP_TEST_CHECK" ]; then
+    # always pass the test_check step
+    test_check() {
+        :
+    }
+else
+    command -v test_check &> /dev/null || test_check() {
+        :
+    }
+fi
 
 command -v test_cleanup &> /dev/null || test_cleanup() {
     :


### PR DESCRIPTION
## Changes

Add an option to force run the test without executing test_check.

## Checklist
- [x] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it

Fixes #
