### PR TITLE
fix: address shellcheck SC2166

### DIFF
--- a/.shellcheckrc
+++ b/.shellcheckrc
@@ -1,7 +1,3 @@
-# SC2166: Prefer [ p ] || [ q ] as [ p -o q ] is not well defined.
-# https://github.com/koalaman/shellcheck/wiki/SC2166
-disable=SC2166
-
 # SC2154: Variable is referenced but not assigned
 # https://github.com/koalaman/shellcheck/wiki/SC2154
 disable=SC2154

--- a/dracut-initramfs-restore.sh
+++ b/dracut-initramfs-restore.sh
@@ -83,7 +83,7 @@ if [[ -d squash ]]; then
 fi
 
 if grep -q -w selinux /sys/kernel/security/lsm 2> /dev/null \
-    && [ -e /etc/selinux/config -a -x /usr/sbin/setfiles ]; then
+    && [ -e /etc/selinux/config ] && [ -x /usr/sbin/setfiles ]; then
     . /etc/selinux/config
     if [[ $SELINUX != "disabled" && -n $SELINUXTYPE ]]; then
         /usr/sbin/setfiles -v -r /run/initramfs /etc/selinux/"${SELINUXTYPE}"/contexts/files/file_contexts /run/initramfs > /dev/null

--- a/modules.d/00warpclock/module-setup.sh
+++ b/modules.d/00warpclock/module-setup.sh
@@ -7,7 +7,7 @@ check() {
 
     # hwclock does not exist on S390(x), bail out silently then
     local _arch=${DRACUT_ARCH:-$(uname -m)}
-    [ "$_arch" = "s390" -o "$_arch" = "s390x" ] && return 1
+    [ "$_arch" = "s390" ] || [ "$_arch" = "s390x" ] && return 1
 
     # If the binary(s) requirements are not fulfilled the module can't be installed.
     require_binaries hwclock || return 1

--- a/modules.d/01fips/fips.sh
+++ b/modules.d/01fips/fips.sh
@@ -101,7 +101,7 @@ fips_load_crypto() {
                 # check if kernel provides generic algo
                 _found=0
                 while read -r _k _ _v || [ -n "$_k" ]; do
-                    [ "$_k" != "name" -a "$_k" != "driver" ] && continue
+                    [ "$_k" != "name" ] && [ "$_k" != "driver" ] && continue
                     [ "$_v" != "$_module" ] && continue
                     _found=1
                     break

--- a/modules.d/02caps/caps.sh
+++ b/modules.d/02caps/caps.sh
@@ -12,12 +12,12 @@ if [ "$capsmode" = "1" ]; then
     info "Loading CAPS_MODULES $CAPS_MODULES"
     for i in $CAPS_MODULES; do modprobe "$i" 2>&1 > /dev/null | vinfo; done
 
-    if [ "$CAPS_MODULES_DISABLED" = "1" -a -e /proc/sys/kernel/modules_disabled ]; then
+    if [ "$CAPS_MODULES_DISABLED" = "1" ] && [ -e /proc/sys/kernel/modules_disabled ]; then
         info "Disabling module loading."
         echo "$CAPS_MODULES_DISABLED" > /proc/sys/kernel/modules_disabled
     fi
 
-    if [ "$CAPS_KEXEC_DISABLED" = "1" -a -e /proc/sys/kernel/kexec_disabled ]; then
+    if [ "$CAPS_KEXEC_DISABLED" = "1" ] && [ -e /proc/sys/kernel/kexec_disabled ]; then
         info "Disabling kexec."
         echo "$CAPS_KEXEC_DISABLED" > /proc/sys/kernel/kexec_disabled
     fi

--- a/modules.d/30convertfs/convertfs.sh
+++ b/modules.d/30convertfs/convertfs.sh
@@ -21,13 +21,13 @@ while [[ $ROOT != "${ROOT%/}" ]]; do
     ROOT=${ROOT%/}
 done
 
-if [ ! -L "$ROOT"/var/run -a -e "$ROOT"/var/run ]; then
+if [ ! -L "$ROOT"/var/run ] && [ -e "$ROOT"/var/run ]; then
     echo "Converting /var/run to symlink"
     mv -f "$ROOT"/var/run "$ROOT"/var/run.runmove~
     ln -sfn ../run "$ROOT"/var/run
 fi
 
-if [ ! -L "$ROOT"/var/lock -a -e "$ROOT"/var/lock ]; then
+if [ ! -L "$ROOT"/var/lock ] && [ -e "$ROOT"/var/lock ]; then
     echo "Converting /var/lock to symlink"
     mv -f "$ROOT"/var/lock "$ROOT"/var/lock.lockmove~
     ln -sfn ../run/lock "$ROOT"/var/lock

--- a/modules.d/35network-legacy/dhclient-script.sh
+++ b/modules.d/35network-legacy/dhclient-script.sh
@@ -114,7 +114,7 @@ parse_option_121() {
         shift
 
         # Is the destination a multicast group?
-        if [ "$1" -ge 224 -a "$1" -lt 240 ]; then
+        if [ "$1" -ge 224 ] && [ "$1" -lt 240 ]; then
             multicast=1
         else
             multicast=0
@@ -153,7 +153,7 @@ parse_option_121() {
         # Multicast routing on Linux
         #  - If you set a next-hop address for a multicast group, this breaks with Cisco switches
         #  - If you simply leave it link-local and attach it to an interface, it works fine.
-        if [ $multicast -eq 1 -o "$gateway" = "0.0.0.0" ]; then
+        if [ $multicast -eq 1 ] || [ "$gateway" = "0.0.0.0" ]; then
             temp_result="$destination dev $interface"
         else
             temp_result="$destination via $gateway dev $interface"

--- a/modules.d/35network-legacy/ifup.sh
+++ b/modules.d/35network-legacy/ifup.sh
@@ -301,7 +301,7 @@ if [ -z "$NO_BOND_MASTER" ]; then
                 key=${arg%%=*}
                 value=${arg##*=}
                 # %{value:0:1} is replaced with non-bash specific construct
-                if [ "${key}" = "arp_ip_target" -a "${#value}" != "0" -a "+${value%%+*}" != "+" ]; then
+                if [ "${key}" = "arp_ip_target" ] && [ "${#value}" != "0" ] && [ "+${value%%+*}" != "+" ]; then
                     OLDIFS=$IFS
                     IFS=','
                     for arp_ip in $value; do
@@ -421,7 +421,7 @@ fi
 
 # disable manual ifup while netroot is set for simplifying our logic
 # in netroot case we prefer netroot to bringup $netif automatically
-[ -n "$2" -a "$2" = "-m" ] && [ -z "$netroot" ] && manualup="$2"
+[ -n "$2" ] && [ "$2" = "-m" ] && [ -z "$netroot" ] && manualup="$2"
 
 if [ -n "$manualup" ]; then
     : > "/tmp/net.$netif.manualup"
@@ -536,12 +536,12 @@ if [ -z "$NO_AUTO_DHCP" ] && [ ! -e "/tmp/net.${netif}.up" ]; then
         # No ip lines, no bootdev -> default to dhcp
         ip=$(getarg ip)
 
-        if getargs 'ip=dhcp6' > /dev/null || [ -z "$ip" -a "$netroot" = "dhcp6" ]; then
+        if getargs 'ip=dhcp6' > /dev/null || [ -z "$ip" ] && [ "$netroot" = "dhcp6" ]; then
             load_ipv6
             do_dhcp -6
             ret=$?
         fi
-        if getargs 'ip=dhcp' > /dev/null || [ -z "$ip" -a "$netroot" != "dhcp6" ]; then
+        if getargs 'ip=dhcp' > /dev/null || [ -z "$ip" ] && [ "$netroot" != "dhcp6" ]; then
             do_dhcp -4
             ret=$?
         fi

--- a/modules.d/35network-legacy/module-setup.sh
+++ b/modules.d/35network-legacy/module-setup.sh
@@ -71,7 +71,7 @@ install() {
         (
             # shellcheck disable=SC1090
             . "$i"
-            if ! [ "${ONBOOT}" = "no" -o "${ONBOOT}" = "NO" ] \
+            if ! [ "${ONBOOT}" = "no" ] || [ "${ONBOOT}" = "NO" ] \
                 && [ -n "${TEAM_MASTER}${TEAM_CONFIG}${TEAM_PORT_CONFIG}" ]; then
                 if [ -n "$TEAM_CONFIG" ] && [ -n "$DEVICE" ]; then
                     mkdir -p "$initdir"/etc/teamd

--- a/modules.d/45net-lib/ifname-genrules.sh
+++ b/modules.d/45net-lib/ifname-genrules.sh
@@ -17,7 +17,7 @@ command -v parse_ifname_opts > /dev/null || . /lib/net-lib.sh
         if [ -f /tmp/ifname-"$ifname_if" ]; then
             read -r oldmac < /tmp/ifname-"$ifname_if"
         fi
-        if [ -n "$oldif" -a -n "$oldmac" -a "$oldif" = "$ifname_if" -a "$oldmac" = "$ifname_mac" ]; then
+        if [ -n "$oldif" ] && [ -n "$oldmac" ] && [ "$oldif" = "$ifname_if" ] && [ "$oldmac" = "$ifname_mac" ]; then
             # skip same ifname= declaration
             continue
         fi

--- a/modules.d/45net-lib/net-lib.sh
+++ b/modules.d/45net-lib/net-lib.sh
@@ -319,7 +319,7 @@ ibft_to_cmdline() {
                         gw="[${gw}]"
                     fi
                 fi
-                if [ -n "$ip" ] && [ -n "$mask" -o -n "$prefix" ]; then
+                if [ -n "$ip" ] && [ -n "$mask" ] || [ -n "$prefix" ]; then
                     echo "ip=$ip::$gw:$mask:$hostname:$dev:none${dns1:+:$dns1}${dns2:+:$dns2}"
                 else
                     warn "${iface} does not contain a valid iBFT configuration"
@@ -517,7 +517,7 @@ ip_to_var() {
         return 0
     fi
 
-    if [ "$2" = "dhcp" -o "$2" = "on" -o "$2" = "any" -o "$2" = "dhcp6" -o "$2" = "auto6" -o "$2" = "either6" ]; then
+    if [ "$2" = "dhcp" ] || [ "$2" = "on" ] || [ "$2" = "any" ] || [ "$2" = "dhcp6" ] || [ "$2" = "auto6" ] || [ "$2" = "either6" ]; then
         # format: ip=<interface>:{dhcp|on|any|dhcp6|auto6}[:[<mtu>][:<macaddr>]]
         [ -n "$1" ] && dev="$1"
         [ -n "$2" ] && autoconf="$2"
@@ -546,16 +546,16 @@ ip_to_var() {
             ;;
         [0-9]*)
             mtu="$8"
-            if [ -n "${9}" -a -z "${10}" ]; then
+            if [ -n "${9}" ] && [ -z "${10}" ]; then
                 macaddr="${9}"
-            elif [ -n "${9}" -a -n "${10}" -a -n "${11}" -a -n "${12}" -a -n "${13}" -a -n "${14}" ]; then
+            elif [ -n "${9}" ] && [ -n "${10}" ] && [ -n "${11}" ] && [ -n "${12}" ] && [ -n "${13}" ] && [ -n "${14}" ]; then
                 macaddr="${9}:${10}:${11}:${12}:${13}:${14}"
             fi
             ;;
         *)
-            if [ -n "${9}" -a -z "${10}" ]; then
+            if [ -n "${9}" ] && [ -z "${10}" ]; then
                 macaddr="${9}"
-            elif [ -n "${9}" -a -n "${10}" -a -n "${11}" -a -n "${12}" -a -n "${13}" -a -n "${14}" ]; then
+            elif [ -n "${9}" ] && [ -n "${10}" ] && [ -n "${11}" ] && [ -n "${12}" ] && [ -n "${13}" ] && [ -n "${14}" ]; then
                 macaddr="${9}:${10}:${11}:${12}:${13}:${14}"
             fi
             ;;

--- a/modules.d/50plymouth/plymouth-pretrigger.sh
+++ b/modules.d/50plymouth/plymouth-pretrigger.sh
@@ -18,10 +18,10 @@ if type plymouthd > /dev/null 2>&1 && [ -z "$DRACUT_SYSTEMD" ]; then
         mkdir -m 0755 /run/plymouth
         read -r consoledev rest < /sys/class/tty/console/active
         consoledev=${consoledev:-tty0}
-        [ -x /lib/udev/console_init -a -e "/dev/$consoledev" ] && /lib/udev/console_init "/dev/$consoledev"
+        [ -x /lib/udev/console_init ] && [ -e "/dev/$consoledev" ] && /lib/udev/console_init "/dev/$consoledev"
         plymouthd --attach-to-session --pid-file /run/plymouth/pid
         plymouth --show-splash 2>&1 | vinfo
         # reset tty after plymouth messed with it
-        [ -x /lib/udev/console_init -a -e "/dev/$consoledev" ] && /lib/udev/console_init "/dev/$consoledev"
+        [ -x /lib/udev/console_init ] && [ -e "/dev/$consoledev" ] && /lib/udev/console_init "/dev/$consoledev"
     fi
 fi

--- a/modules.d/80cms/cmssetup.sh
+++ b/modules.d/80cms/cmssetup.sh
@@ -158,7 +158,7 @@ processcmsfile() {
 [[ $CMSCONFFILE ]] || CMSCONFFILE=$(getarg "CMSCONFFILE=")
 
 # Parse configuration
-if [ -n "$CMSDASD" -a -n "$CMSCONFFILE" ]; then
+if [ -n "$CMSDASD" ] && [ -n "$CMSCONFFILE" ]; then
     if readcmsfile "$CMSDASD" "$CMSCONFFILE"; then
         ln -s /run/initramfs/"$CMSCONFFILE" /tmp/"$CMSCONFFILE"
         ln -s /run/initramfs/"$CMSCONFFILE" /tmp/cms.conf

--- a/modules.d/80cms/module-setup.sh
+++ b/modules.d/80cms/module-setup.sh
@@ -3,7 +3,7 @@
 # called by dracut
 check() {
     arch=${DRACUT_ARCH:-$(uname -m)}
-    [ "$arch" = "s390" -o "$arch" = "s390x" ] || return 1
+    [ "$arch" = "s390" ] || [ "$arch" = "s390x" ] || return 1
     require_binaries chzdev lszdev || return 1
     return 255
 }
@@ -11,7 +11,7 @@ check() {
 # called by dracut
 depends() {
     arch=${DRACUT_ARCH:-$(uname -m)}
-    [ "$arch" = "s390" -o "$arch" = "s390x" ] || return 1
+    [ "$arch" = "s390" ] || [ "$arch" = "s390x" ] || return 1
     echo znet bash
     return 0
 }

--- a/modules.d/81cio_ignore/module-setup.sh
+++ b/modules.d/81cio_ignore/module-setup.sh
@@ -6,7 +6,7 @@
 check() {
     # do not add this module by default
     local arch=${DRACUT_ARCH:-$(uname -m)}
-    [ "$arch" = "s390" -o "$arch" = "s390x" ] || return 1
+    [ "$arch" = "s390" ] || [ "$arch" = "s390x" ] || return 1
     return 0
 }
 
@@ -15,7 +15,7 @@ cmdline() {
 
     if [ -e /boot/zipl/active_devices.txt ]; then
         while read -r dev _; do
-            [ "$dev" = "#" -o "$dev" = "" ] && continue
+            [ "$dev" = "#" ] || [ "$dev" = "" ] && continue
             if [ -z "$cio_accept" ]; then
                 cio_accept="$dev"
             else

--- a/modules.d/90crypt/crypt-lib.sh
+++ b/modules.d/90crypt/crypt-lib.sh
@@ -148,7 +148,7 @@ test_dev() {
     local mount_point
 
     mount_point=$(mkuniqdir /mnt testdev)
-    [ -n "$dev" -a -n "$*" ] || return 1
+    [ -n "$dev" ] && [ -n "$*" ] || return 1
     [ -d "$mount_point" ] || die 'Mount point does not exist!'
 
     if mount -r "$dev" "$mount_point" > /dev/null 2>&1; then
@@ -175,7 +175,7 @@ test_dev() {
 #   match_dev UUID=123 /dev/dm-1
 # Returns true if /dev/dm-1 UUID starts with "123".
 match_dev() {
-    [ -z "$1" -o "$1" = '*' ] && return 0
+    [ -z "$1" ] || [ "$1" = '*' ] && return 0
     local devlist
     local dev
 
@@ -206,7 +206,7 @@ getkey() {
     local key_dev
     local key_path
 
-    [ -z "$keys_file" -o -z "$for_dev" ] && die 'getkey: wrong usage!'
+    [ -z "$keys_file" ] || [ -z "$for_dev" ] && die 'getkey: wrong usage!'
     [ -f "$keys_file" ] || return 1
 
     while IFS=: read -r luks_dev key_dev key_path _ || [ -n "$luks_dev" ]; do

--- a/modules.d/90crypt/cryptroot-ask.sh
+++ b/modules.d/90crypt/cryptroot-ask.sh
@@ -30,7 +30,7 @@ numtries=${4:-10}
 if [ -f /etc/crypttab ] && getargbool 1 rd.luks.crypttab -d -n rd_NO_CRYPTTAB; then
     while read -r name dev luksfile luksoptions || [ -n "$name" ]; do
         # ignore blank lines and comments
-        if [ -z "$name" -o "${name#\#}" != "$name" ]; then
+        if [ -z "$name" ] || [ "${name#\#}" != "$name" ]; then
             continue
         fi
 
@@ -137,7 +137,7 @@ unset allowdiscards
 # fallback to passphrase
 ask_passphrase=1
 
-if [ -n "$luksfile" -a "$luksfile" != "none" -a -e "$luksfile" ]; then
+if [ -n "$luksfile" ] && [ "$luksfile" != "none" ] && [ -e "$luksfile" ]; then
     # shellcheck disable=SC2086
     if readkey "$luksfile" / "$device" \
         | cryptsetup -d - $cryptsetupopts luksOpen "$device" "$luksname"; then
@@ -187,7 +187,7 @@ if [ $ask_passphrase -ne 0 ]; then
     unset _timeout
 fi
 
-if [ "$is_keysource" -ne 0 -a "${luksname##luks-}" != "$luksname" ]; then
+if [ "$is_keysource" -ne 0 ] && [ "${luksname##luks-}" != "$luksname" ]; then
     luks_close="$(command -v cryptsetup) close"
     {
         printf -- '[ -e /dev/mapper/%s ] && ' "$luksname"

--- a/modules.d/90crypt/probe-keydev.sh
+++ b/modules.d/90crypt/probe-keydev.sh
@@ -6,7 +6,7 @@ real_keydev="$1"
 keypath="$2"
 luksdev="$3"
 
-[ -z "$real_keydev" -o -z "$keypath" ] && die 'probe-keydev: wrong usage!'
+[ -z "$real_keydev" ] || [ -z "$keypath" ] && die 'probe-keydev: wrong usage!'
 [ -z "$luksdev" ] && luksdev='*'
 
 info "Probing $real_keydev for $keypath..."

--- a/modules.d/90dmraid/dmraid.sh
+++ b/modules.d/90dmraid/dmraid.sh
@@ -15,7 +15,7 @@ if [ -n "$DM_RAIDS" ] || getargbool 0 rd.auto; then
     info "Scanning for dmraid devices $DM_RAIDS"
     SETS=$(dmraid -c -s)
 
-    if [ "$SETS" = "no raid disks" -o "$SETS" = "no raid sets" ]; then
+    if [ "$SETS" = "no raid disks" ] || [ "$SETS" = "no raid sets" ]; then
         return
     fi
 

--- a/modules.d/90dmsquash-live/apply-live-updates.sh
+++ b/modules.d/90dmsquash-live/apply-live-updates.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 
-if [ -h /dev/root ] && [ -d /run/initramfs/live/updates -o -d /updates ]; then
+if [ -h /dev/root ] && [ -d /run/initramfs/live/updates ] || [ -d /updates ]; then
     info "Applying updates to live image..."
     mount -o bind /run "$NEWROOT"/run
     # avoid overwriting symlinks (e.g. /lib -> /usr/lib) with directories
@@ -16,7 +16,7 @@ if [ -h /dev/root ] && [ -d /run/initramfs/live/updates -o -d /updates ]; then
 fi
 # release resources on iso-scan boots with rd.live.ram
 if [ -d /run/initramfs/isoscan ] \
-    && [ -f /run/initramfs/squashed.img -o -f /run/initramfs/rootfs.img ]; then
+    && [ -f /run/initramfs/squashed.img ] || [ -f /run/initramfs/rootfs.img ]; then
     umount --detach-loop /run/initramfs/live
     umount /run/initramfs/isoscan
 fi

--- a/modules.d/90dmsquash-live/dmsquash-live-root.sh
+++ b/modules.d/90dmsquash-live/dmsquash-live-root.sh
@@ -67,7 +67,7 @@ if [ ! -f "$livedev" ]; then
     check_dev=$(get_check_dev "$livedev")
     # CD/DVD media check
     [ -b "$check_dev" ] && fs=$(det_fs "$check_dev")
-    if [ "$fs" = "iso9660" -o "$fs" = "udf" ]; then
+    if [ "$fs" = "iso9660" ] || [ "$fs" = "udf" ]; then
         check="yes"
     fi
     getarg rd.live.check -d check || check=""
@@ -148,7 +148,7 @@ do_live_overlay() {
         pathspec=${overlay##*:}
     fi
 
-    if [ -z "$pathspec" -o "$pathspec" = "auto" ]; then
+    if [ -z "$pathspec" ] || [ "$pathspec" = "auto" ]; then
         pathspec="/${live_dir}/overlay-$l-$u"
     elif ! str_starts "$pathspec" "/"; then
         pathspec=/"${pathspec}"
@@ -156,7 +156,7 @@ do_live_overlay() {
     devspec=${overlay%%:*}
 
     # need to know where to look for the overlay
-    if [ -z "$setup" -a -n "$devspec" -a -n "$pathspec" -a -n "$overlay" ]; then
+    if [ -z "$setup" ] && [ -n "$devspec" ] && [ -n "$pathspec" ] && [ -n "$overlay" ]; then
         mkdir -m 0755 -p /run/initramfs/overlayfs
         if ismounted "$devspec"; then
             devmnt=$(findmnt -e -v -n -o 'TARGET' --source "$devspec")
@@ -166,7 +166,7 @@ do_live_overlay() {
         else
             mount -n -t auto "$devspec" /run/initramfs/overlayfs || :
         fi
-        if [ -f /run/initramfs/overlayfs$pathspec -a -w /run/initramfs/overlayfs$pathspec ]; then
+        if [ -f /run/initramfs/overlayfs$pathspec ] && [ -w /run/initramfs/overlayfs$pathspec ]; then
             OVERLAY_LOOPDEV=$(losetup -f --show ${readonly_overlay:+-r} /run/initramfs/overlayfs$pathspec)
             over=$OVERLAY_LOOPDEV
             umount -l /run/initramfs/overlayfs || :
@@ -218,10 +218,10 @@ do_live_overlay() {
         fi
     fi
 
-    if [ -z "$setup" -o -n "$readonly_overlay" ]; then
+    if [ -z "$setup" ] || [ -n "$readonly_overlay" ]; then
         if [ -n "$setup" ]; then
             warn "Using temporary overlay."
-        elif [ -n "$devspec" -a -n "$pathspec" ]; then
+        elif [ -n "$devspec" ] && [ -n "$pathspec" ]; then
             [ -z "$m" ] \
                 && m='   Unable to find a persistent overlay; using a temporary one.'
             m="$m"'
@@ -265,7 +265,7 @@ do_live_overlay() {
             fi
         else
             dd if=/dev/null of=/overlay bs=1024 count=1 seek=$((overlay_size * 1024)) 2> /dev/null
-            if [ -n "$setup" -a -n "$readonly_overlay" ]; then
+            if [ -n "$setup" ] && [ -n "$readonly_overlay" ]; then
                 RO_OVERLAY_LOOPDEV=$(losetup -f --show /overlay)
                 over=$RO_OVERLAY_LOOPDEV
             else
@@ -384,9 +384,9 @@ if [ -n "$FSIMG" ]; then
     fi
     # For writable DM images...
     readonly_base=1
-    if [ -z "$SQUASHED" -a -n "$live_ram" -a -z "$overlayfs" ] \
+    if [ -z "$SQUASHED" ] && [ -n "$live_ram" ] && [ -z "$overlayfs" ] \
         || [ -n "$writable_fsimg" ] \
-        || [ "$overlay" = none -o "$overlay" = None -o "$overlay" = NONE ]; then
+        || [ "$overlay" = none ] || [ "$overlay" = None ] || [ "$overlay" = NONE ]; then
         if [ -z "$readonly_overlay" ]; then
             unset readonly_base
             setup=rw

--- a/modules.d/90livenet/livenetroot.sh
+++ b/modules.d/90livenet/livenetroot.sh
@@ -47,7 +47,7 @@ while [ "$i" -le "$RETRIES" ]; do
         imgfile=
     fi
 
-    if [ -n "$imgfile" -a -s "$imgfile" ]; then
+    if [ -n "$imgfile" ] && [ -s "$imgfile" ]; then
         break
     else
         if [ $i -ge "$RETRIES" ]; then

--- a/modules.d/90multipath/module-setup.sh
+++ b/modules.d/90multipath/module-setup.sh
@@ -53,7 +53,7 @@ installkernel() {
     local _arch=${DRACUT_ARCH:-$(uname -m)}
     local _funcs='scsi_register_device_handler|dm_dirty_log_type_register|dm_register_path_selector|dm_register_target'
 
-    if [ "$_arch" = "s390" -o "$_arch" = "s390x" ]; then
+    if [ "$_arch" = "s390" ] || [ "$_arch" = "s390x" ]; then
         _s390drivers="=drivers/s390/scsi"
     fi
 

--- a/modules.d/91zipl/install_zipl_cmdline.sh
+++ b/modules.d/91zipl/install_zipl_cmdline.sh
@@ -23,7 +23,7 @@ fi
 
 if [ -f ${MNT}/active_devices.txt ]; then
     while read -r dev _ || [[ $dev ]]; do
-        [ "$dev" = "#" -o "$dev" = "" ] && continue
+        [ "$dev" = "#" ] || [ "$dev" = "" ] && continue
         cio_ignore -r "$dev"
     done < ${MNT}/active_devices.txt
 fi

--- a/modules.d/91zipl/module-setup.sh
+++ b/modules.d/91zipl/module-setup.sh
@@ -12,7 +12,7 @@ get_boot_zipl_dev() {
 check() {
     local _arch=${DRACUT_ARCH:-$(uname -m)}
     # Only for systems on s390 using indirect booting via userland grub
-    [ "$_arch" = "s390" -o "$_arch" = "s390x" ] || return 1
+    [ "$_arch" = "s390" ] || [ "$_arch" = "s390x" ] || return 1
     # /boot/zipl contains a first stage kernel used to launch grub in initrd
     [ -d /boot/zipl ] || return 1
     return 0

--- a/modules.d/95cifs/cifs-lib.sh
+++ b/modules.d/95cifs/cifs-lib.sh
@@ -30,7 +30,7 @@ cifs_to_var() {
     # shellcheck disable=SC2034
     server=${server%/*}
 
-    if [ ! "$cifsuser" -o ! "$cifspass" ]; then
+    if [ ! "$cifsuser" ] || [ ! "$cifspass" ]; then
         die "For CIFS support you need to specify a cifsuser and cifspass either in the cifsuser and cifspass commandline parameters or in the root= CIFS URL."
     fi
     # shellcheck disable=SC2034

--- a/modules.d/95dasd/module-setup.sh
+++ b/modules.d/95dasd/module-setup.sh
@@ -3,7 +3,7 @@
 # called by dracut
 check() {
     local _arch=${DRACUT_ARCH:-$(uname -m)}
-    [ "$_arch" = "s390" -o "$_arch" = "s390x" ] || return 1
+    [ "$_arch" = "s390" ] || [ "$_arch" = "s390x" ] || return 1
     require_binaries dasdconf.sh || return 1
     return 0
 }

--- a/modules.d/95dasd_mod/module-setup.sh
+++ b/modules.d/95dasd_mod/module-setup.sh
@@ -3,7 +3,7 @@
 # called by dracut
 check() {
     local _arch=${DRACUT_ARCH:-$(uname -m)}
-    [ "$_arch" = "s390" -o "$_arch" = "s390x" ] || return 1
+    [ "$_arch" = "s390" ] || [ "$_arch" = "s390x" ] || return 1
 
     return 0
 }

--- a/modules.d/95fcoe/fcoe-edd.sh
+++ b/modules.d/95fcoe/fcoe-edd.sh
@@ -34,7 +34,7 @@ for disk in /sys/firmware/edd/int13_*; do
     fi
     for nic in "${disk}"/pci_dev/net/*; do
         [ -d "$nic" ] || continue
-        if [ -n "${dev_port}" -a -e "${nic}/dev_port" ]; then
+        if [ -n "${dev_port}" ] && [ -e "${nic}/dev_port" ]; then
             if [ "$(cat "${nic}"/dev_port)" -ne "${dev_port}" ]; then
                 continue
             fi

--- a/modules.d/95fcoe/fcoe-up.sh
+++ b/modules.d/95fcoe/fcoe-up.sh
@@ -11,7 +11,7 @@ type getarg > /dev/null 2>&1 || . /lib/dracut-lib.sh
 type ip_to_var > /dev/null 2>&1 || . /lib/net-lib.sh
 
 # Huh? Missing arguments ??
-[ -z "$1" -o -z "$2" ] && exit 1
+[ -z "$1" ] || [ -z "$2" ] && exit 1
 
 netif=$1
 dcb=$2

--- a/modules.d/95fcoe/parse-fcoe.sh
+++ b/modules.d/95fcoe/parse-fcoe.sh
@@ -72,7 +72,7 @@ parse_fcoe_opts() {
             ;;
     esac
 
-    if [ "$fcoe_dcb" != "nodcb" -a "$fcoe_dcb" != "dcb" ]; then
+    if [ "$fcoe_dcb" != "nodcb" ] && [ "$fcoe_dcb" != "dcb" ]; then
         warn "Invalid FCoE DCB option: $fcoe_dcb"
     fi
 
@@ -81,7 +81,7 @@ parse_fcoe_opts() {
         return 0
     fi
 
-    if [ -z "$fcoe_interface" -a -z "$fcoe_mac" ]; then
+    if [ -z "$fcoe_interface" ] && [ -z "$fcoe_mac" ]; then
         warn "fcoe: Neither interface nor MAC specified for fcoe=$fcoe"
         return 1
     fi

--- a/modules.d/95iscsi/module-setup.sh
+++ b/modules.d/95iscsi/module-setup.sh
@@ -109,11 +109,11 @@ install_iscsiroot() {
     [ -z "$iscsi_address" ] && return
     ip_params_for_remote_addr "$iscsi_address"
 
-    if [ -n "$iscsi_address" -a -n "$iscsi_targetname" ]; then
-        if [ -n "$iscsi_port" -a "$iscsi_port" -eq 3260 ]; then
+    if [ -n "$iscsi_address" ] && [ -n "$iscsi_targetname" ]; then
+        if [ -n "$iscsi_port" ] && [ "$iscsi_port" -eq 3260 ]; then
             iscsi_port=
         fi
-        if [ -n "$iscsi_lun" -a "$iscsi_lun" -eq 0 ]; then
+        if [ -n "$iscsi_lun" ] && [ "$iscsi_lun" -eq 0 ]; then
             iscsi_lun=
         fi
         # In IPv6 case rd.iscsi.initatior= must pass address in [] brackets
@@ -163,7 +163,7 @@ installkernel() {
     instmods bnx2i qla4xxx cxgb3i cxgb4i be2iscsi qedi
     hostonly="" instmods iscsi_tcp iscsi_ibft crc32c iscsi_boot_sysfs 8021q
 
-    if [ "$_arch" = "s390" -o "$_arch" = "s390x" ]; then
+    if [ "$_arch" = "s390" ] || [ "$_arch" = "s390x" ]; then
         _s390drivers="=drivers/s390/scsi"
     fi
 

--- a/modules.d/95nbd/nbdroot.sh
+++ b/modules.d/95nbd/nbdroot.sh
@@ -60,7 +60,7 @@ while [ -n "$nbdopts" ]; do
     if [ -z "$f" ]; then
         break
     fi
-    if [ -z "${f%bs=*}" -o -z "${f%timeout=*}" ]; then
+    if [ -z "${f%bs=*}" ] || [ -z "${f%timeout=*}" ]; then
         preopts="$preopts $f"
         continue
     fi
@@ -75,7 +75,7 @@ while [ -n "$nbdflags" ]; do
     if [ -z "$f" ]; then
         break
     fi
-    if [ "$f" = "ro" -o "$f" = "rw" ]; then
+    if [ "$f" = "ro" ] || [ "$f" = "rw" ]; then
         nbdrw=$f
         continue
     fi
@@ -96,7 +96,7 @@ done
 
 # If we didn't get a root= on the command line, then we need to
 # add the udev rules for mounting the nbd0 device
-if [ "$root" = "block:/dev/root" -o "$root" = "dhcp" ]; then
+if [ "$root" = "block:/dev/root" ] || [ "$root" = "dhcp" ]; then
     printf 'KERNEL=="nbd0", ENV{DEVTYPE}!="partition", ENV{ID_FS_TYPE}=="?*", SYMLINK+="root"\n' > /etc/udev/rules.d/99-nbd-root.rules
     udevadm control --reload
     wait_for_dev -n /dev/root

--- a/modules.d/95resume/resume.sh
+++ b/modules.d/95resume/resume.sh
@@ -2,7 +2,7 @@
 
 PATH=/usr/sbin:/usr/bin:/sbin:/bin
 
-[ -s /.resume -a -b "$resume" ] && {
+[ -s /.resume ] && [ -b "$resume" ] && {
     # First try user level resume; it offers splash etc
     case "$splash" in
         quiet)

--- a/modules.d/95rootfs-block/module-setup.sh
+++ b/modules.d/95rootfs-block/module-setup.sh
@@ -40,7 +40,7 @@ cmdline_rootfs() {
         return
     fi
 
-    if [ -n "$_block" -a -b "$_dev" ]; then
+    if [ -n "$_block" ] && [ -b "$_dev" ]; then
         printf " root=%s" "$(shorten_persistent_dev "$(get_persistent_dev "$_dev")")"
     fi
     _fstype="$(find_mp_fstype /)"

--- a/modules.d/95rootfs-block/mount-root.sh
+++ b/modules.d/95rootfs-block/mount-root.sh
@@ -98,7 +98,7 @@ mount_root() {
     # printf '%s %s %s %s 1 1 \n' "$esc_root" "$NEWROOT" "$rootfs" "$rflags" >/etc/fstab
 
     if ! getargbool 0 ro && fsck_able "$rootfs" \
-        && [ "$rootfsck" != "0" -a -z "$fastboot" ] \
+        && [ "$rootfsck" != "0" ] && [ -z "$fastboot" ] \
         && ! strstr "${rflags}" _netdev \
         && ! getargbool 0 rd.skipfsck; then
         umount "$NEWROOT"
@@ -121,6 +121,6 @@ mount_root() {
     fi
 }
 
-if [ -n "$root" -a -z "${root%%block:*}" ]; then
+if [ -n "$root" ] && [ -z "${root%%block:*}" ]; then
     mount_root
 fi

--- a/modules.d/95virtfs/mount-virtfs.sh
+++ b/modules.d/95virtfs/mount-virtfs.sh
@@ -68,7 +68,7 @@ mount_root() {
     [ -f "$NEWROOT"/.autofsck ] && rm -f -- "$NEWROOT"/.autofsck 2> /dev/null
 }
 
-if [ -n "$root" -a -z "${root%%virtfs:*}" ]; then
+if [ -n "$root" ] && [ -z "${root%%virtfs:*}" ]; then
     mount_root
 fi
 :

--- a/modules.d/95virtiofs/mount-virtiofs.sh
+++ b/modules.d/95virtiofs/mount-virtiofs.sh
@@ -2,7 +2,7 @@
 
 type ismounted > /dev/null 2>&1 || . /lib/dracut-lib.sh
 
-if [ "${fstype}" = "virtiofs" -o "${root%%:*}" = "virtiofs" ]; then
+if [ "${fstype}" = "virtiofs" ] || [ "${root%%:*}" = "virtiofs" ]; then
     if ! load_fstype virtiofs; then
         die "virtiofs is required but not available."
     fi

--- a/modules.d/95virtiofs/parse-virtiofs.sh
+++ b/modules.d/95virtiofs/parse-virtiofs.sh
@@ -3,7 +3,7 @@
 # 	rootfstype=virtiofs root=<tag>
 # 	root=virtiofs:<tag>
 
-if [ "${fstype}" = "virtiofs" -o "${root%%:*}" = "virtiofs" ]; then
+if [ "${fstype}" = "virtiofs" ] || [ "${root%%:*}" = "virtiofs" ]; then
     # shellcheck disable=SC2034
     rootok=1
 fi

--- a/modules.d/95zfcp/module-setup.sh
+++ b/modules.d/95zfcp/module-setup.sh
@@ -3,7 +3,7 @@
 # called by dracut
 check() {
     arch=${DRACUT_ARCH:-$(uname -m)}
-    [ "$arch" = "s390" -o "$arch" = "s390x" ] || return 1
+    [ "$arch" = "s390" ] || [ "$arch" = "s390x" ] || return 1
 
     require_binaries zfcp_cio_free sed || return 1
 

--- a/modules.d/95znet/module-setup.sh
+++ b/modules.d/95znet/module-setup.sh
@@ -3,7 +3,7 @@
 # called by dracut
 check() {
     arch=${DRACUT_ARCH:-$(uname -m)}
-    [ "$arch" = "s390" -o "$arch" = "s390x" ] || return 1
+    [ "$arch" = "s390" ] || [ "$arch" = "s390x" ] || return 1
 
     require_binaries grep sed seq readlink chzdev || return 1
 

--- a/modules.d/98selinux/selinux-loadpolicy.sh
+++ b/modules.d/98selinux/selinux-loadpolicy.sh
@@ -18,7 +18,7 @@ rd_load_policy() {
     fi
 
     # Attempt to load SELinux Policy
-    if [ -x "$NEWROOT/usr/sbin/load_policy" -o -x "$NEWROOT/sbin/load_policy" ]; then
+    if [ -x "$NEWROOT/usr/sbin/load_policy" ] || [ -x "$NEWROOT/sbin/load_policy" ]; then
         local ret=0
         local out
         info "Loading SELinux policy"
@@ -41,7 +41,7 @@ rd_load_policy() {
             return 0
         fi
 
-        if [ $ret -eq 0 -o $ret -eq 2 ]; then
+        if [ $ret -eq 0 ] || [ $ret -eq 2 ]; then
             # If machine requires a relabel, force to permissive mode
             [ -e "$NEWROOT"/.autorelabel ] && LANG=C /usr/sbin/setenforce 0
             mount --rbind /dev "$NEWROOT/dev"
@@ -51,14 +51,14 @@ rd_load_policy() {
         fi
 
         warn "Initial SELinux policy load failed."
-        if [ $ret -eq 3 -o $permissive -eq 0 ]; then
+        if [ $ret -eq 3 ] || [ $permissive -eq 0 ]; then
             warn "Machine in enforcing mode."
             warn "Not continuing"
             emergency_shell -n selinux
             exit 1
         fi
         return 0
-    elif [ $permissive -eq 0 -a "$SELINUX" != "disabled" ]; then
+    elif [ $permissive -eq 0 ] && [ "$SELINUX" != "disabled" ]; then
         warn "Machine in enforcing mode and cannot execute load_policy."
         warn "To disable selinux, add selinux=0 to the kernel command line."
         warn "Not continuing"

--- a/modules.d/99base/dracut-dev-lib.sh
+++ b/modules.d/99base/dracut-dev-lib.sh
@@ -30,7 +30,7 @@ dev_unit_name() {
         return $?
     fi
 
-    if [ "$dev" = "/" -o -z "$dev" ]; then
+    if [ "$dev" = "/" ] || [ -z "$dev" ]; then
         printf -- "-"
         return 0
     fi

--- a/modules.d/99base/dracut-lib.sh
+++ b/modules.d/99base/dracut-lib.sh
@@ -37,7 +37,7 @@ strstr() {
 # matches; as it would match anything, it's not an interesting case.
 strglob() {
     # shellcheck disable=SC2295
-    [ -n "$1" -a -z "${1##$2}" ]
+    [ -n "$1" ] && [ -z "${1##$2}" ]
 }
 
 # returns OK if $1 contains (anywhere) a match of glob pattern $2
@@ -45,7 +45,7 @@ strglob() {
 # matches; as it would match anything, it's not an interesting case.
 strglobin() {
     # shellcheck disable=SC2295
-    [ -n "$1" -a -z "${1##*$2*}" ]
+    [ -n "$1" ] && [ -z "${1##*$2*}" ]
 }
 
 # returns OK if $1 contains literal string $2 at the beginning, and isn't empty
@@ -354,14 +354,14 @@ splitsep() {
     shift 2
     local tmp
 
-    while [ -n "$str" -a "$#" -gt 1 ]; do
+    while [ -n "$str" ] && [ "$#" -gt 1 ]; do
         tmp="${str%%"$sep"*}"
         eval "$1='${tmp}'"
         str="${str#"$tmp"}"
         str="${str#"$sep"}"
         shift
     done
-    [ -n "$str" -a -n "$1" ] && eval "$1='$str'"
+    [ -n "$str" ] && [ -n "$1" ] && eval "$1='$str'"
     debug_on
     return 0
 }

--- a/test/TEST-20-NFS/client-init.sh
+++ b/test/TEST-20-NFS/client-init.sh
@@ -19,7 +19,7 @@ fi
 echo "made it to the rootfs! Powering down."
 
 while read -r dev _ fstype opts rest || [ -n "$dev" ]; do
-    [ "$fstype" != "nfs" -a "$fstype" != "nfs4" ] && continue
+    [ "$fstype" != "nfs" ] && [ "$fstype" != "nfs4" ] && continue
     echo "nfs-OK $dev $fstype $opts" | dd oflag=direct,dsync of=/dev/disk/by-id/scsi-0QEMU_QEMU_HARDDISK_marker status=none
     break
 done < /proc/mounts
@@ -31,7 +31,7 @@ if grep -qF 'rd.live.overlay' /proc/cmdline; then
     fi
 fi
 
-if [ "$fstype" = "nfs" -o "$fstype" = "nfs4" ]; then
+if [ "$fstype" = "nfs" ] || [ "$fstype" = "nfs4" ]; then
 
     serverip=${dev%:*}
     path=${dev#*:}


### PR DESCRIPTION
## Changes

shellcheck complains about SC2166:
> Prefer [ p ] || [ q ] as [ p -o q ] is not well defined.

See https://github.com/koalaman/shellcheck/wiki/SC2166

Address the valid shellcheck complaint instead of ignoring it globally.

## Checklist
- [ ] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it
