### PR TITLE
test(FULL-SYSTEM): simplify and make it easier to maintain

### DIFF
--- a/test/TEST-04-FULL-SYSTEMD/test-init.sh
+++ b/test/TEST-04-FULL-SYSTEMD/test-init.sh
@@ -1,21 +1,7 @@
 #!/bin/sh
 : > /dev/watchdog
-
-export PATH=/usr/sbin:/usr/bin:/sbin:/bin
-command -v plymouth > /dev/null 2>&1 && plymouth --quit
 exec > /dev/console 2>&1
 
-systemctl --failed --no-legend --no-pager > /run/failed
-
-ismounted() {
-    findmnt "$1" > /dev/null 2>&1
-}
-
-if ! ismounted /usr; then
-    echo "**************************FAILED**************************"
-    echo "/usr not mounted!!"
-    cat /proc/mounts >> /run/failed
-    echo "**************************FAILED**************************"
-fi
+/usr/bin/systemctl --failed --no-legend --no-pager > /run/failed
 
 . /sbin/test-init.sh


### PR DESCRIPTION
Remove packaging and distribution specific systemd service files.
    
No need to explicitly check if /usr is mounted as without it Switch Root service would fail with the following error:
'Failed to start initrd-switch-root.service - Switch Root.'

## Checklist
- [X] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it


