### PR TITLE
fix(dracut-init.sh): quote dracutbasedir variable

### DIFF
--- a/dracut-init.sh
+++ b/dracut-init.sh
@@ -35,7 +35,7 @@ if ! [[ $dracutbasedir ]]; then
     dracutbasedir=${BASH_SOURCE[0]%/*}
     [[ $dracutbasedir == dracut-functions* ]] && dracutbasedir="."
     [[ $dracutbasedir ]] || dracutbasedir="."
-    dracutbasedir="$(readlink -f $dracutbasedir)"
+    dracutbasedir="$(readlink -f "$dracutbasedir")"
 fi
 
 if ! is_func dinfo > /dev/null 2>&1; then


### PR DESCRIPTION
## Changes

shellcheck complains about SC2086 (info):
> Double quote to prevent globbing and word splitting.

The variable `dracutbasedir` refers to a path and therefore is safe to be quoted.

## Checklist
- [ ] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it
