### PR TITLE
fix(systemd-pcrphase): make tpm2-tss an optional dependency

### DIFF
--- a/modules.d/01systemd-pcrphase/module-setup.sh
+++ b/modules.d/01systemd-pcrphase/module-setup.sh
@@ -21,7 +21,17 @@ check() {
 # Module dependency requirements.
 depends() {
     # This module has external dependency on other module(s).
-    echo systemd tpm2-tss
+
+    local deps
+    deps="systemd"
+
+    # optional dependencies
+    module="tpm2-tss"
+    module_check $module > /dev/null 2>&1
+    if [[ $? == 255 ]]; then
+        deps+=" $module"
+    fi
+    echo "$deps"
 
     # Return 0 to include the dependent module(s) in the initramfs.
     return 0


### PR DESCRIPTION
## Changes

Only make tpm2-tss a dependency if requirements to install tpm2-tss is met.

Follow-up to https://github.com/dracut-ng/dracut-ng/pull/256 ,

## Checklist
- [ ] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it

Fixes #329

CC @dalto8 