### PR TITLE
fix(dracut-functions): avoid awk in get_maj_min() 

### DIFF
--- a/dracut-functions.sh
+++ b/dracut-functions.sh
@@ -243,7 +243,7 @@ get_maj_min() {
     local _out
 
     if [[ $get_maj_min_cache_file ]]; then
-        _out="$(grep -m1 -oE "^$1 \S+$" "$get_maj_min_cache_file" | awk '{print $NF}')"
+        _out="$(grep -m1 -oE "^$1 \S+$" "$get_maj_min_cache_file" | grep -oE "\S+$")"
     fi
 
     if ! [[ "$_out" ]]; then


### PR DESCRIPTION
## Changes

The `get_maj_min()` cache lookup is commonly used across many flows. While `awk` should be available, some highly constrained environments may not have it. A second call to `grep` can provide the same behaviour without adding a dependency.

Lines in the cache will be of the form "/dev/sda2 8:2". `awk '{print $NF}'` returns the last word of a matching line. Since the initial matching regex is so specific a second call to grep can easily extract the last word.

## Checklist
- [ ] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it

Source: https://github.com/microsoft/azurelinux/pull/9210
