### PR TITLE
ci: drop network-manager from Debian Docker image

### DIFF
--- a/test/container/Dockerfile-Debian
+++ b/test/container/Dockerfile-Debian
@@ -41,7 +41,6 @@ RUN apt-get update -y -qq && apt-get upgrade -y -qq && apt-get install -y -qq --
     multipath-tools \
     nbd-client \
     nbd-server \
-    network-manager \
     nfs-kernel-server \
     ntfs-3g \
     open-iscsi \


### PR DESCRIPTION
## Changes

The network-manager version in Debian stable does not yet support dracut's network-manager module.
Debian trixie resolved this issue, but for the CI we prefer to use Debian stable.

Ubuntu CI container already has the fix and we will be using Ubuntu to test network-manager  dracut module.

This PR will allow to run the test with the default network module, which now will default to systemd-networkd for Debian CI container.

Historical context: https://github.com/dracutdevs/dracut/pull/2123

## Checklist
- [ ] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it

CC @bdrung 