### PR TITLE
fix(dracut): microcode loading named .initramfs

### DIFF
--- a/dracut.sh
+++ b/dracut.sh
@@ -2140,9 +2140,13 @@ if [[ $early_microcode == yes ]]; then
                 if [[ $hostonly ]]; then
                     _src=$(get_ucode_file)
                     [[ $_src ]] || break
-                    [[ -r $_fwdir/$_fw/$_src ]] || _src="${_src}.early"
-                    [[ -r $_fwdir/$_fw/$_src ]] || _src="${_src}.initramfs"
-                    [[ -r $_fwdir/$_fw/$_src ]] || break
+                    if [[ -r "$_fwdir/$_fw/${_src}.early" ]]; then
+                        _src="${_src}.early"
+                    elif [[ -r "$_fwdir/$_fw/${_src}.initramfs" ]]; then
+                        _src="${_src}.initramfs"
+                    else
+                        [[ -r $_fwdir/$_fw/$_src ]] || break
+                    fi
                 fi
 
                 for i in $_fwdir/$_fw/$_src; do


### PR DESCRIPTION
## Changes

intel-microcode on Debian/Ubuntu uses the `.initramfs` suffix for the ucode files (e.g. `/lib/firmware/intel-ucode/06-9e-0b.initramfs`). `get_ucode_file` returns `family-model-stepping` on Intel (e.g. `06-9e-0b`). If the microcode file is found, the loop is broken. Otherwise `.early` is appended to the name (e.g. `06-9e-0b.early`) and tried again. If that file is not found, `.initramfs` is appended to the name (e.g. `06-9e-0b.early.initramfs`), but this suffix should be appended to the initial name (e.g. `06-9e-0b.initramfs`).

Fixes: 16573680d1b6 ("fix(dracut): microcode loading")

## Checklist
- [ ] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it

Fixes #
