### PR TITLE
test(RAID-DEG): fix running test out of tree

### DIFF
--- a/test/TEST-12-RAID-DEG/test.sh
+++ b/test/TEST-12-RAID-DEG/test.sh
@@ -55,7 +55,7 @@ test_run() {
 }
 
 test_setup() {
-    "$basedir"/dracut.sh -N -l --keep --tmpdir "$TESTDIR" \
+    "$DRACUT" -N -l --keep --tmpdir "$TESTDIR" \
         -m "test-root" \
         -f "$TESTDIR"/initramfs.root "$KVERSION" || return 1
     mkdir -p "$TESTDIR"/overlay/source && mv "$TESTDIR"/dracut.*/initramfs/* "$TESTDIR"/overlay/source && rm -rf "$TESTDIR"/dracut.*


### PR DESCRIPTION
## Changes

`test-functions` defines `DRACUT` to allow running the test out of tree against the system-installed dracut.

Fixes: 55e7b7ce6fcf ("test(RAID-DEG): make test 12 use the test dracut modules")

## Checklist
- [ ] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it