### PR TITLE
fix(systemd-networkd): remove default network if at least one other w…

### DIFF
--- a/dracut.sh
+++ b/dracut.sh
@@ -2025,6 +2025,7 @@ if [[ $kernel_only != yes ]]; then
                 printf "%s\n" "systemdutildir=\"$systemdutildir\""
                 printf "%s\n" "systemdsystemunitdir=\"$systemdsystemunitdir\""
                 printf "%s\n" "systemdsystemconfdir=\"$systemdsystemconfdir\""
+                printf "%s\n" "systemdnetworkconfdir=\"$systemdnetworkconfdir\""
             } > "${initdir}"/etc/conf.d/systemd.conf
         fi
     fi

--- a/modules.d/01systemd-networkd/module-setup.sh
+++ b/modules.d/01systemd-networkd/module-setup.sh
@@ -63,7 +63,7 @@ install() {
         "$systemdsystemunitdir"/systemd-networkd-wait-online.service.d/99-dracut.conf
 
     inst_simple "$moddir"/99-default.network \
-        "$systemdnetworkconfdir"/99-default.network
+        "$systemdnetworkconfdir"/99-dracut-default.network
 
     inst_hook cmdline 99 "$moddir"/networkd-config.sh
     inst_hook initqueue/settled 99 "$moddir"/networkd-run.sh

--- a/modules.d/01systemd-networkd/networkd-config.sh
+++ b/modules.d/01systemd-networkd/networkd-config.sh
@@ -18,6 +18,9 @@ for f in /run/systemd/network/*.network; do
         echo "[DHCPv6]"
         echo "RequestOptions=59 60"
     } >> "$f"
+
+    # Remove the default network if at least one was generated
+    rm -f "$systemdnetworkconfdir"/99-dracut-default.network
 done
 
 # Just in case networkd was already running


### PR DESCRIPTION
Otherwise, if the machine has other interfaces, networkd might pick them up and end up calling the netroot script on them.
In theory this should be fine, since it'll just fail and it will call it on the correct interface very soon.
But at least the iscsi 30 test cases, which have two network interfaces but not always use both of them, seem to get upset by it.
My guess is that their success depends on which interface gets a DHCP response first.

## Changes
This change simply removes the default network if any other network file was generated.
It also renames the default network file a bit, to make it less likely to accidentally collide with any hostonly user-provided file.

## Checklist
- [x] I have tested it locally
- [x] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it