### PR TITLE
chore(shellcheck): remove retired SC2039

### DIFF
--- a/.shellcheckrc
+++ b/.shellcheckrc
@@ -1,7 +1,3 @@
-# SC2039: In POSIX sh, 'local' is undefined.
-# https://github.com/koalaman/shellcheck/wiki/SC2039
-disable=SC2039
-
 # SC2166: Prefer [ p ] || [ q ] as [ p -o q ] is not well defined.
 # https://github.com/koalaman/shellcheck/wiki/SC2166
 disable=SC2166


### PR DESCRIPTION
## Changes

The shellcheck SC2039 warning has been retired in favor of individual SC3xxx warnings for each individual issue. So remove the override from `.shellcheckrc`.

## Checklist
- [x] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it
