### PR TITLE
fix(network): network meta module should only make a selection

### DIFF
--- a/modules.d/40network/module-setup.sh
+++ b/modules.d/40network/module-setup.sh
@@ -27,6 +27,6 @@ depends() {
             network_handler="network-legacy"
         fi
     fi
-    echo "net-lib kernel-network-modules $network_handler"
+    echo "$network_handler"
     return 0
 }


### PR DESCRIPTION
## Changes

This is not just a cosmetic change. For Gentoo CI for example net-lib module will no longer be used for systemd-networkd networking.

## Checklist
- [ ] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it

