### PR TITLE
Memoize find_kmod_module_from_sysfs_node

### DIFF
--- a/src/install/hashmap.c
+++ b/src/install/hashmap.c
@@ -273,20 +273,32 @@ int hashmap_replace(Hashmap *h, const void *key, void *value)
         return hashmap_put(h, key, value);
 }
 
-void *hashmap_get(Hashmap *h, const void *key)
+int hashmap_get_exists(Hashmap *h, const void *key, void **value)
 {
         unsigned int hash;
         struct hashmap_entry *e;
 
+        *value = NULL;
+
         if (!h)
-                return NULL;
+                return 0;
 
         hash = h->hash_func(key) % NBUCKETS;
 
         if (!(e = hash_scan(h, hash, key)))
-                return NULL;
+                return 0;
 
-        return e->value;
+        *value = e->value;
+        return 1;
+}
+
+void *hashmap_get(Hashmap *h, const void *key)
+{
+        void *ret;
+
+        hashmap_get_exists(h, key, &ret);
+
+        return ret;
 }
 
 void *hashmap_remove(Hashmap *h, const void *key)

--- a/src/install/hashmap.h
+++ b/src/install/hashmap.h
@@ -51,6 +51,7 @@ int hashmap_ensure_allocated(Hashmap **h, hash_func_t hash_func, compare_func_t 
 int hashmap_put(Hashmap *h, const void *key, void *value);
 int hashmap_replace(Hashmap *h, const void *key, void *value);
 void *hashmap_get(Hashmap *h, const void *key);
+int hashmap_get_exists(Hashmap *h, const void *key, void **value);
 void *hashmap_remove(Hashmap *h, const void *key);
 void *hashmap_remove_value(Hashmap *h, const void *key, void *value);
 int hashmap_remove_and_put(Hashmap *h, const void *old_key, const void *new_key, void *value);


### PR DESCRIPTION
find_kmod_module_from_sysfs_node() is called for every platform device in the system via find_suppliers(). In turn, this calls kmod_module_new_from_lookup() for every device modalias. This is an expensive call that reads the modalias files every single time from scratch.
    
On many platforms, there are many identical platform devices (e.g. multiple serial ports, or dozens or hundreds of power domain devices). Therefore, it's worth memoizing this so we only perform the expensive lookup once per unique modalias.
    
This cuts down dracut generation time on an Apple M1 Pro MacBook Pro from 63 seconds to 24 seconds, give or take, after 80f2caf4f5ee (in fact, this new code/behavior in dracut-ng was the root cause of the major perf regression that was improved in that commit).

## Changes

Memoize find_kmod_module_from_sysfs_node() using a hashmap.

## Checklist
- [x] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it
