### PR TITLE
perf(dracut-install): preload kmod resources for quicker module lookup

### DIFF
--- a/src/install/dracut-install.c
+++ b/src/install/dracut-install.c
@@ -1868,6 +1868,7 @@ static int install_modules(int argc, char **argv)
         int modinst = 0;
 
         ctx = kmod_new(kerneldir, NULL);
+        kmod_load_resources(ctx);
         abskpath = kmod_get_dirname(ctx);
 
         p = strstr(abskpath, "/lib/modules/");


### PR DESCRIPTION
## Changes

libkmod reads the `modules.*.bin` files in the kernel dir every time we call one of the `kmod_module_new_from_lookup()` function. We end up calling it a lot especially in ARM64 systems where we handle fw_devlink supplier relations, which slows down things by a significant margin.

Instead, have it read these files at the start of the dracut-install run so the module information can be looked up quicker. We don't need to unload these resources in the cleanup function because libkmod handles that itself in `kmod_unref()`.

This helps mitigate #316 a bit, but does not entirely fix it.

<details><summary>Benchmarks on ARM64 (mt8183-kukui-jacuzzi-cozmo)</summary>

Before:

```
$ hyperfine './dracut-install -D "$(mktemp -d)" --kerneldir "/lib/modules/$(uname -r)" -o -m $(lsmod | cut -d" " -f1)'
Benchmark 1: ./dracut-install -D "$(mktemp -d)" --kerneldir "/lib/modules/$(uname -r)" -o -m $(lsmod | cut -d" " -f1)
  Time (mean ± σ):      6.557 s ±  0.010 s    [User: 4.343 s, System: 2.177 s]
  Range (min … max):    6.542 s …  6.573 s    10 runs

$ hyperfine './dracut-install -D "$(mktemp -d)" --kerneldir "/lib/modules/$(uname -r)" -o -m $(lsmod | cut -d" " -f1 | head -100)'
Benchmark 1: ./dracut-install -D "$(mktemp -d)" --kerneldir "/lib/modules/$(uname -r)" -o -m $(lsmod | cut -d" " -f1 | head -100)
  Time (mean ± σ):      5.575 s ±  0.014 s    [User: 3.823 s, System: 1.713 s]
  Range (min … max):    5.544 s …  5.596 s    10 runs
 
$ hyperfine './dracut-install -D "$(mktemp -d)" --kerneldir "/lib/modules/$(uname -r)" -o -m $(lsmod | cut -d" " -f1 | head -10)'
Benchmark 1: ./dracut-install -D "$(mktemp -d)" --kerneldir "/lib/modules/$(uname -r)" -o -m $(lsmod | cut -d" " -f1 | head -10)
  Time (mean ± σ):      3.550 s ±  0.006 s    [User: 2.681 s, System: 0.869 s]
  Range (min … max):    3.538 s …  3.557 s    10 runs
 
$ hyperfine './dracut-install -D "$(mktemp -d)" --kerneldir "/lib/modules/$(uname -r)" -o -m nonexistent'
Benchmark 1: ./dracut-install -D "$(mktemp -d)" --kerneldir "/lib/modules/$(uname -r)" -o -m nonexistent
  Time (mean ± σ):      3.313 s ±  0.014 s    [User: 2.513 s, System: 0.797 s]
```

After:

```
$ hyperfine './dracut-install -D "$(mktemp -d)" --kerneldir "/lib/modules/$(uname -r)" -o -m $(lsmod | cut -d" " -f1)'
Benchmark 1: ./dracut-install -D "$(mktemp -d)" --kerneldir "/lib/modules/$(uname -r)" -o -m $(lsmod | cut -d" " -f1)
  Time (mean ± σ):      3.550 s ±  0.014 s    [User: 2.257 s, System: 1.246 s]
  Range (min … max):    3.531 s …  3.570 s    10 runs

$ hyperfine './dracut-install -D "$(mktemp -d)" --kerneldir "/lib/modules/$(uname -r)" -o -m $(lsmod | cut -d" " -f1 | head -100)'
Benchmark 1: ./dracut-install -D "$(mktemp -d)" --kerneldir "/lib/modules/$(uname -r)" -o -m $(lsmod | cut -d" " -f1 | head -100)
  Time (mean ± σ):      2.763 s ±  0.017 s    [User: 1.853 s, System: 0.879 s]
  Range (min … max):    2.741 s …  2.789 s    10 runs
 
$ hyperfine './dracut-install -D "$(mktemp -d)" --kerneldir "/lib/modules/$(uname -r)" -o -m $(lsmod | cut -d" " -f1 | head -10)'
Benchmark 1: ./dracut-install -D "$(mktemp -d)" --kerneldir "/lib/modules/$(uname -r)" -o -m $(lsmod | cut -d" " -f1 | head -10)
  Time (mean ± σ):      1.217 s ±  0.005 s    [User: 0.997 s, System: 0.220 s]
  Range (min … max):    1.205 s …  1.222 s    10 runs
 
$ hyperfine './dracut-install -D "$(mktemp -d)" --kerneldir "/lib/modules/$(uname -r)" -o -m nonexistent'
Benchmark 1: ./dracut-install -D "$(mktemp -d)" --kerneldir "/lib/modules/$(uname -r)" -o -m nonexistent
  Time (mean ± σ):     982.2 ms ±   4.8 ms    [User: 872.6 ms, System: 109.0 ms]
  Range (min … max):   975.2 ms … 990.5 ms    10 runs
```

