### PR TITLE
feat(lsinitrd.sh): support configurable initrd filenames

### DIFF
--- a/dracut-initramfs-restore.sh
+++ b/dracut-initramfs-restore.sh
@@ -19,7 +19,7 @@ SKIP="$dracutbasedir/skipcpio"
 
 find_initrd_for_kernel_version() {
     local kernel_version="$1"
-    local files machine_id
+    local base_path files initrd machine_id
 
     if [[ -d /efi/Default ]] || [[ -d /boot/Default ]] || [[ -d /boot/efi/Default ]]; then
         machine_id="Default"
@@ -30,23 +30,20 @@ find_initrd_for_kernel_version() {
         machine_id="Default"
     fi
 
-    if [[ -d /efi/loader/entries || -L /efi/loader/entries ]] \
-        && [[ -d /efi/$machine_id || -L /efi/$machine_id ]]; then
-        echo "/efi/${machine_id}/${kernel_version}/initrd"
-    elif [[ -d /boot/loader/entries || -L /boot/loader/entries ]] \
-        && [[ -d /boot/$machine_id || -L /boot/$machine_id ]]; then
-        echo "/boot/${machine_id}/${kernel_version}/initrd"
-    elif [[ -d /boot/efi/loader/entries || -L /boot/efi/loader/entries ]] \
-        && [[ -d /boot/efi/$machine_id || -L /boot/efi/$machine_id ]]; then
-        echo "/boot/efi/$machine_id/$kernel_version/initrd"
-    elif [[ -f /lib/modules/${kernel_version}/initrd ]]; then
+    if [ -n "$machine_id" ]; then
+        for base_path in /efi /boot /boot/efi; do
+            initrd="${base_path}/${machine_id}/${kernel_version}/initrd"
+            if [ -f "$initrd" ]; then
+                echo "$initrd"
+                return
+            fi
+        done
+    fi
+
+    if [[ -f /lib/modules/${kernel_version}/initrd ]]; then
         echo "/lib/modules/${kernel_version}/initrd"
     elif [[ -f /boot/initramfs-${kernel_version}.img ]]; then
         echo "/boot/initramfs-${kernel_version}.img"
-    elif mountpoint -q /efi; then
-        echo "/efi/$machine_id/$kernel_version/initrd"
-    elif mountpoint -q /boot/efi; then
-        echo "/boot/efi/$machine_id/$kernel_version/initrd"
     else
         files=(/boot/initr*"${kernel_version}"*)
         if [ "${#files[@]}" -ge 1 ] && [ -e "${files[0]}" ]; then

--- a/lsinitrd.sh
+++ b/lsinitrd.sh
@@ -100,7 +100,7 @@ done
 
 find_initrd_for_kernel_version() {
     local kernel_version="$1"
-    local base_path initrd machine_id
+    local base_path files initrd machine_id
 
     if [[ -d /efi/Default ]] || [[ -d /boot/Default ]] || [[ -d /boot/efi/Default ]]; then
         machine_id="Default"
@@ -127,6 +127,11 @@ find_initrd_for_kernel_version() {
         echo "/lib/modules/${kernel_version}/initramfs.img"
     elif [[ -f /boot/initramfs-${kernel_version}.img ]]; then
         echo "/boot/initramfs-${kernel_version}.img"
+    else
+        files=(/boot/initr*"${kernel_version}"*)
+        if [ "${#files[@]}" -ge 1 ] && [ -e "${files[0]}" ]; then
+            echo "${files[0]}"
+        fi
     fi
 }
 


### PR DESCRIPTION
## Changes

The initrd filename can be configured via `initrdname`. Support this feature also in `lsinitrd` (similar to the code in `dracut-initramfs-restore.sh`).

Fix: 28820e205328 ("feat(dracut.sh): make initramfs-${kernel}.img filename configurable")

## Checklist
- [x] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it

Fixes #
