### PR TITLE
fix(dbus): drop unreachable return statement

### DIFF
--- a/modules.d/09dbus/module-setup.sh
+++ b/modules.d/09dbus/module-setup.sh
@@ -22,10 +22,7 @@ depends() {
     if check_module "dbus-broker"; then
         echo "dbus-broker"
         return 0
-    else
-        echo "dbus-daemon"
-        return 0
     fi
-
-    return 1
+    echo "dbus-daemon"
+    return 0
 }


### PR DESCRIPTION
## Changes

shellcheck complains about SC2317 (info):
> Command appears to be unreachable. Check usage (or ignore if invoked indirectly).

The last `return 1` statement is not reachable. Remove it and move the else clause one level up because the if clause returns from the function.

## Checklist
- [ ] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it
