### PR TITLE
fix(systemd): move installation of libkmod to udev-rules module

### DIFF
--- a/modules.d/00systemd/module-setup.sh
+++ b/modules.d/00systemd/module-setup.sh
@@ -171,6 +171,5 @@ EOF
     _arch=${DRACUT_ARCH:-$(uname -m)}
     inst_libdir_file \
         {"tls/$_arch/",tls/,"$_arch/",}"libgcrypt.so*" \
-        {"tls/$_arch/",tls/,"$_arch/",}"libkmod.so*" \
         {"tls/$_arch/",tls/,"$_arch/",}"libnss_*"
 }

--- a/modules.d/95udev-rules/module-setup.sh
+++ b/modules.d/95udev-rules/module-setup.sh
@@ -93,7 +93,11 @@ install() {
         "${udevdir}"/usb_id \
         "${udevdir}"/v4l_id
 
-    inst_libdir_file "libnss_files*"
+    # Install required libraries.
+    _arch=${DRACUT_ARCH:-$(uname -m)}
+    inst_libdir_file \
+        {"tls/$_arch/",tls/,"$_arch/",}"libkmod.so*" \
+        {"tls/$_arch/",tls/,"$_arch/",}"libnss_files*"
 
     # Install the hosts local user configurations if enabled.
     if [[ $hostonly ]]; then


### PR DESCRIPTION
## Changes
- move installation of libkmod.so from systemd module to udev-rules module

## Checklist
- [x] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it

Downstream bug report: https://bugs.gentoo.org/935548