### PR TITLE
ci: improve FULL-SYSTEMD test

### DIFF
--- a/modules.d/80test-root/test-init.sh
+++ b/modules.d/80test-root/test-init.sh
@@ -18,9 +18,9 @@ grep -q '^tmpfs /run tmpfs' /proc/self/mounts \
 
 exec > /dev/console 2>&1
 
-if [ -s /failed ]; then
+if [ -s /run/failed ]; then
     echo "**************************FAILED**************************"
-    cat /failed
+    cat /run/failed
     echo "**************************FAILED**************************"
 else
     echo "dracut-root-block-success" | dd oflag=direct,dsync status=none of=/dev/disk/by-id/scsi-0QEMU_QEMU_HARDDISK_marker

--- a/test/TEST-04-FULL-SYSTEMD/test-init.sh
+++ b/test/TEST-04-FULL-SYSTEMD/test-init.sh
@@ -5,7 +5,7 @@ export PATH=/usr/sbin:/usr/bin:/sbin:/bin
 command -v plymouth > /dev/null 2>&1 && plymouth --quit
 exec > /dev/console 2>&1
 
-systemctl --failed --no-legend --no-pager > /failed
+systemctl --failed --no-legend --no-pager > /run/failed
 
 ismounted() {
     findmnt "$1" > /dev/null 2>&1
@@ -14,7 +14,7 @@ ismounted() {
 if ! ismounted /usr; then
     echo "**************************FAILED**************************"
     echo "/usr not mounted!!"
-    cat /proc/mounts >> /failed
+    cat /proc/mounts >> /run/failed
     echo "**************************FAILED**************************"
 fi
 

--- a/test/TEST-04-FULL-SYSTEMD/test.sh
+++ b/test/TEST-04-FULL-SYSTEMD/test.sh
@@ -156,7 +156,7 @@ EOF
     echo -n test > /tmp/key
 
     test_dracut \
-        -m "dracut-systemd i18n systemd-ac-power systemd-creds systemd-cryptsetup systemd-integritysetup systemd-ldconfig systemd-pstore systemd-repart systemd-sysext systemd-veritysetup " \
+        -m "dracut-systemd i18n systemd-ac-power systemd-coredump systemd-creds systemd-cryptsetup systemd-integritysetup systemd-ldconfig systemd-pstore systemd-repart systemd-sysext systemd-veritysetup" \
         -d "btrfs" \
         -i "/tmp/key" "/etc/key" \
         -i "/tmp/crypttab" "/etc/crypttab" \

--- a/test/TEST-04-FULL-SYSTEMD/test.sh
+++ b/test/TEST-04-FULL-SYSTEMD/test.sh
@@ -43,6 +43,10 @@ test_run() {
     client_run "readonly root" "ro" || return 1
     client_run "writeable root" "rw" || return 1
 
+    # volatile mode
+    client_run "volatile=overlayfs root" "systemd.volatile=overlayfs" || return 1
+    client_run "volatile=state root" "systemd.volatile=state" || return 1
+
     # shellcheck source=$TESTDIR/luks.uuid
     . "$TESTDIR"/luks.uuid
 

--- a/test/TEST-04-FULL-SYSTEMD/test.sh
+++ b/test/TEST-04-FULL-SYSTEMD/test.sh
@@ -146,9 +146,6 @@ EOF
         return 1
     fi
 
-    [ -e /etc/machine-id ] && EXTRA_MACHINE="/etc/machine-id"
-    [ -e /etc/machine-info ] && EXTRA_MACHINE+=" /etc/machine-info"
-
     grep -F -a -m 1 ID_FS_UUID "$TESTDIR"/marker.img > "$TESTDIR"/luks.uuid
     # shellcheck source=$TESTDIR/luks.uuid
     . "$TESTDIR"/luks.uuid
@@ -160,7 +157,6 @@ EOF
         -d "btrfs" \
         -i "/tmp/key" "/etc/key" \
         -i "/tmp/crypttab" "/etc/crypttab" \
-        ${EXTRA_MACHINE:+-I "$EXTRA_MACHINE"} \
         "$TESTDIR"/initramfs.testing
 
     rm -rf -- "$TESTDIR"/overlay

--- a/test/TEST-04-FULL-SYSTEMD/test.sh
+++ b/test/TEST-04-FULL-SYSTEMD/test.sh
@@ -146,8 +146,7 @@ EOF
     echo -n test > /tmp/key
 
     test_dracut \
-        -m "dracut-systemd i18n systemd-ac-power systemd-coredump systemd-creds systemd-cryptsetup systemd-integritysetup systemd-ldconfig systemd-pstore systemd-repart systemd-sysext systemd-veritysetup" \
-        -d "btrfs" \
+        -m "btrfs dracut-systemd i18n systemd-ac-power systemd-coredump systemd-creds systemd-cryptsetup systemd-integritysetup systemd-ldconfig systemd-pstore systemd-repart systemd-sysext systemd-veritysetup" \
         -i "/tmp/key" "/etc/key" \
         "$TESTDIR"/initramfs.testing
 

--- a/test/TEST-04-FULL-SYSTEMD/test.sh
+++ b/test/TEST-04-FULL-SYSTEMD/test.sh
@@ -140,11 +140,7 @@ EOF
         "${disk_args[@]}" \
         -append "root=/dev/fakeroot rw rootfstype=btrfs quiet console=ttyS0,115200n81" \
         -initrd "$TESTDIR"/initramfs.makeroot || return 1
-
-    if ! test_marker_check dracut-root-block-created; then
-        echo "Could not create root filesystem"
-        return 1
-    fi
+    test_marker_check dracut-root-block-created || return 1
 
     grep -F -a -m 1 ID_FS_UUID "$TESTDIR"/marker.img > "$TESTDIR"/luks.uuid
     echo -n test > /tmp/key

--- a/test/TEST-04-FULL-SYSTEMD/test.sh
+++ b/test/TEST-04-FULL-SYSTEMD/test.sh
@@ -46,7 +46,7 @@ test_run() {
     # shellcheck source=$TESTDIR/luks.uuid
     . "$TESTDIR"/luks.uuid
 
-    client_run "encrypted root" "root=LABEL=dracut_crypt rd.luks.uuid=$ID_FS_UUID" || return 1
+    client_run "encrypted root" "root=LABEL=dracut_crypt rd.luks.uuid=$ID_FS_UUID rd.luks.key=/etc/key" || return 1
     return 0
 }
 
@@ -147,16 +147,12 @@ EOF
     fi
 
     grep -F -a -m 1 ID_FS_UUID "$TESTDIR"/marker.img > "$TESTDIR"/luks.uuid
-    # shellcheck source=$TESTDIR/luks.uuid
-    . "$TESTDIR"/luks.uuid
-    echo "luks-$ID_FS_UUID /dev/disk/by-id/scsi-0QEMU_QEMU_HARDDISK_root_crypt /etc/key" > /tmp/crypttab
     echo -n test > /tmp/key
 
     test_dracut \
         -m "dracut-systemd i18n systemd-ac-power systemd-coredump systemd-creds systemd-cryptsetup systemd-integritysetup systemd-ldconfig systemd-pstore systemd-repart systemd-sysext systemd-veritysetup" \
         -d "btrfs" \
         -i "/tmp/key" "/etc/key" \
-        -i "/tmp/crypttab" "/etc/crypttab" \
         "$TESTDIR"/initramfs.testing
 
     rm -rf -- "$TESTDIR"/overlay

--- a/test/TEST-04-FULL-SYSTEMD/test.sh
+++ b/test/TEST-04-FULL-SYSTEMD/test.sh
@@ -120,7 +120,7 @@ EOF
     # We do it this way so that we do not risk trashing the host mdraid
     # devices, volume groups, encrypted partitions, etc.
     "$DRACUT" -N -l -i "$TESTDIR"/overlay / \
-        -a "test-makeroot bash btrfs" \
+        -a "test-makeroot btrfs" \
         -I "mkfs.btrfs cryptsetup" \
         -i ./create-root.sh /lib/dracut/hooks/initqueue/01-create-root.sh \
         -f "$TESTDIR"/initramfs.makeroot "$KVERSION" || return 1

--- a/test/TEST-04-FULL-SYSTEMD/test.sh
+++ b/test/TEST-04-FULL-SYSTEMD/test.sh
@@ -49,7 +49,9 @@ test_run() {
     # shellcheck source=$TESTDIR/luks.uuid
     . "$TESTDIR"/luks.uuid
 
-    client_run "encrypted root" "root=LABEL=dracut_crypt rd.luks.uuid=$ID_FS_UUID rd.luks.key=/etc/key" || return 1
+    # luks
+    client_run "encrypted root with rd.luks.uuid" "root=LABEL=dracut_crypt rd.luks.uuid=$ID_FS_UUID rd.luks.key=/etc/key" || return 1
+    client_run "encrypted root with rd.luks.name" "root=/dev/mapper/crypt rd.luks.name=$ID_FS_UUID=crypt rd.luks.key=/etc/key" || return 1
     return 0
 }
 

--- a/test/TEST-04-FULL-SYSTEMD/test.sh
+++ b/test/TEST-04-FULL-SYSTEMD/test.sh
@@ -10,7 +10,6 @@ test_check() {
 # Uncomment this to debug failures
 #DEBUGFAIL="rd.shell rd.break"
 #DEBUGOUT="quiet systemd.log_level=debug systemd.log_target=console loglevel=77  rd.info rd.debug"
-DEBUGOUT="loglevel=0 "
 client_run() {
     local test_name="$1"
     shift


### PR DESCRIPTION
## Changes

- test(FULL-SYSTEMD): add test with rd.luks.name
- test(FULL-SYSTEMD): do not disable kernel loglevel
- test(FULL-SYSTEMD): add tests for volatile mode
-  test(FULL-SYSTEMD): remove managing drivers manually
-  test(FULL-SYSTEMD): align with other tests
-  test(FULL-SYSTEMD): control decryption from command line
-  test(FULL-SYSTEMD): no need for explicit bash dependency
-  test(FULL-SYSTEMD): avoid hostonly files for a generic testcase
-  test(FULL-SYSTEMD): add systemd-coredump and systemd-pcrphase testing
-  test: move /failed to /run/failed as rootfs might be read-only