### PR TITLE
fix(01fips): replace read -d that is not supported by dash

### DIFF
--- a/.shellcheckrc
+++ b/.shellcheckrc
@@ -27,8 +27,3 @@ disable=SC3043
 # https://github.com/koalaman/shellcheck/wiki/SC3013
 # ... but dash supports it
 disable=SC3013
-
-# SC3045: In POSIX sh, read -p is undefined.
-# https://github.com/koalaman/shellcheck/wiki/SC3045
-# ... but dash supports it
-disable=SC3045

--- a/modules.d/01fips/fips.sh
+++ b/modules.d/01fips/fips.sh
@@ -94,10 +94,8 @@ fips_load_crypto() {
     local _module
     local _found
 
-    read -d '' -r FIPSMODULES < /etc/fipsmodules
-
     fips_info "Loading and integrity checking all crypto modules"
-    for _module in $FIPSMODULES; do
+    while read -r _module; do
         if [ "$_module" != "tcrypt" ]; then
             if ! nonfatal_modprobe "${_module}" 2> /tmp/fips.modprobe_err; then
                 # check if kernel provides generic algo
@@ -111,7 +109,7 @@ fips_load_crypto() {
                 [ "$_found" = "0" ] && cat /tmp/fips.modprobe_err >&2 && return 1
             fi
         fi
-    done
+    done < /etc/fipsmodules
     if [ -f /etc/fips.conf ]; then
         mkdir -p /run/modprobe.d
         cp /etc/fips.conf /run/modprobe.d/fips.conf

--- a/modules.d/98dracut-systemd/dracut-cmdline-ask.sh
+++ b/modules.d/98dracut-systemd/dracut-cmdline-ask.sh
@@ -14,6 +14,8 @@ echo
 echo
 echo
 echo "Enter additional kernel command line parameter (end with ctrl-d or .)"
+# In POSIX sh, read -p is undefined, but dash supports it
+# shellcheck disable=SC3045
 while read -r -p "> " ${BASH:+-e} line || [ -n "$line" ]; do
     [ "$line" = "." ] && break
     [ -n "$line" ] && printf -- "%s\n" "$line" >> /etc/cmdline.d/99-cmdline-ask.conf

--- a/modules.d/99base/init.sh
+++ b/modules.d/99base/init.sh
@@ -109,6 +109,8 @@ source_conf /etc/conf.d
 
 if getarg "rd.cmdline=ask"; then
     echo "Enter additional kernel command line parameter (end with ctrl-d or .)"
+    # In POSIX sh, read -p is undefined, but dash supports it
+    # shellcheck disable=SC3045
     while read -r -p "> " ${BASH:+-e} line || [ -n "$line" ]; do
         [ "$line" = "." ] && break
         echo "$line" >> /etc/cmdline.d/99-cmdline-ask.conf


### PR DESCRIPTION
## Changes

Move the shellcheck overrides for `SC3045` to the individual occurrences instead of disabling this check globally to not hide valid complains like:

```
In modules.d/01fips/fips.sh line 97:
    read -d '' -r FIPSMODULES < /etc/fipsmodules
         ^-- SC3045 (warning): In POSIX sh, read -d is undefined.
```

`read -d` is not supported by dash. `/etc/fipsmodules` is generated by `installkernel` in `modules.d/01fips/module-setup.sh` and contains kernel module names. So use a while read construct for reading this file.

## Checklist
- [x] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it
