### PR TITLE
fix(multipath): omit module if included with no multipath devices

### DIFF
--- a/modules.d/90multipath/module-setup.sh
+++ b/modules.d/90multipath/module-setup.sh
@@ -23,6 +23,10 @@ majmin_to_mpath_dev() {
 check() {
     local _any_mpath_dev
 
+    # if there's no multipath binary, no go.
+    require_binaries multipath || return 1
+    require_binaries kpartx || return 1
+
     for_each_host_dev_and_slaves is_mpath
     _any_mpath_dev=$?
 
@@ -30,12 +34,8 @@ check() {
         [[ $_any_mpath_dev == 0 ]] || return 255
     }
 
-    # if there's no multipath binary, no go.
-    require_binaries multipath || return 1
-    require_binaries kpartx || return 1
-
     if [[ $_any_mpath_dev != 0 ]] && [[ ! -f /etc/multipath.conf ]]; then
-        return 1
+        return 255
     fi
 
     return 0

--- a/test/TEST-04-FULL-SYSTEMD/test.sh
+++ b/test/TEST-04-FULL-SYSTEMD/test.sh
@@ -27,7 +27,7 @@ client_run() {
     test_marker_reset
     "$testdir"/run-qemu \
         "${disk_args[@]}" \
-        -append "$TEST_KERNEL_CMDLINE systemd.unit=testsuite.target systemd.mask=systemd-firstboot systemd.mask=systemd-vconsole-setup rd.multipath=0 root=LABEL=dracut mount.usr=LABEL=dracutusr mount.usrfstype=btrfs mount.usrflags=subvol=usr,ro $client_opts rd.retry=3 $DEBUGOUT" \
+        -append "$TEST_KERNEL_CMDLINE systemd.unit=testsuite.target systemd.mask=systemd-firstboot systemd.mask=systemd-vconsole-setup root=LABEL=dracut mount.usr=LABEL=dracutusr mount.usrfstype=btrfs mount.usrflags=subvol=usr,ro $client_opts rd.retry=3 $DEBUGOUT" \
         -initrd "$TESTDIR"/initramfs.testing || return 1
 
     if ! test_marker_check; then


### PR DESCRIPTION
## Changes

Follow-up to 4957ffa935. Return 255 instead of 1 and change the order of checks.

This change also allows removing the multipath workaround the the FULL-SYSTEMD test.

## Checklist
- [ ] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it

CC @mwilck @bmarzins @aafeijoo-suse 
