### PR TITLE
fix: address shellcheck SC2319

### DIFF
--- a/modules.d/80lvmthinpool-monitor/start-thinpool-monitor.sh
+++ b/modules.d/80lvmthinpool-monitor/start-thinpool-monitor.sh
@@ -9,7 +9,7 @@ is_lvm2_thinp_device() {
     _lvm2_thin_device=$(lvm lvs -S 'lv_layout=sparse && lv_layout=thin' \
         --nosuffix --noheadings -o vg_name,lv_name "$_device_path" 2> /dev/null)
 
-    [ -n "$_lvm2_thin_device" ] && return $?
+    [ -n "$_lvm2_thin_device" ]
 }
 
 for LV in $LVS; do

--- a/modules.d/95iscsi/iscsiroot.sh
+++ b/modules.d/95iscsi/iscsiroot.sh
@@ -229,7 +229,7 @@ handle_netroot() {
             echo "$target"
         done
     })
-    [ -z "$targets" ] && warn "Target discovery to $iscsi_target_ip:${iscsi_target_port:+$iscsi_target_port} failed with status $?" && return 1
+    [ -z "$targets" ] && warn "Target discovery to $iscsi_target_ip:${iscsi_target_port:+$iscsi_target_port} failed" && return 1
 
     found=
     for target in $targets; do


### PR DESCRIPTION
## Changes

shellcheck complains:

```
In modules.d/80lvmthinpool-monitor/start-thinpool-monitor.sh line 12:
    [ -n "$_lvm2_thin_device" ] && return $?
                                          ^-- SC2319 (warning): This $? refers to a condition, not a command. Assign to a variable to avoid it being overwritten.
```

Let `is_lvm2_thinp_device` directly return the test exit code.

shellcheck complains:

```
In modules.d/95iscsi/iscsiroot.sh line 232:
    [ -z "$targets" ] && warn "Target discovery to $iscsi_target_ip:${iscsi_target_port:+$iscsi_target_port} failed with status $?" && return 1
                                                                                                                                ^-- SC2319 (warning): This $? refers to a condition, not a command. Assign to a variable to avoid it being overwritten.
```

The `while` loop that gets the output from `iscsiadm` via a pipe will exit with 0. Printing the exit code 0 does not help. So just drop it.

## Checklist
- [ ] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it
