### PR TITLE
fix(systemd): systemd-vconsole-setup has a dependency on loadkeys

### DIFF
--- a/modules.d/00systemd/module-setup.sh
+++ b/modules.d/00systemd/module-setup.sh
@@ -36,7 +36,6 @@ install() {
         "$systemdutildir"/systemd-shutdown \
         "$systemdutildir"/systemd-reply-password \
         "$systemdutildir"/systemd-fsck \
-        "$systemdutildir"/systemd-vconsole-setup \
         "$systemdutildir"/systemd-volatile-root \
         "$systemdutildir"/systemd-sysroot-fstab-check \
         "$systemdutildir"/system-generators/systemd-debug-generator \
@@ -79,7 +78,6 @@ install() {
         "$systemdsystemunitdir"/systemd-reboot.service \
         "$systemdsystemunitdir"/systemd-kexec.service \
         "$systemdsystemunitdir"/systemd-fsck@.service \
-        "$systemdsystemunitdir"/systemd-vconsole-setup.service \
         "$systemdsystemunitdir"/systemd-volatile-root.service \
         "$systemdsystemunitdir"/ctrl-alt-del.target \
         "$systemdsystemunitdir"/syslog.socket \
@@ -154,14 +152,18 @@ EOF
         90-vconsole.rules \
         99-systemd.rules
 
-    for i in \
-        emergency.target \
-        rescue.target; do
-        [[ -f "$systemdsystemunitdir"/$i ]] || continue
-        if [ -e "$systemdsystemunitdir"/systemd-vconsole-setup.service ]; then
+    if dracut_module_included "10i18n" && [[ -e "$systemdsystemunitdir"/systemd-vconsole-setup.service ]]; then
+        inst_multiple -o \
+            "$systemdutildir"/systemd-vconsole-setup \
+            "$systemdsystemunitdir"/systemd-vconsole-setup.service
+
+        for i in \
+            emergency.target \
+            rescue.target; do
+            [[ -f "$systemdsystemunitdir"/$i ]] || continue
             $SYSTEMCTL -q --root "$initdir" add-wants "$i" systemd-vconsole-setup.service
-        fi
-    done
+        done
+    fi
 
     mkdir -p "$initdir/etc/systemd"
 


### PR DESCRIPTION
loadkeys is installed by `10i18n` dracut module.

This resolves the following error in tests where `10i18n` dracut module is not included (e.g. TEST-5).

```
[FAILED] Failed to start Virtual Console Setup.
```

## Checklist
- [ ] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it

Fixes #
