### PR TITLE
ci: drop privileged container flag to run tests sandboxed

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -34,7 +34,7 @@ jobs:
                 ]
         container:
             image: ghcr.io/dracut-ng/${{ matrix.container }}
-            options: "--privileged -v /dev:/dev"
+            options: '--device=/dev/kvm'
         steps:
             -   name: "Checkout Repository"
                 uses: actions/checkout@v4
@@ -78,7 +78,7 @@ jobs:
                 ]
         container:
             image: ghcr.io/dracut-ng/${{ matrix.container }}
-            options: "--privileged -v /dev:/dev"
+            options: '--device=/dev/kvm'
         steps:
             -   name: "Checkout Repository"
                 uses: actions/checkout@v4
@@ -102,7 +102,7 @@ jobs:
                 ]
         container:
             image: ghcr.io/dracut-ng/${{ matrix.container }}
-            options: "--privileged -v /dev:/dev"
+            options: '--device=/dev/kvm'
         steps:
             -   name: "Checkout Repository"
                 uses: actions/checkout@v4
@@ -133,7 +133,7 @@ jobs:
             -   name: "Checkout Repository"
                 uses: actions/checkout@v4
             -   name: "${{ matrix.container }} TEST-${{ matrix.test }}"
-                run: docker run --platform linux/arm64 --privileged -v /dev:/dev -v $PWD:/w ghcr.io/dracut-ng/${{ matrix.container }} /w/tools/test-github.sh "TEST-${{ matrix.test }}" ${{ matrix.test }}
+                run: docker run --platform linux/arm64 '--device=/dev/kvm' -v $PWD:/w ghcr.io/dracut-ng/${{ matrix.container }} /w/tools/test-github.sh "TEST-${{ matrix.test }}" ${{ matrix.test }}
     network:
         # all nfs based on default networking
         name: ${{ matrix.test }} on ${{ matrix.container }}
@@ -168,7 +168,7 @@ jobs:
                     network: "network-legacy"
         container:
             image: ghcr.io/dracut-ng/${{ matrix.container }}
-            options: "--privileged -v /dev:/dev"
+            options: '--device=/dev/kvm'
         steps:
             -   name: "Checkout Repository"
                 uses: actions/checkout@v4
@@ -205,7 +205,7 @@ jobs:
                     network: "network-legacy"
         container:
             image: ghcr.io/dracut-ng/${{ matrix.container }}
-            options: "--privileged -v /dev:/dev"
+            options: '--device=/dev/kvm'
         steps:
             -   name: "Checkout Repository"
                 uses: actions/checkout@v4
@@ -240,7 +240,7 @@ jobs:
                     network: "network-legacy"
         container:
             image: ghcr.io/dracut-ng/${{ matrix.container }}
-            options: "--privileged -v /dev:/dev"
+            options: '--device=/dev/kvm'
         steps:
             -   name: "Checkout Repository"
                 uses: actions/checkout@v4


### PR DESCRIPTION
## Changes

Only map /dev/kvm into the container to be able to use kvm when when running VMs with qemu.

## Checklist
- [X] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it


