### PR TITLE
fix(convertfs): drop unused find_mount function

### DIFF
--- a/modules.d/30convertfs/convertfs.sh
+++ b/modules.d/30convertfs/convertfs.sh
@@ -72,15 +72,6 @@ if [[ ! -e $testfile ]]; then
 fi
 rm -f -- "$testfile"
 
-find_mount() {
-    local dev wanted_dev
-    wanted_dev="$(readlink -e -q "$1")"
-    while read -r dev _ || [ -n "$dev" ]; do
-        [ "$dev" = "$wanted_dev" ] && echo "$dev" && return 0
-    done < /proc/mounts
-    return 1
-}
-
 # clean up after ourselves no matter how we die.
 # shellcheck disable=SC2317  # called via EXIT trap
 cleanup() {


### PR DESCRIPTION
## Changes

shellcheck complains about SC2317 (info):
> Command appears to be unreachable. Check usage (or ignore if invoked indirectly).

The function `find_mount` is not called in `convertfs.sh` any more. So drop this unused function.

Fixes: 101b683e1a2 ("refactor(convertfs): drop duplicate def. of ismounted()")

## Checklist
- [ ] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it
