### PR TITLE
fix(test): reenable extended tests for Arch

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -142,6 +142,7 @@ jobs:
         strategy:
             matrix:
                 container: [
+                        "arch",
                         "debian",
                         "fedora",
                         "gentoo",

--- a/test/TEST-12-RAID-DEG/test.sh
+++ b/test/TEST-12-RAID-DEG/test.sh
@@ -97,7 +97,8 @@ test_setup() {
     chmod 0600 /tmp/key
 
     test_dracut \
-        -m "crypt lvm mdraid" \
+        -a "crypt lvm mdraid" \
+        -o "systemd" \
         -i "./cryptroot-ask.sh" "/sbin/cryptroot-ask" \
         -i "/tmp/mdadm.conf" "/etc/mdadm.conf" \
         -i "/tmp/crypttab" "/etc/crypttab" \

--- a/test/TEST-14-IMSM/test.sh
+++ b/test/TEST-14-IMSM/test.sh
@@ -90,6 +90,8 @@ test_setup() {
     echo "$MD_UUID" > "$TESTDIR"/mduuid
 
     test_dracut \
+        -a "dmraid" \
+        -o "systemd" \
         "$TESTDIR"/initramfs.testing
 }
 

--- a/test/TEST-16-DMSQUASH/test.sh
+++ b/test/TEST-16-DMSQUASH/test.sh
@@ -128,14 +128,16 @@ SUBSYSTEM=="block", ENV{ID_FS_TYPE}=="ntfs", ENV{ID_FS_TYPE}="ntfs3"
 EOF
 
     test_dracut \
-        --modules "dash dmsquash-live qemu" \
+        --add "dash dmsquash-live qemu" \
+        --omit "systemd" \
         --drivers "ntfs3" \
         --install "mkfs.ext4" \
         --include /tmp/ntfs3.rules /lib/udev/rules.d/ntfs3.rules \
         "$TESTDIR"/initramfs.testing
 
     test_dracut \
-        --modules "dmsquash-live-autooverlay qemu" \
+        --add "dmsquash-live-autooverlay qemu" \
+        --omit "systemd" \
         --install "mkfs.ext4" \
         "$TESTDIR"/initramfs.testing-autooverlay
 


### PR DESCRIPTION
## Changes
Passing tests require omitting some dracut modules, which is likely masking some dracut bugs, but the changes in this PR still increases test coverage overall even with the potential masking of some systemd related dracut bugs. 

## Checklist
- [ ] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it

Fixes #382 
