### PR TITLE
fix(watchdog): change the priority of watchdog kernel modules

### DIFF
--- a/modules.d/04watchdog/watchdog.sh
+++ b/modules.d/04watchdog/watchdog.sh
@@ -7,6 +7,6 @@ if [ -e /dev/watchdog ]; then
     info "Triggering watchdog"
     : > /dev/watchdog
 else
-    modprobe ib700wdt
     modprobe i6300esb
+    modprobe ib700wdt
 fi


### PR DESCRIPTION
## Changes

i6300esb should be prioritized over ib700wdt.

The recommended watchdog device is i6300esb, see https://libvirt.org/formatdomain.html#watchdog-devices.

Follow-up to f0a7fc5b4 .

As the CI is using the `watchdog` module, should should make the CI more stable as well and eliminates the following warning

```
[    0.757152] watchdog: i6300ESB timer: cannot register miscdev on minor=130 (err=-16).
[    0.757902] watchdog: i6300ESB timer: a legacy watchdog module is probably present.
[    1.042544] ib700wdt: WDT device closed unexpectedly.  WDT will not stop!
```

## Checklist
- [ ] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it

