### PR TITLE
fix(dracut-systemd): include systemd-cryptsetup module when needed

### DIFF
--- a/modules.d/90crypt/module-setup.sh
+++ b/modules.d/90crypt/module-setup.sh
@@ -18,7 +18,15 @@ check() {
 
 # called by dracut
 depends() {
-    echo dm rootfs-block
+    local deps
+    deps="dm rootfs-block"
+
+    if dracut_module_included "systemd"; then
+        deps+=" systemd-cryptsetup"
+    fi
+
+    echo "$deps"
+    return 0
 }
 
 # called by dracut

--- a/test/TEST-04-FULL-SYSTEMD/test.sh
+++ b/test/TEST-04-FULL-SYSTEMD/test.sh
@@ -127,7 +127,6 @@ EOF
     echo -n test > /tmp/key
 
     test_dracut \
-        --no-hostonly \
         -m "btrfs dracut-systemd i18n systemd-ac-power systemd-coredump systemd-creds systemd-cryptsetup systemd-integritysetup systemd-ldconfig systemd-pcrphase systemd-pstore systemd-repart systemd-sysext systemd-veritysetup" \
         -i "/tmp/key" "/etc/key" \
         "$TESTDIR"/initramfs.testing

--- a/test/TEST-10-RAID/test.sh
+++ b/test/TEST-10-RAID/test.sh
@@ -58,7 +58,7 @@ test_setup() {
     echo -n "test" > /tmp/key
 
     test_dracut \
-        --no-hostonly \
+        -a "crypt lvm mdraid" \
         -i "./cryptroot-ask.sh" "/sbin/cryptroot-ask" \
         -i "/tmp/crypttab" "/etc/crypttab" \
         -i "/tmp/key" "/etc/key" \

--- a/test/TEST-13-ENC-RAID-LVM/test.sh
+++ b/test/TEST-13-ENC-RAID-LVM/test.sh
@@ -98,7 +98,7 @@ test_setup() {
     chmod 0600 /tmp/key
 
     test_dracut \
-        --no-hostonly \
+        -a "crypt lvm mdraid" \
         -i "./cryptroot-ask.sh" "/sbin/cryptroot-ask" \
         -i "/tmp/crypttab" "/etc/crypttab" \
         -i "/tmp/key" "/etc/key" \


### PR DESCRIPTION
Make `systemd-cryptsetup` a dependency of the `crypt` module when systemd dracut module is included.
Improve tests with crypt dracut module to work in hostonly mode. Enable running these test both in hostonly and non-hostonly mode.

## Checklist
- [x] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it

Fixes #563
