### PR TITLE
fix(nfs): include also entries from /usr/lib/{passwd,group}

### DIFF
--- a/modules.d/95nfs/module-setup.sh
+++ b/modules.d/95nfs/module-setup.sh
@@ -125,8 +125,16 @@ install() {
 
     # Rather than copy the passwd file in, just set a user for rpcbind
     # We'll save the state and restart the daemon from the root anyway
-    grep -E '^(nfsnobody|_rpc|rpc|rpcuser):' "$dracutsysrootdir"/etc/passwd >> "$initdir/etc/passwd"
-    grep -E '^nogroup:|^rpc:|^nobody:' "$dracutsysrootdir"/etc/group >> "$initdir/etc/group"
+
+    local _confdir
+    for _confdir in etc usr/lib; do
+
+        grep -sE '^(nfsnobody|_rpc|rpc|rpcuser):' "${dracutsysrootdir}/${_confdir}/passwd" \
+            >> "$initdir/${_confdir}/passwd"
+
+        grep -sE '^(nogroup|rpc|nobody):' "${dracutsysrootdir}/${_confdir}/group" \
+            >> "$initdir/${_confdir}/group"
+    done
 
     dracut_need_initqueue
 }


### PR DESCRIPTION
as those paths are used by bootc instead of the /etc ones.

## Changes

Handle  /usr/lib/{passwd,group} configs additionally to /etc/ variants in nfs module.

## Checklist
- [ ] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it