### PR TITLE
Fix nbd tests

### DIFF
--- a/test/TEST-40-NBD/test.sh
+++ b/test/TEST-40-NBD/test.sh
@@ -84,7 +84,7 @@ client_test() {
         -initrd "$TESTDIR"/initramfs.testing
 
     # shellcheck disable=SC2181
-    if [[ $? -ne 0 ]] || ! test_marker_check nbd-OK "$TESTDIR"/marker.img; then
+    if [[ $? -ne 0 ]] || ! test_marker_check nbd-OK; then
         echo "CLIENT TEST END: $test_name [FAILED - BAD EXIT]"
         return 1
     fi

--- a/test/TEST-40-NBD/test.sh
+++ b/test/TEST-40-NBD/test.sh
@@ -80,7 +80,7 @@ client_test() {
         "${disk_args[@]}" \
         -net nic,macaddr="$mac",model=e1000 \
         -net socket,connect=127.0.0.1:12340 \
-        -append "$cmdline rd.auto ro" \
+        -append "$cmdline rd.auto ro console=ttyS0,115200n81" \
         -initrd "$TESTDIR"/initramfs.testing
 
     # shellcheck disable=SC2181

--- a/test/TEST-40-NBD/test.sh
+++ b/test/TEST-40-NBD/test.sh
@@ -120,7 +120,9 @@ test_run() {
         return 1
     fi
     client_run
+    local res="$?"
     kill_server
+    return "$res"
 }
 
 client_run() {


### PR DESCRIPTION
The NBD tests so far were near totally borked.
They were actually failing a lot, but due to the test_run() function ending with killing the server, which always succeeded, that was the results the tests actually returned.

This PR will probably break CI, but it just un-hides breakage that was there before, but counted as pass.