### PR TITLE
fix(syslog): quote conf variable

### DIFF
--- a/modules.d/98syslog/rsyslogd-start.sh
+++ b/modules.d/98syslog/rsyslogd-start.sh
@@ -41,7 +41,7 @@ rsyslog_config() {
 if [ "$type" = "rsyslogd" ]; then
     template=/etc/templates/rsyslog.conf
     if [ -n "$server" ]; then
-        rsyslog_config "$server" "$template" "$filters" > $conf
+        rsyslog_config "$server" "$template" "$filters" > "$conf"
         rsyslogd -c3
     fi
 fi


### PR DESCRIPTION
## Changes

shellcheck complains about SC2086 (info):
> Double quote to prevent globbing and word splitting.

The variable `conf` refers to a path and therefore is safe to be quoted.

## Checklist
- [ ] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it