### PR TITLE
fix: disable SC2317 for calls by for_each_host_dev_and_slaves

### DIFF
--- a/modules.d/90kernel-modules/module-setup.sh
+++ b/modules.d/90kernel-modules/module-setup.sh
@@ -5,6 +5,7 @@ installkernel() {
     local _blockfuncs='ahci_platform_get_resources|ata_scsi_ioctl|scsi_add_host|blk_cleanup_queue|register_mtd_blktrans|scsi_esp_register|register_virtio_device|usb_stor_disconnect|mmc_add_host|sdhci_add_host|scsi_add_host_with_dma|blk_alloc_disk|blk_mq_alloc_disk|blk_mq_alloc_request|blk_mq_destroy_queue|blk_cleanup_disk'
     local -A _hostonly_drvs
 
+    # shellcheck disable=SC2317  # called later by for_each_host_dev_and_slaves
     record_block_dev_drv() {
 
         for _mod in $(get_dev_module /dev/block/"$1"); do

--- a/modules.d/90multipath/module-setup.sh
+++ b/modules.d/90multipath/module-setup.sh
@@ -69,6 +69,7 @@ install() {
     local -A _allow
     local config_dir
 
+    # shellcheck disable=SC2317  # called later by for_each_host_dev_and_slaves
     add_hostonly_mpath_conf() {
         if is_mpath "$1"; then
             local _dev

--- a/modules.d/95fcoe-uefi/module-setup.sh
+++ b/modules.d/95fcoe-uefi/module-setup.sh
@@ -2,6 +2,7 @@
 
 # called by dracut
 check() {
+    # shellcheck disable=SC2317  # called later by for_each_host_dev_and_slaves
     is_fcoe() {
         block_is_fcoe "$1" || return 1
     }

--- a/modules.d/95fcoe/module-setup.sh
+++ b/modules.d/95fcoe/module-setup.sh
@@ -2,6 +2,7 @@
 
 # called by dracut
 check() {
+    # shellcheck disable=SC2317  # called later by for_each_host_dev_and_slaves
     is_fcoe() {
         block_is_fcoe "$1" || return 1
     }

--- a/modules.d/95iscsi/module-setup.sh
+++ b/modules.d/95iscsi/module-setup.sh
@@ -134,6 +134,7 @@ install_iscsiroot() {
 install_softiscsi() {
     [ -d /sys/firmware/ibft ] && return 0
 
+    # shellcheck disable=SC2317  # called later by for_each_host_dev_and_slaves
     is_softiscsi() {
         local _dev=$1
         local iscsi_dev

--- a/modules.d/95lunmask/module-setup.sh
+++ b/modules.d/95lunmask/module-setup.sh
@@ -4,6 +4,7 @@
 
 # called by dracut
 cmdline() {
+    # shellcheck disable=SC2317  # called later by for_each_host_dev_and_slaves
     get_lunmask() {
         local _dev=$1
         local _devpath _sdev _lun _rport _end_device _classdev _wwpn _sas_address

--- a/modules.d/95nvmf/module-setup.sh
+++ b/modules.d/95nvmf/module-setup.sh
@@ -4,6 +4,7 @@
 check() {
     require_binaries nvme jq || return 1
 
+    # shellcheck disable=SC2317  # called later by for_each_host_dev_and_slaves
     is_nvmf() {
         local _dev=$1
         local trtype
@@ -68,6 +69,7 @@ cmdline() {
     local _hostnqn
     local _hostid
 
+    # shellcheck disable=SC2317  # called later by for_each_host_dev_and_slaves
     gen_nvmf_cmdline() {
         local _dev=$1
         local trtype


### PR DESCRIPTION
## Changes

shellcheck 0.10 complains about SC2317 (info): Command appears to be unreachable. Check usage (or ignore if invoked indirectly). It fails to detect cases where a function is defined and later called by `for_each_host_dev_and_slaves`. Disable shellcheck in this case.

## Checklist
- [ ] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it