### PR TITLE
refactor: use inst_sysusers to install sysusers files

### DIFF
--- a/dracut-init.sh
+++ b/dracut-init.sh
@@ -709,6 +709,15 @@ inst_libdir_file() {
     [[ ${#_files[@]} -gt 0 ]] && inst_multiple "${_files[@]}"
 }
 
+# install sysusers files
+inst_sysusers() {
+    inst_multiple -o "$sysusers/$*"
+
+    if [[ $hostonly ]]; then
+        inst_multiple -H -o "$sysusersconfdir/$*"
+    fi
+}
+
 # get a command to decompress the given file
 get_decompress_cmd() {
     case "$1" in

--- a/modules.d/01systemd-coredump/module-setup.sh
+++ b/modules.d/01systemd-coredump/module-setup.sh
@@ -30,6 +30,8 @@ depends() {
 install() {
 
     inst_dir /var/lib/systemd/coredump
+    inst_sysusers systemd-coredump.conf
+
     inst_multiple -o \
         "$sysctld"/50-coredump.conf \
         "$systemdutildir"/coredump.conf \
@@ -37,7 +39,6 @@ install() {
         "$systemdsystemunitdir"/systemd-coredump.socket \
         "$systemdsystemunitdir"/systemd-coredump@.service \
         "$systemdsystemunitdir"/sockets.target.wants/systemd-coredump.socket \
-        "$sysusers"/systemd-coredump.conf \
         coredumpctl
 
     # Install library file(s)
@@ -56,7 +57,6 @@ install() {
             "$systemdsystemconfdir/systemd-coredump.socket.d/*.conf" \
             "$systemdsystemconfdir"/systemd-coredump@.service \
             "$systemdsystemconfdir/systemd-coredump@.service.d/*.conf" \
-            "$systemdsystemconfdir"/sockets.target.wants/systemd-coredump.socket \
-            "$sysusersconfdir"/systemd-coredump.conf
+            "$systemdsystemconfdir"/sockets.target.wants/systemd-coredump.socket
     fi
 }

--- a/modules.d/01systemd-journald/module-setup.sh
+++ b/modules.d/01systemd-journald/module-setup.sh
@@ -31,6 +31,8 @@ install() {
 
     inst_simple "$moddir/initrd.conf" "$systemdutildir/journald.conf.d/initrd.conf"
 
+    inst_sysusers systemd-journal.conf
+
     inst_multiple -o \
         "$systemdutildir"/journald.conf \
         "$systemdutildir/journald.conf.d/*.conf" \
@@ -47,7 +49,6 @@ install() {
         "$systemdsystemunitdir"/sockets.target.wants/systemd-journald-dev-log.socket \
         "$systemdsystemunitdir"/sockets.target.wants/systemd-journald.socket \
         "$systemdsystemunitdir"/sysinit.target.wants/systemd-journald.service \
-        "$sysusers"/systemd-journal.conf \
         journalctl
 
     # Install library file(s)
@@ -66,8 +67,7 @@ install() {
             "$systemdsystemconfdir"/systemd-journald.service \
             "$systemdsystemconfdir/systemd-journald.service.d/*.conf" \
             "$systemdsystemconfdir"/systemd-journal-catalog-update.service \
-            "$systemdsystemconfdir/systemd-journal-catalog-update.service.d/*.conf" \
-            "$sysusersconfdir"/systemd-journal.conf
+            "$systemdsystemconfdir/systemd-journal-catalog-update.service.d/*.conf"
     fi
 
 }

--- a/modules.d/01systemd-networkd/module-setup.sh
+++ b/modules.d/01systemd-networkd/module-setup.sh
@@ -31,6 +31,8 @@ depends() {
 # Install the required file(s) and directories for the module in the initramfs.
 install() {
 
+    inst_sysusers systemd-network.conf
+
     inst_multiple -o \
         "$tmpfilesdir"/systemd-network.conf \
         "$dbussystem"/org.freedesktop.network1.conf \
@@ -55,7 +57,6 @@ install() {
         "$systemdsystemunitdir"/systemd-networkd-wait-online.service \
         "$systemdsystemunitdir"/systemd-networkd-wait-online@.service \
         "$systemdsystemunitdir"/systemd-network-generator.service \
-        "$sysusers"/systemd-network.conf \
         ip
 
     # Enable systemd type units
@@ -82,7 +83,6 @@ install() {
             "$systemdsystemconfdir"/systemd-networkd-wait-online.service \
             "$systemdsystemconfdir/systemd-networkd-wait-online.service.d/*.conf" \
             "$systemdsystemconfdir"/systemd-networkd-wait-online@.service \
-            "$systemdsystemconfdir/systemd-networkd-wait-online@.service.d/*.conf" \
-            "$sysusersconfdir"/systemd-network.conf
+            "$systemdsystemconfdir/systemd-networkd-wait-online@.service.d/*.conf"
     fi
 }

--- a/modules.d/01systemd-resolved/module-setup.sh
+++ b/modules.d/01systemd-resolved/module-setup.sh
@@ -31,6 +31,8 @@ install() {
 
     inst_simple "$moddir/resolved-tmpfile-dracut.conf" "$tmpfilesdir/resolved-tmpfile-dracut.conf"
 
+    inst_sysusers systemd-resolve.conf
+
     inst_multiple -o \
         "$dbussystem"/org.freedesktop.resolve1.conf \
         "$dbussystemservices"/org.freedesktop.resolve1.service \
@@ -40,7 +42,6 @@ install() {
         "$systemdutildir"/systemd-resolved \
         "$systemdsystemunitdir"/systemd-resolved.service \
         "$systemdsystemunitdir/systemd-resolved.service.d/*.conf" \
-        "$sysusers"/systemd-resolve.conf \
         resolvectl
 
     # Enable systemd type unit(s)
@@ -52,7 +53,6 @@ install() {
             "$systemdutilconfdir"/resolved.conf \
             "$systemdutilconfdir/resolved.conf.d/*.conf" \
             "$systemdsystemconfdir"/systemd-resolved.service \
-            "$systemdsystemconfdir/systemd-resolved.service.d/*.conf" \
-            "$sysusersconfdir"/systemd-resolve.conf
+            "$systemdsystemconfdir/systemd-resolved.service.d/*.conf"
     fi
 }

--- a/modules.d/01systemd-sysusers/module-setup.sh
+++ b/modules.d/01systemd-sysusers/module-setup.sh
@@ -26,9 +26,10 @@ install() {
 
     inst_simple "$moddir/sysusers-dracut.conf" "$systemdsystemunitdir/systemd-sysusers.service.d/sysusers-dracut.conf"
 
+    inst_sysusers basic.conf
+    inst_sysusers systemd.conf
+
     inst_multiple -o \
-        "$sysusers"/basic.conf \
-        "$sysusers"/systemd.conf \
         "$systemdsystemunitdir"/systemd-sysusers.service \
         "$systemdsystemunitdir"/sysinit.target.wants/systemd-sysusers.service \
         systemd-sysusers
@@ -36,8 +37,6 @@ install() {
     # Install the hosts local user configurations if enabled.
     if [[ $hostonly ]]; then
         inst_multiple -H -o \
-            "$sysusersconfdir"/basic.conf \
-            "$sysusersconfdir"/systemd.conf \
             "$systemdsystemconfdir"/systemd-sysusers.service \
             "$systemdsystemconfdir/systemd-sysusers.service.d/*.conf"
     fi

--- a/modules.d/01systemd-timesyncd/module-setup.sh
+++ b/modules.d/01systemd-timesyncd/module-setup.sh
@@ -32,6 +32,8 @@ install() {
     # Enable this if networkd ( not the module ) is disabled at build time and you want to use timesyncd
     # inst_simple "$moddir/timesyncd-tmpfile-dracut.conf" "$tmpfilesdir/timesyncd-tmpfile-dracut.conf"
 
+    inst_sysusers systemd-timesync.conf
+
     inst_multiple -o \
         "$dbussystem"/org.freedesktop.timesync1.conf \
         "$dbussystemservices"/org.freedesktop.timesync1.service \
@@ -42,8 +44,7 @@ install() {
         "$systemdsystemunitdir"/systemd-timesyncd.service \
         "$systemdsystemunitdir/systemd-timesyncd.service.d/*.conf" \
         "$systemdsystemunitdir"/systemd-time-wait-sync.service \
-        "$systemdsystemunitdir/systemd-time-wait-sync.service.d/*.conf" \
-        "$sysusers"/systemd-timesync.conf
+        "$systemdsystemunitdir/systemd-time-wait-sync.service.d/*.conf"
 
     # Enable systemd type unit(s)
     for i in \
@@ -61,7 +62,6 @@ install() {
             "$systemdsystemconfdir"/systemd-timesyncd.service \
             "$systemdsystemconfdir/systemd-timesyncd.service.d/*.conf" \
             "$systemdsystemconfdir"/systemd-time-wait-sync.service \
-            "$systemdsystemconfdir/systemd-time-wait-sync.service.d/*.conf" \
-            "$sysusersconfdir"/systemd-timesync.conf
+            "$systemdsystemconfdir/systemd-time-wait-sync.service.d/*.conf"
     fi
 }

--- a/modules.d/06dbus-broker/module-setup.sh
+++ b/modules.d/06dbus-broker/module-setup.sh
@@ -41,13 +41,14 @@ install() {
     inst_dir "$dbussystemconfdir"
     inst_dir "$dbussystemservicesconfdir"
 
+    inst_sysusers dbus.conf
+
     inst_multiple -o \
         "$dbus"/session.conf \
         "$dbus"/system.conf \
         "$dbussystem"/org.freedesktop.systemd1.conf \
         "$dbusservicesconfdir"/org.freedesktop.systemd1.service \
         "$dbussystemservices"/org.freedesktop.systemd1.service \
-        "$sysusers"/dbus.conf \
         "$systemdcatalog"/dbus-broker.catalog \
         "$systemdcatalog"/dbus-broker-launch.catalog \
         "$systemdsystemunitdir"/dbus-broker.service \
@@ -75,7 +76,6 @@ install() {
         inst_multiple -H -o \
             "$dbusconfdir"/session.conf \
             "$dbusconfdir"/system.conf \
-            "$sysusersconfdir"/dbus.conf \
             "$systemdsystemconfdir"/dbus.socket \
             "$systemdsystemconfdir"/dbus.socket.d/*.conf \
             "$systemdsystemconfdir"/dbus-broker.service \

--- a/modules.d/91tpm2-tss/module-setup.sh
+++ b/modules.d/91tpm2-tss/module-setup.sh
@@ -30,9 +30,9 @@ installkernel() {
 
 # Install the required file(s) and directories for the module in the initramfs.
 install() {
+    inst_sysusers tpm2-tss.conf
 
     inst_multiple -o \
-        "$sysusers"/tpm2-tss.conf \
         "$tmpfilesdir"/tpm2-tss-fapi.conf \
         "$udevrulesdir"/60-tpm-udev.rules \
         "$systemdutildir"/system-generators/systemd-tpm2-generator \


### PR DESCRIPTION
## Changes

Refactor the way systemd-sysusers config files gets installed to make it easier for distributions to customize.

## Checklist
- [ ] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it

CC @AndrewAmmerlaan 