### PR TITLE
feat(pcmcia): factor out pcmcia support into its own module

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -546,6 +546,10 @@ net-lib:
   - changed-files:
     - any-glob-to-any-file: 'modules.d/45net-lib/*'
 
+pcmcia:
+  - changed-files:
+    - any-glob-to-any-file: 'modules.d/90pcmcia/*'
+
 test:
   - changed-files:
     - any-glob-to-any-file: ['test/*', 'test/**/*', 'modules.d/80test*', 'modules.d/80test*/*']

--- a/modules.d/90kernel-modules/module-setup.sh
+++ b/modules.d/90kernel-modules/module-setup.sh
@@ -56,10 +56,9 @@ installkernel() {
 
         instmods \
             yenta_socket intel_lpss_pci spi_pxa2xx_platform \
-            atkbd i8042 firewire-ohci pcmcia hv-vmbus \
+            atkbd i8042 firewire-ohci hv-vmbus \
             virtio virtio_ring virtio_pci pci_hyperv \
-            surface_aggregator_registry psmouse \
-            "=drivers/pcmcia"
+            surface_aggregator_registry psmouse
 
         if [[ ${DRACUT_ARCH:-$(uname -m)} == arm* || ${DRACUT_ARCH:-$(uname -m)} == aarch64 || ${DRACUT_ARCH:-$(uname -m)} == riscv* ]]; then
             # arm/aarch64 specific modules

--- a/modules.d/90pcmcia/module-setup.sh
+++ b/modules.d/90pcmcia/module-setup.sh
@@ -1,0 +1,33 @@
+#!/bin/bash
+
+# called by dracut
+check() {
+    return 0
+}
+
+# called by dracut
+depends() {
+    echo udev-rules
+    return 0
+}
+
+# called by dracut
+installkernel() {
+    instmods pcmcia \
+        "=drivers/pcmcia"
+}
+
+# called by dracut
+install() {
+    inst_rules 60-pcmcia.rules
+
+    inst_multiple -o \
+        "${udevdir}"/pcmcia-socket-startup \
+        "${udevdir}"/pcmcia-check-broken-cis
+
+    # Install the hosts local user configurations if enabled.
+    if [[ $hostonly ]]; then
+        inst_multiple -H -o \
+            /etc/pcmcia/config.opts
+    fi
+}

--- a/modules.d/95udev-rules/module-setup.sh
+++ b/modules.d/95udev-rules/module-setup.sh
@@ -31,7 +31,6 @@ install() {
         59-scsi-sg3_utils.rules \
         60-block.rules \
         60-cdrom_id.rules \
-        60-pcmcia.rules \
         60-persistent-storage.rules \
         64-btrfs.rules \
         70-uaccess.rules \
@@ -67,11 +66,7 @@ install() {
         "${udevdir}"/path_id \
         "${udevdir}"/input_id \
         "${udevdir}"/scsi_id \
-        "${udevdir}"/usb_id \
-        "${udevdir}"/pcmcia-socket-startup \
-        "${udevdir}"/pcmcia-check-broken-cis
-
-    inst_multiple -o /etc/pcmcia/config.opts
+        "${udevdir}"/usb_id
 
     inst_libdir_file "libnss_files*"
 


### PR DESCRIPTION
## Changes

Main motivation is to move out obsolete infrastructure from the core modules. This allows downstream packaging to completely remove the support, while still provide limited support upstream.

Related read: https://git.kernel.org/pub/scm/linux/kernel/git/gregkh/char-misc.git/commit/?h=char-misc-next&id=9b12f050c76f090cc6d0aebe0ef76fed79ec3f15

## Checklist
- [ ] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it


