### PR TITLE
fix(test): always install kernel modules

### DIFF
--- a/modules.d/80test-makeroot/module-setup.sh
+++ b/modules.d/80test-makeroot/module-setup.sh
@@ -10,7 +10,7 @@ depends() {
 }
 
 installkernel() {
-    instmods piix ide-gd_mod ata_piix ext4 sd_mod
+    hostonly='' instmods piix ide-gd_mod ata_piix ext4 sd_mod
 }
 
 install() {

--- a/modules.d/80test/module-setup.sh
+++ b/modules.d/80test/module-setup.sh
@@ -10,7 +10,7 @@ depends() {
 }
 
 installkernel() {
-    instmods \
+    hostonly='' instmods \
         ata_piix \
         ext4 \
         i6300esb \


### PR DESCRIPTION
Always install Linux kernel modules regardless of the value of hostonly.

## Checklist
- [ ] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it

