### PR TITLE
fix(dracut-logger.sh): quote _dlogfd variable

### DIFF
--- a/dracut-logger.sh
+++ b/dracut-logger.sh
@@ -327,7 +327,7 @@ _do_dlog() {
 
     if ((lvl <= sysloglvl)); then
         if [[ "$_dlogfd" ]]; then
-            printf -- "<%s>%s\n" "$(($(_dlvl2syslvl "$lvl") & 7))" "$msg" >&$_dlogfd
+            printf -- "<%s>%s\n" "$(($(_dlvl2syslvl "$lvl") & 7))" "$msg" >&"$_dlogfd"
         else
             logger -t "dracut[$$]" -p "$(_lvl2syspri "$lvl")" -- "$msg"
         fi


### PR DESCRIPTION
## Changes

shellcheck complains about SC2086 (info):
> Double quote to prevent globbing and word splitting.

The variable `_dlogfd` refers to an integer and therefore is safe to be quoted.

## Checklist
- [ ] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it
