### PR TITLE
Add an explicit --basedir

### DIFF
--- a/dracut.sh
+++ b/dracut.sh
@@ -160,6 +160,8 @@ Creates initial ramdisk images for preloading modules
   --tmpdir [DIR]        Temporary directory to be used instead of default
                          ${TMPDIR:-/var/tmp}.
   -r, --sysroot [DIR]   Specify sysroot directory to collect files from.
+  -b, --basedir [DIR]   Specify basedir directory to use for dracut, by
+                         default it is {sysrootdir}/usr/lib/dracut.
   -l, --local           Local mode. Use modules from the current working
                          directory instead of the system-wide installed in
                          /usr/lib/dracut/modules.d.
@@ -360,7 +362,7 @@ rearrange_params() {
     TEMP=$(
         unset POSIXLY_CORRECT
         getopt \
-            -o "a:m:o:d:I:k:c:r:L:fvqlHhMNp" \
+            -o "a:m:o:d:I:k:c:r:L:b:fvqlHhMNp" \
             --long kver: \
             --long add: \
             --long force-add: \
@@ -387,6 +389,7 @@ rearrange_params() {
             --long confdir: \
             --long tmpdir: \
             --long sysroot: \
+            --long basedir: \
             --long stdlog: \
             --long compress: \
             --long squash-compressor: \
@@ -671,6 +674,11 @@ while :; do
             PARMS_TO_STORE+=" '$2'"
             shift
             ;;
+        -b | --basedir)
+            basedir_l="$2"
+            PARMS_TO_STORE+=" '$2'"
+            shift
+            ;;
         -L | --stdlog)
             stdloglvl_l="$2"
             PARMS_TO_STORE+=" '$2'"
@@ -869,6 +877,7 @@ while (($# > 0)); do
 done
 
 [[ $sysroot_l ]] && dracutsysrootdir="$sysroot_l"
+[[ $basedir_l ]] && dracutbasedir="$basedir_l"
 
 export LC_ALL=C
 export LANG=C


### PR DESCRIPTION
I'd like to get dracut to assemble an initramfs for `target-arch` from `host-arch` by passing `--sysroot` but then it tries to look for its own files within the sysroot.

This is an attempt to fix it.