### PR TITLE
fix(systemd): remove duplicate systemd cryptsetup targets

### DIFF
--- a/modules.d/00systemd/module-setup.sh
+++ b/modules.d/00systemd/module-setup.sh
@@ -45,9 +45,7 @@ install() {
         "$systemdutildir"/system.conf \
         "$systemdutildir"/system.conf.d/*.conf \
         "$systemdsystemunitdir"/debug-shell.service \
-        "$systemdsystemunitdir"/cryptsetup.target \
         "$systemdsystemunitdir"/cryptsetup-pre.target \
-        "$systemdsystemunitdir"/remote-cryptsetup.target \
         "$systemdsystemunitdir"/emergency.target \
         "$systemdsystemunitdir"/sysinit.target \
         "$systemdsystemunitdir"/basic.target \


### PR DESCRIPTION
These targets are installed in the systemd-cryptsetup dracut module.

## Checklist
- [ ] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it

