### PR TITLE
fix(dracut): fix shellcheck SC2004

### DIFF
--- a/dracut.sh
+++ b/dracut.sh
@@ -1378,8 +1378,8 @@ unset omit_drivers_corrected
 
 # prepare args for logging
 for ((i = 0; i < ${#dracut_args[@]}; i++)); do
-    [[ ${dracut_args[$i]} == *\ * ]] \
-        && dracut_args[$i]="\"${dracut_args[$i]}\""
+    [[ ${dracut_args[i]} == *\ * ]] \
+        && dracut_args[i]="\"${dracut_args[i]}\""
     #" keep vim happy
 done
 


### PR DESCRIPTION
## Changes

shellcheck complains:

```
In dracut.sh line 1382:
        && dracut_args[$i]="\"${dracut_args[$i]}\""
                       ^-- SC2004 (style): $/${} is unnecessary on arithmetic variables.
```

## Checklist
- [ ] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it