### PR TITLE
fix(dracut): re-enable extended attributes in containers

### DIFF
--- a/dracut.conf.d/50-no-xattr.conf.example
+++ b/dracut.conf.d/50-no-xattr.conf.example
@@ -1,0 +1,2 @@
+# disable xattr
+export DRACUT_NO_XATTR=1

--- a/dracut.sh
+++ b/dracut.sh
@@ -1282,7 +1282,7 @@ if [[ -f $dracutbasedir/dracut-version.sh ]]; then
 fi
 
 if systemd-detect-virt -c &> /dev/null; then
-    export DRACUT_NO_MKNOD=1 DRACUT_NO_XATTR=1
+    export DRACUT_NO_MKNOD=1
     if [[ $hostonly ]]; then
         printf "%s\n" "dracut[W]: Running in hostonly mode in a container!" >&2
     fi


### PR DESCRIPTION
## Changes

Add common config to make it easier to disable xattr.
Running inside a container is not a good proxy for making decisions about filesystem properties.

Partial revert of https://github.com/dracutdevs/dracut/pull/1499

## Checklist
- [ ] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it

CC @cgwalters  @DaanDeMeyer for visibility
