### PR TITLE
fix(network-legacy): quote bridgename variable

### DIFF
--- a/modules.d/35network-legacy/parse-bridge.sh
+++ b/modules.d/35network-legacy/parse-bridge.sh
@@ -45,5 +45,5 @@ for bridge in $(getargs bridge=); do
     {
         echo "bridgename=$bridgename"
         echo "bridgeslaves=\"$bridgeslaves\""
-    } > /tmp/bridge.${bridgename}.info
+    } > "/tmp/bridge.${bridgename}.info"
 done


### PR DESCRIPTION
## Changes

shellcheck complains about SC2086 (info): Double quote to prevent globbing and word splitting.

The variable `bridgename` refers to a bridge name which is not expected to contain a space and therefore is safe to be quoted.

## Checklist
- [ ] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it