### PR TITLE
fix(dbus-daemon): actually enable the dbus service and socket

### DIFF
--- a/modules.d/06dbus-daemon/module-setup.sh
+++ b/modules.d/06dbus-daemon/module-setup.sh
@@ -53,6 +53,8 @@ install() {
         "$systemdsystemunitdir"/dbus.service \
         "$systemdsystemunitdir"/dbus.socket \
         "$systemdsystemunitdir"/dbus.target.wants \
+        "$systemdsystemunitdir"/multi-user.target.wants/dbus.service \
+        "$systemdsystemunitdir"/sockets.target.wants/dbus.socket \
         busctl dbus-send dbus-daemon
 
     # Adjusting dependencies for initramfs in the dbus service unit.


### PR DESCRIPTION
The dbus daemon not actually running has surprisingly little ill effects, since systemctl falls back to some built-in backup of pid1 to do its thing.
But one issue I ran into was that networkd was not setting the hostname it was sent via DHCP. Turns out this is due to there being no running dbus, so it fails to communicate the hostname-change to hostnamed.
It also makes debugging issues in an emergency shell a lot harder, since most systemd-commands outside of systemctl are inoperative.

## Changes
The two units don't have an Install-Section. They instead ship with respective links to them in the systems unit directory.
So those just need to be copied as well.

## Checklist
- [x] I have tested it locally
- [x] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it

Fixes #309
