### PR TITLE
revert(crypt): do not  unlock encrypted devices by default during boot

### DIFF
--- a/modules.d/90crypt/parse-crypt.sh
+++ b/modules.d/90crypt/parse-crypt.sh
@@ -174,7 +174,7 @@ else
                 } >> "$hookdir/emergency/90-crypt.sh"
             fi
         done
-    elif getargbool 1 rd.auto && [ -z "$(getargs rd.luks.name)" ]; then
+    elif getargbool 0 rd.auto; then
         if [ -z "$DRACUT_SYSTEMD" ]; then
             {
                 printf -- 'ENV{ID_FS_TYPE}=="crypto_LUKS", RUN+="%s ' "$(command -v initqueue)"


### PR DESCRIPTION
## Changes

This reverts commit 2339acfaeee60d6bb26a1103db2e53bc8f9cb2d1.

This change needs more test cases and more granular conditionals.

## Checklist
- [ ] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it

Fixes #492 , Reopens #255
