### PR TITLE
Erofs tests

### DIFF
--- a/modules.d/90dmsquash-live/module-setup.sh
+++ b/modules.d/90dmsquash-live/module-setup.sh
@@ -17,7 +17,7 @@ depends() {
 
 # called by dracut
 installkernel() {
-    instmods squashfs loop iso9660
+    instmods squashfs loop iso9660 erofs
 }
 
 # called by dracut

--- a/test/TEST-16-DMSQUASH/create-root.sh
+++ b/test/TEST-16-DMSQUASH/create-root.sh
@@ -27,6 +27,18 @@ cp -a -t /root /source/*
 echo "Creating squashfs"
 mksquashfs /source /root/testdir/rootfs.img -quiet
 
+# Write the erofs compressed filesystem to the partition
+if [ -e "/dev/disk/by-id/scsi-0QEMU_QEMU_HARDDISK_root_erofs" ]; then
+    sfdisk /dev/disk/by-id/scsi-0QEMU_QEMU_HARDDISK_root_erofs << EOF
+2048,161792
+EOF
+
+    udevadm settle
+
+    echo "Creating erofs"
+    mkfs.erofs /dev/disk/by-id/scsi-0QEMU_QEMU_HARDDISK_root_erofs-part1 /source
+fi
+
 # Copy rootfs.img to the NTFS drive if exists
 if [ -e "/dev/disk/by-id/scsi-0QEMU_QEMU_HARDDISK_root_ntfs" ]; then
     mkfs.ntfs -q -F -L dracut_ntfs /dev/disk/by-id/scsi-0QEMU_QEMU_HARDDISK_root_ntfs


### PR DESCRIPTION

## Changes

Adds testing for erofs support in dmsquash-live, makes sure the erofs kernel module is installed when using dmsquash-live.

## Checklist
- [X] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [X] I am providing new code and test(s) for it
