### PR TITLE
ci(Debian): make clang the default C compiler

### DIFF
--- a/test/container/Dockerfile-Debian
+++ b/test/container/Dockerfile-Debian
@@ -13,6 +13,7 @@ RUN apt-get update -y -qq && apt-get upgrade -y -qq && apt-get install -y -qq --
     bzip2 \
     ca-certificates \
     cargo \
+    clang \
     console-setup \
     cpio \
     cryptsetup \
@@ -66,3 +67,7 @@ RUN apt-get update -y -qq && apt-get upgrade -y -qq && apt-get install -y -qq --
     vim \
     wget \
     && apt-get clean
+
+# make clang the default C compiler
+RUN \
+  update-alternatives --install /usr/bin/cc cc /usr/bin/clang 100


### PR DESCRIPTION
Debian will allow to test clang both amd64 on and on arm64

## Checklist
- [ ] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it

Fixes #593
