### PR TITLE
fix(dracut-install): do not assume handled path starts with sysrootdir

### DIFF
--- a/src/install/dracut-install.c
+++ b/src/install/dracut-install.c
@@ -885,7 +885,10 @@ static int dracut_install(const char *orig_src, const char *orig_dst, bool isdir
         if (ret == 0) {
                 if (resolvedeps && S_ISREG(sb.st_mode) && (sb.st_mode & (S_IXUSR | S_IXGRP | S_IXOTH))) {
                         log_debug("'%s' already exists, but checking for any deps", fulldstpath);
-                        ret = resolve_deps(fullsrcpath + sysrootdirlen);
+                        if (sysrootdirlen && (strncmp(fulldstpath, sysrootdir, sysrootdirlen) == 0))
+                                ret = resolve_deps(fulldstpath + sysrootdirlen);
+                        else
+                                ret = resolve_deps(fullsrcpath);
                 } else
                         log_debug("'%s' already exists", fulldstpath);
 
@@ -982,8 +985,13 @@ static int dracut_install(const char *orig_src, const char *orig_dst, bool isdir
                 }
 
                 if (src_mode & (S_IXUSR | S_IXGRP | S_IXOTH)) {
-                        if (resolvedeps)
-                                ret += resolve_deps(fullsrcpath + sysrootdirlen);
+                        if (resolvedeps) {
+                                /* ensure fullsrcpath contains sysrootdir */
+                                if (sysrootdirlen && (strncmp(fullsrcpath, sysrootdir, sysrootdirlen) == 0))
+                                        ret += resolve_deps(fullsrcpath + sysrootdirlen);
+                                else
+                                        ret += resolve_deps(fullsrcpath);
+                        }
                         if (arg_hmac) {
                                 /* copy .hmac files also */
                                 hmac_install(src, dst, NULL);


### PR DESCRIPTION
When using `--sysrootdir` argument, we cannot assume `fulldstpath` and `fullsrcpath` always start with `sysrootdir`. When `dracut_install` is called on the `destination` directory, this can result in a passing pointer which is often beyond the valid buffer.

This pull request checks the handled path and only if it starts with `sysrootdir `, the pointer is incremented by the `sysrootdirlen` to get a path relative to the `sysrootdir`

Arguably current behaviour is dangerous, since if the passed buffer is shorter than `sysrootdirlen`, the resulting pointer, which is passed further, is to the random memory location.
This can be seen in debug logs when `resolve_deps('` log is either empty or has random garble printed.

## Changes
Check the path for `sysrootdir` before incrementing the pointer.

## Checklist
- [x ] I have tested it locally
- [ x] I have reviewed and updated any documentation if relevant
- [ x] I am providing new code and test(s) for it

Fixes #
https://github.com/dracut-ng/dracut-ng/issues/549