### PR TITLE
fix(lsinitrd): check skipcpio file directly

### DIFF
--- a/lsinitrd.sh
+++ b/lsinitrd.sh
@@ -347,7 +347,7 @@ case $bin in
                 echo "Early CPIO image"
                 list_files
             fi
-            if [[ -d "$dracutbasedir/src/skipcpio" ]]; then
+            if [[ -f "$dracutbasedir/src/skipcpio/skipcpio" ]]; then
                 SKIP="$dracutbasedir/src/skipcpio/skipcpio"
             else
                 SKIP="$dracutbasedir/skipcpio"


### PR DESCRIPTION
as the folder in /usr/lib/dracut/src might just exist; but the file might not.

## Changes

`lsinitrd` currently checks for directory existence, and assumes the file is just there; but that might not be the case. I have changed the check to explicitly check for the file in that folder. No behaviour change.

## Checklist
- [x] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it