### PR TITLE
feat(qemu): include the virtio_crypto kernel module

### DIFF
--- a/modules.d/90qemu/module-setup.sh
+++ b/modules.d/90qemu/module-setup.sh
@@ -15,7 +15,7 @@ installkernel() {
     # qemu specific modules
     hostonly='' instmods \
         ata_piix ata_generic pata_acpi cdrom sr_mod ahci \
-        virtio_blk virtio virtio_ring virtio_pci \
+        virtio_blk virtio virtio_crypto virtio_ring virtio_pci \
         virtio_scsi virtio_console virtio_rng virtio_mem \
         spapr-vscsi \
         qemu_fw_cfg \


### PR DESCRIPTION
## Changes

The virtio crypto is a virtual crypto device.

- https://wiki.qemu.org/Features/VirtioCrypto

## Checklist
- [ ] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it


