### PR TITLE
revert(dracut-init.sh): add module to mods_to_load before checking dependencies

### DIFF
--- a/dracut-init.sh
+++ b/dracut-init.sh
@@ -893,9 +893,6 @@ check_mount() {
         fi
     fi
 
-    [[ " $mods_to_load " == *\ $_mod\ * ]] \
-        || mods_to_load+=" $_mod "
-
     for _moddep in $(module_depends "$_mod" "$_moddir"); do
         # handle deps as if they were manually added
         [[ " $dracutmodules " == *\ $_mod\ * ]] \
@@ -913,6 +910,9 @@ check_mount() {
             return 1
         fi
     done
+
+    [[ " $mods_to_load " == *\ $_mod\ * ]] \
+        || mods_to_load+=" $_mod "
 
     return 0
 }
@@ -968,9 +968,6 @@ check_module() {
         fi
     fi
 
-    [[ " $mods_to_load " == *\ $_mod\ * ]] \
-        || mods_to_load+=" $_mod "
-
     for _moddep in $(module_depends "$_mod" "$_moddir"); do
         # handle deps as if they were manually added
         [[ " $dracutmodules " == *\ $_mod\ * ]] \
@@ -988,6 +985,9 @@ check_module() {
             return 1
         fi
     done
+
+    [[ " $mods_to_load " == *\ $_mod\ * ]] \
+        || mods_to_load+=" $_mod "
 
     return 0
 }


### PR DESCRIPTION
This reverts commit d0f8fde5668cfd7fda1d15824e268b4949b4fd04.

This PR resolves the issue where during initrd generation dracut modules where dependencies are not met are included in the initrd (e.g. rngd for Alpine).

## Checklist
- [ ] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it

