### PR TITLE
fix(udev-rules): install libkmod.so even if systemd is not installed

### DIFF
--- a/modules.d/00systemd/module-setup.sh
+++ b/modules.d/00systemd/module-setup.sh
@@ -170,7 +170,5 @@ EOF
     # Install library file(s)
     _arch=${DRACUT_ARCH:-$(uname -m)}
     inst_libdir_file \
-        {"tls/$_arch/",tls/,"$_arch/",}"libgcrypt.so*" \
-        {"tls/$_arch/",tls/,"$_arch/",}"libkmod.so*" \
-        {"tls/$_arch/",tls/,"$_arch/",}"libnss_*"
+        {"tls/$_arch/",tls/,"$_arch/",}"libgcrypt.so*"
 }

--- a/modules.d/95udev-rules/module-setup.sh
+++ b/modules.d/95udev-rules/module-setup.sh
@@ -93,7 +93,11 @@ install() {
         "${udevdir}"/usb_id \
         "${udevdir}"/v4l_id
 
-    inst_libdir_file "libnss_files*"
+    # Install library file(s)
+    _arch=${DRACUT_ARCH:-$(uname -m)}
+    inst_libdir_file \
+        {"tls/$_arch/",tls/,"$_arch/",}"libkmod.so*" \
+        {"tls/$_arch/",tls/,"$_arch/",}"libnss_*"
 
     # Install the hosts local user configurations if enabled.
     if [[ $hostonly ]]; then


### PR DESCRIPTION
## Changes

Related discussion: - https://github.com/zbm-dev/zfsbootmenu/issues/648#issuecomment-2224147934

## Checklist
- [ ] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it

