### PR TITLE
fix(lsinitrd.sh): disable SC2317 for cat functions

### DIFF
--- a/lsinitrd.sh
+++ b/lsinitrd.sh
@@ -398,6 +398,7 @@ type "${CAT%% *}" > /dev/null 2>&1 || {
     exit 1
 }
 
+# shellcheck disable=SC2317  # assigned to CAT and $CAT called later
 skipcpio() {
     $SKIP "$@" | $ORIG_CAT
 }
@@ -410,6 +411,7 @@ fi
 if ((${#filenames[@]} > 1)); then
     TMPFILE="$TMPDIR/initrd.cpio"
     $CAT "$image" 2> /dev/null > "$TMPFILE"
+    # shellcheck disable=SC2317  # assigned to CAT and $CAT called later
     pre_decompress() {
         cat "$TMPFILE"
     }


### PR DESCRIPTION
## Changes

shellcheck 0.10 complains about SC2317 (info):
> Command appears to be unreachable. Check usage (or ignore if invoked indirectly).

It fails to detect that these functions are assigned to `CAT` and `$CAT` is called later. Disable shellcheck in this case.

## Checklist
- [ ] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it