### PR TITLE
wip: gento defaults to networkd

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -50,6 +50,7 @@ jobs:
             matrix:
                 container: [
                         "fedora",
+                        "gentoo",
                 ]
                 network: [
                         "network",


### PR DESCRIPTION
This pull request changes...

## Changes

## Checklist
- [ ] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it

Fixes #
