### PR TITLE
ci: improve test LVM, IMSM and LVM-THIN to work in hostonly mode

### DIFF
--- a/test/TEST-11-LVM/test.sh
+++ b/test/TEST-11-LVM/test.sh
@@ -56,7 +56,7 @@ test_setup() {
     test_marker_check dracut-root-block-created || return 1
 
     test_dracut \
-        --no-hostonly \
+        -a "lvm" \
         "$TESTDIR"/initramfs.testing
 }
 

--- a/test/TEST-14-IMSM/test.sh
+++ b/test/TEST-14-IMSM/test.sh
@@ -90,7 +90,7 @@ test_setup() {
     echo "$MD_UUID" > "$TESTDIR"/mduuid
 
     test_dracut \
-        --no-hostonly \
+        -a "lvm mdraid dmraid" \
         "$TESTDIR"/initramfs.testing
 }
 

--- a/test/TEST-17-LVM-THIN/test.sh
+++ b/test/TEST-17-LVM-THIN/test.sh
@@ -57,7 +57,7 @@ test_setup() {
     test_marker_check dracut-root-block-created || return 1
 
     test_dracut \
-        --no-hostonly \
+        -a "lvm mdraid" \
         -I lvs \
         "$TESTDIR"/initramfs.testing
 }


### PR DESCRIPTION
## Changes

Adding modules explicitly is required in hostonly mode as the actual CI continaer host is not using these modules to boot.

## Checklist
- [x] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it

Fixes #
