### PR TITLE
fix(test): run tests with systemd again

### DIFF
--- a/test/TEST-30-DMSQUASH/test.sh
+++ b/test/TEST-30-DMSQUASH/test.sh
@@ -159,7 +159,6 @@ EOF
     test_dracut \
         --no-hostonly \
         --add "dmsquash-live qemu" \
-        --omit "systemd" \
         --drivers "ntfs3" \
         --install "mkfs.ext4" \
         -a bash \
@@ -169,7 +168,6 @@ EOF
     test_dracut \
         --no-hostonly \
         --add "dmsquash-live-autooverlay qemu" \
-        --omit "systemd" \
         --install "mkfs.ext4" \
         -a bash \
         "$TESTDIR"/initramfs.testing-autooverlay


### PR DESCRIPTION
## Changes

Commit 061a1068ba4c872e48605b9b0ecd282f4630ea8f ("test: avoid writing to rootfs as it might be read-only") fixes the test failure with systemd
256. So revert the changes to `test/` from commit 130f4dfce48b187944be9a0cacca794dd32428ad.

## Checklist
- [ ] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it
