### PR TITLE
test(RAID-DEG): make it not flaky

### DIFF
--- a/test/TEST-12-RAID-DEG/test.sh
+++ b/test/TEST-12-RAID-DEG/test.sh
@@ -97,8 +97,7 @@ test_setup() {
     chmod 0600 /tmp/key
 
     test_dracut \
-        -a "crypt lvm mdraid" \
-        -o "systemd" \
+        -m "bash crypt lvm mdraid kernel-modules" \
         -i "./cryptroot-ask.sh" "/sbin/cryptroot-ask" \
         -i "/tmp/mdadm.conf" "/etc/mdadm.conf" \
         -i "/tmp/crypttab" "/etc/crypttab" \


### PR DESCRIPTION
## Changes

130f4dfce48b187944be9a0cacca794dd32428ad inadvertently made this test flaky by including additional dracut modules not required to pass the test.

This PR should restore stable CI, but it masks some instabilities that will be tracked as part of https://github.com/dracut-ng/dracut-ng/issues/491.

## Checklist
- [ ] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it

