### PR TITLE
fix(systemd-hostnamed): Also enable socket units

### DIFF
--- a/modules.d/01systemd-hostnamed/module-setup.sh
+++ b/modules.d/01systemd-hostnamed/module-setup.sh
@@ -41,6 +41,7 @@ install() {
         "$systemdsystemunitdir/systemd-hostnamed.service.d/*.conf" \
         "$systemdsystemunitdir"/systemd-hostnamed.socket \
         "$systemdsystemunitdir/systemd-hostnamed.socket.d/*.conf" \
+        "$systemdsystemunitdir"/sockets.target.wants/systemd-hostnamed.socket \
         "$systemdsystemunitdir"/dbus-org.freedesktop.hostname1.service \
         hostnamectl
 
@@ -51,6 +52,7 @@ install() {
             "$systemdsystemconfdir"/systemd-hostnamed.service \
             "$systemdsystemconfdir/systemd-hostnamed.service.d/*.conf" \
             "$systemdsystemconfdir"/systemd-hostnamed.socket \
+            "$systemdsystemconfdir"/sockets.target.wants/systemd-hostnamed.socket \
             "$systemdsystemconfdir/systemd-hostnamed.socket.d/*.conf"
     fi
 }


### PR DESCRIPTION
Followup to https://github.com/dracut-ng/dracut-ng/pull/421

I didn't know systemd is shipping these files rather than enabling the units via presets and due to the reproducer in #420 pulling the unit in explicitely this was noticed in local testing.

## Checklist
- [x] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it

Fixes #420
