### PR TITLE
fix(dracut-install): refuse empty DRACUT_LDD environment variable

### DIFF
--- a/src/install/dracut-install.c
+++ b/src/install/dracut-install.c
@@ -2292,7 +2292,7 @@ int main(int argc, char **argv)
         log_debug("PATH=%s", path);
 
         ldd = getenv("DRACUT_LDD");
-        if (ldd == NULL)
+        if (isempty(ldd))
                 ldd = "ldd";
         log_debug("LDD=%s", ldd);
 


### PR DESCRIPTION
With DRACUT_LDD='', let's fallback to default ldd. Better safe than sorry.

This pull request changes...

## Changes

## Checklist
- [x] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it

Fixes #
