### PR TITLE
ci: do not remove native dracut installation from the test containers

### DIFF
--- a/test/container/Dockerfile-Debian
+++ b/test/container/Dockerfile-Debian
@@ -65,4 +65,4 @@ RUN apt-get update -y -qq && apt-get upgrade -y -qq && apt-get install -y -qq --
     tpm2-tools \
     vim \
     wget \
-    && apt-get clean && dpkg -P --force-depends dracut dracut-core initramfs-tools-core
+    && apt-get clean

--- a/test/container/Dockerfile-Fedora-latest
+++ b/test/container/Dockerfile-Fedora-latest
@@ -69,4 +69,4 @@ RUN dnf -y install --setopt=install_weak_deps=False \
     tpm2-tools \
     wget \
     xz \
-    && dnf -y remove dracut --noautoremove && dnf -y update && dnf clean all
+    && dnf -y update && dnf clean all

--- a/test/container/Dockerfile-OpenSuse-latest
+++ b/test/container/Dockerfile-OpenSuse-latest
@@ -52,4 +52,4 @@ RUN dnf -y install --setopt=install_weak_deps=False \
     util-linux-systemd \
     wget \
     xz \
-    && rpm -e --nodeps dracut && dnf -y update && dnf clean all
+    && dnf -y update && dnf clean all


### PR DESCRIPTION
## Changes

The change allows the CI to pick up distribution config from the dracut package.

CI should be able to run not only in pristine default configuration, but also in the configuration that the distribution set as the default.

As an example Fedora CI should run tests in hostonly mode (unless specified otherwise).

Without this change some containers (e.g. Void, Ubunut, Arch) has the native dracut package installed and some do not (e.g. Fedora).

## Checklist
- [ ] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it

Fixes #
