### PR TITLE
fix(systemd-hostnamed): add missing systemd-hostnamed.socket

### DIFF
--- a/modules.d/01systemd-hostnamed/module-setup.sh
+++ b/modules.d/01systemd-hostnamed/module-setup.sh
@@ -39,6 +39,8 @@ install() {
         "$systemdutildir"/systemd-hostnamed \
         "$systemdsystemunitdir"/systemd-hostnamed.service \
         "$systemdsystemunitdir/systemd-hostnamed.service.d/*.conf" \
+        "$systemdsystemunitdir"/systemd-hostnamed.socket \
+        "$systemdsystemunitdir/systemd-hostnamed.socket.d/*.conf" \
         "$systemdsystemunitdir"/dbus-org.freedesktop.hostname1.service \
         hostnamectl
 
@@ -47,6 +49,8 @@ install() {
         inst_multiple -H -o \
             /etc/hostname \
             "$systemdsystemconfdir"/systemd-hostnamed.service \
-            "$systemdsystemconfdir/systemd-hostnamed.service.d/*.conf"
+            "$systemdsystemconfdir/systemd-hostnamed.service.d/*.conf" \
+            "$systemdsystemconfdir"/systemd-hostnamed.socket \
+            "$systemdsystemconfdir/systemd-hostnamed.socket.d/*.conf"
     fi
 }


### PR DESCRIPTION
Added in systemd v256

This pull request changes...

## Changes

Add `systemd-hostnamed.socket` to the initrd to not have `Failed to bind to Varlink socket` messages.

## Checklist
- [x] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it

Fixes #420 
