### PR TITLE
feat(dracut.sh): add --add-confdir option

### DIFF
--- a/man/dracut.8.asc
+++ b/man/dracut.8.asc
@@ -307,6 +307,14 @@ Default:
 Default:
    _/etc/dracut.conf.d_
 
+**--add-confdir** _<configuration directory>_::
+    Add an extra configuration directory to use *.conf files from. If the
+    directory is not existed, will look for subdirectory under confdir.
++
+Default:
+    _empty_
+
+
 **--tmpdir** _<temporary directory>_::
     Specify temporary directory to use.
 +

--- a/shell-completion/bash/dracut
+++ b/shell-completion/bash/dracut
@@ -47,14 +47,14 @@ _dracut() {
             --kernel-cmdline --sshkey --persistent-policy --install-optional
             --loginstall --uefi-stub --kernel-image --squash-compressor
             --sysroot --hostonly-mode --hostonly-nics --include --logfile
-            --uefi-splash-image --sbat
+            --uefi-splash-image --sbat --add-confdir
             '
     )
 
     # shellcheck disable=SC2086
     if __contains_word "$prev" ${OPTS[ARG]}; then
         case $prev in
-            --kmoddir | -k | --fwdir | --confdir | --tmpdir | -r | --sysroot)
+            --kmoddir | -k | --fwdir | --confdir | --add-confdir | --tmpdir | -r | --sysroot)
                 comps=$(compgen -d -- "$cur")
                 compopt -o filenames
                 ;;


### PR DESCRIPTION
This pull request changes...

## Changes

Add --extra-confdir option 

When generating kdump's initrd, we want to keep [omit_]dracutmodules empty and let kdump to handle the modules. And we don't want to affect the first kernel's initrd, so we cannot place our conf file to /etc/dracut.conf.d or /usr/lib/dracut/dracut.conf.d.

This patch adds a new option to allow user to add an extra configuration directory to use *.conf files from.

After that, kdump will use --extra-confdir /usr/lib/kdump/dracut.conf.d to apply its own dracut conf.

See also:
https://github.com/rhkdump/kdump-utils/issues/11
https://github.com/rhkdump/kdump-utils/pull/31

## Checklist
- [*] I have tested it locally
- [*] I have reviewed and updated any documentation if relevant
- [*] I am providing new code and test(s) for it
