### PR TITLE
fix(dracut-install): fixes for fw_devlink supplier handling

### DIFF
--- a/src/install/dracut-install.c
+++ b/src/install/dracut-install.c
@@ -1574,6 +1574,10 @@ static void find_suppliers_for_sys_node(struct kmod_ctx *ctx, Hashmap *suppliers
                         closedir(d);
                 }
                 strncat(node_path, "/..", 3); // Also find suppliers of parents
+                char *parent_path = realpath(node_path, NULL);
+                if (parent_path != NULL)
+                        if (hashmap_put(suppliers, parent_path, parent_path) < 0)
+                                free(parent_path);
         }
 }
 

--- a/src/install/dracut-install.c
+++ b/src/install/dracut-install.c
@@ -1687,20 +1687,20 @@ static int install_dependent_modules(struct kmod_ctx *ctx, struct kmod_list *mod
                 _cleanup_destroy_hashmap_ Hashmap *modules = hashmap_new(string_hash_func, string_compare_func);
                 find_modules_from_sysfs_node(ctx, supplier_path, modules);
 
-                _cleanup_destroy_hashmap_ Hashmap *suppliers = hashmap_new(string_hash_func, string_compare_func);
-                find_suppliers_for_sys_node(ctx, suppliers, supplier_path, strlen(supplier_path));
-
                 if (!hashmap_isempty(modules)) { // Supplier is a module
                         const char *module;
                         Iterator j;
                         HASHMAP_FOREACH(module, modules, j) {
                                 _cleanup_kmod_module_unref_ struct kmod_module *mod = NULL;
                                 if (!kmod_module_new_from_name(ctx, module, &mod)) {
+                                        Hashmap *suppliers = find_suppliers_paths_for_module(kmod_module_get_name(mod));
                                         if (install_dependent_module(ctx, mod, suppliers, &ret))
                                                 return -1;
                                 }
                         }
                 } else { // Supplier is builtin
+                        _cleanup_destroy_hashmap_ Hashmap *suppliers = hashmap_new(string_hash_func, string_compare_func);
+                        find_suppliers_for_sys_node(ctx, suppliers, supplier_path, strlen(supplier_path));
                         install_dependent_modules(ctx, NULL, suppliers);
                 }
         }

--- a/src/install/dracut-install.c
+++ b/src/install/dracut-install.c
@@ -1507,8 +1507,26 @@ static bool check_module_path(const char *path)
         return true;
 }
 
