### PR TITLE
chore: treat compilation warning as errors

### DIFF
--- a/src/install/dracut-install.c
+++ b/src/install/dracut-install.c
@@ -1569,8 +1569,8 @@ static int find_kmod_module_from_sysfs_driver(struct kmod_ctx *ctx, const char *
 {
         char mod_path[PATH_MAX], mod_realpath[PATH_MAX];
         const char *mod_name;
-        if (snprintf(mod_path, sizeof(mod_path), "%.*s/driver/module",
-                     sysfs_node_len, sysfs_node) >= sizeof(mod_path))
+        if ((size_t)snprintf(mod_path, sizeof(mod_path), "%.*s/driver/module",
+                             sysfs_node_len, sysfs_node) >= sizeof(mod_path))
                 return -1;
 
         if (realpath(mod_path, mod_realpath) == NULL)
@@ -1586,8 +1586,8 @@ static int find_kmod_module_from_sysfs_modalias(struct kmod_ctx *ctx, const char
                                                 struct kmod_list **modules)
 {
         char modalias_path[PATH_MAX];
-        if (snprintf(modalias_path, sizeof(modalias_path), "%.*s/modalias", sysfs_node_len,
-                     sysfs_node) >= sizeof(modalias_path))
+        if ((size_t)snprintf(modalias_path, sizeof(modalias_path), "%.*s/modalias", sysfs_node_len,
+                             sysfs_node) >= sizeof(modalias_path))
                 return -1;
 
         _cleanup_close_ int modalias_file = -1;
@@ -1657,8 +1657,8 @@ static void find_suppliers_for_sys_node(struct kmod_ctx *ctx, Hashmap *suppliers
                         size_t real_path_len = strlen(real_path);
                         while ((dir = readdir(d)) != NULL) {
                                 if (strstr(dir->d_name, "supplier:platform") != NULL) {
-                                        if (snprintf(real_path + real_path_len, sizeof(real_path) - real_path_len, "/%s/supplier",
-                                                     dir->d_name) < sizeof(real_path) - real_path_len) {
+                                        if ((size_t)snprintf(real_path + real_path_len, sizeof(real_path) - real_path_len, "/%s/supplier",
+                                                             dir->d_name) < sizeof(real_path) - real_path_len) {
                                                 char *real_supplier_path = realpath(real_path, NULL);
                                                 if (real_supplier_path != NULL)
                                                         if (hashmap_put(suppliers, real_supplier_path, real_supplier_path) < 0)
@@ -1668,7 +1668,7 @@ static void find_suppliers_for_sys_node(struct kmod_ctx *ctx, Hashmap *suppliers
                         }
                         closedir(d);
                 }
-                strncat(node_path, "/..", 3); // Also find suppliers of parents
+                strcat(node_path, "/.."); // Also find suppliers of parents
         }
 }
 

--- a/tools/test-github.sh
+++ b/tools/test-github.sh
@@ -16,10 +16,12 @@ fi
 
 NCPU=$(getconf _NPROCESSORS_ONLN)
 
+# treat warnings as error
+
 if ! [[ $TESTS ]]; then
-    make -j "$NCPU" all syncheck logtee
+    CFLAGS="-Wextra -Werror" make -j "$NCPU" all syncheck logtee
 else
-    make -j "$NCPU" enable_documentation=no all logtee
+    CFLAGS="-Wextra -Werror" make -j "$NCPU" enable_documentation=no all logtee
 
     cd test
 


### PR DESCRIPTION
The intention of this PR is to enforce that on all CI containers C code builds without any warnings.

This PR intentionally does not enforce the same for normal builds.

Follow-up to https://github.com/dracut-ng/dracut-ng/commit/d71bec4aa444d92820e428c0629d0e75e268c815 (https://github.com/dracut-ng/dracut-ng/pull/479)

## Checklist
- [ ] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it

Fixes #
