### PR TITLE
docs: correct shutdown path disucssion

### DIFF
--- a/man/dracut.asc
+++ b/man/dracut.asc
@@ -130,19 +130,19 @@ procedure.
 
 The following steps are executed during a shutdown:
 
-* systemd switches to the shutdown.target
-* systemd starts
-  $prefix/lib/systemd/system/shutdown.target.wants/dracut-shutdown.service
-* dracut-shutdown.service executes /usr/lib/dracut/dracut-initramfs-restore
-  which unpacks the initramfs to /run/initramfs
-* systemd finishes shutdown.target
+* The system starts to shut down
+* ``$prefix/lib/systemd/system/sysinit.target.wants/dracut-shutdown.service``
+  gets its ``ExecStop`` target triggered.
+* ``dracut-shutdown.service`` executes
+  ``/usr/lib/dracut/dracut-initramfs-restore`` which unpacks the initramfs to
+  ``/run/initramfs``
 * systemd kills all processes
 * systemd tries to unmount everything and mounts the remaining read-only
-* systemd checks, if there is a /run/initramfs/shutdown executable
-* if yes, it does a pivot_root to /run/initramfs and executes ./shutdown.
-  The old root is then mounted on /oldroot.
-  /usr/lib/dracut/modules.d/99shutdown/shutdown.sh is the shutdown executable.
-* shutdown will try to unmount every /oldroot mount and calls the various
+* systemd checks if there is a ``/run/initramfs/shutdown`` executable
+* if yes, it does a pivot_root to ``/run/initramfs`` and executes ``./shutdown``.
+  The old root is then mounted on ``/oldroot``.
+  ``/usr/lib/dracut/modules.d/99shutdown/shutdown.sh`` is the shutdown executable.
+* shutdown will try to unmount every ``/oldroot`` mount and calls the various
   shutdown hooks from the dracut modules
 
 This ensures, that all devices are disassembled and unmounted cleanly.

--- a/modules.d/98dracut-systemd/dracut-shutdown.service.8.asc
+++ b/modules.d/98dracut-systemd/dracut-shutdown.service.8.asc
@@ -20,15 +20,20 @@ can be safely unmounted.
 
 The following steps are executed during a shutdown:
 
-* systemd switches to the shutdown.target
-* systemd starts /lib/systemd/system/shutdown.target.wants/dracut-shutdown.service
-* dracut-shutdown.service executes /usr/lib/dracut/dracut-initramfs-restore which unpacks the initramfs to /run/initramfs
-* systemd finishes shutdown.target
+* The system starts to shut down
+* ``$prefix/lib/systemd/system/sysinit.target.wants/dracut-shutdown.service``
+  gets its ``ExecStop`` target triggered.
+* ``dracut-shutdown.service`` executes
+  ``/usr/lib/dracut/dracut-initramfs-restore`` which unpacks the initramfs to
+  ``/run/initramfs``
 * systemd kills all processes
 * systemd tries to unmount everything and mounts the remaining read-only
-* systemd checks, if there is a /run/initramfs/shutdown executable
-* if yes, it does a pivot_root to /run/initramfs and executes ./shutdown. The old root is then mounted on /oldroot. /usr/lib/dracut/modules.d/99shutdown/shutdown.sh is the shutdown executable.
-* shutdown will try to umount every /oldroot mount and calls the various shutdown hooks from the dracut modules 
+* systemd checks if there is a ``/run/initramfs/shutdown`` executable
+* if yes, it does a pivot_root to ``/run/initramfs`` and executes ``./shutdown``.
+  The old root is then mounted on ``/oldroot``.
+  ``/usr/lib/dracut/modules.d/99shutdown/shutdown.sh`` is the shutdown executable.
+* shutdown will try to unmount every ``/oldroot`` mount and calls the various
+  shutdown hooks from the dracut modules
 
 This ensures, that all devices are disassembled and unmounted cleanly.
 


### PR DESCRIPTION
Since 4f03054e540427682221e4c62b4d44f79424e38a, these shutdown steps have been in response to the ExecStop= called from the sysinit.target.

Correct the doc in the two places it mentions this.