### PR TITLE
fix(convertfs): quote single CP_HARDLINK variable

### DIFF
--- a/modules.d/30convertfs/convertfs.sh
+++ b/modules.d/30convertfs/convertfs.sh
@@ -114,7 +114,7 @@ for dir in bin sbin lib lib64; do
     echo "Merge the copy with \`$ROOT/$dir'."
     [[ -d "$ROOT/usr/${dir}.usrmove-new" ]] \
         || mkdir -p "$ROOT/usr/${dir}.usrmove-new"
-    cp -axT $CP_HARDLINK --backup --suffix=.usrmove~ "$ROOT/$dir" "$ROOT/usr/${dir}.usrmove-new"
+    cp -axT ${CP_HARDLINK:+"$CP_HARDLINK"} --backup --suffix=.usrmove~ "$ROOT/$dir" "$ROOT/usr/${dir}.usrmove-new"
     echo "Clean up duplicates in \`$ROOT/usr/$dir'."
     # delete all symlinks that have been backed up
     find "$ROOT/usr/${dir}.usrmove-new" -type l -name '*.usrmove~' -delete || :


### PR DESCRIPTION
## Changes

shellcheck complains about SC2086 (info):
> Double quote to prevent globbing and word splitting.

The variable `CP_HARDLINK` contains either nothing or exactly one parameter. Use shell substitution to quote this single parameter in case it is not empty.

## Checklist
- [ ] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it