### PR TITLE
feat: add common config when networking is not desired

### DIFF
--- a/dracut.conf.d/50-no-network.conf.example
+++ b/dracut.conf.d/50-no-network.conf.example
@@ -1,0 +1,3 @@
+# ensure networking is not included in the generated initrd
+# all networking dracut modules either depend on net-lib or systemd-networkd
+omit_dracutmodules+=" net-lib systemd-networkd "


### PR DESCRIPTION
## Changes

This is especially useful for distributions like Arch or Gentoo that do not package networking dracut modules into its own package.

Earlier relevant discussion for context: https://github.com/dracut-ng/dracut-ng/pull/297#issuecomment-2123395363

## Checklist
- [ ] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it

