### PR TITLE
fix(fips): Remove /dev/{random,urandom} pre-creation

### DIFF
--- a/modules.d/01fips/module-setup.sh
+++ b/modules.d/01fips/module-setup.sh
@@ -67,16 +67,4 @@ install() {
     inst_multiple sha512hmac rmmod insmod mount uname umount grep sed cut find sort
 
     inst_simple /etc/system-fips
-    [ -c "${initdir}"/dev/random ] || mknod "${initdir}"/dev/random c 1 8 \
-        || {
-            dfatal "Cannot create /dev/random"
-            dfatal "To create an initramfs with fips support, dracut has to run as root"
-            return 1
-        }
-    [ -c "${initdir}"/dev/urandom ] || mknod "${initdir}"/dev/urandom c 1 9 \
-        || {
-            dfatal "Cannot create /dev/urandom"
-            dfatal "To create an initramfs with fips support, dracut has to run as root"
-            return 1
-        }
 }


### PR DESCRIPTION
Random device nodes were required to workaround libgcrypt initialization problem (see https://bugzilla.redhat.com/show_bug.cgi?id=1401444) which is gone since libgcrypt-1.10 (2022): modern Linux kernels (3.17+) support getrandom() syscall and libgcrypt has switch to using getentropy() (glibc-2.25+).

The requirement to run dracut as root (which is needed to mknod /dev/{random,urandom}) is a particular problem for building UKIs in distro build systems where packages are not built by a privileged user.

Note, dracut itself always pre-creates /dev/{null,kmsg,console,random,urandom} devices when running privileged so the patch has no effect on 'traditional' setup.

## Changes
'fips' module doesn't pre-create /dev/{random,urandom} anymore and thus can run unpriviliged.

## Checklist
- [ X ] I have tested it locally
- [ - ] I have reviewed and updated any documentation if relevant
- [ - ] I am providing new code and test(s) for it
