### PR TITLE
ci: install systemd-experimental  into openSUSE container

### DIFF
--- a/test/container/Dockerfile-OpenSuse-latest
+++ b/test/container/Dockerfile-OpenSuse-latest
@@ -43,6 +43,7 @@ RUN dnf -y install --setopt=install_weak_deps=False \
     squashfs \
     strace \
     systemd-boot \
+    systemd-experimental \
     tar \
     tcpdump \
     tgt \


### PR DESCRIPTION
## Changes

This PR is required to run FULL-SYSTEMD on openSUSE. Test will pass once the CI container gets regenerated.

Reference: https://software.opensuse.org/package/systemd-experimental

## Checklist
- [ ] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it

Fixes #
