### PR TITLE
test: run ci with distro configuration from the host

### DIFF
--- a/test/TEST-16-DMSQUASH/test.sh
+++ b/test/TEST-16-DMSQUASH/test.sh
@@ -149,6 +149,7 @@ SUBSYSTEM=="block", ENV{ID_FS_TYPE}=="ntfs", ENV{ID_FS_TYPE}="ntfs3"
 EOF
 
     test_dracut \
+        --no-hostonly \
         --add "dmsquash-live qemu" \
         --omit "systemd" \
         --drivers "ntfs3" \
@@ -157,6 +158,7 @@ EOF
         "$TESTDIR"/initramfs.testing
 
     test_dracut \
+        --no-hostonly \
         --add "dmsquash-live-autooverlay qemu" \
         --omit "systemd" \
         --install "mkfs.ext4" \

--- a/test/TEST-20-NFS/test.sh
+++ b/test/TEST-20-NFS/test.sh
@@ -401,6 +401,7 @@ test_setup() {
 
     # Make client's dracut image
     test_dracut \
+        --no-hostonly --no-hostonly-cmdline \
         -a "dmsquash-live ${USE_NETWORK}" \
         "$TESTDIR"/initramfs.testing
 

--- a/test/TEST-30-ISCSI/test.sh
+++ b/test/TEST-30-ISCSI/test.sh
@@ -221,6 +221,7 @@ test_setup() {
 
     # Make client's dracut image
     test_dracut \
+        --no-hostonly --no-hostonly-cmdline \
         --add "$USE_NETWORK" \
         --include "./client.link" "/etc/systemd/network/01-client.link" \
         --kernel-cmdline "rw rd.auto rd.retry=50" \

--- a/test/TEST-35-ISCSI-MULTI/test.sh
+++ b/test/TEST-35-ISCSI-MULTI/test.sh
@@ -226,6 +226,7 @@ test_setup() {
 
     # Make client's dracut image
     test_dracut \
+        --no-hostonly --no-hostonly-cmdline \
         --add "$USE_NETWORK" \
         -i "./client.link" "/etc/systemd/network/01-client.link" \
         "$TESTDIR"/initramfs.testing

--- a/test/TEST-40-NBD/test.sh
+++ b/test/TEST-40-NBD/test.sh
@@ -332,6 +332,7 @@ test_setup() {
     echo -n test > /tmp/key
 
     test_dracut \
+        --no-hostonly --no-hostonly-cmdline \
         -a "${USE_NETWORK}" \
         -i "./cryptroot-ask.sh" "/sbin/cryptroot-ask" \
         -i "./client.link" "/etc/systemd/network/01-client.link" \

--- a/test/TEST-50-MULTINIC/test.sh
+++ b/test/TEST-50-MULTINIC/test.sh
@@ -340,6 +340,7 @@ test_setup() {
     )
     # Make client's dracut image
     test_dracut \
+        --no-hostonly --no-hostonly-cmdline \
         -a "${USE_NETWORK}" \
         "$TESTDIR"/initramfs.testing
 

--- a/test/TEST-60-BONDBRIDGEVLAN/test.sh
+++ b/test/TEST-60-BONDBRIDGEVLAN/test.sh
@@ -367,6 +367,7 @@ test_setup() {
     )
     # Make client's dracut image
     test_dracut \
+        --no-hostonly --no-hostonly-cmdline \
         -a "debug ${USE_NETWORK} ifcfg" \
         "$TESTDIR"/initramfs.testing
 

--- a/test/container/Dockerfile-Fedora-latest
+++ b/test/container/Dockerfile-Fedora-latest
@@ -70,3 +70,9 @@ RUN dnf -y install --setopt=install_weak_deps=False \
     wget \
     xz \
     && dnf -y update && dnf clean all
+
+# discard configurations that enforce an out-of-tree dracut module
+# which would break test automation
+# since this is a distro specific change, lets do it in the container
+RUN \
+  rm -rf /usr/lib/dracut/dracut.conf.d/50-nss-softokn.conf

--- a/test/container/Dockerfile-OpenSuse-latest
+++ b/test/container/Dockerfile-OpenSuse-latest
@@ -53,3 +53,8 @@ RUN dnf -y install --setopt=install_weak_deps=False \
     wget \
     xz \
     && dnf -y update && dnf clean all
+
+# configuration in the package is not compatible
+# with the upstream CI, lets remove it
+RUN \
+  rm -rf /usr/lib/dracut/dracut.conf.d

--- a/test/test-functions
+++ b/test/test-functions
@@ -25,7 +25,16 @@ if [[ $V != "1" && $V != "2" ]]; then
 fi
 
 test_dracut() {
-    TEST_DRACUT_ARGS+=" --local --no-early-microcode --add test --force --kver $KVERSION"
+    # directory for test configurations
+    mkdir -p /tmp/dracut.conf.d
+
+    # grab the distro configuration from the host and make it available for the tests
+    if [ -d /usr/lib/dracut/dracut.conf.d ]; then
+        cp -a /usr/lib/dracut/dracut.conf.d /tmp/
+    fi
+
+    # pick up configuration from /tmp/dracut.conf.d when running the tests
+    TEST_DRACUT_ARGS+=" --local --confdir /tmp/dracut.conf.d --no-early-microcode --add test --force --kver $KVERSION"
 
     # include $TESTDIR"/overlay if exists
     if [ -d "$TESTDIR"/overlay ]; then

--- a/test/test-functions
+++ b/test/test-functions
@@ -25,7 +25,7 @@ if [[ $V != "1" && $V != "2" ]]; then
 fi
 
 test_dracut() {
-    TEST_DRACUT_ARGS+=" --local --no-hostonly --no-hostonly-cmdline --no-early-microcode --add test --force --kver $KVERSION"
+    TEST_DRACUT_ARGS+=" --local --no-early-microcode --add test --force --kver $KVERSION"
 
     # include $TESTDIR"/overlay if exists
     if [ -d "$TESTDIR"/overlay ]; then


### PR DESCRIPTION
## Changes

1./  test: do not force no-hostonly for all test runs
Different distributions and containers might prefer different defaults.
The motivation of this work is to increase test coverage and to run the tests in the same configurations as dracut is used.

2./ test: grab the distro configuration from the host and make it available to the tests
Fix failing test cases by enforcing no-hostonly for those tests cases that need it.   

3./ ci: remove dracut native config that is not compatible with upstream ci from the container                                                                                                            

## Checklist
- [x] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it

Fixes #543
