### PR TITLE
fix(lunmask): quote LUN variable

### DIFF
--- a/modules.d/95lunmask/fc_transport_scan_lun.sh
+++ b/modules.d/95lunmask/fc_transport_scan_lun.sh
@@ -23,4 +23,4 @@ if [ -f /sys"$DEVPATH"/scsi_target_id ]; then
     read -r TARGET < /sys"$DEVPATH"/scsi_target_id
 fi
 [ -z "$TARGET" ] && exit 1
-echo "$CHANNEL" "$TARGET" $LUN > /sys/class/scsi_host/host"$HOST"/scan
+echo "$CHANNEL $TARGET $LUN" > /sys/class/scsi_host/host"$HOST"/scan

--- a/modules.d/95lunmask/sas_transport_scan_lun.sh
+++ b/modules.d/95lunmask/sas_transport_scan_lun.sh
@@ -23,4 +23,4 @@ if [ -f /sys"$DEVPATH"/scsi_target_id ]; then
     read -r TARGET < /sys"$DEVPATH"/scsi_target_id
 fi
 [ -z "$TARGET" ] && exit 1
-echo 0 "$TARGET" $LUN > /sys/class/scsi_host/host"$HOST"/scan
+echo "0 $TARGET $LUN" > /sys/class/scsi_host/host"$HOST"/scan


### PR DESCRIPTION
## Changes

shellcheck complains about SC2086 (info): Double quote to prevent globbing and word splitting.

The variable `LUN` refers to a single logical unit number (LUN) and therefore is safe to be quoted.

## Checklist
- [ ] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it