### PR TITLE
test(DMSQUASH): no need to partition root_erofs disk

### DIFF
--- a/test/TEST-16-DMSQUASH/create-root.sh
+++ b/test/TEST-16-DMSQUASH/create-root.sh
@@ -29,14 +29,8 @@ mksquashfs /source /root/testdir/rootfs.img -quiet
 
 # Write the erofs compressed filesystem to the partition
 if [ -e "/dev/disk/by-id/scsi-0QEMU_QEMU_HARDDISK_root_erofs" ]; then
-    sfdisk /dev/disk/by-id/scsi-0QEMU_QEMU_HARDDISK_root_erofs << EOF
-2048,161792
-EOF
-
-    udevadm settle
-
     echo "Creating erofs"
-    mkfs.erofs /dev/disk/by-id/scsi-0QEMU_QEMU_HARDDISK_root_erofs-part1 /source
+    mkfs.erofs /dev/disk/by-id/scsi-0QEMU_QEMU_HARDDISK_root_erofs /source
 fi
 
 # Copy rootfs.img to the NTFS drive if exists

--- a/test/TEST-16-DMSQUASH/test.sh
+++ b/test/TEST-16-DMSQUASH/test.sh
@@ -37,7 +37,7 @@ test_run() {
         "$testdir"/run-qemu \
             "${disk_args[@]}" \
             -boot order=d \
-            -append "$TEST_KERNEL_CMDLINE rd.live.overlay.overlayfs=1 root=live:/dev/disk/by-id/scsi-0QEMU_QEMU_HARDDISK_root_erofs-part1" \
+            -append "$TEST_KERNEL_CMDLINE rd.live.overlay.overlayfs=1 root=live:/dev/disk/by-id/scsi-0QEMU_QEMU_HARDDISK_root_erofs" \
             -initrd "$TESTDIR"/initramfs.testing
 
         test_marker_check || return 1


### PR DESCRIPTION
## Changes

Only one partition is needed, so need need to repartition. This makes the code easier to reason about and test runs a bit faster.

## Checklist
- [ ] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it

