### PR TITLE
fix(dracut-functions): allow for \ in get_maj_min file path

### DIFF
--- a/dracut-functions.sh
+++ b/dracut-functions.sh
@@ -243,7 +243,7 @@ get_maj_min() {
     local _out
 
     if [[ $get_maj_min_cache_file ]]; then
-        _out="$(grep -m1 -oE "^$1 \S+$" "$get_maj_min_cache_file" | grep -oE "\S+$")"
+        _out="$(grep -m1 -oE "^${1//\\/\\\\} \S+$" "$get_maj_min_cache_file" | grep -oE "\S+$")"
     fi
 
     if ! [[ "$_out" ]]; then


### PR DESCRIPTION
as the path might be f.e. /dev/disk/by-partlabel/EFI\x20System\x20Partition

which would produce Warning 'grep: warning: stray \ before x' in get_maj_min

## Changes

Escape the \ to preserve it in the path when passing to grep.

## Checklist
- [x] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it

Resolves: !505
