### PR TITLE
revert(dracut-install): check the existing file—not the source

### DIFF
--- a/src/install/dracut-install.c
+++ b/src/install/dracut-install.c
@@ -828,7 +828,7 @@ static int dracut_install(const char *orig_src, const char *orig_dst, bool isdir
         if (ret == 0) {
                 if (resolvedeps && S_ISREG(sb.st_mode) && (sb.st_mode & (S_IXUSR | S_IXGRP | S_IXOTH))) {
                         log_debug("'%s' already exists, but checking for any deps", fulldstpath);
-                        ret = resolve_deps(fulldstpath + sysrootdirlen);
+                        ret = resolve_deps(fullsrcpath + sysrootdirlen);
                 } else
                         log_debug("'%s' already exists", fulldstpath);
 


### PR DESCRIPTION
## Changes

This reverts commit 5ac581ef66dd8f1939e771419824137aebbc8f66. 

Reverts https://github.com/dracutdevs/dracut/pull/2359 .

## Checklist
- [ ] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it

Fixes #307

CC @FGrose 
