### PR TITLE
fix(convertfs): disable SC2317 for EXIT trap function

### DIFF
--- a/modules.d/30convertfs/convertfs.sh
+++ b/modules.d/30convertfs/convertfs.sh
@@ -82,6 +82,7 @@ find_mount() {
 }
 
 # clean up after ourselves no matter how we die.
+# shellcheck disable=SC2317  # called via EXIT trap
 cleanup() {
     echo "Something failed. Move back to the original state"
     for dir in "$ROOT/bin" "$ROOT/sbin" "$ROOT/lib" "$ROOT/lib64" \


### PR DESCRIPTION
## Changes

shellcheck complains about SC2317 (info):
> Command appears to be unreachable. Check usage (or ignore if invoked indirectly).

It fails to detect cases where a function is defined and later called by a trap. Disable shellcheck in this case.

## Checklist
- [ ] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it

Fixes #
