### PR TITLE
test(SYSTEMD-INITRD): kernel-independent systemd-based initrd

### DIFF
--- a/test/TEST-05-SYSTEMD-INITRD/test.sh
+++ b/test/TEST-05-SYSTEMD-INITRD/test.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 # shellcheck disable=SC2034
-TEST_DESCRIPTION="root filesystem on a ext4 filesystem"
+TEST_DESCRIPTION="root filesystem on a ext4 filesystem with systemd but without dracut-systemd"
 
 test_check() {
     command -v systemctl &> /dev/null
@@ -8,7 +8,13 @@ test_check() {
 
 # Uncomment this to debug failures
 #DEBUGFAIL="rd.shell=1 rd.break=pre-mount"
-test_run() {
+client_run() {
+    local test_name="$1"
+    shift
+    local client_opts="$*"
+
+    echo "CLIENT TEST START: $test_name"
+
     declare -a disk_args=()
     declare -i disk_index=0
     qemu_add_drive disk_index disk_args "$TESTDIR"/marker.img marker
@@ -17,10 +23,24 @@ test_run() {
     test_marker_reset
     "$testdir"/run-qemu \
         "${disk_args[@]}" \
-        -append "$TEST_KERNEL_CMDLINE root=LABEL=dracut rw systemd.log_target=console rd.retry=3 init=/sbin/init" \
+        -append "$TEST_KERNEL_CMDLINE root=LABEL=dracut $client_opts" \
         -initrd "$TESTDIR"/initramfs.testing || return 1
 
-    test_marker_check || return 1
+    if ! test_marker_check; then
+        echo "CLIENT TEST END: $test_name [FAILED]"
+        return 1
+    fi
+    echo "CLIENT TEST END: $test_name [OK]"
+}
+
+test_run() {
+    client_run "no option specified" || return 1
+    client_run "readonly root" "ro" || return 1
+    client_run "writeable root" "rw" || return 1
+
+    # volatile mode
+    client_run "volatile=overlayfs root" "systemd.volatile=overlayfs" || return 1
+    client_run "volatile=state root" "systemd.volatile=state" || return 1
 }
 
 test_setup() {
@@ -55,10 +75,28 @@ test_setup() {
     test_marker_check dracut-root-block-created || return 1
     rm -- "$TESTDIR"/marker.img
 
+    # initrd for test infra and required kernel modules
     test_dracut \
+        -m "kernel-modules" \
+        "$TESTDIR"/initramfs-test
+
+    # vanilla kernel-independent systemd-based initrd without dracut specific customizations
+    # since dracut-systemd is not included in the generated initrd, only systemd options are supported during boot
+    test_dracut --no-kernel --keep --tmpdir "$TESTDIR" \
         --omit test \
-        -m "kernel-modules systemd-initrd qemu test-root" \
-        "$TESTDIR"/initramfs.testing
+        -m "systemd-initrd" \
+        "$TESTDIR"/initramfs-systemd-initrd
+
+    # verify that dracut systemd services are not included
+    (
+        cd "$TESTDIR"/dracut.*/initramfs/usr/lib/systemd/system/ || return 1
+        for f in dracut*.service; do
+            [ -e "$f" ] && echo "unexpected dracut service found: $f" && return 1
+        done
+    )
+
+    # combine systemd-based initrd with the test infra initrd
+    cat "$TESTDIR"/initramfs-test "$TESTDIR"/initramfs-systemd-initrd > "$TESTDIR"/initramfs.testing
 }
 
 # shellcheck disable=SC1090


### PR DESCRIPTION
Separate systemd-based initrd out from the rest of the test infrastructure to make it easier to check (e.g. by passing -v) what is included in this minimal initrd.

Explicitly verify that dracut systemd services are not included in this test.

This test produces initrd that is comparable design to the systemd based initrd produced by mkosi or mkinitcpio.

Copy some additional tests steps from FULL-SYSTEMD and include it in this test as well.

## Checklist
- [ ] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it

Fixes #
