### PR TITLE
fix(zipl): quote ID_FS_TYPE variable

### DIFF
--- a/modules.d/91zipl/module-setup.sh
+++ b/modules.d/91zipl/module-setup.sh
@@ -36,7 +36,7 @@ installkernel() {
                     ID_FS_TYPE=ext4
                     ;;
             esac
-            instmods ${ID_FS_TYPE}
+            instmods "${ID_FS_TYPE}"
         fi
     fi
 }


### PR DESCRIPTION
## Changes

shellcheck complains about SC2086 (info):
> Double quote to prevent globbing and word splitting.

The variable `ID_FS_TYPE` refers to a single file system type which is not expected to contain a space and therefore is safe to be quoted.

## Checklist
- [ ] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it
