### PR TITLE
feat(dracut-install): add weak dependencies support

### DIFF
--- a/src/install/dracut-install.c
+++ b/src/install/dracut-install.c
@@ -1652,6 +1652,7 @@ static int install_dependent_module(struct kmod_ctx *ctx, struct kmod_module *mo
                 _cleanup_kmod_module_unref_list_ struct kmod_list *modlist = NULL;
                 _cleanup_kmod_module_unref_list_ struct kmod_list *modpre = NULL;
                 _cleanup_kmod_module_unref_list_ struct kmod_list *modpost = NULL;
+                _cleanup_kmod_module_unref_list_ struct kmod_list *modweak = NULL;
                 log_debug("dracut_install '%s' '%s' OK", path, &path[kerneldirlen]);
                 install_firmware(mod);
                 modlist = kmod_module_get_dependencies(mod);
@@ -1664,6 +1665,9 @@ static int install_dependent_module(struct kmod_ctx *ctx, struct kmod_module *mo
                                 r = install_dependent_modules(ctx, modpost, NULL);
                                 *err = *err ? : r;
                         }
+                        *err = kmod_module_get_weakdeps(mod, &modweak);
+                        if (*err == 0)
+                                *err = install_dependent_modules(ctx, modweak, NULL);
                 }
         } else {
                 log_error("dracut_install '%s' '%s' ERROR", path, &path[kerneldirlen]);
@@ -1723,6 +1727,7 @@ static int install_module(struct kmod_ctx *ctx, struct kmod_module *mod)
         _cleanup_kmod_module_unref_list_ struct kmod_list *modlist = NULL;
         _cleanup_kmod_module_unref_list_ struct kmod_list *modpre = NULL;
         _cleanup_kmod_module_unref_list_ struct kmod_list *modpost = NULL;
+        _cleanup_kmod_module_unref_list_ struct kmod_list *modweak = NULL;
         const char *path = NULL;
         const char *name = NULL;
 
@@ -1779,6 +1784,9 @@ static int install_module(struct kmod_ctx *ctx, struct kmod_module *mod)
                         r = install_dependent_modules(ctx, modpost, NULL);
                         ret = ret ? : r;
                 }
+                ret = kmod_module_get_weakdeps(mod, &modweak);
+                if (ret == 0)
+                        ret = install_dependent_modules(ctx, modweak, NULL);
         }
 
         return ret;


### PR DESCRIPTION
It has been seen that for some network mac drivers (i.e. lan78xx) the related module for the phy is loaded dynamically depending on the current hardware. In this case, the associated phy is read using mdio bus and then the associated phy module is loaded during runtime (kernel function phy_request_driver_module). However, no software dependency is defined, so the user tools will no be able to get this dependency. For example, if dracut is used and the hardware is present, lan78xx will be included but no phy module will be added, and in the next restart the device will not work from boot because no related phy will be found during initramfs stage.

In order to solve this, we could define a normal 'pre' software dependency in lan78xx module with all the possible phy modules (there may be some), but proceeding in that way, all the possible phy modules would be loaded while only one is necessary.

So, a new type of dependency has been created, that we are going to call 'weak' to be used only by the user tools that need to detect this situation. In that way, for example, dracut could check the 'weak' dependency of the modules involved in order to install these dependencies in initramfs too. That is, for the commented lan78xx module, defining the 'weak' dependency with the possible phy modules list, only the necessary phy would be loaded on demand keeping the same behavior, but all the possible phy modules would be available from initramfs.

The 'weak' dependency support has been already included in kmod: https://github.com/kmod-project/kmod/commit/05828b4a6e9327a63ef94df544a042b5e9ce4fe7 And in kernel:
https://git.kernel.org/pub/scm/linux/kernel/git/mcgrof/linux.git/commit/?h=modules-next&id=1f3dacc0dcef6681c2acf5890e018012f6b53085 After these, 'weak' dependencies for modules will start to appear. Read the possible weak dependencies from dracut in order to take them into account.

All related documentation has been filled for kmod.
Tests have been added in kmod test-suite: 
https://github.com/kmod-project/kmod/commit/d06712b51404061eef92cb275b8303814fca86ec

## Changes
Add weak dependencies support

## Checklist
- [X] I have tested it locally
- [X] I have reviewed and updated any documentation if relevant (kmod help)
- [X] I am providing new code and test(s) for it (kmod test-suite)

Fixes #
New feature