### PR TITLE
test(RAID-DEG): make it not flaky

### DIFF
--- a/test/TEST-12-RAID-DEG/test.sh
+++ b/test/TEST-12-RAID-DEG/test.sh
@@ -21,7 +21,7 @@ client_run() {
     test_marker_reset
     "$testdir"/run-qemu \
         "${disk_args[@]}" \
-        -append "$TEST_KERNEL_CMDLINE $* systemd.log_target=kmsg root=LABEL=root rw log_buf_len=2M systemd.mask=systemd-vconsole-setup" \
+        -append "$TEST_KERNEL_CMDLINE $* systemd.log_target=kmsg root=LABEL=root ro log_buf_len=2M systemd.mask=systemd-vconsole-setup" \
         -initrd "$TESTDIR"/initramfs.testing
 
     if ! test_marker_check; then

--- a/test/test-functions
+++ b/test/test-functions
@@ -98,6 +98,7 @@ qemu_add_drive() {
 
     if [ "${size}" -ne 0 ]; then
         dd if=/dev/zero of="${file}" bs=1MiB count="${size}" status=none
+        sync
     fi
 
     eval "${2}"'+=(' \
@@ -112,6 +113,7 @@ qemu_add_drive() {
 
 test_marker_reset() {
     dd if=/dev/zero of="$TESTDIR"/marker.img bs=1MiB count=1 status=none
+    sync
 }
 
 test_marker_check() {


### PR DESCRIPTION
## Changes

- mount rootfs read-only to avoid subtests to interfere
- make sure test marker is reset properly. sync explicitly to flush cashes. Used `sync` as some of the `dd` arguments are not portable (for the `busybox` `dd` implementation).

## Checklist
- [x] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it

