### PR TITLE
test: increase VM memory size to pass test 40 on more VMs

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -64,9 +64,9 @@ jobs:
                         "60",
                 ]
                 exclude:
-                  - test: "40"
-                include:
-                  - container: "fedora"
+                  - container: "gentoo"
+                    test: "40"
+                  - container: "ubuntu"
                     test: "40"
             fail-fast: false
         container:

--- a/test/run-qemu
+++ b/test/run-qemu
@@ -36,7 +36,7 @@ case "$ARCH" in
 esac
 
 # Provide rng device sourcing the hosts /dev/urandom and other standard parameters
-ARGS+=(-smp 2 -m 1024 -nodefaults -vga none -display none -no-reboot -watchdog-action poweroff -device virtio-rng-pci)
+ARGS+=(-smp 2 -m 2048 -nodefaults -vga none -display none -no-reboot -watchdog-action poweroff -device virtio-rng-pci)
 
 if ! [[ $* == *-daemonize* ]] && ! [[ $* == *-daemonize* ]]; then
     ARGS+=(-serial stdio)


### PR DESCRIPTION
## Changes

Test 40 runs out of memory. Give the VMs more RAM (2GB). With this change, CI can now run Test 40 on Arch and openSUSE as well. Now it only fails on Gentoo and Ubuntu (for other additional reasons).

## Checklist
- [ ] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it

Fixes #193 (partially)
