### PR TITLE
fix(systemd): check for systemd-vconsole-setup.service

### DIFF
--- a/modules.d/00systemd/module-setup.sh
+++ b/modules.d/00systemd/module-setup.sh
@@ -158,7 +158,9 @@ EOF
         emergency.target \
         rescue.target; do
         [[ -f "$systemdsystemunitdir"/$i ]] || continue
-        $SYSTEMCTL -q --root "$initdir" add-wants "$i" systemd-vconsole-setup.service
+        if [ -e "$systemdsystemunitdir"/systemd-vconsole-setup.service ]; then
+            $SYSTEMCTL -q --root "$initdir" add-wants "$i" systemd-vconsole-setup.service
+        fi
     done
 
     mkdir -p "$initdir/etc/systemd"


### PR DESCRIPTION
## Changes

Make systemd consistent with [systemd-ask-password](https://github.com/dracut-ng/dracut-ng/blob/main/modules.d/01systemd-ask-password/module-setup.sh#L51)

Resolves the following error on Debian based systems

```
Failed to add dependency on unit, unit systemd-vconsole-setup.service does not exist.
Failed to add dependency on unit, unit systemd-vconsole-setup.service does not exist.
```

## Checklist
- [ ] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it


