### PR TITLE
fix(crypt): install dm_crypt module in non-hostonly mode as well

### DIFF
--- a/modules.d/90crypt/module-setup.sh
+++ b/modules.d/90crypt/module-setup.sh
@@ -23,8 +23,7 @@ depends() {
 
 # called by dracut
 installkernel() {
-    hostonly="" instmods drbg
-    instmods dm_crypt
+    hostonly="" instmods drbg dm_crypt
 
     # in case some of the crypto modules moved from compiled in
     # to module based, try to install those modules


### PR DESCRIPTION
Without dm_crypt Linux module, the dracut module will not be fully functional.

## Checklist
- [X] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it