-static int find_kmod_module_from_sysfs_node(struct kmod_ctx *ctx, const char *sysfs_node, int sysfs_node_len,
-                                            struct kmod_list **modules)
+static int find_kmod_module_from_sysfs_driver(struct kmod_ctx *ctx, const char *sysfs_node, int sysfs_node_len,
+                                              struct kmod_module **module)
+{
+        char mod_path[PATH_MAX], mod_realpath[PATH_MAX];
+        const char *mod_name;
+        if (snprintf(mod_path, sizeof(mod_path), "%.*s/driver/module",
+                     sysfs_node_len, sysfs_node) >= sizeof(mod_path))
+                return -1;
+
+        if (realpath(mod_path, mod_realpath) == NULL)
+                return -1;
+
+        if ((mod_name = basename(mod_realpath)) == NULL)
+                return -1;
+
+        return kmod_module_new_from_name(ctx, mod_name, module);
+}
+
+static int find_kmod_module_from_sysfs_modalias(struct kmod_ctx *ctx, const char *sysfs_node, int sysfs_node_len,
+                                                struct kmod_list **modules)
 {
         char modalias_path[PATH_MAX];
         if (snprintf(modalias_path, sizeof(modalias_path), "%.*s/modalias", sysfs_node_len,
@@ -1529,9 +1547,17 @@ static int find_kmod_module_from_sysfs_node(struct kmod_ctx *ctx, const char *sy
 static int find_modules_from_sysfs_node(struct kmod_ctx *ctx, const char *sysfs_node, Hashmap *modules)
 {
         _cleanup_kmod_module_unref_list_ struct kmod_list *list = NULL;
+        _cleanup_kmod_module_unref_ struct kmod_module *drv = NULL;
         struct kmod_list *l = NULL;
 
-        if (find_kmod_module_from_sysfs_node(ctx, sysfs_node, strlen(sysfs_node), &list) >= 0) {
+        if (find_kmod_module_from_sysfs_driver(ctx, sysfs_node, strlen(sysfs_node), &drv) >= 0) {
+                char *module = strdup(kmod_module_get_name(drv));
+                if (hashmap_put(modules, module, module) < 0)
+                        free(module);
+                return 0;
+        }
+
+        if (find_kmod_module_from_sysfs_modalias(ctx, sysfs_node, strlen(sysfs_node), &list) >= 0) {
                 kmod_list_foreach(l, list) {
                         struct kmod_module *mod = kmod_module_get_module(l);
                         char *module = strdup(kmod_module_get_name(mod));
@@ -1590,9 +1616,24 @@ static void find_suppliers(struct kmod_ctx *ctx)
         for (FTSENT *ftsent = fts_read(fts); ftsent != NULL; ftsent = fts_read(fts)) {
                 if (strcmp(ftsent->fts_name, "modalias") == 0) {
                         _cleanup_kmod_module_unref_list_ struct kmod_list *list = NULL;
+                        _cleanup_kmod_module_unref_ struct kmod_module *drv = NULL;
                         struct kmod_list *l;
 
-                        if (find_kmod_module_from_sysfs_node(ctx, ftsent->fts_parent->fts_path, ftsent->fts_parent->fts_pathlen, &list) < 0)
+                        if (find_kmod_module_from_sysfs_driver(ctx, ftsent->fts_parent->fts_path, ftsent->fts_parent->fts_pathlen, &drv) >= 0) {
+                                const char *name = kmod_module_get_name(drv);
+                                Hashmap *suppliers = hashmap_get(modules_suppliers, name);
+                                if (suppliers == NULL) {
+                                        suppliers = hashmap_new(string_hash_func, string_compare_func);
+                                        hashmap_put(modules_suppliers, strdup(name), suppliers);
+                                }
+
+                                find_suppliers_for_sys_node(ctx, suppliers, ftsent->fts_parent->fts_path, ftsent->fts_parent->fts_pathlen);
+
+                                /* Skip modalias check because it's expensive */
+                                continue;
+                        }
+
+                        if (find_kmod_module_from_sysfs_modalias(ctx, ftsent->fts_parent->fts_path, ftsent->fts_parent->fts_pathlen, &list) < 0)
                                 continue;
 
                         kmod_list_foreach(l, list) {

--- a/src/install/dracut-install.c
+++ b/src/install/dracut-install.c
@@ -1561,7 +1561,7 @@ static void find_suppliers_for_sys_node(struct kmod_ctx *ctx, Hashmap *suppliers
                 if (d) {
                         size_t real_path_len = strlen(real_path);
                         while ((dir = readdir(d)) != NULL) {
-                                if (strstr(dir->d_name, "supplier:platform") != NULL) {
+                                if (strstr(dir->d_name, "supplier:") != NULL) {
                                         if (snprintf(real_path + real_path_len, sizeof(real_path) - real_path_len, "/%s/supplier",
                                                      dir->d_name) < sizeof(real_path) - real_path_len) {
                                                 char *real_supplier_path = realpath(real_path, NULL);
@@ -1584,7 +1584,7 @@ static void find_suppliers_for_sys_node(struct kmod_ctx *ctx, Hashmap *suppliers
 static void find_suppliers(struct kmod_ctx *ctx)
 {
         _cleanup_fts_close_ FTS *fts;
-        char *paths[] = { "/sys/devices/platform", NULL };
+        char *paths[] = { "/sys/devices", NULL };
         fts = fts_open(paths, FTS_NOSTAT | FTS_PHYSICAL, NULL);
 
         for (FTSENT *ftsent = fts_read(fts); ftsent != NULL; ftsent = fts_read(fts)) {


### PR DESCRIPTION
## Changes

Some small changes to fw_devlinks supplier handling to include some dependencies it misses, and a faster method to find out the module name for a sysfs node:
- Add sysfs node parents' modules as dependencies (and parents of suppliers and so on)
- Do not limit supplier handling to the `platform` bus 
- Install modules for all suppliers of a supplier's module
- Use `driver/module` sysfs dirs for module name

Ends up cutting start-up time by half (~500ms) on ARM64. But it adds some start-up time (<100ms) on AMD64 because of devices outside `/sys/devices/platform` which this now handles.

<details><summary>Benchmarks on ARM64  (mt8183-kukui-jacuzzi-cozmo)</summary>

Before:
```
$ hyperfine -L count "250,125,50,10,1" './dracut-install -D "$(mktemp -d)" -o -m $(lsmod | cut -d" " -f1 | head -n {count})'
Benchmark 1: ./dracut-install -D "$(mktemp -d)" -o -m $(lsmod | cut -d" " -f1 | head -n 250)
  Time (mean ± σ):      3.710 s ±  0.030 s    [User: 2.299 s, System: 1.365 s]
  Range (min … max):    3.644 s …  3.750 s    10 runs
 
Benchmark 2: ./dracut-install -D "$(mktemp -d)" -o -m $(lsmod | cut -d" " -f1 | head -n 125)
  Time (mean ± σ):      2.947 s ±  0.015 s    [User: 1.930 s, System: 0.994 s]
  Range (min … max):    2.912 s …  2.964 s    10 runs
 
Benchmark 3: ./dracut-install -D "$(mktemp -d)" -o -m $(lsmod | cut -d" " -f1 | head -n 50)
  Time (mean ± σ):      2.394 s ±  0.026 s    [User: 1.621 s, System: 0.742 s]
  Range (min … max):    2.354 s …  2.437 s    10 runs
 
Benchmark 4: ./dracut-install -D "$(mktemp -d)" -o -m $(lsmod | cut -d" " -f1 | head -n 10)
  Time (mean ± σ):      1.255 s ±  0.009 s    [User: 1.004 s, System: 0.249 s]
  Range (min … max):    1.245 s …  1.274 s    10 runs
 
Benchmark 5: ./dracut-install -D "$(mktemp -d)" -o -m $(lsmod | cut -d" " -f1 | head -n 1)
  Time (mean ± σ):      1.021 s ±  0.007 s    [User: 0.888 s, System: 0.136 s]
  Range (min … max):    1.011 s …  1.030 s    10 runs
```

After:
```
$ hyperfine -L count "250,125,50,10,1" './dracut-install -D "$(mktemp -d)" -o -m $(lsmod | cut -d" " -f1 | head -n {count})'
Benchmark 1: ./dracut-install -D "$(mktemp -d)" -o -m $(lsmod | cut -d" " -f1 | head -n 250)
  Time (mean ± σ):      3.023 s ±  0.022 s    [User: 1.519 s, System: 1.450 s]
  Range (min … max):    2.994 s …  3.059 s    10 runs
 
Benchmark 2: ./dracut-install -D "$(mktemp -d)" -o -m $(lsmod | cut -d" " -f1 | head -n 125)
  Time (mean ± σ):      2.504 s ±  0.025 s    [User: 1.248 s, System: 1.214 s]
  Range (min … max):    2.461 s …  2.545 s    10 runs
 
Benchmark 3: ./dracut-install -D "$(mktemp -d)" -o -m $(lsmod | cut -d" " -f1 | head -n 50)
  Time (mean ± σ):      1.766 s ±  0.035 s    [User: 0.902 s, System: 0.840 s]
  Range (min … max):    1.719 s …  1.824 s    10 runs
 
Benchmark 4: ./dracut-install -D "$(mktemp -d)" -o -m $(lsmod | cut -d" " -f1 | head -n 10)
  Time (mean ± σ):     674.9 ms ±   8.9 ms    [User: 363.1 ms, System: 309.5 ms]
  Range (min … max):   665.8 ms … 698.9 ms    10 runs
 
Benchmark 5: ./dracut-install -D "$(mktemp -d)" -o -m $(lsmod | cut -d" " -f1 | head -n 1)
  Time (mean ± σ):     435.7 ms ±   3.1 ms    [User: 236.3 ms, System: 203.0 ms]
  Range (min … max):   430.5 ms … 438.5 ms    10 runs
```

</details>
<details><summary>Benchmarks on AMD64</summary>

Before:
```
$ hyperfine -L count "250,125,50,10,1" './dracut-install -D "$(mktemp -d)" -o -m $(lsmod | cut -d" " -f1 | head -n {count})'
Benchmark 1: ./dracut-install -D "$(mktemp -d)" -o -m $(lsmod | cut -d" " -f1 | head -n 250)
  Time (mean ± σ):      1.635 s ±  0.022 s    [User: 1.182 s, System: 0.459 s]
  Range (min … max):    1.610 s …  1.674 s    10 runs
 
Benchmark 2: ./dracut-install -D "$(mktemp -d)" -o -m $(lsmod | cut -d" " -f1 | head -n 125)
  Time (mean ± σ):     537.1 ms ±   4.8 ms    [User: 441.7 ms, System: 98.1 ms]
  Range (min … max):   529.1 ms … 544.5 ms    10 runs
 
Benchmark 3: ./dracut-install -D "$(mktemp -d)" -o -m $(lsmod | cut -d" " -f1 | head -n 50)
  Time (mean ± σ):     250.0 ms ±   1.8 ms    [User: 197.2 ms, System: 54.9 ms]
  Range (min … max):   245.8 ms … 252.8 ms    12 runs
 
Benchmark 4: ./dracut-install -D "$(mktemp -d)" -o -m $(lsmod | cut -d" " -f1 | head -n 10)
  Time (mean ± σ):      71.8 ms ±   0.9 ms    [User: 53.9 ms, System: 19.4 ms]
  Range (min … max):    69.1 ms …  75.3 ms    41 runs
 
Benchmark 5: ./dracut-install -D "$(mktemp -d)" -o -m $(lsmod | cut -d" " -f1 | head -n 1)
  Time (mean ± σ):      10.7 ms ±   0.3 ms    [User: 3.9 ms, System: 8.1 ms]
  Range (min … max):    10.2 ms …  12.4 ms    266 runs
```

After:
```
$ hyperfine -L count "250,125,50,10,1" './dracut-install -D "$(mktemp -d)" -o -m $(lsmod | cut -d" " -f1 | head -n {count})'
Benchmark 1: ./dracut-install -D "$(mktemp -d)" -o -m $(lsmod | cut -d" " -f1 | head -n 250)
  Time (mean ± σ):      1.836 s ±  0.039 s    [User: 1.211 s, System: 0.631 s]
  Range (min … max):    1.778 s …  1.884 s    10 runs
 
Benchmark 2: ./dracut-install -D "$(mktemp -d)" -o -m $(lsmod | cut -d" " -f1 | head -n 125)
  Time (mean ± σ):      1.670 s ±  0.029 s    [User: 1.118 s, System: 0.557 s]
  Range (min … max):    1.634 s …  1.716 s    10 runs
 
Benchmark 3: ./dracut-install -D "$(mktemp -d)" -o -m $(lsmod | cut -d" " -f1 | head -n 50)
  Time (mean ± σ):     323.8 ms ±   4.2 ms    [User: 217.9 ms, System: 108.0 ms]
  Range (min … max):   319.0 ms … 331.0 ms    10 runs
 
Benchmark 4: ./dracut-install -D "$(mktemp -d)" -o -m $(lsmod | cut -d" " -f1 | head -n 10)
  Time (mean ± σ):     143.5 ms ±   3.0 ms    [User: 73.0 ms, System: 72.0 ms]
  Range (min … max):   138.4 ms … 151.8 ms    20 runs
 
Benchmark 5: ./dracut-install -D "$(mktemp -d)" -o -m $(lsmod | cut -d" " -f1 | head -n 1)
  Time (mean ± σ):      71.6 ms ±   1.1 ms    [User: 13.6 ms, System: 59.4 ms]
  Range (min … max):    69.3 ms …  73.9 ms    40 runs
```
(The 1s jump at 125 modules is due to `amdgpu` now being pulled in as a supplier of `snd_hda_intel`)

</details>

## Checklist
- [x] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it

Fixes #316 to a hopefully acceptable point, and fixes some issues I discovered while working on that.
