### PR TITLE
fix(nfs): quote rpcpipefspath variable

### DIFF
--- a/modules.d/95nfs/nfsroot-cleanup.sh
+++ b/modules.d/95nfs/nfsroot-cleanup.sh
@@ -16,12 +16,12 @@ pid=$(pidof rpcbind)
 
 if incol2 /proc/mounts /var/lib/nfs/rpc_pipefs; then
     # try to create the destination directory
-    [ -d "$NEWROOT"/$rpcpipefspath ] \
-        || mkdir -m 0755 -p "$NEWROOT"/$rpcpipefspath 2> /dev/null
+    [ -d "$NEWROOT/$rpcpipefspath" ] \
+        || mkdir -m 0755 -p "$NEWROOT/$rpcpipefspath" 2> /dev/null
 
-    if [ -d "$NEWROOT"/$rpcpipefspath ]; then
+    if [ -d "$NEWROOT/$rpcpipefspath" ]; then
         # mount --move does not seem to work???
-        mount --bind /var/lib/nfs/rpc_pipefs "$NEWROOT"/$rpcpipefspath
+        mount --bind /var/lib/nfs/rpc_pipefs "$NEWROOT/$rpcpipefspath"
         umount /var/lib/nfs/rpc_pipefs 2> /dev/null
     else
         umount /var/lib/nfs/rpc_pipefs 2> /dev/null


### PR DESCRIPTION
## Changes

shellcheck complains about SC2086 (info):
> Double quote to prevent globbing and word splitting.

The variable `rpcpipefspath` refers to a path and therefore is safe to be quoted.

## Checklist
- [ ] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it