### PR TITLE
feat(systemd*): Include systemd config files from /usr/lib/systemd

### DIFF
--- a/modules.d/00systemd/module-setup.sh
+++ b/modules.d/00systemd/module-setup.sh
@@ -42,6 +42,8 @@ install() {
         "$systemdutildir"/system-generators/systemd-debug-generator \
         "$systemdutildir"/system-generators/systemd-fstab-generator \
         "$systemdutildir"/system-generators/systemd-gpt-auto-generator \
+        "$systemdutildir"/system.conf \
+        "$systemdutildir"/system.conf.d/*.conf \
         "$systemdsystemunitdir"/debug-shell.service \
         "$systemdsystemunitdir"/cryptsetup.target \
         "$systemdsystemunitdir"/cryptsetup-pre.target \
@@ -94,8 +96,8 @@ install() {
 
     if [[ $hostonly ]]; then
         inst_multiple -H -o \
-            /etc/systemd/system.conf \
-            /etc/systemd/system.conf.d/*.conf \
+            "$systemdutilconfdir"/system.conf \
+            "$systemdutilconfdir"/system.conf.d/*.conf \
             /etc/hosts \
             /etc/hostname \
             /etc/nsswitch.conf \

--- a/modules.d/01systemd-coredump/module-setup.sh
+++ b/modules.d/01systemd-coredump/module-setup.sh
@@ -35,6 +35,7 @@ install() {
     inst_multiple -o \
         "$sysctld"/50-coredump.conf \
         "$systemdutildir"/coredump.conf \
+        "$systemdutildir/coredump.conf.d/*.conf" \
         "$systemdutildir"/systemd-coredump \
         "$systemdsystemunitdir"/systemd-coredump.socket \
         "$systemdsystemunitdir"/systemd-coredump@.service \
@@ -52,7 +53,7 @@ install() {
     if [[ $hostonly ]]; then
         inst_multiple -H -o \
             "$systemdutilconfdir"/coredump.conf \
-            "$systemdsystemconfdir/coredump.conf.d/*.conf" \
+            "$systemdutilconfdir/coredump.conf.d/*.conf" \
             "$systemdsystemconfdir"/systemd-coredump.socket \
             "$systemdsystemconfdir/systemd-coredump.socket.d/*.conf" \
             "$systemdsystemconfdir"/systemd-coredump@.service \

--- a/modules.d/01systemd-pstore/module-setup.sh
+++ b/modules.d/01systemd-pstore/module-setup.sh
@@ -34,6 +34,8 @@ install() {
     inst_dir /var/lib/systemd/pstore
     inst_multiple -o \
         "$tmpfilesdir/systemd-pstore.conf" \
+        "$systemdutildir"/pstore.conf \
+        "$systemdutildir/pstore.conf.d/*.conf" \
         "$systemdutildir"/systemd-pstore \
         "$systemdsystemunitdir"/systemd-pstore.service \
         "$systemdsystemunitdir/systemd-pstore.service.d/*.conf"

--- a/modules.d/01systemd-resolved/module-setup.sh
+++ b/modules.d/01systemd-resolved/module-setup.sh
@@ -50,6 +50,7 @@ install() {
     # Install the hosts local user configurations if enabled.
     if [[ $hostonly ]]; then
         inst_multiple -H -o \
+            "$systemdutilconfdir"/resolv.conf \
             "$systemdutilconfdir"/resolved.conf \
             "$systemdutilconfdir/resolved.conf.d/*.conf" \
             "$systemdsystemconfdir"/systemd-resolved.service \

--- a/modules.d/01systemd-timesyncd/module-setup.sh
+++ b/modules.d/01systemd-timesyncd/module-setup.sh
@@ -40,6 +40,7 @@ install() {
         "$systemdntpunits/*.list" \
         "$systemdutildir"/systemd-timesyncd \
         "$systemdutildir"/systemd-time-wait-sync \
+        "$systemdutildir"/timesyncd.conf \
         "$systemdutildir/timesyncd.conf.d/*.conf" \
         "$systemdsystemunitdir"/systemd-timesyncd.service \
         "$systemdsystemunitdir/systemd-timesyncd.service.d/*.conf" \


### PR DESCRIPTION
and also use proper variables for the paths.

## Changes

The new systemd reads from both /etc and /usr/, so to accomodate this, I've added new paths to install configs from (I probably haven't covered all). This changes only hostonly behaviour; uses global variables:

```
# dracut.sh
set_global_var "systemd" "systemdutildir" "/lib/systemd:/lib/systemd/systemd-udevd" "/usr/lib/systemd:/usr/lib/systemd/systemd-udevd"
set_global_var "systemd" "systemdutilconfdir" "/etc/systemd"
```
(also defined in the config `/usr/lib/dracut/dracut.conf.d/01-dist.conf`)

Ref: https://issues.redhat.com/browse/RHEL-32506

## Checklist
- [x] I have tested it locally
```bash
# F41 (vagrant; cloud variant):
[root@localhost ~]# lsinitrd | grep system.conf
-rw-r--r--   1 root     root         2342 Jun  2 00:00 usr/lib/systemd/system.conf

# F40 (VM, server variant):
~ lsinitrd | grep system.conf
-rw-r--r--   1 root     root         2124 Mar 10 20:00 etc/systemd/system.conf
-rw-r--r--   1 root     root         2318 May  8 20:00 usr/lib/systemd/system.conf
drwxr-xr-x   2 root     root            0 Jun  3 20:00 usr/lib/systemd/system.conf.d
-rw-r--r--   1 root     root          217 Apr 11 20:00 usr/lib/systemd/system.conf.d/longer-default-shutdown-timeout.conf

# Rawhide (workstation):
$ sudo lsinitrd /boot/initramfs-6.10.0-64.fc41.x86_64.img | grep systemd\.conf
-rw-r--r--   1 root     root          124 Jun  4 02:00 etc/conf.d/systemd.conf
-rw-r--r--   1 root     root          773 Sep 27  2023 usr/lib/modprobe.d/systemd.conf
-rw-r--r--   1 root     root         2289 Sep 27  2023 usr/lib/tmpfiles.d/systemd.conf
```
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it
