### PR TITLE
fix(95squash-erofs): properly exclude $squashdir

### DIFF
--- a/modules.d/95squash-erofs/module-setup.sh
+++ b/modules.d/95squash-erofs/module-setup.sh
@@ -20,7 +20,8 @@ erofs_installpost() {
     local _img="$squashdir/erofs-root.img"
     local -a _erofs_args
 
-    _erofs_args+=("--exclude-path=$squashdir")
+    # --exclude-path requires a relative path
+    _erofs_args+=("--exclude-path=${squashdir#"$initdir"/}")
     _erofs_args+=("-E" "fragments")
 
     if [[ -n $squash_compress ]]; then


### PR DESCRIPTION
Option --exclude-path from mkfs.erofs requires a path relative to the source of the image. Otherwise the path won't be excluded resulting in a slightly larger (~1M) initrd.

Fixes: ebc9e84d ("feat(squash): add module 95squash-erofs")

## Checklist
- [x] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it