### PR TITLE
fix(systemd-crypt): add potentially needed modules to generic initrd

### DIFF
--- a/modules.d/90systemd-cryptsetup/module-setup.sh
+++ b/modules.d/90systemd-cryptsetup/module-setup.sh
@@ -30,6 +30,13 @@ depends() {
         if grep -q "tpm2-device=" "$dracutsysrootdir"/etc/crypttab; then
             deps+=" tpm2-tss"
         fi
+    elif [[ ! $hostonly ]]; then
+        for module in fido2 pkcs11 tpm2-tss; do
+            module_check $module > /dev/null 2>&1
+            if [[ $? == 255 ]]; then
+                deps+=" $module"
+            fi
+        done
     fi
     echo "$deps"
     return 0


### PR DESCRIPTION
This pull request adds missing modules potentially required for disk decryption to a generic initrd. It is based on https://github.com/dracutdevs/dracut/pull/2520

## Changes

## Checklist
- [X] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it
