### PR TITLE
fix(udev-rules): install more udev rules even if systemd is not installed

### DIFF
--- a/modules.d/01systemd-udevd/module-setup.sh
+++ b/modules.d/01systemd-udevd/module-setup.sh
@@ -31,30 +31,6 @@ install() {
 
     inst_multiple -o \
         /etc/udev/udev.hwdb \
-        "$udevdir"/hwdb.bin \
-        "$udevdir"/dmi_memory_id \
-        "$udevdir"/fido_id \
-        "$udevdir"/mtd_probe \
-        "$udevdir"/mtp-probe \
-        "$udevdir"/v4l_id \
-        "$udevrulesdir"/60-autosuspend.rules \
-        "$udevrulesdir"/60-drm.rules \
-        "$udevrulesdir"/60-evdev.rules \
-        "$udevrulesdir"/60-fido-id.rules \
-        "$udevrulesdir"/60-input-id.rules \
-        "$udevrulesdir"/60-persistent-alsa.rules \
-        "$udevrulesdir"/60-persistent-input.rules \
-        "$udevrulesdir"/60-persistent-storage-tape.rules \
-        "$udevrulesdir"/60-persistent-v4l.rules \
-        "$udevrulesdir"/60-sensor.rules \
-        "$udevrulesdir"/60-serial.rules \
-        "$udevrulesdir"/70-joystick.rules \
-        "$udevrulesdir"/70-memory.rules \
-        "$udevrulesdir"/70-mouse.rules \
-        "$udevrulesdir"/70-touchpad.rules \
-        "$udevrulesdir"/75-probe_mtd.rules \
-        "$udevrulesdir"/78-sound-card.rules \
-        "$udevrulesdir"/81-net-dhcp.rules \
         "$udevrulesdir"/99-systemd.rules \
         "$systemdutildir"/systemd-udevd \
         "$systemdsystemunitdir"/systemd-udevd.service \
@@ -73,8 +49,6 @@ install() {
     # Install the hosts local user configurations if enabled.
     if [[ $hostonly ]]; then
         inst_multiple -H -o \
-            "$udevconfdir"/hwdb.bin \
-            "$udevrulesconfdir/*.rules" \
             "$systemdutilconfdir"/hwdb/hwdb.bin \
             "$systemdsystemconfdir"/systemd-udevd.service \
             "$systemdsystemconfdir/systemd-udevd.service.d/*.conf" \

--- a/modules.d/95udev-rules/module-setup.sh
+++ b/modules.d/95udev-rules/module-setup.sh
@@ -29,16 +29,36 @@ install() {
         55-scsi-sg3_id.rules \
         58-scsi-sg3_symlink.rules \
         59-scsi-sg3_utils.rules \
+        60-autosuspend.rules \
         60-block.rules \
         60-cdrom_id.rules \
+        60-drm.rules \
+        60-evdev.rules \
+        60-fido-id.rules \
+        60-input-id.rules \
+        60-persistent-alsa.rules \
+        60-persistent-input.rules \
+        60-persistent-storage-tape.rules \
         60-persistent-storage.rules \
+        60-persistent-v4l.rules \
+        60-sensor.rules \
+        60-serial.rules \
         64-btrfs.rules \
+        70-joystick.rules \
+        70-memory.rules \
+        70-mouse.rules \
+        70-touchpad.rules \
         70-uaccess.rules \
         71-seat.rules \
         73-seat-late.rules \
         75-net-description.rules \
-        80-drivers.rules 95-udev-late.rules \
-        80-net-name-slot.rules 80-net-setup-link.rules \
+        75-probe_mtd.rules \
+        78-sound-card.rules \
+        80-drivers.rules \
+        80-net-name-slot.rules \
+        80-net-setup-link.rules \
+        81-net-dhcp.rules \
+        95-udev-late.rules \
         "$moddir/59-persistent-storage.rules" \
         "$moddir/61-persistent-storage.rules"
 
@@ -58,15 +78,22 @@ install() {
     } >> "$initdir/etc/group"
 
     inst_multiple -o \
+        /etc/udev/udev.hwdb \
         "${udevdir}"/ata_id \
         "${udevdir}"/cdrom_id \
         "${udevdir}"/create_floppy_devices \
+        "${udevdir}"/dmi_memory_id \
+        "${udevdir}"/fido_id \
         "${udevdir}"/fw_unit_symlinks.sh \
         "${udevdir}"/hid2hci \
-        "${udevdir}"/path_id \
+        "${udevdir}"/hwdb.bin \
         "${udevdir}"/input_id \
+        "${udevdir}"/mtd_probe \
+        "${udevdir}"/mtp-probe \
+        "${udevdir}"/path_id \
         "${udevdir}"/scsi_id \
-        "${udevdir}"/usb_id
+        "${udevdir}"/usb_id \
+        "${udevdir}"/v4l_id
 
     inst_libdir_file "libnss_files*"
 
@@ -74,6 +101,8 @@ install() {
     if [[ $hostonly ]]; then
         inst_dir /etc/udev
         inst_multiple -H -o \
-            /etc/udev/udev.conf
+            /etc/udev/udev.conf \
+            "$udevconfdir"/hwdb.bin \
+            "$udevrulesconfdir/*.rules"
     fi
 }

--- a/test/TEST-35-ISCSI-MULTI/test.sh
+++ b/test/TEST-35-ISCSI-MULTI/test.sh
@@ -173,9 +173,9 @@ test_setup() {
     declare -a disk_args=()
     declare -i disk_index=0
     qemu_add_drive disk_index disk_args "$TESTDIR"/marker.img marker 1
-    qemu_add_drive disk_index disk_args "$TESTDIR"/singleroot.img singleroot 400
-    qemu_add_drive disk_index disk_args "$TESTDIR"/raid0-1.img raid0-1 200
-    qemu_add_drive disk_index disk_args "$TESTDIR"/raid0-2.img raid0-2 200
+    qemu_add_drive disk_index disk_args "$TESTDIR"/singleroot.img singleroot 800
+    qemu_add_drive disk_index disk_args "$TESTDIR"/raid0-1.img raid0-1 400
+    qemu_add_drive disk_index disk_args "$TESTDIR"/raid0-2.img raid0-2 400
 
     # Invoke KVM and/or QEMU to actually create the target filesystem.
     "$testdir"/run-qemu \
@@ -215,7 +215,7 @@ test_setup() {
     declare -a disk_args=()
     declare -i disk_index=0
     qemu_add_drive disk_index disk_args "$TESTDIR"/marker.img marker 1
-    qemu_add_drive disk_index disk_args "$TESTDIR"/server.img root 120
+    qemu_add_drive disk_index disk_args "$TESTDIR"/server.img root 240
 
     # Invoke KVM and/or QEMU to actually create the target filesystem.
     "$testdir"/run-qemu \


### PR DESCRIPTION
## Changes

Install all udev dependencies as part of the udev-rules dracut modules.

For non-systemd initrd's this will make devices properly initialized (at the expense of slightly more storage space).

## Checklist
- [ ] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it

