### PR TITLE
feat(squash): Add support for erofs

### DIFF
--- a/dracut-init.sh
+++ b/dracut-init.sh
@@ -882,6 +882,9 @@ check_mount() {
         fi
     fi
 
+    [[ " $mods_to_load " == *\ $_mod\ * ]] \
+        || mods_to_load+=" $_mod "
+
     for _moddep in $(module_depends "$_mod" "$_moddir"); do
         # handle deps as if they were manually added
         [[ " $dracutmodules " == *\ $_mod\ * ]] \
@@ -899,9 +902,6 @@ check_mount() {
             return 1
         fi
     done
-
-    [[ " $mods_to_load " == *\ $_mod\ * ]] \
-        || mods_to_load+=" $_mod "
 
     return 0
 }
@@ -957,6 +957,9 @@ check_module() {
         fi
     fi
 
+    [[ " $mods_to_load " == *\ $_mod\ * ]] \
+        || mods_to_load+=" $_mod "
+
     for _moddep in $(module_depends "$_mod" "$_moddir"); do
         # handle deps as if they were manually added
         [[ " $dracutmodules " == *\ $_mod\ * ]] \
@@ -974,9 +977,6 @@ check_module() {
             return 1
         fi
     done
-
-    [[ " $mods_to_load " == *\ $_mod\ * ]] \
-        || mods_to_load+=" $_mod "
 
     return 0
 }

--- a/dracut-initramfs-restore.sh
+++ b/dracut-initramfs-restore.sh
@@ -81,9 +81,15 @@ else
     exit 1
 fi
 
-if [[ -d squash ]]; then
-    if ! unsquashfs -no-xattrs -f -d . squash-root.img > /dev/null; then
+if [[ -f squashfs-root.img ]]; then
+    if ! unsquashfs -no-xattrs -f -d . squashfs-root.img > /dev/null; then
         echo "Squash module is enabled for this initramfs but failed to unpack squash-root.img" >&2
+        rm -f -- /run/initramfs/shutdown
+        exit 1
+    fi
+elif [[ -f erofs-root.img ]]; then
+    if ! fsck.erofs --extract=. --overwrite erofs-root.img > /dev/null; then
+        echo "Squash module is enabled for this initramfs but failed to unpack erofs-root.img" >&2
         rm -f -- /run/initramfs/shutdown
         exit 1
     fi

--- a/dracut.sh
+++ b/dracut.sh
@@ -1260,6 +1260,7 @@ trap '
 trap 'exit 1;' SIGINT
 
 readonly initdir="${DRACUT_TMPDIR}/initramfs"
+readonly squashdir="$initdir/squash_root"
 mkdir -p "$initdir"
 
 if [[ $early_microcode == yes ]] || { [[ $acpi_override == yes ]] && [[ -d $acpi_table_dir ]]; }; then
@@ -1787,7 +1788,8 @@ export initdir dracutbasedir \
     host_fs_types host_devs swap_devs sshkey add_fstab \
     DRACUT_VERSION \
     prefix filesystems drivers \
-    hostonly_cmdline loginstall
+    hostonly_cmdline loginstall \
+    squashdir squash_compress
 
 mods_to_load=""
 # check all our modules to see if they should be sourced.
@@ -1891,6 +1893,8 @@ if [[ $kernel_only != yes ]]; then
         [[ -c ${initdir}/dev/urandom ]] || mknod "${initdir}"/dev/urandom c 1 9
     fi
 fi
+
+dracut_module_included "squash" && mkdir -p "$squashdir"
 
 _isize=0 #initramfs size
 modules_loaded=" "
@@ -2243,14 +2247,6 @@ if [[ $kernel_only != yes ]]; then
     build_ld_cache
 fi
 
-if dracut_module_included "squash"; then
-    readonly squash_dir="$initdir/squash/root"
-    readonly squash_img="$initdir/squash-root.img"
-    mkdir -p "$squash_dir"
-    dinfo "*** Install squash loader ***"
-    DRACUT_SQUASH_POST_INST=1 module_install "squash"
-fi
-
 if [[ $do_strip == yes ]] && ! [[ $DRACUT_FIPS_MODE ]]; then
     # stripping files negates (dedup) benefits of using reflink
     [[ -n $enhanced_cpio ]] && ddebug "strip is enabled alongside cpio reflink"
@@ -2270,25 +2266,8 @@ fi
 
 if dracut_module_included "squash"; then
     dinfo "*** Squashing the files inside the initramfs ***"
-    declare squash_compress_arg
-    # shellcheck disable=SC2086
-    if [[ $squash_compress ]]; then
-        if ! mksquashfs /dev/null "$DRACUT_TMPDIR"/.squash-test.img -no-progress -comp $squash_compress &> /dev/null; then
-            dwarn "mksquashfs doesn't support compressor '$squash_compress', failing back to default compressor."
-        else
-            squash_compress_arg="$squash_compress"
-        fi
-    fi
-
-    # shellcheck disable=SC2086
-    if ! mksquashfs "$squash_dir" "$squash_img" \
-        -no-xattrs -no-exports -noappend -no-recovery -always-use-fragments \
-        -no-progress ${squash_compress_arg:+-comp $squash_compress_arg} 1> /dev/null; then
-        dfatal "Failed making squash image"
-        exit 1
-    fi
-
-    rm -rf "$squash_dir"
+    DRACUT_SQUASH_POST_INST=1 module_install "squash"
+    rm -rf "$squashdir"
     dinfo "*** Squashing the files inside the initramfs done ***"
 
     # Skip initramfs compress

--- a/modules.d/95squash-erofs/module-setup.sh
+++ b/modules.d/95squash-erofs/module-setup.sh
@@ -1,0 +1,45 @@
+#!/bin/bash
+
+check() {
+    require_binaries mkfs.erofs || return 1
+    require_kernel_modules erofs || return 1
+
+    return 255
+}
+
+depends() {
+    echo "squash"
+    return 0
+}
+
+erofs_install() {
+    hostonly="" instmods "erofs"
+}
+
+erofs_installpost() {
+    local _img="$squashdir/erofs-root.img"
+    local -a _erofs_args
+
+    _erofs_args+=("--exclude-path=$squashdir")
+    _erofs_args+=("-E" "fragments")
+
+    if [[ -n $squash_compress ]]; then
+        if mkfs.erofs "${_erofs_args[@]}" -z "$squash_compress" "$_img" "$initdir" &> /dev/null; then
+            return
+        fi
+        dwarn "mkfs.erofs doesn't support compressor '$squash_compress', failing back to default compressor."
+    fi
+
+    if ! mkfs.erofs "${_erofs_args[@]}" "$_img" "$initdir" &> /dev/null; then
+        dfatal "Failed making squash image"
+        exit 1
+    fi
+}
+
+install() {
+    if [[ $DRACUT_SQUASH_POST_INST ]]; then
+        erofs_installpost
+    else
+        dstdir="$squashdir" erofs_install
+    fi
+}

--- a/modules.d/95squash-erofs/module-setup.sh
+++ b/modules.d/95squash-erofs/module-setup.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 check() {
-    require_binaries mkfs.erofs || return 1
+    require_binaries mkfs.erofs fsck.erofs || return 1
     require_kernel_modules erofs || return 1
 
     return 255

--- a/modules.d/95squash-squashfs/module-setup.sh
+++ b/modules.d/95squash-squashfs/module-setup.sh
@@ -1,0 +1,48 @@
+#!/bin/bash
+
+check() {
+    require_binaries mksquashfs unsquashfs || return 1
+    require_kernel_modules squashfs || return 1
+
+    return 255
+}
+
+depends() {
+    echo "squash"
+    return 0
+}
+
+squashfs_install() {
+    hostonly="" instmods "squashfs"
+}
+
+squashfs_installpost() {
+    local _img="$squashdir/squashfs-root.img"
+    local _comp
+
+    # shellcheck disable=SC2086
+    if [[ $squash_compress ]]; then
+        if ! mksquashfs /dev/null "$DRACUT_TMPDIR"/.squash-test.img -no-progress -comp $squash_compress &> /dev/null; then
+            dwarn "mksquashfs doesn't support compressor '$squash_compress', failing back to default compressor."
+        else
+            _comp="$squash_compress"
+        fi
+    fi
+
+    # shellcheck disable=SC2086
+    if ! mksquashfs "$initdir" "$_img" \
+        -no-xattrs -no-exports -noappend -no-recovery -always-use-fragments \
+        -no-progress ${_comp:+-comp $_comp} \
+        -e "$squashdir" 1> /dev/null; then
+        dfatal "Failed making squash image"
+        exit 1
+    fi
+}
+
+install() {
+    if [[ $DRACUT_SQUASH_POST_INST ]]; then
+        squashfs_installpost
+    else
+        dstdir="$squashdir" squashfs_install
+    fi
+}

--- a/modules.d/99busybox/module-setup.sh
+++ b/modules.d/99busybox/module-setup.sh
@@ -10,6 +10,7 @@ check() {
 # called by dracut
 install() {
     local _i _path _busybox
+    local _dstdir="${dstdir:-"$initdir"}"
     local _progs=()
     _busybox=$(find_binary busybox)
     inst "$_busybox" /usr/bin/busybox
@@ -26,7 +27,7 @@ install() {
         [ -z "$_path" ] && continue
 
         # do not remove existing destination files
-        [ -e "${initdir}/$_path" ] && continue
+        [ -e "${_dstdir}/$_path" ] && continue
 
         ln_r /usr/bin/busybox "$_path"
     done

--- a/modules.d/99squash/init-squash.sh
+++ b/modules.d/99squash/init-squash.sh
@@ -13,15 +13,23 @@ grep -q '^devtmpfs /dev devtmpfs' /proc/self/mounts \
 grep -q '^tmpfs /run tmpfs' /proc/self/mounts \
     || (mkdir -p /run && mount -t tmpfs -o mode=755,noexec,nosuid,strictatime tmpfs /run)
 
+if [ -e /erofs-root.img ]; then
+    _fs=erofs
+    _img=erofs-root.img
+else
+    _fs=squashfs
+    _img=squashfs-root.img
+fi
+
 # Load required modules
 modprobe loop
-modprobe squashfs
+modprobe "$_fs"
 modprobe overlay
 
 # Mount the squash image
 mount -t ramfs ramfs /squash
 mkdir -p /squash/root /squash/overlay/upper /squash/overlay/work
-mount -t squashfs -o ro,loop /squashfs-root.img /squash/root
+mount -t "$_fs" -o ro,loop /"$_img" /squash/root
 
 # Setup new root overlay
 mkdir /newroot

--- a/modules.d/99squash/init-squash.sh
+++ b/modules.d/99squash/init-squash.sh
@@ -21,7 +21,7 @@ modprobe overlay
 # Mount the squash image
 mount -t ramfs ramfs /squash
 mkdir -p /squash/root /squash/overlay/upper /squash/overlay/work
-mount -t squashfs -o ro,loop /squash-root.img /squash/root
+mount -t squashfs -o ro,loop /squashfs-root.img /squash/root
 
 # Setup new root overlay
 mkdir /newroot

--- a/modules.d/99squash/module-setup.sh
+++ b/modules.d/99squash/module-setup.sh
@@ -18,7 +18,7 @@ depends() {
 squash_get_handler() {
     local _module _handler
 
-    for _module in squash-squashfs; do
+    for _module in squash-squashfs squash-erofs; do
         if dracut_module_included "$_module"; then
             _handler="$_module"
             break
@@ -28,6 +28,8 @@ squash_get_handler() {
     if [ -z "$_handler" ]; then
         if check_module "squash-squashfs"; then
             _handler="squash-squashfs"
+        elif check_module "squash-erofs"; then
+            _handler="squash-erofs"
         else
             dfatal "No valid handler for found"
             return 1

--- a/modules.d/99squash/module-setup.sh
+++ b/modules.d/99squash/module-setup.sh
@@ -52,10 +52,7 @@ squash_install() {
 
     # Install required modules and binaries for the squash image init script.
     if [[ $_busybox ]]; then
-        inst "$_busybox" /usr/bin/busybox
-        for _i in sh echo mount modprobe mkdir switch_root grep umount; do
-            ln_r /usr/bin/busybox /usr/bin/$_i
-        done
+        module_install "busybox"
     else
         DRACUT_RESOLVE_DEPS=1 inst_multiple sh mount modprobe mkdir switch_root grep umount
 

--- a/modules.d/99squash/module-setup.sh
+++ b/modules.d/99squash/module-setup.sh
@@ -40,12 +40,15 @@ squash_get_handler() {
 }
 
 squash_install() {
-    local _busybox
+    local _busybox _dir
     _busybox=$(find_binary busybox)
 
-    # Create mount points for squash loader
-    mkdir -p "$initdir"/squash/
-    mkdir -p "$squashdir"/squash/
+    # Create mount points for squash loader and basic directories
+    mkdir -p "$initdir"/squash
+    for _dir in squash usr/bin usr/sbin usr/lib; do
+        mkdir -p "$squashdir/$_dir"
+        [[ $_dir == usr/* ]] && ln_r "/$_dir" "${_dir#usr}"
+    done
 
     # Install required modules and binaries for the squash image init script.
     if [[ $_busybox ]]; then
@@ -67,8 +70,6 @@ squash_install() {
     dracut_kernel_post
 
     # Install squash image init script.
-    ln_r /usr/bin /bin
-    ln_r /usr/sbin /sbin
     inst_simple "$moddir"/init-squash.sh /init
 
     # make sure that library links are correct and up to date for squash loader


### PR DESCRIPTION
This pull request adds support for erofs for the 99squash module. For this it first cleans up the special handling needed in dracut.sh, then splits out the squashfs specific code into 95squash-squashfs and, finally adds a new 95squash-erofs module. The "new" 99squash module is designed in a way that it picks an appropriate back end automatically if added directly and none of the back ends is provided. Default is to use squashfs to keep the current behavior.

There are still some small things to do in lsinitrd and dracut-rescue-initramfs. Nevertheless, it would be good to get some feedback about the overall approach.