### PR TITLE
chore(github): use committer team for code owners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -5,4 +5,4 @@
 # the repo. Unless a later match takes precedence,
 # @global-owner1 and @global-owner2 will be requested for
 # review when someone opens a pull request.
-*       @laszlogombos @Conan-Kudo
+*       @dracut-ng/committers


### PR DESCRIPTION
By using a GitHub team for the CODEOWNERS file, we can easily add and remove people through the interface for global committers and avoid unnecessary churn.