### PR TITLE
fix(dracut.sh): account for the kernel being named kernel

### DIFF
--- a/dracut.sh
+++ b/dracut.sh
@@ -1138,7 +1138,9 @@ if ! [[ $outfile ]]; then
             outfile="$dracutsysrootdir/boot/efi/${MACHINE_ID}/${kernel}/initrd"
         elif [[ -f "$dracutsysrootdir"/lib/modules/${kernel}/initrd ]]; then
             outfile="$dracutsysrootdir/lib/modules/${kernel}/initrd"
-        elif [[ -e $dracutsysrootdir/boot/vmlinuz-${kernel} || -e $dracutsysrootdir/boot/vmlinux-${kernel} ]]; then
+        elif [[ -e $dracutsysrootdir/boot/vmlinuz-${kernel} ||
+            -e $dracutsysrootdir/boot/vmlinux-${kernel} ||
+            -e $dracutsysrootdir/boot/kernel-${kernel} ]]; then
             outfile="$dracutsysrootdir/boot/$initrdname"
         elif [[ -z $dracutsysrootdir ]] \
             && [[ $MACHINE_ID ]] \


### PR DESCRIPTION
`kernel` is also a name accepted by `grub-mkconfig`.

On Gentoo the kernel is named this way if systemd's `kernel-install` is used.

This pull request changes...

## Changes

## Checklist
- [x] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it

Fixes #
