### PR TITLE
fix(base): remove undocumented real_init, realinitpath and rd.distroinit

### DIFF
--- a/modules.d/99base/init.sh
+++ b/modules.d/99base/init.sh
@@ -276,7 +276,7 @@ source_hook cleanup
 
 # By the time we get here, the root filesystem should be mounted.
 # Try to find init.
-for i in "$(getarg real_init=)" "$(getarg init=)" $(getargs rd.distroinit=) /sbin/init; do
+for i in "$(getarg init=)" /sbin/init; do
     [ -n "$i" ] || continue
 
     __p="${NEWROOT}/${i}"

--- a/modules.d/99base/module-setup.sh
+++ b/modules.d/99base/module-setup.sh
@@ -61,12 +61,6 @@ install() {
         inst_hook cmdline 10 "$moddir/parse-root-opts.sh"
     fi
 
-    if [[ $realinitpath ]]; then
-        for i in $realinitpath; do
-            echo "rd.distroinit=$i"
-        done > "${initdir}/etc/cmdline.d/distroinit.conf"
-    fi
-
     ln -fs /proc/self/mounts "$initdir/etc/mtab"
     if [[ $ro_mnt == yes ]]; then
         echo ro >> "${initdir}/etc/cmdline.d/base.conf"


### PR DESCRIPTION
Not needed since https://github.com/dracut-ng/dracut-ng/commit/348baca3e401f2526b0f936cb172874f4bbe9dcd

## Checklist
- [ ] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it

Fixes #
