### PR TITLE
test: drop 'quiet' from kernel cmdline on verbose runs

### DIFF
--- a/test/test-functions
+++ b/test/test-functions
@@ -19,7 +19,10 @@ if [[ -z $basedir ]]; then basedir="$(realpath ../..)"; fi
 DRACUT=${DRACUT-${basedir}/dracut.sh}
 PKGLIBDIR=${PKGLIBDIR-$basedir}
 
-TEST_KERNEL_CMDLINE+=" panic=1 oops=panic softlockup_panic=1 systemd.crash_reboot quiet console=ttyS0,115200n81 $DEBUGFAIL "
+TEST_KERNEL_CMDLINE+=" panic=1 oops=panic softlockup_panic=1 systemd.crash_reboot console=ttyS0,115200n81 $DEBUGFAIL "
+if [[ $V != "1" && $V != "2" ]]; then
+    TEST_KERNEL_CMDLINE+="quiet "
+fi
 
 test_dracut() {
     TEST_DRACUT_ARGS+=" --local --no-hostonly --no-hostonly-cmdline --no-early-microcode --add test --force --kver $KVERSION"


### PR DESCRIPTION
## Changes

If the test cases are run in verbose with (i.e. with `V=1` or `V=2` set), do not add `quiet` to the kernel cmdline.

## Checklist
- [x] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it
