### PR TITLE
fix(dracut-functions.sh): Only return block devices from get_persistent_dev

### DIFF
--- a/dracut-functions.sh
+++ b/dracut-functions.sh
@@ -294,8 +294,7 @@ get_persistent_dev() {
         /dev/disk/by-partlabel/* \
         /dev/disk/by-id/* \
         /dev/disk/by-path/*; do
-        [[ -e $i ]] || continue
-        [[ $i == /dev/mapper/control ]] && continue
+        [[ -b $i ]] || continue
         [[ $i == /dev/mapper/mpath* ]] && continue
         _tmp=$(get_maj_min "$i")
         if [ "$_tmp" = "$_dev" ]; then


### PR DESCRIPTION
With udev 256, there are now directories such as
/dev/disk/by-path/pci-0000:02:00.0-nvme-1-part/ which match here.

In case a nonexisting file/device was passed to get_persistent_dev, it returned the first directory it looked at because both have maj:min 0:0. This accidental conversion from garbage to a sensible looking path leads to weird behaviour later.

Instead of filtering out directories explicitly switch the check to only return block devices, which also takes care of the character special /dev/mapper/control.

## Changes

## Checklist
- [X] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it