### PR TITLE
docs: remove suggesting that hostonly option is only for experts

### DIFF
--- a/man/dracut.usage.asc
+++ b/man/dracut.usage.asc
@@ -38,9 +38,8 @@ the --hostonly or -H option. Using this option, the resulting image will
 contain only those dracut modules, kernel modules and filesystems, which are
 needed to boot this specific machine. This has the drawback, that you can't put
 the disk on another controller or machine, and that you can't switch to another
-root filesystem, without recreating the initramfs image. The usage of the
---hostonly option is only for experts and you will have to keep the broken
-pieces. At least keep a copy of a general purpose image (and corresponding
+root filesystem, without recreating the initramfs image.
+It is recommended to keep a copy of a general purpose image (and corresponding
 kernel) as a fallback to rescue your system.
 
 === Inspecting the Contents


### PR DESCRIPTION
## Changes

Since some distributions set hostonly the default, suggesting that it is only for experts is a bit of overstatement.

## Checklist
- [ ] I have tested it locally
- [X] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it


