### PR TITLE
test(FULL-SYSTEMD): add a test for encrypted root

### DIFF
--- a/test/TEST-04-FULL-SYSTEMD/create-root.sh
+++ b/test/TEST-04-FULL-SYSTEMD/create-root.sh
@@ -13,21 +13,37 @@ set -e
 udevadm settle
 modprobe btrfs || :
 mkfs.btrfs -q -L dracut /dev/disk/by-id/scsi-0QEMU_QEMU_HARDDISK_root
+printf test > keyfile
+cryptsetup -q luksFormat /dev/disk/by-id/scsi-0QEMU_QEMU_HARDDISK_root_crypt /keyfile
+cryptsetup luksOpen /dev/disk/by-id/scsi-0QEMU_QEMU_HARDDISK_root_crypt dracut_crypt_test < /keyfile
+mkfs.btrfs -q -L dracut_crypt /dev/mapper/dracut_crypt_test
 mkfs.btrfs -q -L dracutusr /dev/disk/by-id/scsi-0QEMU_QEMU_HARDDISK_usr
 btrfs device scan /dev/disk/by-id/scsi-0QEMU_QEMU_HARDDISK_root
+btrfs device scan /dev/mapper/dracut_crypt_test
 btrfs device scan /dev/disk/by-id/scsi-0QEMU_QEMU_HARDDISK_usr
-mkdir -p /root
+mkdir -p /root /root_crypt
 mount -t btrfs /dev/disk/by-id/scsi-0QEMU_QEMU_HARDDISK_root /root
+mount -t btrfs /dev/mapper/dracut_crypt_test /root_crypt
 [ -d /root/usr ] || mkdir -p /root/usr
+[ -d /root-crypt/usr ] || mkdir -p /root_crypt/usr
 mount -t btrfs /dev/disk/by-id/scsi-0QEMU_QEMU_HARDDISK_usr /root/usr
 btrfs subvolume create /root/usr/usr
 umount /root/usr
 mount -t btrfs -o subvol=usr /dev/disk/by-id/scsi-0QEMU_QEMU_HARDDISK_usr /root/usr
+mount --bind /root/usr /root_crypt/usr
 cp -a -t /root /source/*
-mkdir -p /root/run
+cp -a -t /root_crypt /source/*
+mkdir -p /root/run /root_crypt/run
 btrfs filesystem sync /root/usr
 btrfs filesystem sync /root
-umount /root/usr
-umount /root
-echo "dracut-root-block-created" | dd oflag=direct,dsync of=/dev/disk/by-id/scsi-0QEMU_QEMU_HARDDISK_marker status=none
+btrfs filesystem sync /root_crypt/usr
+btrfs filesystem sync /root_crypt
+umount /root/usr /root_crypt/usr
+umount /root /root_crypt
+cryptsetup luksClose /dev/mapper/dracut_crypt_test
+eval "$(udevadm info --query=property --name=/dev/disk/by-id/scsi-0QEMU_QEMU_HARDDISK_root_crypt | while read -r line || [ -n "$line" ]; do [ "$line" != "${line#*ID_FS_UUID*}" ] && echo "$line"; done)"
+{
+    echo "dracut-root-block-created"
+    echo "ID_FS_UUID=$ID_FS_UUID"
+} | dd oflag=direct,dsync of=/dev/disk/by-id/scsi-0QEMU_QEMU_HARDDISK_marker status=none
 poweroff -f

--- a/test/TEST-04-FULL-SYSTEMD/fstab
+++ b/test/TEST-04-FULL-SYSTEMD/fstab
@@ -1,2 +1,0 @@
-/dev/disk/by-id/scsi-0QEMU_QEMU_HARDDISK_root	/                       btrfs   defaults         0 0
-/dev/disk/by-id/scsi-0QEMU_QEMU_HARDDISK_usr	/usr                    btrfs   subvol=usr,ro    0 0

--- a/test/TEST-04-FULL-SYSTEMD/test.sh
+++ b/test/TEST-04-FULL-SYSTEMD/test.sh
@@ -28,7 +28,7 @@ client_run() {
     test_marker_reset
     "$testdir"/run-qemu \
         "${disk_args[@]}" \
-        -append "$TEST_KERNEL_CMDLINE systemd.unit=testsuite.target systemd.mask=systemd-firstboot systemd.mask=systemd-vconsole-setup rd.multipath=0 root=LABEL=dracut $client_opts rd.retry=3 $DEBUGOUT" \
+        -append "$TEST_KERNEL_CMDLINE systemd.unit=testsuite.target systemd.mask=systemd-firstboot systemd.mask=systemd-vconsole-setup rd.multipath=0 root=LABEL=dracut mount.usr=LABEL=dracutusr mount.usrfstype=btrfs mount.usrflags=subvol=usr,ro $client_opts rd.retry=3 $DEBUGOUT" \
         -initrd "$TESTDIR"/initramfs.testing || return 1
 
     if ! test_marker_check; then
@@ -61,7 +61,6 @@ test_setup() {
         -i "${PKGLIBDIR}/modules.d/80test-root/test-init.sh" "/sbin/test-init.sh" \
         -i ./test-init.sh /sbin/test-init \
         -I "findmnt" \
-        -i ./fstab /etc/fstab \
         -f "$TESTDIR"/initramfs.root "$KVERSION" || return 1
 
     mkdir -p "$TESTDIR"/overlay/source && cp -a "$TESTDIR"/dracut.*/initramfs/* "$TESTDIR"/overlay/source && rm -rf "$TESTDIR"/dracut.* && export initdir=$TESTDIR/overlay/source

--- a/test/TEST-04-FULL-SYSTEMD/test.sh
+++ b/test/TEST-04-FULL-SYSTEMD/test.sh
@@ -146,7 +146,7 @@ EOF
     [ -e /etc/machine-info ] && EXTRA_MACHINE+=" /etc/machine-info"
 
     test_dracut \
-        -a "systemd i18n qemu" \
+        -m "dracut-systemd i18n systemd-ac-power systemd-creds systemd-cryptsetup systemd-integritysetup systemd-ldconfig systemd-pstore systemd-repart systemd-sysext systemd-veritysetup " \
         -d "btrfs" \
         ${EXTRA_MACHINE:+-I "$EXTRA_MACHINE"} \
         "$TESTDIR"/initramfs.testing


### PR DESCRIPTION
## Changes

- Include more systemd modules. Most of modules added had no test coverage in any of the tests on CI.
- Add a test for encrypted root
- remove /etc/fstab from the rootfs. This PR moves /usr mounting into initrd instead of after switch_root.

## Checklist
- [X] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it


