### PR TITLE
fix(systemd-cryptsetup): install cryptsetup-pre.target

### DIFF
--- a/modules.d/00systemd/module-setup.sh
+++ b/modules.d/00systemd/module-setup.sh
@@ -44,7 +44,6 @@ install() {
         "$systemdutildir"/system.conf \
         "$systemdutildir"/system.conf.d/*.conf \
         "$systemdsystemunitdir"/debug-shell.service \
-        "$systemdsystemunitdir"/cryptsetup-pre.target \
         "$systemdsystemunitdir"/emergency.target \
         "$systemdsystemunitdir"/sysinit.target \
         "$systemdsystemunitdir"/basic.target \

--- a/modules.d/90crypt/module-setup.sh
+++ b/modules.d/90crypt/module-setup.sh
@@ -18,15 +18,7 @@ check() {
 
 # called by dracut
 depends() {
-    local deps
-    deps="dm rootfs-block"
-
-    if dracut_module_included "systemd"; then
-        deps+=" systemd-cryptsetup"
-    fi
-
-    echo "$deps"
-    return 0
+    echo dm rootfs-block
 }
 
 # called by dracut

--- a/modules.d/90systemd-cryptsetup/module-setup.sh
+++ b/modules.d/90systemd-cryptsetup/module-setup.sh
@@ -50,6 +50,7 @@ install() {
         "$tmpfilesdir"/cryptsetup.conf \
         "$systemdutildir"/system-generators/systemd-cryptsetup-generator \
         "$systemdutildir"/systemd-cryptsetup \
+        "$systemdsystemunitdir"/cryptsetup-pre.target \
         "$systemdsystemunitdir"/cryptsetup.target \
         "$systemdsystemunitdir"/sysinit.target.wants/cryptsetup.target \
         "$systemdsystemunitdir"/remote-cryptsetup.target \

--- a/modules.d/98dracut-systemd/module-setup.sh
+++ b/modules.d/98dracut-systemd/module-setup.sh
@@ -12,7 +12,17 @@ check() {
 
 # called by dracut
 depends() {
-    echo "systemd-initrd systemd-ask-password"
+    local deps
+    deps="systemd-initrd systemd-ask-password"
+
+    # when systemd and crypt are both included
+    # systemd-cryptsetup is mandatory dependency
+    # see https://github.com/dracut-ng/dracut-ng/issues/563
+    if dracut_module_included "crypt"; then
+        deps+=" systemd-cryptsetup"
+    fi
+
+    echo "$deps"
     return 0
 }
 


### PR DESCRIPTION
After d0f8fde5668cfd7fda1d15824e268b4949b4fd04 regressed module dependency check, it made the tree vulnerable to a module dependency cycle. 

8907ba124e9dcd57049c2ccb4fd20b98b3bd83c2 introduced a cycle in the module dependency. 

Now that the module dependency check is fixed, the cycle is detected and the CI is failing.

This PR resolves the cycle by reverting the offending commit and instead adds an alternative fix that was originally proposed in the PR that introduced the cycle.

Also moves cryptsetup-pre.target from systemd dracut module to systemd-cryptsetup dracut module.


## Checklist
- [ ] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it

Fixes #563
