### PR TITLE
feat(hwdb): separate out hwdb module

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -418,6 +418,10 @@ fstab-sys:
   - changed-files:
     - any-glob-to-any-file: 'modules.d/95fstab-sys/*'
 
+hwdb:
+  - changed-files:
+    - any-glob-to-any-file: 'modules.d/95hwdb/*'
+
 iscsi:
   - changed-files:
     - any-glob-to-any-file: 'modules.d/95iscsi/*'

--- a/modules.d/01systemd-udevd/module-setup.sh
+++ b/modules.d/01systemd-udevd/module-setup.sh
@@ -30,7 +30,6 @@ depends() {
 install() {
 
     inst_multiple -o \
-        /etc/udev/udev.hwdb \
         "$udevrulesdir"/99-systemd.rules \
         "$systemdutildir"/systemd-udevd \
         "$systemdsystemunitdir"/systemd-udevd.service \
@@ -49,7 +48,6 @@ install() {
     # Install the hosts local user configurations if enabled.
     if [[ $hostonly ]]; then
         inst_multiple -H -o \
-            "$systemdutilconfdir"/hwdb/hwdb.bin \
             "$systemdsystemconfdir"/systemd-udevd.service \
             "$systemdsystemconfdir/systemd-udevd.service.d/*.conf" \
             "$systemdsystemconfdir"/systemd-udev-trigger.service \
@@ -64,6 +62,11 @@ install() {
             "$systemdsystemconfdir"/sockets.target.wants/systemd-udevd-kernel.socket \
             "$systemdsystemconfdir"/sysinit.target.wants/systemd-udevd.service \
             "$systemdsystemconfdir"/sysinit.target.wants/systemd-udev-trigger.service
+
+        if dracut_module_included "hwdb"; then
+            inst_multiple -H -o \
+                "$systemdutilconfdir"/hwdb/hwdb.bin
+        fi
     fi
 
     # Install required libraries.

--- a/modules.d/95hwdb/module-setup.sh
+++ b/modules.d/95hwdb/module-setup.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+# This file is part of dracut.
+# SPDX-License-Identifier: GPL-2.0-or-later
+
+# called by dracut
+install() {
+    inst_multiple -o \
+        /etc/udev/udev.hwdb \
+        "${udevdir}"/hwdb.bin
+
+    # Install the hosts local user configurations if enabled.
+    if [[ $hostonly ]]; then
+        inst_multiple -H -o \
+            "$udevconfdir"/hwdb.bin
+    fi
+}

--- a/modules.d/95udev-rules/module-setup.sh
+++ b/modules.d/95udev-rules/module-setup.sh
@@ -78,7 +78,6 @@ install() {
     } >> "$initdir/etc/group"
 
     inst_multiple -o \
-        /etc/udev/udev.hwdb \
         "${udevdir}"/ata_id \
         "${udevdir}"/cdrom_id \
         "${udevdir}"/create_floppy_devices \
@@ -86,7 +85,6 @@ install() {
         "${udevdir}"/fido_id \
         "${udevdir}"/fw_unit_symlinks.sh \
         "${udevdir}"/hid2hci \
-        "${udevdir}"/hwdb.bin \
         "${udevdir}"/input_id \
         "${udevdir}"/mtd_probe \
         "${udevdir}"/mtp-probe \
@@ -102,7 +100,6 @@ install() {
         inst_dir /etc/udev
         inst_multiple -H -o \
             /etc/udev/udev.conf \
-            "$udevconfdir"/hwdb.bin \
             "$udevrulesconfdir/*.rules"
     fi
 }


### PR DESCRIPTION
## Changes

This PR is just a refactor. hwdb module is installed by default.

This PR makes it possible to omit the hwdb when it is safe to do with 'dracut -o hwdb' command line option.

This refactor allows to make further progress on #203.

## Checklist
- [ ] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it

CC @pvalena 
