### PR TITLE
feat: add common config for Integrity Measurement Architecture (IMA) 

### DIFF
--- a/dracut.conf.d/50-ima.conf.example
+++ b/dracut.conf.d/50-ima.conf.example
@@ -1,0 +1,2 @@
+# turn on Linux Integrity Measurement Architecture (IMA) modules
+add_dracutmodules+=" integrity "


### PR DESCRIPTION
## Changes

Source: https://github.com/openSUSE/dracut-ng/commit/dd118bab29a38fa221cedc7d66a91f3ff40f9f6b

Related read: https://en.opensuse.org/SDB:Ima_evm#Enabling_IMA/EVM_during_early_boot

## Checklist
- [ ] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it

