### PR TITLE
test: use --kernel-cmdline to set only dracut arguments

### DIFF
--- a/test/TEST-01-BASIC/test.sh
+++ b/test/TEST-01-BASIC/test.sh
@@ -14,7 +14,7 @@ test_run() {
     test_marker_reset
     "$testdir"/run-qemu \
         "${disk_args[@]}" \
-        -append 'rw "root=LABEL=  rdinit=/bin/sh" rd.retry=3' \
+        -append "$TEST_KERNEL_CMDLINE rw \"root=LABEL=  rdinit=/bin/sh\" rd.retry=3" \
         -initrd "$TESTDIR"/initramfs.testing || return 1
 
     test_marker_check || return 1

--- a/test/TEST-02-SYSTEMD/test.sh
+++ b/test/TEST-02-SYSTEMD/test.sh
@@ -17,7 +17,7 @@ test_run() {
     test_marker_reset
     "$testdir"/run-qemu \
         "${disk_args[@]}" \
-        -append "root=LABEL=dracut rw systemd.log_target=console rd.retry=3 init=/sbin/init" \
+        -append "$TEST_KERNEL_CMDLINE root=LABEL=dracut rw systemd.log_target=console rd.retry=3 init=/sbin/init" \
         -initrd "$TESTDIR"/initramfs.testing || return 1
 
     test_marker_check || return 1

--- a/test/TEST-03-USR-MOUNT/test.sh
+++ b/test/TEST-03-USR-MOUNT/test.sh
@@ -22,7 +22,7 @@ client_run() {
     test_marker_reset
     "$testdir"/run-qemu \
         "${disk_args[@]}" \
-        -append "root=LABEL=dracut $client_opts rd.retry=3" \
+        -append "$TEST_KERNEL_CMDLINE root=LABEL=dracut $client_opts rd.retry=3" \
         -initrd "$TESTDIR"/initramfs.testing || return 1
 
     if ! test_marker_check; then

--- a/test/TEST-04-FULL-SYSTEMD/test.sh
+++ b/test/TEST-04-FULL-SYSTEMD/test.sh
@@ -27,7 +27,7 @@ client_run() {
     test_marker_reset
     "$testdir"/run-qemu \
         "${disk_args[@]}" \
-        -append "systemd.unit=testsuite.target systemd.mask=systemd-firstboot systemd.mask=systemd-vconsole-setup rd.multipath=0 root=LABEL=dracut $client_opts rd.retry=3 $DEBUGOUT" \
+        -append "$TEST_KERNEL_CMDLINE systemd.unit=testsuite.target systemd.mask=systemd-firstboot systemd.mask=systemd-vconsole-setup rd.multipath=0 root=LABEL=dracut $client_opts rd.retry=3 $DEBUGOUT" \
         -initrd "$TESTDIR"/initramfs.testing || return 1
 
     if ! test_marker_check; then

--- a/test/TEST-10-RAID/test.sh
+++ b/test/TEST-10-RAID/test.sh
@@ -16,7 +16,7 @@ test_run() {
     test_marker_reset
     "$testdir"/run-qemu \
         "${disk_args[@]}" \
-        -append "root=/dev/dracut/root rd.auto rw" \
+        -append "$TEST_KERNEL_CMDLINE root=/dev/dracut/root rd.auto rw" \
         -initrd "$TESTDIR"/initramfs.testing || return 1
 
     test_marker_check || return 1

--- a/test/TEST-11-LVM/test.sh
+++ b/test/TEST-11-LVM/test.sh
@@ -17,7 +17,7 @@ test_run() {
     test_marker_reset
     "$testdir"/run-qemu \
         "${disk_args[@]}" \
-        -append "root=/dev/dracut/root rw rd.auto=1 rd.retry=3" \
+        -append "$TEST_KERNEL_CMDLINE root=/dev/dracut/root rw rd.auto=1 rd.retry=3" \
         -initrd "$TESTDIR"/initramfs.testing || return 1
 
     test_marker_check || return 1

--- a/test/TEST-12-RAID-DEG/test.sh
+++ b/test/TEST-12-RAID-DEG/test.sh
@@ -21,7 +21,7 @@ client_run() {
     test_marker_reset
     "$testdir"/run-qemu \
         "${disk_args[@]}" \
-        -append "$* systemd.log_target=kmsg root=LABEL=root rw log_buf_len=2M systemd.mask=systemd-vconsole-setup" \
+        -append "$TEST_KERNEL_CMDLINE $* systemd.log_target=kmsg root=LABEL=root rw log_buf_len=2M systemd.mask=systemd-vconsole-setup" \
         -initrd "$TESTDIR"/initramfs.testing
 
     if ! test_marker_check; then

--- a/test/TEST-13-ENC-RAID-LVM/test.sh
+++ b/test/TEST-13-ENC-RAID-LVM/test.sh
@@ -22,7 +22,7 @@ test_run() {
     test_marker_reset
     "$testdir"/run-qemu \
         "${disk_args[@]}" \
-        -append "root=/dev/dracut/root ro rd.auto rd.retry=20 rootwait $LUKSARGS" \
+        -append "$TEST_KERNEL_CMDLINE root=/dev/dracut/root ro rd.auto rd.retry=20 rootwait $LUKSARGS" \
         -initrd "$TESTDIR"/initramfs.testing
     test_marker_check || return 1
     echo "CLIENT TEST END: [OK]"
@@ -32,7 +32,7 @@ test_run() {
     echo "CLIENT TEST START: Any LUKS"
     "$testdir"/run-qemu \
         "${disk_args[@]}" \
-        -append "root=/dev/dracut/root rw rd.auto rd.retry=20" \
+        -append "$TEST_KERNEL_CMDLINE root=/dev/dracut/root rw rd.auto rd.retry=20" \
         -initrd "$TESTDIR"/initramfs.testing
     test_marker_check || return 1
     echo "CLIENT TEST END: [OK]"
@@ -42,7 +42,7 @@ test_run() {
     echo "CLIENT TEST START: Wrong LUKS UUID"
     "$testdir"/run-qemu \
         "${disk_args[@]}" \
-        -append "root=/dev/dracut/root rw rd.auto rd.luks.uuid=failme" \
+        -append "$TEST_KERNEL_CMDLINE root=/dev/dracut/root rw rd.auto rd.luks.uuid=failme" \
         -initrd "$TESTDIR"/initramfs.testing
     test_marker_check && return 1
     echo "CLIENT TEST END: [OK]"

--- a/test/TEST-14-IMSM/test.sh
+++ b/test/TEST-14-IMSM/test.sh
@@ -18,7 +18,7 @@ client_run() {
     test_marker_reset
     "$testdir"/run-qemu \
         "${disk_args[@]}" \
-        -append "$* root=LABEL=root rw rd.retry=5" \
+        -append "$TEST_KERNEL_CMDLINE $* root=LABEL=root rw rd.retry=5" \
         -initrd "$TESTDIR"/initramfs.testing || return 1
 
     if ! test_marker_check; then

--- a/test/TEST-15-BTRFSRAID/test.sh
+++ b/test/TEST-15-BTRFSRAID/test.sh
@@ -16,7 +16,7 @@ test_run() {
     test_marker_reset
     "$testdir"/run-qemu \
         "${disk_args[@]}" \
-        -append "root=LABEL=root rw rd.retry=3" \
+        -append "$TEST_KERNEL_CMDLINE root=LABEL=root rw rd.retry=3" \
         -initrd "$TESTDIR"/initramfs.testing
     test_marker_check || return 1
 }

--- a/test/TEST-16-DMSQUASH/test.sh
+++ b/test/TEST-16-DMSQUASH/test.sh
@@ -21,7 +21,7 @@ test_run() {
     "$testdir"/run-qemu \
         "${disk_args[@]}" \
         -boot order=d \
-        -append "rd.live.overlay.overlayfs=1 root=live:/dev/disk/by-label/dracut" \
+        -append "$TEST_KERNEL_CMDLINE rd.live.overlay.overlayfs=1 root=live:/dev/disk/by-label/dracut" \
         -initrd "$TESTDIR"/initramfs.testing
 
     test_marker_check || return 1
@@ -30,7 +30,7 @@ test_run() {
     "$testdir"/run-qemu \
         "${disk_args[@]}" \
         -boot order=d \
-        -append "rd.live.image rd.live.overlay.overlayfs=1 root=LABEL=dracut" \
+        -append "$TEST_KERNEL_CMDLINE rd.live.image rd.live.overlay.overlayfs=1 root=LABEL=dracut" \
         -initrd "$TESTDIR"/initramfs.testing
 
     test_marker_check || return 1
@@ -39,7 +39,7 @@ test_run() {
     "$testdir"/run-qemu \
         "${disk_args[@]}" \
         -boot order=d \
-        -append "rd.live.image rd.live.overlay.overlayfs=1 rd.live.dir=testdir root=LABEL=dracut" \
+        -append "$TEST_KERNEL_CMDLINE rd.live.image rd.live.overlay.overlayfs=1 rd.live.dir=testdir root=LABEL=dracut" \
         -initrd "$TESTDIR"/initramfs.testing
 
     test_marker_check || return 1
@@ -50,7 +50,7 @@ test_run() {
         "$testdir"/run-qemu \
             "${disk_args[@]}" \
             -boot order=d \
-            -append "rd.live.image rd.live.overlay.overlayfs=1 rd.live.dir=testdir root=LABEL=dracut_ntfs quiet rd.info rd.shell=0" \
+            -append "$TEST_KERNEL_CMDLINE rd.live.image rd.live.overlay.overlayfs=1 rd.live.dir=testdir root=LABEL=dracut_ntfs" \
             -initrd "$TESTDIR"/initramfs.testing
 
         test_marker_check || return 1

--- a/test/TEST-17-LVM-THIN/test.sh
+++ b/test/TEST-17-LVM-THIN/test.sh
@@ -16,7 +16,7 @@ test_run() {
     test_marker_reset
     "$testdir"/run-qemu \
         "${disk_args[@]}" \
-        -append "root=/dev/dracut/root rw rd.auto=1 rd.driver.pre=dm_thin_pool rd.retry=3" \
+        -append "$TEST_KERNEL_CMDLINE root=/dev/dracut/root rw rd.auto=1 rd.driver.pre=dm_thin_pool rd.retry=3" \
         -initrd "$TESTDIR"/initramfs.testing || return 1
     test_marker_check || return 1
 }

--- a/test/TEST-20-NFS/test.sh
+++ b/test/TEST-20-NFS/test.sh
@@ -66,7 +66,7 @@ client_test() {
         "${disk_args[@]}" \
         -net nic,macaddr="$mac",model=e1000 \
         -net socket,connect=127.0.0.1:12320 \
-        -append "$cmdline ro" \
+        -append "$TEST_KERNEL_CMDLINE $cmdline ro" \
         -initrd "$TESTDIR"/initramfs.testing
 
     # shellcheck disable=SC2181

--- a/test/TEST-30-ISCSI/test.sh
+++ b/test/TEST-30-ISCSI/test.sh
@@ -62,7 +62,7 @@ run_client() {
         -net nic,macaddr=52:54:00:12:34:01,model=e1000 \
         -net socket,connect=127.0.0.1:12330 \
         -acpitable file=ibft.table \
-        -append "$*" \
+        -append "$TEST_KERNEL_CMDLINE $*" \
         -initrd "$TESTDIR"/initramfs.testing
 
     # shellcheck disable=SC2181

--- a/test/TEST-35-ISCSI-MULTI/test.sh
+++ b/test/TEST-35-ISCSI-MULTI/test.sh
@@ -60,7 +60,7 @@ run_client() {
         -net nic,macaddr=52:54:00:12:34:00,model=e1000 \
         -net nic,macaddr=52:54:00:12:34:01,model=e1000 \
         -net socket,connect=127.0.0.1:12331 \
-        -append "rw rd.auto rd.retry=50 $*" \
+        -append "$TEST_KERNEL_CMDLINE rw rd.auto rd.retry=50 $*" \
         -initrd "$TESTDIR"/initramfs.testing
     if ! test_marker_check iscsi-OK; then
         echo "CLIENT TEST END: $test_name [FAILED - BAD EXIT]"

--- a/test/TEST-50-MULTINIC/test.sh
+++ b/test/TEST-50-MULTINIC/test.sh
@@ -76,7 +76,7 @@ client_test() {
         -netdev hubport,id=n2,hubid=2 \
         -device e1000,netdev=n1,mac=52:54:00:12:34:98 \
         -device e1000,netdev=n2,mac=52:54:00:12:34:99 \
-        -append "$cmdline rd.retry=5 ro init=/sbin/init systemd.log_target=console" \
+        -append "$TEST_KERNEL_CMDLINE $cmdline rd.retry=5 ro init=/sbin/init systemd.log_target=console" \
         -initrd "$TESTDIR"/initramfs.testing || return 1
 
     {

--- a/test/TEST-60-BONDBRIDGEVLAN/test.sh
+++ b/test/TEST-60-BONDBRIDGEVLAN/test.sh
@@ -92,6 +92,7 @@ client_test() {
         -netdev hubport,id=n5,hubid=1 -device virtio-net-pci,mac=52:54:00:12:34:05,netdev=n5 \
         -hda "$TESTDIR"/client.img \
         -append "
+        $TEST_KERNEL_CMDLINE
         ifname=net1:52:54:00:12:34:01
         ifname=net2:52:54:00:12:34:02
         ifname=net3:52:54:00:12:34:03

--- a/test/test-functions
+++ b/test/test-functions
@@ -19,6 +19,8 @@ if [[ -z $basedir ]]; then basedir="$(realpath ../..)"; fi
 DRACUT=${DRACUT-${basedir}/dracut.sh}
 PKGLIBDIR=${PKGLIBDIR-$basedir}
 
+TEST_KERNEL_CMDLINE+=" panic=1 oops=panic softlockup_panic=1 systemd.crash_reboot quiet selinux=0 console=ttyS0,115200n81 $DEBUGFAIL "
+
 test_dracut() {
     TEST_DRACUT_ARGS+=" --local --no-hostonly --no-hostonly-cmdline --no-early-microcode --add test --force --kver $KVERSION"
 
@@ -31,7 +33,7 @@ test_dracut() {
     IFS=' ' read -a TEST_DRACUT_ARGS_ARRAY <<< "$TEST_DRACUT_ARGS"
 
     "$DRACUT" \
-        --kernel-cmdline "panic=1 oops=panic softlockup_panic=1 systemd.crash_reboot quiet rd.retry=10 rd.info rd.shell=0 selinux=0 console=ttyS0,115200n81 $DEBUGFAIL" \
+        --kernel-cmdline "rd.retry=10 rd.info rd.shell=0" \
         "${TEST_DRACUT_ARGS_ARRAY[@]}" \
         "$@" || return 1
 }


### PR DESCRIPTION
## Changes

Resolve regression from https://github.com/dracut-ng/dracut-ng/pull/252 .

Follow-up to https://github.com/dracut-ng/dracut-ng/commit/1993786f8aa183ce44705fce2a748cefdd2ed5c9

Linux kernel arguments should not be set with --kernel-cmdline, see #400

## Checklist
- [ ] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it


