### PR TITLE
fix(test): run test 14 with systemd again

### DIFF
--- a/test/TEST-14-IMSM/test.sh
+++ b/test/TEST-14-IMSM/test.sh
@@ -90,8 +90,6 @@ test_setup() {
     echo "$MD_UUID" > "$TESTDIR"/mduuid
 
     test_dracut \
-        -a "dmraid" \
-        -o "systemd" \
         "$TESTDIR"/initramfs.testing
 }
 


### PR DESCRIPTION
## Changes

Commit 061a1068ba4c872e48605b9b0ecd282f4630ea8f ("test: avoid writing to rootfs as it might be read-only") fixes the test failure with systemd
256. So revert the changes to `test/TEST-14-IMSM` from commit 130f4dfce48b187944be9a0cacca794dd32428ad.

## Checklist
- [ ] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it
