### PR TITLE
ci: add systemd-coredump to Debian/Ubuntu containers

### DIFF
--- a/test/container/Dockerfile-Debian
+++ b/test/container/Dockerfile-Debian
@@ -57,6 +57,7 @@ RUN apt-get update -y -qq && apt-get upgrade -y -qq && apt-get install -y -qq --
     squashfs-tools \
     strace \
     systemd-boot-efi \
+    systemd-coredump \
     tcpdump \
     tgt \
     thin-provisioning-tools \

--- a/test/container/Dockerfile-Ubuntu
+++ b/test/container/Dockerfile-Ubuntu
@@ -56,6 +56,7 @@ RUN apt-get update -y -qq && apt-get upgrade -y -qq && \
     squashfs-tools \
     strace \
     systemd-boot-efi \
+    systemd-coredump \
     systemd-ukify \
     tcpdump \
     tgt \


### PR DESCRIPTION
## Changes

PR to enable testing systemd-coredump module.

## Checklist
- [ ] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it


