### PR TITLE
fix(dracut-catimages.sh): drop unused dwarning function

### DIFF
--- a/dracut-catimages.sh
+++ b/dracut-catimages.sh
@@ -16,10 +16,6 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #
 
-dwarning() {
-    echo "Warning: $*" >&2
-}
-
 dinfo() {
     [[ $beverbose ]] && echo "$@" >&2
 }


### PR DESCRIPTION
## Changes

shellcheck complains about SC2317 (info):
> Command appears to be unreachable. Check usage (or ignore if invoked indirectly).

The function `dwarning` is not called in `dracut-catimages.sh`. So drop this unused function. It can be re-introduced once it is needed.

## Checklist
- [ ] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it
