### PR TITLE
fix(dracut): ldd output borked with `--sysroot`

### DIFF
--- a/dracut-init.sh
+++ b/dracut-init.sh
@@ -101,6 +101,17 @@ if ! [[ $libdirs ]]; then
     export libdirs
 fi
 
+# ldd needs LD_LIBRARY_PATH pointing to the libraries within the sysroot directory
+if [[ -n $dracutsysrootdir ]]; then
+    for lib in $libdirs; do
+        mapfile -t -d '' lib_subdirs < <(find "$lib" -type d -print0 2> /dev/null)
+        for lib_subdir in "${lib_subdirs[@]}"; do
+            LD_LIBRARY_PATH="${LD_LIBRARY_PATH:+"$LD_LIBRARY_PATH":}$dracutsysrootdir$lib_subdir"
+        done
+    done
+    export LD_LIBRARY_PATH
+fi
+
 # helper function for check() in module-setup.sh
 # to check for required installed binaries
 # issues a standardized warning message


### PR DESCRIPTION
dracut-install calls `ldd` to resolve dependencies, but when the `--sysroot` option is used, `ldd` is not performing the search within the sysroot directory. To fix this issue, the `LD_LIBRARY_PATH` variable needs to be properly set to the directories containing shared libraries within the specified sysroot directory.

E.g., running dracut with `--sysroot` produces an initrd without the required systemd shared libraries when the version between the host system and the sysroot directory differs:

```
localhost:~ # ldd /.snapshots/9/snapshot/usr/lib/systemd/systemd | grep libsystemd
    libsystemd-core-256.so => not found
    libsystemd-shared-256.so => not found
localhost:~ # export LD_LIBRARY_PATH=/.snapshots/9/snapshot/usr/lib64/systemd
localhost:~ # ldd /.snapshots/9/snapshot/usr/lib/systemd/systemd | grep libsystemd
    libsystemd-core-256.so => /.snapshots/9/snapshot/usr/lib64/systemd/libsystemd-core-256.so (0x00007f817b600000)
    libsystemd-shared-256.so => /.snapshots/9/snapshot/usr/lib64/systemd/libsystemd-shared-256.so (0x00007f817b000000)
```

Another example:

```
I: Executing: /usr/bin/dracut --sysroot /.snapshots/9/snapshot ...
...
I: *** Including module: dm ***
E: FAILED: /.snapshots/9/snapshot/usr/lib/dracut/dracut-install -r /.snapshots/9/snapshot -D /var/tmp/dracut.rAIUA7/initramfs -a -l /sbin/dmsetup
...
I: *** Creating initramfs image file '...' done ***
```

Manually calling `dracut-install` with `--debug` showed the problem:

```
localhost:~ # /.snapshots/9/snapshot/usr/lib/dracut/dracut-install --debug -r /.snapshots/9/snapshot -D /var/tmp/dracut.rAIUA7/initramfs -a -l dmsetup
...
dracut-install: get_real_file('/.snapshots/9/snapshot/sbin/dmsetup')
dracut-install: resolve_deps('/sbin/dmsetup') -> get_real_file('/sbin/dmsetup', true) = '/.snapshots/9/snapshot/sbin/dmsetup'
dracut-install: ldd /.snapshots/9/snapshot/sbin/dmsetup
dracut-install: ldd: '/.snapshots/9/snapshot/sbin/dmsetup: /lib64/libdevmapper.so.1.03: version `DM_1_02_197' not found (required by /.snapshots/9/snapshot/sbin/dmsetup)
dracut-install: '
dracut-install: dracut_install('/sbin/dmsetup:', '/sbin/dmsetup:', 0, 0, 1)
dracut-install: ERROR: failed to install '/.snapshots/9/snapshot/sbin/dmsetup:' for '/sbin/dmsetup'
...
dracut-install: dracut_install ret = 1
dracut-install: ERROR: installing 'dmsetup'
```

The `dmsetup` binary within the sysroot directory depends on a different version of `libdevmapper`:

```
localhost:~ # ldd /.snapshots/9/snapshot/sbin/dmsetup
/.snapshots/9/snapshot/sbin/dmsetup: /lib64/libdevmapper.so.1.03: version `DM_1_02_197' not found (required by /.snapshots/9/snapshot/sbin/dmsetup)
    linux-vdso.so.1 (0x00007ffe4d9f3000)
    libdevmapper.so.1.03 => /lib64/libdevmapper.so.1.03 (0x00007f5b551d8000)
    libc.so.6 => /lib64/libc.so.6 (0x00007f5b54e00000)
    libselinux.so.1 => /lib64/libselinux.so.1 (0x00007f5b551aa000)
    libudev.so.1 => /lib64/libudev.so.1 (0x00007f5b55174000)
    libm.so.6 => /lib64/libm.so.6 (0x00007f5b5508d000)
    /lib64/ld-linux-x86-64.so.2 (0x00007f5b55265000)
    libpcre2-8.so.0 => /lib64/libpcre2-8.so.0 (0x00007f5b54d54000)
    libcap.so.2 => /lib64/libcap.so.2 (0x00007f5b55081000)
```

If `LD_LIBRARY_PATH` is set to the right paths, the `ldd` output is ok:

```
localhost:~ # export LD_LIBRARY_PATH=/.snapshots/9/snapshot/usr/lib64
localhost:~ # ldd /.snapshots/9/snapshot/sbin/dmsetup
    linux-vdso.so.1 (0x00007ffd40bfa000)
    libdevmapper.so.1.03 => /.snapshots/9/snapshot/usr/lib64/libdevmapper.so.1.03 (0x00007f7add6af000)
    libc.so.6 => /.snapshots/9/snapshot/usr/lib64/libc.so.6 (0x00007f7add400000)
    libselinux.so.1 => /.snapshots/9/snapshot/usr/lib64/libselinux.so.1 (0x00007f7add680000)
    libudev.so.1 => /.snapshots/9/snapshot/usr/lib64/libudev.so.1 (0x00007f7add63a000)
    libm.so.6 => /.snapshots/9/snapshot/usr/lib64/libm.so.6 (0x00007f7add319000)
    /lib64/ld-linux-x86-64.so.2 (0x00007f7add738000)
    libpcre2-8.so.0 => /.snapshots/9/snapshot/usr/lib64/libpcre2-8.so.0 (0x00007f7add26d000)
    libcap.so.2 => /.snapshots/9/snapshot/usr/lib64/libcap.so.2 (0x00007f7add62e000)
```

## Checklist
- [X] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it