### PR TITLE
fix(test): tests needs more storage space

### DIFF
--- a/test/TEST-10-RAID/test.sh
+++ b/test/TEST-10-RAID/test.sh
@@ -43,9 +43,9 @@ test_setup() {
     declare -a disk_args=()
     declare -i disk_index=0
     qemu_add_drive disk_index disk_args "$TESTDIR"/marker.img marker 1
-    qemu_add_drive disk_index disk_args "$TESTDIR"/raid-1.img raid1 40
-    qemu_add_drive disk_index disk_args "$TESTDIR"/raid-2.img raid2 40
-    qemu_add_drive disk_index disk_args "$TESTDIR"/raid-3.img raid3 40
+    qemu_add_drive disk_index disk_args "$TESTDIR"/raid-1.img raid1 80
+    qemu_add_drive disk_index disk_args "$TESTDIR"/raid-2.img raid2 80
+    qemu_add_drive disk_index disk_args "$TESTDIR"/raid-3.img raid3 80
 
     "$testdir"/run-qemu \
         "${disk_args[@]}" \

--- a/test/TEST-12-RAID-DEG/test.sh
+++ b/test/TEST-12-RAID-DEG/test.sh
@@ -75,9 +75,9 @@ test_setup() {
     declare -a disk_args=()
     declare -i disk_index=0
     qemu_add_drive disk_index disk_args "$TESTDIR"/marker.img marker 1
-    qemu_add_drive disk_index disk_args "$TESTDIR"/raid-1.img raid1 40
-    qemu_add_drive disk_index disk_args "$TESTDIR"/raid-2.img raid2 40
-    qemu_add_drive disk_index disk_args "$TESTDIR"/raid-3.img raid3 40
+    qemu_add_drive disk_index disk_args "$TESTDIR"/raid-1.img raid1 80
+    qemu_add_drive disk_index disk_args "$TESTDIR"/raid-2.img raid2 80
+    qemu_add_drive disk_index disk_args "$TESTDIR"/raid-3.img raid3 80
 
     "$testdir"/run-qemu \
         "${disk_args[@]}" \


### PR DESCRIPTION
As the git repository is growing (e.g. by adding files at https://github.com/dracut-ng/dracut-ng/pull/389), some tests starts failing as the drive runs out of space. Fix it.

## Checklist
- [ ] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it