</details>

<details><summary>Benchmarks on AMD64</summary>

Before:

```
$ hyperfine './dracut-install -D "$(mktemp -d)" --kerneldir "/lib/modules/$(uname -r)" -o -m $(lsmod | cut -d" " -f1)'
Benchmark 1: ./dracut-install -D "$(mktemp -d)" --kerneldir "/lib/modules/$(uname -r)" -o -m $(lsmod | cut -d" " -f1)
  Time (mean ± σ):      1.530 s ±  0.027 s    [User: 1.138 s, System: 0.397 s]
  Range (min … max):    1.495 s …  1.573 s    10 runs

$ hyperfine './dracut-install -D "$(mktemp -d)" --kerneldir "/lib/modules/$(uname -r)" -o -m $(lsmod | cut -d" " -f1 | head -100)'
Benchmark 1: ./dracut-install -D "$(mktemp -d)" --kerneldir "/lib/modules/$(uname -r)" -o -m $(lsmod | cut -d" " -f1 | head -100)
  Time (mean ± σ):     441.4 ms ±   4.1 ms    [User: 360.8 ms, System: 83.3 ms]
  Range (min … max):   434.6 ms … 446.2 ms    10 runs
 
$ hyperfine './dracut-install -D "$(mktemp -d)" --kerneldir "/lib/modules/$(uname -r)" -o -m $(lsmod | cut -d" " -f1 | head -10)'
Benchmark 1: ./dracut-install -D "$(mktemp -d)" --kerneldir "/lib/modules/$(uname -r)" -o -m $(lsmod | cut -d" " -f1 | head -10)
  Time (mean ± σ):      75.9 ms ±   0.9 ms    [User: 58.0 ms, System: 19.3 ms]
  Range (min … max):    73.8 ms …  78.3 ms    38 runs
 
$ hyperfine './dracut-install -D "$(mktemp -d)" --kerneldir "/lib/modules/$(uname -r)" -o -m nonexistent'
Benchmark 1: ./dracut-install -D "$(mktemp -d)" --kerneldir "/lib/modules/$(uname -r)" -o -m nonexistent
  Time (mean ± σ):       9.6 ms ±   0.6 ms    [User: 5.0 ms, System: 4.7 ms]
  Range (min … max):     9.1 ms …  14.6 ms    303 runs
```

After:

```
$ hyperfine './dracut-install -D "$(mktemp -d)" --kerneldir "/lib/modules/$(uname -r)" -o -m $(lsmod | cut -d" " -f1)'
Benchmark 1: ./dracut-install -D "$(mktemp -d)" --kerneldir "/lib/modules/$(uname -r)" -o -m $(lsmod | cut -d" " -f1)
  Time (mean ± σ):      1.709 s ±  0.081 s    [User: 1.189 s, System: 0.526 s]
  Range (min … max):    1.597 s …  1.799 s    10 runs

$ hyperfine './dracut-install -D "$(mktemp -d)" --kerneldir "/lib/modules/$(uname -r)" -o -m $(lsmod | cut -d" " -f1 | head -100)'
Benchmark 1: ./dracut-install -D "$(mktemp -d)" --kerneldir "/lib/modules/$(uname -r)" -o -m $(lsmod | cut -d" " -f1 | head -100)
  Time (mean ± σ):     440.7 ms ±   4.5 ms    [User: 357.6 ms, System: 85.8 ms]
  Range (min … max):   432.4 ms … 446.7 ms    10 runs
 
$ hyperfine './dracut-install -D "$(mktemp -d)" --kerneldir "/lib/modules/$(uname -r)" -o -m $(lsmod | cut -d" " -f1 | head -10)'
Benchmark 2: ./dracut-install -D "$(mktemp -d)" --kerneldir "/lib/modules/$(uname -r)" -o -m $(lsmod | cut -d" " -f1 | head -10)
  Time (mean ± σ):      71.8 ms ±   1.3 ms    [User: 54.0 ms, System: 19.3 ms]
  Range (min … max):    70.5 ms …  77.9 ms    41 runs
 
$ hyperfine './dracut-install -D "$(mktemp -d)" --kerneldir "/lib/modules/$(uname -r)" -o -m nonexistent'
Benchmark 3: ./dracut-install -D "$(mktemp -d)" --kerneldir "/lib/modules/$(uname -r)" -o -m nonexistent
  Time (mean ± σ):       6.0 ms ±   0.4 ms    [User: 2.5 ms, System: 3.6 ms]
  Range (min … max):     5.5 ms …   9.0 ms    464 runs
```

</details>

## Checklist
- [x] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it
