### PR TITLE
fix: quote single CTTY parameter and _ctty variable

### DIFF
--- a/modules.d/80test-root/test-init.sh
+++ b/modules.d/80test-root/test-init.sh
@@ -38,8 +38,7 @@ echo "made it to the rootfs!"
 
 if getargbool 0 rd.shell; then
     strstr "$(setsid --help)" "control" && CTTY="-c"
-    # shellcheck disable=SC2086
-    setsid $CTTY sh -i
+    setsid ${CTTY:+"${CTTY}"} sh -i
 fi
 
 echo "Powering down."

--- a/modules.d/99base/dracut-lib.sh
+++ b/modules.d/99base/dracut-lib.sh
@@ -937,15 +937,15 @@ _emergency_shell() {
         _ctty="$(RD_DEBUG='' getarg rd.ctty=)" && _ctty="/dev/${_ctty##*/}"
         if [ -z "$_ctty" ]; then
             _ctty=console
-            while [ -f /sys/class/tty/$_ctty/active ]; do
-                read -r _ctty < /sys/class/tty/$_ctty/active
+            while [ -f "/sys/class/tty/$_ctty/active" ]; do
+                read -r _ctty < "/sys/class/tty/$_ctty/active"
                 _ctty=${_ctty##* } # last one in the list
             done
             _ctty=/dev/$_ctty
         fi
         [ -c "$_ctty" ] || _ctty=/dev/tty1
         case "$(/usr/bin/setsid --help 2>&1)" in *--ctty*) CTTY="--ctty" ;; esac
-        setsid ${CTTY:+"${CTTY}"} /bin/sh -i -l 0<> $_ctty 1<> $_ctty 2<> $_ctty
+        setsid ${CTTY:+"${CTTY}"} /bin/sh -i -l 0<> "$_ctty" 1<> "$_ctty" 2<> "$_ctty"
     fi
 }
 

--- a/modules.d/99base/dracut-lib.sh
+++ b/modules.d/99base/dracut-lib.sh
@@ -945,7 +945,7 @@ _emergency_shell() {
         fi
         [ -c "$_ctty" ] || _ctty=/dev/tty1
         case "$(/usr/bin/setsid --help 2>&1)" in *--ctty*) CTTY="--ctty" ;; esac
-        setsid $CTTY /bin/sh -i -l 0<> $_ctty 1<> $_ctty 2<> $_ctty
+        setsid ${CTTY:+"${CTTY}"} /bin/sh -i -l 0<> $_ctty 1<> $_ctty 2<> $_ctty
     fi
 }
 

--- a/test/TEST-20-NFS/client-init.sh
+++ b/test/TEST-20-NFS/client-init.sh
@@ -13,7 +13,7 @@ stty sane
 if getargbool 0 rd.shell; then
     [ -c /dev/watchdog ] && printf 'V' > /dev/watchdog
     strstr "$(setsid --help)" "control" && CTTY="-c"
-    setsid $CTTY sh -i
+    setsid ${CTTY:+"${CTTY}"} sh -i
 fi
 
 echo "made it to the rootfs! Powering down."

--- a/test/TEST-30-ISCSI/client-init.sh
+++ b/test/TEST-30-ISCSI/client-init.sh
@@ -17,7 +17,7 @@ done < /proc/mounts
 
 if getargbool 0 rd.shell; then
     strstr "$(setsid --help)" "control" && CTTY="-c"
-    setsid $CTTY sh -i
+    setsid ${CTTY:+"${CTTY}"} sh -i
 fi
 
 sync

--- a/test/TEST-35-ISCSI-MULTI/client-init.sh
+++ b/test/TEST-35-ISCSI-MULTI/client-init.sh
@@ -17,7 +17,7 @@ done < /proc/mounts
 
 if getargbool 0 rd.shell; then
     strstr "$(setsid --help)" "control" && CTTY="-c"
-    setsid $CTTY sh -i
+    setsid ${CTTY:+"${CTTY}"} sh -i
 fi
 
 sync

--- a/test/TEST-40-NBD/client-init.sh
+++ b/test/TEST-40-NBD/client-init.sh
@@ -20,7 +20,7 @@ echo "made it to the rootfs! Powering down."
 
 if getargbool 0 rd.shell; then
     strstr "$(setsid --help)" "control" && CTTY="-c"
-    setsid $CTTY sh -i
+    setsid ${CTTY:+"${CTTY}"} sh -i
 fi
 
 mount -n -o remount,ro /


### PR DESCRIPTION
## Changes

shellcheck complains about SC2086 (info):
> Double quote to prevent globbing and word splitting.

The variable `CTTY` contains either nothing or exactly one parameter. Use shell substitution to quote this single parameter in case it is not empty.

The variable `_ctty` contains a path and therefore is safe to quote.

## Checklist
- [ ] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it