### PR TITLE
fix(dmsquash-live-autooverlay): quote variables

### DIFF
--- a/modules.d/90dmsquash-live-autooverlay/create-overlay.sh
+++ b/modules.d/90dmsquash-live-autooverlay/create-overlay.sh
@@ -14,14 +14,12 @@ gatherData() {
         info "Skipping overlay creation: kernel command line parameter 'rd.live.overlay' is not set"
         exit 0
     fi
-    # shellcheck disable=SC2086
-    if ! str_starts ${overlay} LABEL=; then
+    if ! str_starts "${overlay}" LABEL=; then
         die "Overlay creation failed: the partition must be set by LABEL in the 'rd.live.overlay' kernel parameter"
     fi
 
     overlayLabel=${overlay#LABEL=}
-    # shellcheck disable=SC2086
-    if [ -b /dev/disk/by-label/${overlayLabel} ]; then
+    if [ -b "/dev/disk/by-label/${overlayLabel}" ]; then
         info "Skipping overlay creation: overlay already exists"
         exit 0
     fi
@@ -41,32 +39,24 @@ gatherData() {
     # The kernel command line's 'root=' parameter was parsed into the $root variable by the dmsquash-live module.
     # $root contains the path to a symlink within /dev/disk/by-label, which points to a partition.
     # This script needs that partition's parent block device.
-    # shellcheck disable=SC2046
-    # shellcheck disable=SC2086
-    rootDeviceAbsolutePath=$(readlink -f ${rootDevice})
-    rootDeviceSysfsPath=/sys/class/block/${rootDeviceAbsolutePath##*/}
+    rootDeviceAbsolutePath=$(readlink -f "${rootDevice}")
+    rootDeviceSysfsPath="/sys/class/block/${rootDeviceAbsolutePath##*/}"
     if [ -f "${rootDeviceSysfsPath}/partition" ]; then
-        # shellcheck disable=SC2086
-        read -r partition < ${rootDeviceSysfsPath}/partition
+        read -r partition < "${rootDeviceSysfsPath}/partition"
     else
         partition=0
     fi
-    # shellcheck disable=SC2086
-    read -r readonly < ${rootDeviceSysfsPath}/ro
-    # shellcheck disable=SC2086
+    read -r readonly < "${rootDeviceSysfsPath}/ro"
     if [ "$partition" != "1" ] || [ "$readonly" != "0" ]; then
         info "Skipping overlay creation: unpartitioned or read-only media detected"
         exit 0
     fi
-    # shellcheck disable=SC2046
-    # shellcheck disable=SC2086
-    fullDriveSysfsPath=$(readlink -f ${rootDeviceSysfsPath}/..)
-    blockDevice=/dev/${fullDriveSysfsPath##*/}
+    fullDriveSysfsPath=$(readlink -f "${rootDeviceSysfsPath}/..")
+    blockDevice="/dev/${fullDriveSysfsPath##*/}"
     currentPartitionCount=$(grep --count -E "${blockDevice#/dev/}[0-9]+" /proc/partitions)
 
-    # shellcheck disable=SC2086
-    freeSpaceStart=$(parted --script ${blockDevice} unit % print free \
-        | awk -v x=${currentPartitionCount} '$1 == x {getline; print $1}')
+    freeSpaceStart=$(parted --script "${blockDevice}" unit % print free \
+        | awk -v "x=${currentPartitionCount}" '$1 == x {getline; print $1}')
     if [ -z "$freeSpaceStart" ]; then
         info "Skipping overlay creation: there is no free space after the last partition"
         exit 0
@@ -87,22 +77,18 @@ gatherData() {
 }
 
 createPartition() {
-    # shellcheck disable=SC2086
-    parted --script --align optimal ${blockDevice} mkpart primary ${partitionStart}% 100%
+    parted --script --align optimal "${blockDevice}" mkpart primary ${partitionStart}% 100%
 }
 
 createFilesystem() {
-    # shellcheck disable=SC2086
-    mkfs.${filesystem} -L ${overlayLabel} ${overlayPartition}
+    "mkfs.${filesystem}" -L "${overlayLabel}" "${overlayPartition}"
 
     baseDir=/run/initramfs/create-overlayfs
     mkdir -p ${baseDir}
-    # shellcheck disable=SC2086
-    mount -t ${filesystem} ${overlayPartition} ${baseDir}
+    mount -t "${filesystem}" "${overlayPartition}" ${baseDir}
 
-    mkdir -p ${baseDir}/${live_dir}/ovlwork
-    # shellcheck disable=SC2086
-    mkdir ${baseDir}/${live_dir}/overlay-${label}-${uuid}
+    mkdir -p "${baseDir}/${live_dir}/ovlwork"
+    mkdir "${baseDir}/${live_dir}/overlay-${label}-${uuid}"
 
     umount ${baseDir}
     rm -r ${baseDir}


### PR DESCRIPTION
## Changes

shellcheck complains about SC2086 (info):
> Double quote to prevent globbing and word splitting.

Instead of ignoring those complains fix them instead. The variable `overlay` should be quoted since it might contain spaces. The variables `rootDevice`, `rootDeviceAbsolutePath`, `rootDeviceSysfsPath`, `fullDriveSysfsPath`, `blockDevice` refer to paths. Therefore they are safe to quote.

## Checklist
- [ ] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it
