### PR TITLE
test: document and fix extra verbose mode (V=2)

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -5,7 +5,9 @@ on:
         branches: [ main ]
 
 env:
-    DEBUGFAIL: "${{ secrets.ACTIONS_STEP_DEBUG && 'rd.debug' }}"
+    # set V to 2 when re-running jobs with debug logging enabled
+    # see https://docs.github.com/en/actions/monitoring-and-troubleshooting-workflows/troubleshooting-workflows/enabling-debug-logging
+    V: "${{ secrets.ACTIONS_STEP_DEBUG && '2' }}"
 
 jobs:
     basic:

--- a/docs/HACKING.md
+++ b/docs/HACKING.md
@@ -256,9 +256,14 @@ mentioned in the `test/container` Dockerfiles.
 $ make clean check
 ```
 
-in verbose mode:
+in verbose mode (enabled for GitHub Actions):
 ```
 $ make V=1 clean check
+```
+
+in extra verbose mode (enabled for debug logging):
+```
+$ make V=2 clean check
 ```
 
 only specific test:

--- a/test/test-functions
+++ b/test/test-functions
@@ -24,6 +24,10 @@ if [[ $V != "1" && $V != "2" ]]; then
     TEST_KERNEL_CMDLINE+="quiet "
 fi
 
+if [[ $V == "2" ]]; then
+    TEST_KERNEL_CMDLINE+="rd.debug "
+fi
+
 test_dracut() {
     # directory for test configurations
     mkdir -p /tmp/dracut.conf.d

--- a/tools/test-github.sh
+++ b/tools/test-github.sh
@@ -34,6 +34,6 @@ else
         )" \
         TEST_RUN_ID="$RUN_ID" \
         ${TESTS:+TESTS="$TESTS"} \
-        -k V=1 \
+        -k V="${V:=1}" \
         check
 fi


### PR DESCRIPTION
Set 'rd.debug' for all tests  in 'V=2' mode to make it more verbose than 'V=1' test mode.

## Checklist
- [ ] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it

Fixes #
