### PR TITLE
fix(dracut-lib): quote _b and var variable

### DIFF
--- a/modules.d/99base/dracut-lib.sh
+++ b/modules.d/99base/dracut-lib.sh
@@ -1002,8 +1002,8 @@ export_n() {
     local var
     local val
     for var in "$@"; do
-        eval val=\$$var
-        unset $var
+        eval "val=\$$var"
+        unset "$var"
         [ -n "$val" ] && eval "$var=\"$val\""
     done
 }

--- a/modules.d/99base/dracut-lib.sh
+++ b/modules.d/99base/dracut-lib.sh
@@ -266,7 +266,7 @@ getargnum() {
     _b=$(getarg "$1") || _b=${_b:-"$_default"}
     if [ -n "$_b" ]; then
         isdigit "$_b" && _b=$((_b)) \
-            && [ $_b -ge "$_min" ] && [ $_b -le "$_max" ] && echo $_b && return
+            && [ "$_b" -ge "$_min" ] && [ "$_b" -le "$_max" ] && echo "$_b" && return
     fi
     echo "$_default"
 }


### PR DESCRIPTION
## Changes

shellcheck complains about SC2086 (info):
> Double quote to prevent globbing and word splitting.

The variable `_b` contains a digit without spaces (as validated by `isdigit`) and therefore is safe to quote.

The variable `var` refers to one environment variable and therefore is safe to quote.

## Checklist
- [ ] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it