### PR TITLE
fix: microcode initrd generation

### DIFF
--- a/dracut.sh
+++ b/dracut.sh
@@ -2140,9 +2140,13 @@ if [[ $early_microcode == yes ]]; then
                 if [[ $hostonly ]]; then
                     _src=$(get_ucode_file)
                     [[ $_src ]] || break
-                    [[ -r $_fwdir/$_fw/$_src ]] || _src="${_src}.early"
-                    [[ -r $_fwdir/$_fw/$_src ]] || _src="${_src}.initramfs"
-                    [[ -r $_fwdir/$_fw/$_src ]] || break
+                    [[ -r $_fwdir/$_fw/$_src ]] || _src_early_postfix="${_src}.early"
+                    [[ ! -d $_fwdir/$_fw/$_src_early_postfix && -r $_fwdir/$_fw/$_src_early_postfix ]] && _src=$_src_early_postfix || _src_initramfs_postfix="${_src}.initramfs"
+                    [[ ! -d $_fwdir/$_fw/$_src_initramfs_postfix && -r $_fwdir/$_fw/$_src_initramfs_postfix ]] && _src=$_src_initramfs_postfix || _src_early_initramfs_postfix="${_src}.early.initramfs"
+                    [[ ! -d $_fwdir/$_fw/$_src_early_initramfs_postfix && -r $_fwdir/$_fw/$_src_early_initramfs_postfix ]] && _src=$_src_early_initramfs_postfix
+
+                    [[ -r $_fwdir/$_fw/$_src ]] || dinfo "ERROR: Could not locate suitable microcode file. No CPU microcode update will be applied at boot!"
+                    [[ ! -r $_fwdir/$_fw/$_src ]] && break
                 fi
 
                 for i in $_fwdir/$_fw/$_src; do


### PR DESCRIPTION
CPU microcode patch files called `$name.initramfs` will be considered for inclusion to the early initrd.

This pull request changes...

.. the logic which tries to find a suitable CPU microcode patch file for inclusion in early boot.

Previously Dracut would look for a file called either `$name.early` or `$name.early.initramfs`. But at least on Debian the proper file is called `$name.initramfs`. This bug resulted in an initrd created by Dracut which did not include any CPU microcode update files, and no "early CPIO image" was created at all on my box.

(This may actually even be security relevant as CPU microcode updates may include security fixes.)

## Checklist
- [x] I have tested it locally

Sure. Without this fix no "early CPIO image" was created on my box. With this patch the "early CPIO image" containing the Intel CPU microcode patch gets created.

- [ ] I have reviewed and updated any documentation if relevant

The affected logic isn't documented anywhere as far as I can tell. I'm not going to change that.

(But maybe you should consider documenting how this part works.)

- [ ] I am providing new code and test(s) for it

Not really. To be honest: I've done already more than planed. I'm not going to write test for this. Do with this PR what you want but I won't put any more effort into it. Switching back to `initramfs-tools`.

This is a "drive by commit". May it be helpful, but I'm not really interested in Dracut at this point; I did the debugging already, so wasting a little bit more time to share the outcome seems bearable. But not more.

I found out just by sheer chance that my CPU didn't get any microcode update during boot any more. Debugging this was no fun. This is a shell script tire-fire. Should be rewritten in some sane programming language, imho. One does not write some multi 10kLOC programs in shell. Also just another example of the fact that mutable variables are devil's work. The intended logic could be expressed clearly and safely in a simple pattern match without any mutation, and this hard to spot bug would have never existed... Just my 2ct.