### PR TITLE
test(UEFI): second initrd would just overwrite the first

### DIFF
--- a/test/TEST-18-UEFI/test.sh
+++ b/test/TEST-18-UEFI/test.sh
@@ -44,15 +44,6 @@ test_setup() {
     mkdir -p "$TESTDIR"/ESP/EFI/BOOT
 
     test_dracut \
-        --add 'rootfs-block' \
-        --kernel-cmdline 'root=/dev/disk/by-id/scsi-0QEMU_QEMU_HARDDISK_root ro rd.skipfsck rootfstype=squashfs' \
-        --drivers 'squashfs' \
-        --uefi \
-        "$TESTDIR"/ESP/EFI/BOOT/BOOTX64.efi
-
-    test_dracut \
-        --hostonly \
-        --add 'rootfs-block' \
         --kernel-cmdline 'root=/dev/disk/by-id/scsi-0QEMU_QEMU_HARDDISK_root ro rd.skipfsck rootfstype=squashfs' \
         --drivers 'squashfs' \
         --uefi \


### PR DESCRIPTION
## Changes

Now that we have hostonly and no-hostonly CI containers, no need to run the same test twice in the same container.

Also, the current approach did not actually work as the second initrd would just overwrite the first one without testing the boot.

No need to add `rootfs-block` module explicitly as it is always included.

## Checklist
- [X] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it


