### PR TITLE
fix(nfs): support rpcbind user named _rpc

### DIFF
--- a/modules.d/95nfs/module-setup.sh
+++ b/modules.d/95nfs/module-setup.sh
@@ -125,7 +125,7 @@ install() {
 
     # Rather than copy the passwd file in, just set a user for rpcbind
     # We'll save the state and restart the daemon from the root anyway
-    grep -E '^nfsnobody:|^rpc:|^rpcuser:' "$dracutsysrootdir"/etc/passwd >> "$initdir/etc/passwd"
+    grep -E '^(nfsnobody|_rpc|rpc|rpcuser):' "$dracutsysrootdir"/etc/passwd >> "$initdir/etc/passwd"
     grep -E '^nogroup:|^rpc:|^nobody:' "$dracutsysrootdir"/etc/group >> "$initdir/etc/group"
 
     dracut_need_initqueue

--- a/modules.d/95nfs/nfs-lib.sh
+++ b/modules.d/95nfs/nfs-lib.sh
@@ -155,3 +155,16 @@ mount_nfs() {
     fi
     mount -t "$nfs" -o"$options" "$server:$path" "$mntdir"
 }
+
+get_rpc_user() {
+    while read -r line; do
+        user="${line%%:*}"
+        case $user in
+            _rpc | rpc | rpcuser | nfsnobody)
+                echo "$user"
+                return
+                ;;
+        esac
+    done < /etc/passwd
+    echo "root"
+}

--- a/modules.d/95nfs/nfs-start-rpc.sh
+++ b/modules.d/95nfs/nfs-start-rpc.sh
@@ -8,8 +8,9 @@ if load_fstype sunrpc rpc_pipefs; then
     # FIXME occasionally saw 'rpcbind: fork failed: No such device' -- why?
     command -v portmap > /dev/null && [ -z "$(pidof portmap)" ] && portmap
     if command -v rpcbind > /dev/null && [ -z "$(pidof rpcbind)" ]; then
+        . /lib/nfs-lib.sh
         mkdir -p /run/rpcbind
-        chown rpc:rpc /run/rpcbind
+        chown "$(get_rpc_user):root" /run/rpcbind
         rpcbind
     fi
 

--- a/modules.d/95nfs/parse-nfsroot.sh
+++ b/modules.d/95nfs/parse-nfsroot.sh
@@ -126,5 +126,5 @@ echo '[ -e $NEWROOT/proc ]' > "$hookdir"/initqueue/finished/nfsroot.sh
 # rpc user needs to be able to write to this directory to save the warmstart
 # file
 mkdir -p /var/lib/rpcbind
-chown rpc:rpc /var/lib/rpcbind
+chown "$(get_rpc_user):root" /var/lib/rpcbind
 chmod 770 /var/lib/rpcbind


### PR DESCRIPTION
## Changes

The Debian/Ubuntu package `rpcbind` creates a user named `_rpc`. Support running `rpcbind` with that user. Add a helper function `get_rpc_user` that derives the desired user from parsing `/etc/passwd`.

## Checklist
- [ ] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it
