### PR TITLE
fix(Makefile): install dracut config examples under /usr/lib/dracut/dracut.conf.d

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -167,7 +167,7 @@ install: all
 	ln -fs dracut-functions.sh $(DESTDIR)$(pkglibdir)/dracut-functions
 	install -m 0755 dracut-logger.sh $(DESTDIR)$(pkglibdir)/dracut-logger.sh
 	install -m 0755 dracut-initramfs-restore.sh $(DESTDIR)$(pkglibdir)/dracut-initramfs-restore
-	cp -arx modules.d $(DESTDIR)$(pkglibdir)
+	cp -arx modules.d dracut.conf.d $(DESTDIR)$(pkglibdir)
 ifneq ($(enable_documentation),no)
 	for i in $(man1pages); do install -m 0644 $$i $(DESTDIR)$(mandir)/man1/$${i##*/}; done
 	for i in $(man5pages); do install -m 0644 $$i $(DESTDIR)$(mandir)/man5/$${i##*/}; done


### PR DESCRIPTION
## Changes

This PR allows users and distributions to discover configuration examples and take advantage of them either during packaging or during using dracut.

## Checklist
- [ ] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it

