### PR TITLE
fix(test-root): quote _terminfodir variable

### DIFF
--- a/modules.d/80test-root/module-setup.sh
+++ b/modules.d/80test-root/module-setup.sh
@@ -22,9 +22,9 @@ install() {
     inst_multiple mkdir ln dd stty mount poweroff umount setsid sync
 
     for _terminfodir in /lib/terminfo /etc/terminfo /usr/share/terminfo; do
-        [ -f ${_terminfodir}/l/linux ] && break
+        [ -f "${_terminfodir}/l/linux" ] && break
     done
-    inst_multiple -o ${_terminfodir}/l/linux
+    inst_multiple -o "${_terminfodir}/l/linux"
 
     inst_binary "${dracutbasedir}/dracut-util" "/usr/bin/dracut-util"
     ln -s dracut-util "${initdir}/usr/bin/dracut-getarg"


### PR DESCRIPTION
## Changes

shellcheck complains about SC2086 (info):
> Double quote to prevent globbing and word splitting.

The variable `_terminfodir` refers to a path and therefore is safe to be quoted.

## Checklist
- [ ] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it