### PR TITLE
Remove reference to kernel module zlib in fips module

### DIFF
--- a/modules.d/01fips/module-setup.sh
+++ b/modules.d/01fips/module-setup.sh
@@ -30,7 +30,7 @@ installkernel() {
         _fipsmodules+="ecb cbc ctr xts gcm ccm authenc hmac cmac ofb cts "
 
         # Compression algs:
-        _fipsmodules+="deflate lzo zlib "
+        _fipsmodules+="deflate lzo "
 
         # PRNG algs:
         _fipsmodules+="ansi_cprng "


### PR DESCRIPTION
## Changes

Remove reference to kernel module zlib (deprecated in kernel v4.6+) since the pedantic dracut behavior causes initramfs generation to fail otherwise.

See: https://cateee.net/lkddb/web-lkddb/CRYPTO_ZLIB.html

Source: https://raw.githubusercontent.com/microsoft/azurelinux/3.0-dev/SPECS/dracut/0011-Remove-reference-to-kernel-module-zlib-in-fips-module.patch

## Checklist
- [ ] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it

