### PR TITLE
support kernels without initrd

### DIFF
--- a/dracut-functions.sh
+++ b/dracut-functions.sh
@@ -732,6 +732,11 @@ fs_get_option() {
 check_kernel_config() {
     local _config_opt="$1"
     local _config_file
+
+    # If $no_kernel is set, $kernel will point to the running kernel.
+    # Avoid reading the current kernel config by mistake.
+    [[ $no_kernel == yes ]] && return 0
+
     [[ -f $dracutsysrootdir/boot/config-$kernel ]] \
         && _config_file="/boot/config-$kernel"
     [[ -f $dracutsysrootdir/lib/modules/$kernel/config ]] \

--- a/dracut-functions.sh
+++ b/dracut-functions.sh
@@ -737,16 +737,26 @@ check_kernel_config() {
     # Avoid reading the current kernel config by mistake.
     [[ $no_kernel == yes ]] && return 0
 
-    [[ -f $dracutsysrootdir/boot/config-$kernel ]] \
-        && _config_file="/boot/config-$kernel"
-    [[ -f $dracutsysrootdir/lib/modules/$kernel/config ]] \
-        && _config_file="/lib/modules/$kernel/config"
+    local _config_paths=(
+        "/lib/modules/$kernel/config"
+        "/lib/modules/$kernel/build/.config"
+        "/lib/modules/$kernel/source/.config"
+        "/usr/src/linux-$kernel/.config"
+        "/boot/config-$kernel"
+    )
+
+    for _config in "${_config_paths[@]}"; do
+        if [[ -f $dracutsysrootdir$_config ]]; then
+            _config_file="$_config"
+            break
+        fi
+    done
 
     # no kernel config file, so return true
     [[ $_config_file ]] || return 0
 
-    grep -q -F "${_config_opt}=" "$dracutsysrootdir$_config_file" && return 0
-    return 1
+    grep -q "^${_config_opt}=" "$dracutsysrootdir$_config_file"
+    return $?
 }
 
 # 0 if the kernel module is either built-in or available

--- a/dracut.sh
+++ b/dracut.sh
@@ -1334,6 +1334,11 @@ if ! [[ $print_cmdline ]]; then
     rm -fr -- "${initdir:?}"/*
 fi
 
+if ! check_kernel_config CONFIG_BLK_DEV_INITRD; then
+    echo "This kernel doesn't support initramfs, skipping generation"
+    exit 0
+fi
+
 dracutfunctions=$dracutbasedir/dracut-functions.sh
 export dracutfunctions
 


### PR DESCRIPTION
If the installed kernel has no initrd support, skip the image creation.

This pull request changes...

## Changes

## Checklist
- [x] I have tested it locally
- [x] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it

Fixes #
