### PR TITLE
feat(fips): add support for UKIs

### DIFF
--- a/modules.d/01fips/module-setup.sh
+++ b/modules.d/01fips/module-setup.sh
@@ -59,7 +59,7 @@ install() {
     inst_hook pre-udev 01 "$moddir/fips-load-crypto.sh"
     inst_script "$moddir/fips.sh" /sbin/fips.sh
 
-    inst_multiple sha512hmac rmmod insmod mount uname umount grep sed cut find sort
+    inst_multiple sha512hmac rmmod insmod mount uname umount grep sed cut find sort cat tail tr
 
     inst_simple /etc/system-fips
 }


### PR DESCRIPTION
Kernel integrity check in FIPS module is incompatible with UKIs as neither /boot/vmlinuz-`uname-r` nor /boot/.vmlinuz-`uname-r`.hmac are present. UKI is placed to $ESP\EFI\Linux\<install-tag>-<uname-r>.efi and if a .hmac file is present next to it, it is possible to do similar check.

Note, UKIs have a 'one size fits all' command line and 'boot=' is not expected to be set. Luckily, if the UKI is systemd-stub based then we can expect 'LoaderDevicePartUUID' variable containing PARTUUID of the ESP to be set. Mount it to /boot using the existing logic.

## Changes
Support for UKI integrity checking added to the FIPS module.

## Checklist
- [ X ] I have tested it locally
- [ - ] I have reviewed and updated any documentation if relevant
- [ X ] I am providing new code. Testing this outside of a real UKI based environment is problematic.

References:
Fedora/ARK kernel MR (creating .hmac for UKI): https://gitlab.com/cki-project/kernel-ark/-/merge_requests/3314
virt-firmware MR (installing .hmac to the ESP): https://gitlab.com/kraxel/virt-firmware/-/merge_requests/17