### PR TITLE
fix(shell-completion): remove hashbang from bash completions

### DIFF
--- a/shell-completion/bash/dracut
+++ b/shell-completion/bash/dracut
@@ -1,4 +1,5 @@
-#!/bin/bash
+# bash completion for dracut
+# shellcheck shell=bash
 # Copyright 2013 Red Hat, Inc.  All rights reserved.
 #
 # This program is free software; you can redistribute it and/or modify

--- a/shell-completion/bash/lsinitrd
+++ b/shell-completion/bash/lsinitrd
@@ -1,4 +1,5 @@
-#!/bin/bash
+# bash completion for lsinitrd
+# shellcheck shell=bash
 # Copyright 2013 Red Hat, Inc.  All rights reserved.
 #
 # This program is free software; you can redistribute it and/or modify


### PR DESCRIPTION
## Changes

Debian's lintian complains about bash-completion-with-hashbang:
> This file starts with the #! sequence that marks interpreted scripts, but it is a bash completion script that is merely intended to be sourced. Please remove the line with hashbang, including any designated interpreter. Please refer to https://salsa.debian.org/lintian/lintian/-/merge_requests/292#note_139494 for details.

Remove hashbang from bash completions and add a shellcheck directive instead.

## Checklist
- [x] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it