### PR TITLE
feat(shell-interpreter): meta package for improved shell selection

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -554,6 +554,10 @@ pcmcia:
   - changed-files:
     - any-glob-to-any-file: 'modules.d/90pcmcia/*'
 
+shell-interpreter:
+  - changed-files:
+    - any-glob-to-any-file: 'modules.d/00shell-interpreter/*'
+
 test:
   - changed-files:
     - any-glob-to-any-file: ['test/*', 'test/**/*', 'modules.d/80test*', 'modules.d/80test*/*']

--- a/modules.d/00shell-interpreter/module-setup.sh
+++ b/modules.d/00shell-interpreter/module-setup.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+# This file is part of dracut.
+# SPDX-License-Identifier: GPL-2.0-or-later
+
+# Module dependency requirements.
+depends() {
+    # priority order
+    shells='bash dash busybox'
+
+    for shell in $shells; do
+        if dracut_module_included "$shell"; then
+            echo "$shell"
+            return 0
+        fi
+    done
+
+    shell=$(realpath /bin/sh)
+    shell=${shell##*/}
+
+    echo "$shell"
+    return 0
+}

--- a/modules.d/05busybox/module-setup.sh
+++ b/modules.d/05busybox/module-setup.sh
@@ -14,18 +14,8 @@ depends() {
 
 # called by dracut
 install() {
-    local _i _path _busybox
-    local _progs=()
+    local _busybox
     _busybox=$(find_binary busybox)
     inst "$_busybox" /usr/bin/busybox
-    for _i in $($_busybox --list); do
-        [[ ${_i} == busybox ]] && continue
-        _progs+=("${_i}")
-    done
-
-    for _i in "${_progs[@]}"; do
-        _path=$(find_binary "$_i")
-        [ -z "$_path" ] && continue
-        ln_r /usr/bin/busybox "$_path"
-    done
+    $_busybox --install -s /bin/
 }

--- a/modules.d/80test-makeroot/module-setup.sh
+++ b/modules.d/80test-makeroot/module-setup.sh
@@ -6,7 +6,7 @@ check() {
 }
 
 depends() {
-    echo "dash rootfs-block kernel-modules qemu"
+    echo "rootfs-block kernel-modules qemu"
 }
 
 installkernel() {

--- a/modules.d/99base/module-setup.sh
+++ b/modules.d/99base/module-setup.sh
@@ -7,7 +7,7 @@ check() {
 
 # called by dracut
 depends() {
-    echo udev-rules
+    echo udev-rules shell-interpreter
     return 0
 }
 

--- a/test/TEST-12-RAID-DEG/test.sh
+++ b/test/TEST-12-RAID-DEG/test.sh
@@ -97,7 +97,7 @@ test_setup() {
     chmod 0600 /tmp/key
 
     test_dracut \
-        -m "bash crypt lvm mdraid kernel-modules" \
+        -m "crypt lvm mdraid kernel-modules" \
         -i "./cryptroot-ask.sh" "/sbin/cryptroot-ask" \
         -i "/tmp/mdadm.conf" "/etc/mdadm.conf" \
         -i "/tmp/crypttab" "/etc/crypttab" \

--- a/test/TEST-16-DMSQUASH/test.sh
+++ b/test/TEST-16-DMSQUASH/test.sh
@@ -149,7 +149,7 @@ SUBSYSTEM=="block", ENV{ID_FS_TYPE}=="ntfs", ENV{ID_FS_TYPE}="ntfs3"
 EOF
 
     test_dracut \
-        --add "dash dmsquash-live qemu" \
+        --add "dmsquash-live qemu" \
         --omit "systemd" \
         --drivers "ntfs3" \
         --install "mkfs.ext4" \

--- a/test/TEST-30-ISCSI/test.sh
+++ b/test/TEST-30-ISCSI/test.sh
@@ -212,7 +212,7 @@ test_setup() {
 
     # Make server's dracut image
     "$DRACUT" -l \
-        -a "dash rootfs-block test kernel-modules ${USE_NETWORK}" \
+        -a "rootfs-block test kernel-modules ${USE_NETWORK}" \
         -d "piix ide-gd_mod ata_piix ext4 sd_mod e1000 drbg virtio_pci virtio_scsi" \
         -i "./server.link" "/etc/systemd/network/01-server.link" \
         -i ./wait-if-server.sh /lib/dracut/hooks/pre-mount/99-wait-if-server.sh \

--- a/test/TEST-35-ISCSI-MULTI/test.sh
+++ b/test/TEST-35-ISCSI-MULTI/test.sh
@@ -232,7 +232,7 @@ test_setup() {
 
     # Make server's dracut image
     "$DRACUT" -l -i "$TESTDIR"/overlay / \
-        -a "test dash rootfs-block debug kernel-modules ${USE_NETWORK}" \
+        -a "test rootfs-block debug kernel-modules ${USE_NETWORK}" \
         -d "af_packet piix ide-gd_mod ata_piix ext4 sd_mod e1000 drbg" \
         -i "./server.link" "/etc/systemd/network/01-server.link" \
         -i "./wait-if-server.sh" "/lib/dracut/hooks/pre-mount/99-wait-if-server.sh" \


### PR DESCRIPTION
## Changes

cherry-pick the dracut module from https://github.com/dracutdevs/dracut/pull/2564 and use it to improve the CI and demonstrate the usefulness of this new dracut module and fix all the exposed bugs.

If dash and busybox is NOT installed or **bash module gets included explicitly (as it happens always when systemd gets included), this module should have no impact in the generated initramfs.** 

The module is independent and additive - a distribution might decide not to package the module with core dracut modules.

One notable side effect of this PR is that now the CI has test coverage for the `busybox` dracut module (without explicitly mentioning `busybox` in any of the test case), since the on Alpine `/bin/sh` points to `busybox`. Getting test coverage without adding a lot of code is very useful. As an example `01 on alpine` test now boots using busybox in the generated initrd.

**One valuable side effect of this change is that CI no longer requires `dash` so a distribution can decide not to package the `dash` dracut module and still run the CI tests downstream.** 

## Checklist
- [x] I have tested it locally
- [x] I have reviewed and updated any documentation if relevant
- [x] I am providing new code and test(s) for it

Fixes #522
