### PR TITLE
feat(multipath): omit module if included with no multipath devices and no user conf

### DIFF
--- a/modules.d/90multipath/module-setup.sh
+++ b/modules.d/90multipath/module-setup.sh
@@ -35,8 +35,7 @@ check() {
     require_binaries kpartx || return 1
 
     if [[ $_any_mpath_dev != 0 ]] && [[ ! -f /etc/multipath.conf ]]; then
-        dwarn "multipath: including module with no multipath devices and empty" \
-            "configuration, the root disk may be unintentionally multipathed."
+        return 1
     fi
 
     return 0


### PR DESCRIPTION
## Changes

The multipath module is always included in no-hostonly mode, but including it in the initramfs might activate multipath on the root device, which could be undesirable. This behavior can be manually fixed by explicitly excluding the root device from multipath in /etc/multipath.conf.

Therefore, issue a warning in no-hostonly mode, if there is no multipath device and the user has not configured multipath.

EDIT: instead of warning, omit including multipath module.

bsc#1069169

## Checklist
- [ ] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it

Fixes #465

See:
 - https://github.com/openSUSE/dracut/pull/239 
 - https://github.com/openSUSE/dracut-ng/commit/03e801f4a27da27983f77d0e7d25779d21a822e1
