### PR TITLE
fix(znet): quote initdir variable

### DIFF
--- a/modules.d/95znet/module-setup.sh
+++ b/modules.d/95znet/module-setup.sh
@@ -45,14 +45,12 @@ install() {
         # shellcheck disable=SC2155
         local _nullglob=$(shopt -p nullglob)
         shopt -u nullglob
-        # shellcheck disable=SC2086
         readarray -t _array < <(
-            ls -1 $initdir/etc/udev/rules.d/41-*.rules 2> /dev/null
+            ls -1 "$initdir"/etc/udev/rules.d/41-*.rules 2> /dev/null
         )
         [[ ${#_array[@]} -gt 0 ]] && mark_hostonly "${_array[@]#$initdir}"
-        # shellcheck disable=SC2086
         readarray -t _array < <(
-            ls -1 $initdir/etc/modprobe.d/s390x-*.conf 2> /dev/null
+            ls -1 "$initdir"/etc/modprobe.d/s390x-*.conf 2> /dev/null
         )
         [[ ${#_array[@]} -gt 0 ]] && mark_hostonly "${_array[@]#$initdir}"
         $_nullglob


### PR DESCRIPTION
## Changes

shellcheck complains about SC2086 (info):
> Double quote to prevent globbing and word splitting.

The variable `initdir` refers to a path and therefore is safe to be quoted.

## Checklist
- [ ] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it