### PR TITLE
fix(dracut): microcode loading

### DIFF
--- a/dracut.sh
+++ b/dracut.sh
@@ -2158,6 +2158,7 @@ if [[ $early_microcode == yes ]]; then
                     _src=$(get_ucode_file)
                     [[ $_src ]] || break
                     [[ -r $_fwdir/$_fw/$_src ]] || _src="${_src}.early"
+                    [[ -r $_fwdir/$_fw/$_src ]] || _src="${_src}.initramfs"
                     [[ -r $_fwdir/$_fw/$_src ]] || break
                 fi
 


### PR DESCRIPTION
## Changes

intel-microcode uses the .initramfs suffix for the ucode files.

Reference 
 - https://packages.debian.org/sid/amd64/intel-microcode/filelist
 - https://salsa.debian.org/debian/dracut/-/blob/master/debian/patches/microcode

## Checklist
- [ ] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it

CC @bdrung 
