### PR TITLE
fix(base): init from base is not needed when systemd is enabled

### DIFF
--- a/modules.d/99base/module-setup.sh
+++ b/modules.d/99base/module-setup.sh
@@ -38,7 +38,6 @@ install() {
     [[ $hostonly ]] && grep '^root:' "$dracutsysrootdir"/etc/shadow >> "$initdir/etc/shadow"
 
     # install our scripts and hooks
-    inst_script "$moddir/init.sh" "/init"
     inst_script "$moddir/initqueue.sh" "/sbin/initqueue"
     inst_script "$moddir/loginit.sh" "/sbin/loginit"
     inst_script "$moddir/rdsosreport.sh" "/sbin/rdsosreport"
@@ -58,6 +57,7 @@ install() {
 
     if ! dracut_module_included "systemd"; then
         inst_multiple switch_root || dfatal "Failed to install switch_root"
+        inst_script "$moddir/init.sh" "/init"
         inst_hook cmdline 10 "$moddir/parse-root-opts.sh"
     fi
 


### PR DESCRIPTION

## Checklist
- [ ] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it

Fixes #
