### PR TITLE
fix(man): update description of the --gzip option

### DIFF
--- a/man/dracut.8.asc
+++ b/man/dracut.8.asc
@@ -436,9 +436,13 @@ example:
     Install the space separated list of files into the initramfs, if they exist.
 
 **--gzip**::
-    Compress the generated initramfs using gzip. This will be done by default,
-    unless another compression option or --no-compress is passed. Equivalent to
-    "--compress=gzip -9".
+    Compress the generated initramfs using gzip.
++
+[WARNING]
+====
+Make sure your kernel has gzip decompression support compiled in, otherwise you
+will not be able to boot. Equivalent to "--compress=gzip -9".
+====
 
 **--bzip2**::
     Compress the generated initramfs using bzip2.


### PR DESCRIPTION
dracut no longer defaults to gzip. There is a list of compressors and the first available is used. See 9663307c and 693b7a32.

Add a warning about kernel support for gzip decompression, similar to all of the other compressor options.