### PR TITLE
feat(kernel-modules): Install platform/chrome modules on ARM/RISC-V

### DIFF
--- a/modules.d/90kernel-modules/module-setup.sh
+++ b/modules.d/90kernel-modules/module-setup.sh
@@ -81,6 +81,7 @@ installkernel() {
                 "=drivers/mmc/host" \
                 "=drivers/nvmem" \
                 "=drivers/phy" \
+                "=drivers/platform/chrome" \
                 "=drivers/power" \
                 "=drivers/regulator" \
                 "=drivers/reset" \


### PR DESCRIPTION
## Changes

Most ARM Chromebooks need the ChromiumOS Embedded Controller drivers located under kernel/drivers/platform/chrome for essential functionality like keyboard, USB, and display backlight. Add them to the non-hostonly initramfs by adding them to the ARM/RISC-V-specific instmods call.

On Fedora 40 (ARM64), the following modules are added:

```
$ tree --du -h lib/modules/6.9.7-200.fc40.aarch64/kernel/drivers/platform/chrome
[ 99K]  lib/modules/6.9.7-200.fc40.aarch64/kernel/drivers/platform/chrome
├── [5.1K]  chromeos_acpi.ko.xz
├── [3.0K]  chromeos_privacy_screen.ko.xz
├── [5.7K]  cros_ec_chardev.ko.xz
├── [4.5K]  cros_ec_i2c.ko.xz
├── [5.2K]  cros_ec.ko.xz
├── [4.6K]  cros_ec_rpmsg.ko.xz
├── [ 14K]  cros-ec-sensorhub.ko.xz
├── [6.7K]  cros_ec_spi.ko.xz
├── [4.9K]  cros_ec_sysfs.ko.xz
├── [ 16K]  cros-ec-typec.ko.xz
├── [4.9K]  cros_ec_uart.ko.xz
├── [3.2K]  cros_ec_vbc.ko.xz
├── [3.1K]  cros_hps_i2c.ko.xz
├── [3.6K]  cros_kbd_led_backlight.ko.xz
├── [5.7K]  cros_typec_switch.ko.xz
├── [4.8K]  cros_usbpd_logger.ko.xz
└── [3.8K]  cros_usbpd_notify.ko.xz
```

## Checklist
- [X] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it