### PR TITLE
feat(test): support V=2 without logtee

### DIFF
--- a/test/test-functions
+++ b/test/test-functions
@@ -143,7 +143,11 @@ while (($# > 0)); do
             else
                 echo -e "TEST: $TEST_DESCRIPTION " "$COLOR_SUCCESS" "[STARTED]" "$COLOR_NORMAL"
             fi
-            if [[ $V == "1" ]]; then
+            if [[ $V == "1" || $V == "2" ]]; then
+                tee_command="tee"
+                if [[ $V == "2" ]]; then
+                    tee_command="$basedir/logtee"
+                fi
                 set -o pipefail
                 (
                     test_setup && test_run
@@ -155,20 +159,7 @@ while (($# > 0)); do
                     rm -fr -- "$TESTDIR"
                     rm -f -- .testdir${TEST_RUN_ID:+-$TEST_RUN_ID}
                     exit $ret
-                ) < /dev/null 2>&1 | tee "test${TEST_RUN_ID:+-$TEST_RUN_ID}.log"
-            elif [[ $V == "2" ]]; then
-                set -o pipefail
-                (
-                    test_setup && test_run
-                    ret=$?
-                    test_cleanup
-                    if ((ret != 0)) && [[ -f "$TESTDIR"/server.log ]]; then
-                        mv "$TESTDIR"/server.log ./server${TEST_RUN_ID:+-$TEST_RUN_ID}.log
-                    fi
-                    rm -fr -- "$TESTDIR"
-                    rm -f -- .testdir${TEST_RUN_ID:+-$TEST_RUN_ID}
-                    exit $ret
-                ) < /dev/null 2>&1 | "$basedir/logtee" "test${TEST_RUN_ID:+-$TEST_RUN_ID}.log"
+                ) < /dev/null 2>&1 | "$tee_command" "test${TEST_RUN_ID:+-$TEST_RUN_ID}.log"
             else
                 (
                     test_setup && test_run

--- a/test/test-functions
+++ b/test/test-functions
@@ -145,7 +145,7 @@ while (($# > 0)); do
             fi
             if [[ $V == "1" || $V == "2" ]]; then
                 tee_command="tee"
-                if [[ $V == "2" ]]; then
+                if [[ $V == "2" && -x "$basedir/logtee" ]]; then
                     tee_command="$basedir/logtee"
                 fi
                 set -o pipefail


### PR DESCRIPTION
## Changes

The Debian/Ubuntu autopkgtest runs the tests out of tree. In that environment `gcc` might not be installed, but it is needed to compile `logtee`.

So support running the tests with `V=2` but without `logtee`. Only use `logtee` if it is available.

## Checklist
- [x] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it