### PR TITLE
fix(dracut-init.sh): clarify the error message

### DIFF
--- a/dracut-init.sh
+++ b/dracut-init.sh
@@ -932,7 +932,7 @@ check_mount() {
             && force_add_dracutmodules+=" $_moddep "
         # if a module we depend on fail, fail also
         if ! check_module "$_moddep"; then
-            derror "Module '$_mod' depends on '$_moddep', which can't be installed"
+            derror "Module '$_mod' depends on module '$_moddep', which can't be installed"
             return 1
         fi
     done
@@ -1007,7 +1007,7 @@ check_module() {
             && force_add_dracutmodules+=" $_moddep "
         # if a module we depend on fail, fail also
         if ! check_module "$_moddep"; then
-            derror "Module '$_mod' depends on '$_moddep', which can't be installed"
+            derror "Module '$_mod' depends on module '$_moddep', which can't be installed"
             return 1
         fi
     done


### PR DESCRIPTION
## Changes

Clarify that dracut module is missing and not Linux command or package.

This will help clarify to the users what action to take as a response of this message - 

## Checklist
- [ ] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it

Fixes #329

CC @dalto8 