### PR TITLE
fix(crypt): unlock encrypted devices by default during boot

### DIFF
--- a/modules.d/90crypt/parse-crypt.sh
+++ b/modules.d/90crypt/parse-crypt.sh
@@ -174,7 +174,7 @@ else
                 } >> "$hookdir/emergency/90-crypt.sh"
             fi
         done
-    elif getargbool 0 rd.auto; then
+    elif getargbool 1 rd.auto; then
         if [ -z "$DRACUT_SYSTEMD" ]; then
             {
                 printf -- 'ENV{ID_FS_TYPE}=="crypto_LUKS", RUN+="%s ' "$(command -v initqueue)"


### PR DESCRIPTION
This pull request changes the default for unlocking LUKS encrypted devices at boot for generic images from previously only doing so when rd.auto=1 was specified. It is based on https://github.com/dracutdevs/dracut/pull/2520

## Checklist
- [X] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it

Fixes #255
