### PR TITLE
fix(dracut-initramfs-restore.sh): correct initrd globbing

### DIFF
--- a/dracut-initramfs-restore.sh
+++ b/dracut-initramfs-restore.sh
@@ -46,7 +46,7 @@ elif mountpoint -q /efi; then
 elif mountpoint -q /boot/efi; then
     IMG="/boot/efi/$MACHINE_ID/$KERNEL_VERSION/initrd"
 else
-    files=("/boot/initr*${KERNEL_VERSION}*")
+    files=(/boot/initr*"${KERNEL_VERSION}"*)
     if [ "${#files[@]}" -ge 1 ] && [ -e "${files[0]}" ]; then
         IMG="${files[0]}"
     elif [[ -f /boot/initramfs-linux.img ]]; then


### PR DESCRIPTION
## Changes

Quoting the globbing `*` will prevent Bash from use globbing. So only quote the kernel version variable that could potentially contain spaces.

Fixes: 28820e205328 ("feat(dracut.sh): make initramfs-${kernel}.img filename configurable")

## Checklist
- [x] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it
