### PR TITLE
fix(udev-rules): install dropins for udev.conf

### DIFF
--- a/modules.d/95udev-rules/module-setup.sh
+++ b/modules.d/95udev-rules/module-setup.sh
@@ -91,7 +91,9 @@ install() {
         "${udevdir}"/path_id \
         "${udevdir}"/scsi_id \
         "${udevdir}"/usb_id \
-        "${udevdir}"/v4l_id
+        "${udevdir}"/v4l_id \
+        "${udevdir}"/udev.conf \
+        "${udevdir}"/udev.conf.d/*.conf
 
     # Install required libraries.
     _arch=${DRACUT_ARCH:-$(uname -m)}
@@ -101,9 +103,10 @@ install() {
 
     # Install the hosts local user configurations if enabled.
     if [[ $hostonly ]]; then
-        inst_dir /etc/udev
+        inst_dir "$udevconfdir"
         inst_multiple -H -o \
-            /etc/udev/udev.conf \
+            "$udevconfdir"/udev.conf \
+            "$udevconfdir/udev.conf.d/*.conf" \
             "$udevrulesconfdir/*.rules"
     fi
 }


### PR DESCRIPTION
Follow-up to https://github.com/dracut-ng/dracut-ng/pull/511  - specifically to https://github.com/dracut-ng/dracut-ng/pull/511#issuecomment-2258395025 .

## Checklist
- [ ] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it

