### PR TITLE
fix(dracut-functions.sh): skip dir in get_persistent_dev()

### DIFF
--- a/dracut-functions.sh
+++ b/dracut-functions.sh
@@ -294,7 +294,7 @@ get_persistent_dev() {
         /dev/disk/by-partlabel/* \
         /dev/disk/by-id/* \
         /dev/disk/by-path/*; do
-        [[ -e $i ]] || continue
+        [[ -f $i ]] || continue
         [[ $i == /dev/mapper/control ]] && continue
         [[ $i == /dev/mapper/mpath* ]] && continue
         _tmp=$(get_maj_min "$i")


### PR DESCRIPTION
I observed the following directory layout under /dev/disk/by-path:

/dev/disk/by-path/
├── pci-0000:00:07.0 -> ../../vda
├── pci-0000:00:07.0-part
│   ├── by-partnum
│   │   ├── 1 -> ../../../../vda1
│   │   ├── 2 -> ../../../../vda2
│   │   └── 3 -> ../../../../vda3
│   ├── by-partuuid
│   │   ├── 102645f0-b6a7-47d5-93ae-60bd063ecbc5 -> ../../../../vda1 │   │   ├── 32dc3e8a-70cb-4afb-8642-d4f2e0a92941 -> ../../../../vda3 │   │   └── 46beb739-55c1-4746-ab90-b329a0c82ea5 -> ../../../../vda2 │   └── by-uuid
│       └── 11ea5cf3-7132-40d4-a114-a8d76edca51f -> ../../../../vda2
├── pci-0000:00:07.0-part1 -> ../../vda1
├── pci-0000:00:07.0-part2 -> ../../vda2
├── pci-0000:00:07.0-part3 -> ../../vda3
├── virtio-pci-0000:00:07.0 -> ../../vda
├── virtio-pci-0000:00:07.0-part1 -> ../../vda1
├── virtio-pci-0000:00:07.0-part2 -> ../../vda2
└── virtio-pci-0000:00:07.0-part3 -> ../../vda3

As showed above, 'pci-0000:00:07.0-part' is a directory, so get_maj_min() returns '0:0' for it.

This will raise an issue in the case that kdump dumps the vmcore through nfs. In that case, no block device is passed to
get_persistent_dev(), so _dev=$(get_maj_min "$1") also equals '0:0'. Finally, it wrongly fits into the match:
        if [ "$_tmp" = "$_dev" ]; then
            printf -- "%s" "$i"
            return
        fi

And kdump kernel boots up and wait for 'pci-0000:00:07.0-part' indefinitely.

This pull request changes...

## Changes

## Checklist
- [ ] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it

Fixes #
