### PR TITLE
fix(TEST-NFS): use --add instead of --modules to create test-makeroot

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -121,8 +121,6 @@ jobs:
                         "40",
                 ]
                 exclude:
-                  - container: "arch"
-                    test: "20"
                   - container: "gentoo"
                     test: "40"
             fail-fast: false

--- a/test/TEST-20-NFS/test.sh
+++ b/test/TEST-20-NFS/test.sh
@@ -366,7 +366,7 @@ test_setup() {
     # We do it this way so that we do not risk trashing the host mdraid
     # devices, volume groups, encrypted partitions, etc.
     "$DRACUT" -l -i "$TESTDIR"/server/overlay / \
-        -m "bash rootfs-block kernel-modules qemu" \
+        -a "bash rootfs-block kernel-modules qemu" \
         -d "piix ide-gd_mod ata_piix ext4 sd_mod" \
         --nomdadmconf \
         --no-hostonly-cmdline -N \
@@ -416,7 +416,7 @@ test_setup() {
     )
     # Make server's dracut image
     "$DRACUT" -l -i "$TESTDIR"/overlay / \
-        -m "bash rootfs-block debug kernel-modules watchdog qemu network-legacy" \
+        -a "bash rootfs-block debug kernel-modules watchdog qemu network-legacy" \
         -d "af_packet piix ide-gd_mod ata_piix ext4 sd_mod e1000 i6300esb" \
         --no-hostonly-cmdline -N \
         -f "$TESTDIR"/initramfs.server "$KVERSION" || return 1


### PR DESCRIPTION
## Changes

Reenable systemd-networkd for TEST-NFS on Arch.

## Checklist
- [X] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it

Fixes #382 (partially)

CC @BtbN for visibility
