### PR TITLE
fix(net-lib): require and install only the necessary binaries

### DIFF
--- a/modules.d/45net-lib/module-setup.sh
+++ b/modules.d/45net-lib/module-setup.sh
@@ -1,6 +1,7 @@
 #!/bin/bash
 
 check() {
+    require_binaries ip awk grep || return 1
     return 255
 }
 
@@ -14,7 +15,7 @@ install() {
     inst_simple "$moddir/net-lib.sh" "/lib/net-lib.sh"
     inst_hook pre-udev 50 "$moddir/ifname-genrules.sh"
     inst_hook cmdline 91 "$moddir/dhcp-root.sh"
-    inst_multiple ip sed awk grep pgrep tr
+    inst_multiple ip awk grep
     inst_multiple -o arping arping2
     dracut_need_initqueue
 }


### PR DESCRIPTION
- `pgrep`, `tr` not needed.
- `sed` installed by `base`.

## Checklist
- [X] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it