### PR TITLE
fix(test): use `-cpu max` by default

### DIFF
--- a/test/run-qemu
+++ b/test/run-qemu
@@ -4,13 +4,6 @@
 
 export PATH=/usr/sbin:/usr/bin:/sbin:/bin
 ARCH="${ARCH-$(uname -m)}"
-
-case "$ARCH" in
-    amd64 | i?86 | x86_64)
-        QEMU_CPU="IvyBridge-v2"
-        ;;
-esac
-
 QEMU_CPU="${QEMU_CPU:-max}"
 
 [[ -x /usr/bin/qemu ]] && BIN=/usr/bin/qemu && ARGS=(-cpu "$QEMU_CPU")


### PR DESCRIPTION
## Changes

Running the tests on an AMD Ryzen 7 5700G without KVM, qemu-system-x86_64 will print following warnings:

```
qemu-system-x86_64: warning: TCG doesn't support requested feature: CPUID.01H:ECX.x2apic [bit 21]
qemu-system-x86_64: warning: TCG doesn't support requested feature: CPUID.01H:ECX.tsc-deadline [bit 24]
qemu-system-x86_64: warning: TCG doesn't support requested feature: CPUID.07H:EDX.spec-ctrl [bit 26]
qemu-system-x86_64: warning: TCG doesn't support requested feature: CPUID.01H:ECX.x2apic [bit 21]
qemu-system-x86_64: warning: TCG doesn't support requested feature: CPUID.01H:ECX.tsc-deadline [bit 24]
qemu-system-x86_64: warning: TCG doesn't support requested feature: CPUID.07H:EDX.spec-ctrl [bit 26]
```

Use `-cpu max` by default to avoid those warnings.

Commit 3f56d481e8a3 ("test: don't use `-cpu max` in GH Actions") added `-cpu IvyBridge-v2` in 2021. Let's try using `-cpu max` on GitHub actions again.

## Checklist
- [x] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it