### PR TITLE
chore: remove deprecated command line options

### DIFF
--- a/man/dracut.cmdline.7.asc
+++ b/man/dracut.cmdline.7.asc
@@ -1431,8 +1431,6 @@ rd_LUKS_KEYDEV_UUID:: rd.luks.keydev.uuid
 
 rd_LUKS_KEYPATH:: rd.luks.keypath
 
-rd_NO_LUKS:: rd.luks=0
-
 rd_LUKS_UUID:: rd.luks.uuid
 
 rd_NO_LVMCONF:: rd.lvm.conf

--- a/man/dracut.cmdline.7.asc
+++ b/man/dracut.cmdline.7.asc
@@ -1391,8 +1391,6 @@ Deprecated, renamed Options
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~
 Here is a list of options and their new replacement.
 
-rd.ccw:: rd.znet
-
 rd_NO_DM:: rd.dm=0
 
 rdblacklist:: rd.driver.blacklist

--- a/man/dracut.cmdline.7.asc
+++ b/man/dracut.cmdline.7.asc
@@ -1393,28 +1393,6 @@ Here is a list of options and their new replacement.
 
 rd_NO_DM:: rd.dm=0
 
-rdblacklist:: rd.driver.blacklist
-
-rdinsmodpost:: rd.driver.post
-
-rdloaddriver:: rd.driver.pre
-
-check:: rd.live.check
-
-rdlivedebug:: rd.live.debug
-
-live_dir:: rd.live.dir
-
-liveimg:: rd.live.image
-
-overlay:: rd.live.overlay
-
-readonly_overlay:: rd.live.overlay.readonly
-
-reset_overlay:: rd.live.overlay.reset
-
-live_ram:: rd.live.ram
-
 rd_NO_MDADMCONF:: rd.md.conf=0
 
 rd_NO_MDIMSM:: rd.md.imsm=0

--- a/man/dracut.cmdline.7.asc
+++ b/man/dracut.cmdline.7.asc
@@ -1453,8 +1453,6 @@ rd_MD_UUID:: rd.md.uuid
 
 rd_NO_MULTIPATH: rd.multipath=0
 
-rd_NFS_DOMAIN:: rd.nfs.domain
-
 iscsi_initiator:: rd.iscsi.initiator
 
 iscsi_target_name:: rd.iscsi.target.name

--- a/man/dracut.cmdline.7.asc
+++ b/man/dracut.cmdline.7.asc
@@ -1493,10 +1493,6 @@ rd.udev.debug:: rd.udev.udev_log=debug
 
 rd.udev.info:: rd.udev.udev_log=info
 
-rd_NO_ZFCPCONF:: rd.zfcp.conf=0
-
-rd_ZNET:: rd.znet
-
 KEYMAP:: vconsole.keymap
 
 KEYTABLE:: vconsole.keymap

--- a/man/dracut.cmdline.7.asc
+++ b/man/dracut.cmdline.7.asc
@@ -1394,7 +1394,6 @@ Here is a list of options and their new replacement.
 rdbreak:: rd.break
 
 rd.ccw:: rd.znet
-rd_CCW:: rd.znet
 
 rd_DASD_MOD:: rd.dasd
 

--- a/man/dracut.cmdline.7.asc
+++ b/man/dracut.cmdline.7.asc
@@ -1399,8 +1399,6 @@ rdinitdebug rdnetdebug:: rd.debug
 
 rd_NO_DM:: rd.dm=0
 
-rd_DM_UUID:: rd.dm.uuid
-
 rdblacklist:: rd.driver.blacklist
 
 rdinsmodpost:: rd.driver.post

--- a/man/dracut.cmdline.7.asc
+++ b/man/dracut.cmdline.7.asc
@@ -1475,13 +1475,9 @@ iscsi_in_password:: rd.iscsi.in.password
 
 iscsi_firmware:: rd.iscsi.firmware=0
 
-rd_NO_PLYMOUTH:: rd.plymouth=0
-
 rd_retry:: rd.retry
 
 rdshell:: rd.shell
-
-rd_NO_SPLASH:: rd.splash
 
 rdudevdebug:: rd.udev.udev_log=debug
 

--- a/man/dracut.cmdline.7.asc
+++ b/man/dracut.cmdline.7.asc
@@ -1393,8 +1393,6 @@ Here is a list of options and their new replacement.
 
 rd.ccw:: rd.znet
 
-rdinitdebug rdnetdebug:: rd.debug
-
 rd_NO_DM:: rd.dm=0
 
 rdblacklist:: rd.driver.blacklist
@@ -1402,8 +1400,6 @@ rdblacklist:: rd.driver.blacklist
 rdinsmodpost:: rd.driver.post
 
 rdloaddriver:: rd.driver.pre
-
-rdinfo:: rd.info
 
 check:: rd.live.check
 
@@ -1450,10 +1446,6 @@ iscsi_in_username:: rd.iscsi.in.username
 iscsi_in_password:: rd.iscsi.in.password
 
 iscsi_firmware:: rd.iscsi.firmware=0
-
-rd_retry:: rd.retry
-
-rdshell:: rd.shell
 
 rdudevdebug:: rd.udev.udev_log=debug
 

--- a/man/dracut.cmdline.7.asc
+++ b/man/dracut.cmdline.7.asc
@@ -1427,17 +1427,9 @@ live_ram:: rd.live.ram
 
 rd_NO_CRYPTTAB:: rd.luks.crypttab=0
 
-rd_LUKS_KEYDEV_UUID:: rd.luks.keydev.uuid
-
-rd_LUKS_KEYPATH:: rd.luks.keypath
-
 rd_NO_LVMCONF:: rd.lvm.conf
 
-rd_LVM_LV:: rd.lvm.lv
-
 rd_NO_LVM:: rd.lvm=0
-
-rd_LVM_VG:: rd.lvm.vg
 
 rd_NO_MDADMCONF:: rd.md.conf=0
 

--- a/man/dracut.cmdline.7.asc
+++ b/man/dracut.cmdline.7.asc
@@ -1391,8 +1391,6 @@ Deprecated, renamed Options
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~
 Here is a list of options and their new replacement.
 
-rdbreak:: rd.break
-
 rd.ccw:: rd.znet
 
 rdinitdebug rdnetdebug:: rd.debug

--- a/man/dracut.cmdline.7.asc
+++ b/man/dracut.cmdline.7.asc
@@ -1405,8 +1405,6 @@ rdinsmodpost:: rd.driver.post
 
 rdloaddriver:: rd.driver.pre
 
-rd_NO_FSTAB:: rd.fstab=0
-
 rdinfo:: rd.info
 
 check:: rd.live.check
@@ -1424,12 +1422,6 @@ readonly_overlay:: rd.live.overlay.readonly
 reset_overlay:: rd.live.overlay.reset
 
 live_ram:: rd.live.ram
-
-rd_NO_CRYPTTAB:: rd.luks.crypttab=0
-
-rd_NO_LVMCONF:: rd.lvm.conf
-
-rd_NO_LVM:: rd.lvm=0
 
 rd_NO_MDADMCONF:: rd.md.conf=0
 

--- a/man/dracut.cmdline.7.asc
+++ b/man/dracut.cmdline.7.asc
@@ -1395,10 +1395,6 @@ rdbreak:: rd.break
 
 rd.ccw:: rd.znet
 
-rd_DASD_MOD:: rd.dasd
-
-rd_DASD:: rd.dasd
-
 rdinitdebug rdnetdebug:: rd.debug
 
 rd_NO_DM:: rd.dm=0
@@ -1498,8 +1494,6 @@ rd.udev.debug:: rd.udev.udev_log=debug
 rd.udev.info:: rd.udev.udev_log=info
 
 rd_NO_ZFCPCONF:: rd.zfcp.conf=0
-
-rd_ZFCP:: rd.zfcp
 
 rd_ZNET:: rd.znet
 

--- a/man/dracut.cmdline.7.asc
+++ b/man/dracut.cmdline.7.asc
@@ -1431,8 +1431,6 @@ rd_LUKS_KEYDEV_UUID:: rd.luks.keydev.uuid
 
 rd_LUKS_KEYPATH:: rd.luks.keypath
 
-rd_LUKS_UUID:: rd.luks.uuid
-
 rd_NO_LVMCONF:: rd.lvm.conf
 
 rd_LVM_LV:: rd.lvm.lv

--- a/modules.d/35connman/cm-config.sh
+++ b/modules.d/35connman/cm-config.sh
@@ -6,7 +6,7 @@ if [ -n "$netroot" ] || [ -e /tmp/net.ifaces ]; then
     echo rd.neednet >> /etc/cmdline.d/connman.conf
 fi
 
-if getargbool 0 rd.debug -d -y rdinitdebug -d -y rdnetdebug; then
+if getargbool 0 rd.debug; then
     if [ -n "$DRACUT_SYSTEMD" ]; then
         # Enable tty output if a usable console is found
         # shellcheck disable=SC2217

--- a/modules.d/35network-manager/nm-config.sh
+++ b/modules.d/35network-manager/nm-config.sh
@@ -6,7 +6,7 @@ if [ -n "$netroot" ] || [ -e /tmp/net.ifaces ]; then
     echo rd.neednet >> /etc/cmdline.d/35-neednet.conf
 fi
 
-if getargbool 0 rd.debug -d -y rdinitdebug -d -y rdnetdebug; then
+if getargbool 0 rd.debug; then
     # shellcheck disable=SC2174
     mkdir -m 0755 -p /run/NetworkManager/conf.d
     (

--- a/modules.d/50plymouth/plymouth-pretrigger.sh
+++ b/modules.d/50plymouth/plymouth-pretrigger.sh
@@ -1,7 +1,7 @@
 #!/bin/sh
 
 if type plymouthd > /dev/null 2>&1 && [ -z "$DRACUT_SYSTEMD" ]; then
-    if getargbool 1 plymouth.enable && getargbool 1 rd.plymouth -d -n rd_NO_PLYMOUTH; then
+    if getargbool 1 plymouth.enable && getargbool 1 rd.plymouth; then
         # first trigger graphics subsystem
         udevadm trigger --action=add --attr-match=class=0x030000 > /dev/null 2>&1
         # first trigger graphics and tty subsystem

--- a/modules.d/80lvmthinpool-monitor/start-thinpool-monitor.sh
+++ b/modules.d/80lvmthinpool-monitor/start-thinpool-monitor.sh
@@ -2,7 +2,7 @@
 
 type getarg > /dev/null 2>&1 || . /lib/dracut-lib.sh
 
-LVS=$(getargs rd.lvm.lv -d rd_LVM_LV=)
+LVS=$(getargs rd.lvm.lv)
 
 is_lvm2_thinp_device() {
     _device_path=$1

--- a/modules.d/90crypt/crypt-cleanup.sh
+++ b/modules.d/90crypt/crypt-cleanup.sh
@@ -3,7 +3,7 @@
 # close everything which is not busy
 rm -f -- /etc/udev/rules.d/70-luks.rules > /dev/null 2>&1
 
-if ! getarg rd.luks.uuid -d rd_LUKS_UUID > /dev/null 2>&1 && getargbool 1 rd.luks -d -n rd_NO_LUKS > /dev/null 2>&1; then
+if ! getarg rd.luks.uuid -d rd_LUKS_UUID > /dev/null 2>&1 && getargbool 1 rd.luks > /dev/null 2>&1; then
     while true; do
         local do_break="y"
         for i in /dev/mapper/luks-*; do

--- a/modules.d/90crypt/crypt-cleanup.sh
+++ b/modules.d/90crypt/crypt-cleanup.sh
@@ -3,7 +3,7 @@
 # close everything which is not busy
 rm -f -- /etc/udev/rules.d/70-luks.rules > /dev/null 2>&1
 
-if ! getarg rd.luks.uuid -d rd_LUKS_UUID > /dev/null 2>&1 && getargbool 1 rd.luks > /dev/null 2>&1; then
+if ! getarg rd.luks.uuid > /dev/null 2>&1 && getargbool 1 rd.luks > /dev/null 2>&1; then
     while true; do
         local do_break="y"
         for i in /dev/mapper/luks-*; do

--- a/modules.d/90crypt/cryptroot-ask.sh
+++ b/modules.d/90crypt/cryptroot-ask.sh
@@ -27,7 +27,7 @@ is_keysource=${3:-0}
 numtries=${4:-10}
 
 # TODO: improve to support what cmdline does
-if [ -f /etc/crypttab ] && getargbool 1 rd.luks.crypttab -d -n rd_NO_CRYPTTAB; then
+if [ -f /etc/crypttab ] && getargbool 1 rd.luks.crypttab; then
     while read -r name dev luksfile luksoptions || [ -n "$name" ]; do
         # ignore blank lines and comments
         if [ -z "$name" ] || [ "${name#\#}" != "$name" ]; then

--- a/modules.d/90crypt/parse-crypt.sh
+++ b/modules.d/90crypt/parse-crypt.sh
@@ -22,7 +22,7 @@ _cryptgetargsname() {
     return 1
 }
 
-if ! getargbool 1 rd.luks -d -n rd_NO_LUKS; then
+if ! getargbool 1 rd.luks; then
     info "rd.luks=0: removing cryptoluks activation"
     rm -f -- /etc/udev/rules.d/70-luks.rules
 else

--- a/modules.d/90crypt/parse-crypt.sh
+++ b/modules.d/90crypt/parse-crypt.sh
@@ -31,9 +31,9 @@ else
         echo 'ACTION!="add|change", GOTO="luks_end"'
     } > /etc/udev/rules.d/70-luks.rules.new
 
-    PARTUUID=$(getargs rd.luks.partuuid -d rd_LUKS_PARTUUID)
-    SERIAL=$(getargs rd.luks.serial -d rd_LUKS_SERIAL)
-    LUKS=$(getargs rd.luks.uuid -d rd_LUKS_UUID)
+    PARTUUID=$(getargs rd.luks.partuuid)
+    SERIAL=$(getargs rd.luks.serial)
+    LUKS=$(getargs rd.luks.uuid)
     tout=$(getarg rd.luks.key.tout)
 
     if [ -e /etc/crypttab ]; then

--- a/modules.d/90crypt/parse-keydev.sh
+++ b/modules.d/90crypt/parse-keydev.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 
-if getargbool 1 rd.luks -n rd_NO_LUKS \
+if getargbool 1 rd.luks \
     && [ -n "$(getarg rd.luks.key)" ]; then
     exec 7> /etc/udev/rules.d/65-luks-keydev.rules
     echo 'SUBSYSTEM!="block", GOTO="luks_keydev_end"' >&7

--- a/modules.d/90dmraid/dmraid.sh
+++ b/modules.d/90dmraid/dmraid.sh
@@ -8,7 +8,7 @@ devenc=$(str_replace "$1" '/' '\2f')
 
 : > /tmp/dmraid."$devenc"
 
-DM_RAIDS=$(getargs rd.dm.uuid -d rd_DM_UUID=)
+DM_RAIDS=$(getargs rd.dm.uuid)
 
 if [ -n "$DM_RAIDS" ] || getargbool 0 rd.auto; then
     # run dmraid if udev has settled

--- a/modules.d/90dmraid/parse-dm.sh
+++ b/modules.d/90dmraid/parse-dm.sh
@@ -20,7 +20,7 @@ if ! command -v mdadm > /dev/null \
     udevproperty rd_NO_MDDDF=1
 fi
 
-DM_RAIDS=$(getargs rd.dm.uuid -d rd_DM_UUID=)
+DM_RAIDS=$(getargs rd.dm.uuid)
 
 if [ -z "$DM_RAIDS" ] && ! getargbool 0 rd.auto; then
     udevproperty rd_NO_DM=1

--- a/modules.d/90dmsquash-live-autooverlay/create-overlay.sh
+++ b/modules.d/90dmsquash-live-autooverlay/create-overlay.sh
@@ -2,7 +2,7 @@
 
 type getarg > /dev/null 2>&1 || . /lib/dracut-lib.sh
 
-if getargbool 0 rd.live.debug -n -y rdlivedebug; then
+if getargbool 0 rd.live.debug; then
     exec > /tmp/create-overlay.$$.out
     exec 2>> /tmp/create-overlay.$$.out
     set -x

--- a/modules.d/90dmsquash-live/dmsquash-generator.sh
+++ b/modules.d/90dmsquash-live/dmsquash-generator.sh
@@ -5,7 +5,7 @@ type getarg > /dev/null 2>&1 || . /lib/dracut-lib.sh
 [ -z "$root" ] && root=$(getarg root=)
 
 # support legacy syntax of passing liveimg and then just the base root
-if getargbool 0 rd.live.image -d -y liveimg; then
+if getargbool 0 rd.live.image; then
     liveroot="live:$root"
 fi
 
@@ -45,7 +45,7 @@ GENERATOR_DIR="$2"
 [ -z "$GENERATOR_DIR" ] && exit 1
 [ -d "$GENERATOR_DIR" ] || mkdir -p "$GENERATOR_DIR"
 
-getargbool 0 rd.live.overlay.readonly -d -y readonly_overlay && readonly_overlay="--readonly" || readonly_overlay=""
+getargbool 0 rd.live.overlay.readonly && readonly_overlay="--readonly" || readonly_overlay=""
 getargbool 0 rd.live.overlay.overlayfs && overlayfs="yes"
 [ -e /xor_overlayfs ] && xor_overlayfs="yes"
 [ -e /xor_readonly ] && xor_readonly="--readonly"

--- a/modules.d/90dmsquash-live/dmsquash-live-root.sh
+++ b/modules.d/90dmsquash-live/dmsquash-live-root.sh
@@ -7,7 +7,7 @@ command -v unpack_archive > /dev/null || . /lib/img-lib.sh
 
 PATH=/usr/sbin:/usr/bin:/sbin:/bin
 
-if getargbool 0 rd.live.debug -n -y rdlivedebug; then
+if getargbool 0 rd.live.debug; then
     exec > /tmp/liveroot.$$.out
     exec 2>> /tmp/liveroot.$$.out
     set -x
@@ -18,16 +18,16 @@ livedev="$1"
 
 # parse various live image specific options that make sense to be
 # specified as their own things
-live_dir=$(getarg rd.live.dir -d live_dir)
+live_dir=$(getarg rd.live.dir)
 [ -z "$live_dir" ] && live_dir="LiveOS"
 squash_image=$(getarg rd.live.squashimg)
 [ -z "$squash_image" ] && squash_image="squashfs.img"
 
-getargbool 0 rd.live.ram -d -y live_ram && live_ram="yes"
-getargbool 0 rd.live.overlay.reset -d -y reset_overlay && reset_overlay="yes"
-getargbool 0 rd.live.overlay.readonly -d -y readonly_overlay && readonly_overlay="--readonly" || readonly_overlay=""
-overlay=$(getarg rd.live.overlay -d overlay)
-getargbool 0 rd.writable.fsimg -d -y writable_fsimg && writable_fsimg="yes"
+getargbool 0 rd.live.ram && live_ram="yes"
+getargbool 0 rd.live.overlay.reset && reset_overlay="yes"
+getargbool 0 rd.live.overlay.readonly && readonly_overlay="--readonly" || readonly_overlay=""
+overlay=$(getarg rd.live.overlay)
+getargbool 0 rd.writable.fsimg && writable_fsimg="yes"
 overlay_size=$(getarg rd.live.overlay.size=)
 [ -z "$overlay_size" ] && overlay_size=32768
 
@@ -70,7 +70,7 @@ if [ ! -f "$livedev" ]; then
     if [ "$fs" = "iso9660" ] || [ "$fs" = "udf" ]; then
         check="yes"
     fi
-    getarg rd.live.check -d check || check=""
+    getarg rd.live.check || check=""
     if [ -n "$check" ]; then
         type plymouth > /dev/null 2>&1 && plymouth --hide-splash
         if [ -n "$DRACUT_SYSTEMD" ]; then

--- a/modules.d/90dmsquash-live/parse-dmsquash-live.sh
+++ b/modules.d/90dmsquash-live/parse-dmsquash-live.sh
@@ -5,7 +5,7 @@
 [ -z "$root" ] && root=$(getarg root=)
 
 # support legacy syntax of passing liveimg and then just the base root
-if getargbool 0 rd.live.image -d -y liveimg; then
+if getargbool 0 rd.live.image; then
     liveroot="live:$root"
 fi
 

--- a/modules.d/90kernel-modules/insmodpost.sh
+++ b/modules.d/90kernel-modules/insmodpost.sh
@@ -2,7 +2,7 @@
 
 . /lib/dracut-lib.sh
 
-for modlist in $(getargs rd.driver.post -d rdinsmodpost=); do
+for modlist in $(getargs rd.driver.post); do
     (
         IFS=,
         for m in $modlist; do

--- a/modules.d/90kernel-modules/parse-kernel.sh
+++ b/modules.d/90kernel-modules/parse-kernel.sh
@@ -5,7 +5,7 @@ if [ ! -d $_modprobe_d ]; then
     mkdir -p $_modprobe_d
 fi
 
-for i in $(getargs rd.driver.pre -d rdloaddriver=); do
+for i in $(getargs rd.driver.pre); do
     (
         IFS=,
         for p in $i; do
@@ -14,7 +14,7 @@ for i in $(getargs rd.driver.pre -d rdloaddriver=); do
     )
 done
 
-for i in $(getargs rd.driver.blacklist -d rdblacklist=); do
+for i in $(getargs rd.driver.blacklist); do
     (
         IFS=,
         for p in $i; do
@@ -23,7 +23,7 @@ for i in $(getargs rd.driver.blacklist -d rdblacklist=); do
     )
 done
 
-for p in $(getargs rd.driver.post -d rdinsmodpost=); do
+for p in $(getargs rd.driver.post); do
     echo "blacklist $p" >> $_modprobe_d/initramfsblacklist.conf
     _do_insmodpost=1
 done

--- a/modules.d/90livenet/livenet-generator.sh
+++ b/modules.d/90livenet/livenet-generator.sh
@@ -5,7 +5,7 @@ type getarg > /dev/null 2>&1 || . /lib/dracut-lib.sh
 [ -z "$root" ] && root=$(getarg root=)
 
 # support legacy syntax of passing liveimg and then just the base root
-if getargbool 0 rd.live.image -d -y liveimg; then
+if getargbool 0 rd.live.image; then
     liveroot="live:$root"
 fi
 
@@ -49,7 +49,7 @@ GENERATOR_DIR="$2"
 
 [ -d "$GENERATOR_DIR" ] || mkdir -p "$GENERATOR_DIR"
 
-getargbool 0 rd.live.overlay.readonly -d -y readonly_overlay && readonly_overlay="--readonly" || readonly_overlay=""
+getargbool 0 rd.live.overlay.readonly && readonly_overlay="--readonly" || readonly_overlay=""
 getargbool 0 rd.live.overlay.overlayfs && overlayfs="yes"
 [ -e /xor_overlayfs ] && xor_overlayfs="yes"
 [ -e /xor_readonly ] && xor_readonly="--readonly"

--- a/modules.d/90lvm/lvm_scan.sh
+++ b/modules.d/90lvm/lvm_scan.sh
@@ -5,8 +5,8 @@
 extraargs="$*"
 type getarg > /dev/null 2>&1 || . /lib/dracut-lib.sh
 
-VGS=$(getargs rd.lvm.vg -d rd_LVM_VG=)
-LVS=$(getargs rd.lvm.lv -d rd_LVM_LV=)
+VGS=$(getargs rd.lvm.vg)
+LVS=$(getargs rd.lvm.lv)
 
 # shellcheck disable=SC2174
 [ -d /etc/lvm ] || mkdir -m 0755 -p /etc/lvm

--- a/modules.d/90lvm/parse-lvm.sh
+++ b/modules.d/90lvm/parse-lvm.sh
@@ -1,12 +1,12 @@
 #!/bin/sh
 
-if [ -e /etc/lvm/lvm.conf ] && ! getargbool 1 rd.lvm.conf -d -n rd_NO_LVMCONF; then
+if [ -e /etc/lvm/lvm.conf ] && ! getargbool 1 rd.lvm.conf; then
     rm -f -- /etc/lvm/lvm.conf
 fi
 
 LV_DEVS="$(getargs rd.lvm.vg) $(getargs rd.lvm.lv)"
 
-if ! getargbool 1 rd.lvm -d -n rd_NO_LVM \
+if ! getargbool 1 rd.lvm \
     || { [ -z "$LV_DEVS" ] && ! getargbool 0 rd.auto; }; then
     info "rd.lvm=0: removing LVM activation"
     rm -f -- /etc/udev/rules.d/64-lvm*.rules

--- a/modules.d/90lvm/parse-lvm.sh
+++ b/modules.d/90lvm/parse-lvm.sh
@@ -4,7 +4,7 @@ if [ -e /etc/lvm/lvm.conf ] && ! getargbool 1 rd.lvm.conf -d -n rd_NO_LVMCONF; t
     rm -f -- /etc/lvm/lvm.conf
 fi
 
-LV_DEVS="$(getargs rd.lvm.vg -d rd_LVM_VG=) $(getargs rd.lvm.lv -d rd_LVM_LV=)"
+LV_DEVS="$(getargs rd.lvm.vg) $(getargs rd.lvm.lv)"
 
 if ! getargbool 1 rd.lvm -d -n rd_NO_LVM \
     || { [ -z "$LV_DEVS" ] && ! getargbool 0 rd.auto; }; then

--- a/modules.d/90overlayfs/mount-overlayfs.sh
+++ b/modules.d/90overlayfs/mount-overlayfs.sh
@@ -3,7 +3,7 @@
 type getarg > /dev/null 2>&1 || . /lib/dracut-lib.sh
 
 getargbool 0 rd.live.overlay.overlayfs && overlayfs="yes"
-getargbool 0 rd.live.overlay.readonly -d -y readonly_overlay && readonly_overlay="--readonly" || readonly_overlay=""
+getargbool 0 rd.live.overlay.readonly && readonly_overlay="--readonly" || readonly_overlay=""
 
 ROOTFLAGS="$(getarg rootflags)"
 

--- a/modules.d/90overlayfs/prepare-overlayfs.sh
+++ b/modules.d/90overlayfs/prepare-overlayfs.sh
@@ -3,7 +3,7 @@
 type getarg > /dev/null 2>&1 || . /lib/dracut-lib.sh
 
 getargbool 0 rd.live.overlay.overlayfs && overlayfs="yes"
-getargbool 0 rd.live.overlay.reset -d -y reset_overlay && reset_overlay="yes"
+getargbool 0 rd.live.overlay.reset && reset_overlay="yes"
 
 if [ -n "$overlayfs" ]; then
     if ! [ -e /run/rootfsbase ]; then

--- a/modules.d/95nfs/parse-nfsroot.sh
+++ b/modules.d/95nfs/parse-nfsroot.sh
@@ -87,7 +87,7 @@ esac
 
 # Check required arguments
 
-if nfsdomain=$(getarg rd.nfs.domain -d rd_NFS_DOMAIN); then
+if nfsdomain=$(getarg rd.nfs.domain); then
     if [ -f /etc/idmapd.conf ]; then
         sed -i -e \
             "s/^[[:space:]#]*Domain[[:space:]]*=.*/Domain = $nfsdomain/g" \

--- a/modules.d/95rootfs-block/mount-root.sh
+++ b/modules.d/95rootfs-block/mount-root.sh
@@ -65,7 +65,7 @@ mount_root() {
     fi
 
     rootopts=
-    if getargbool 1 rd.fstab -d -n rd_NO_FSTAB \
+    if getargbool 1 rd.fstab \
         && ! getarg rootflags > /dev/null \
         && [ -f "$NEWROOT/etc/fstab" ] \
         && ! [ -L "$NEWROOT/etc/fstab" ]; then

--- a/modules.d/95virtfs/mount-virtfs.sh
+++ b/modules.d/95virtfs/mount-virtfs.sh
@@ -34,7 +34,7 @@ mount_root() {
     mount -t ${rootfs} -o "$rflags",ro "${root#virtfs:}" "$NEWROOT"
 
     rootopts=
-    if getargbool 1 rd.fstab -n rd_NO_FSTAB \
+    if getargbool 1 rd.fstab \
         && ! getarg rootflags \
         && [ -f "$NEWROOT/etc/fstab" ] \
         && ! [ -L "$NEWROOT/etc/fstab" ]; then

--- a/modules.d/95zfcp/parse-zfcp.sh
+++ b/modules.d/95zfcp/parse-zfcp.sh
@@ -1,5 +1,5 @@
 #!/bin/sh
 
-getargbool 1 rd.zfcp.conf -d -n rd_NO_ZFCPCONF || rm /etc/zfcp.conf
+getargbool 1 rd.zfcp.conf || rm /etc/zfcp.conf
 
 zfcp_cio_free

--- a/modules.d/95znet/parse-ccw.sh
+++ b/modules.d/95znet/parse-ccw.sh
@@ -13,7 +13,7 @@ znet_vinfo() {
     done
 }
 
-for ccw_arg in $(getargs rd.ccw -d 'rd_CCW=') $(getargs rd.znet -d 'rd_ZNET='); do
+for ccw_arg in $(getargs rd.ccw) $(getargs rd.znet -d 'rd_ZNET='); do
     (
         SAVED_IFS="$IFS"
         IFS=","

--- a/modules.d/95znet/parse-ccw.sh
+++ b/modules.d/95znet/parse-ccw.sh
@@ -13,7 +13,7 @@ znet_vinfo() {
     done
 }
 
-for ccw_arg in $(getargs rd.ccw) $(getargs rd.znet); do
+for ccw_arg in $(getargs rd.znet); do
     (
         SAVED_IFS="$IFS"
         IFS=","

--- a/modules.d/95znet/parse-ccw.sh
+++ b/modules.d/95znet/parse-ccw.sh
@@ -13,7 +13,7 @@ znet_vinfo() {
     done
 }
 
-for ccw_arg in $(getargs rd.ccw) $(getargs rd.znet -d 'rd_ZNET='); do
+for ccw_arg in $(getargs rd.ccw) $(getargs rd.znet); do
     (
         SAVED_IFS="$IFS"
         IFS=","

--- a/modules.d/98dracut-systemd/dracut-cmdline.sh
+++ b/modules.d/98dracut-systemd/dracut-cmdline.sh
@@ -47,7 +47,7 @@ export fstype
 
 make_trace_mem "hook cmdline" '1+:mem' '1+:iomem' '3+:slab'
 # run scriptlets to parse the command line
-getargs 'rd.break=cmdline' -d 'rdbreak=cmdline' && emergency_shell -n cmdline "Break before cmdline"
+getargs 'rd.break=cmdline' && emergency_shell -n cmdline "Break before cmdline"
 source_hook cmdline
 
 [ -f /lib/dracut/parse-resume.sh ] && . /lib/dracut/parse-resume.sh

--- a/modules.d/98dracut-systemd/dracut-emergency.sh
+++ b/modules.d/98dracut-systemd/dracut-emergency.sh
@@ -13,7 +13,7 @@ type plymouth > /dev/null 2>&1 && plymouth quit
 export _rdshell_name="dracut" action="Boot" hook="emergency"
 _emergency_action=$(getarg rd.emergency)
 
-if getargbool 1 rd.shell -d -y rdshell || getarg rd.break; then
+if getargbool 1 rd.shell || getarg rd.break; then
     FSTXT="/run/dracut/fsck/fsck_help_$fstype.txt"
     RDSOSREPORT="$(rdsosreport)"
     source_hook "$hook"

--- a/modules.d/98dracut-systemd/dracut-emergency.sh
+++ b/modules.d/98dracut-systemd/dracut-emergency.sh
@@ -13,7 +13,7 @@ type plymouth > /dev/null 2>&1 && plymouth quit
 export _rdshell_name="dracut" action="Boot" hook="emergency"
 _emergency_action=$(getarg rd.emergency)
 
-if getargbool 1 rd.shell -d -y rdshell || getarg rd.break -d rdbreak; then
+if getargbool 1 rd.shell -d -y rdshell || getarg rd.break; then
     FSTXT="/run/dracut/fsck/fsck_help_$fstype.txt"
     RDSOSREPORT="$(rdsosreport)"
     source_hook "$hook"

--- a/modules.d/98dracut-systemd/dracut-initqueue.sh
+++ b/modules.d/98dracut-systemd/dracut-initqueue.sh
@@ -9,7 +9,7 @@ type getarg > /dev/null 2>&1 || . /lib/dracut-lib.sh
 source_conf /etc/conf.d
 
 make_trace_mem "hook initqueue" '1:shortmem' '2+:mem' '3+:slab'
-getargs 'rd.break=initqueue' -d 'rdbreak=initqueue' && emergency_shell -n initqueue "Break before initqueue"
+getargs 'rd.break=initqueue' && emergency_shell -n initqueue "Break before initqueue"
 
 RDRETRY=$(getarg rd.retry -d 'rd_retry=')
 RDRETRY=${RDRETRY:-180}

--- a/modules.d/98dracut-systemd/dracut-initqueue.sh
+++ b/modules.d/98dracut-systemd/dracut-initqueue.sh
@@ -11,7 +11,7 @@ source_conf /etc/conf.d
 make_trace_mem "hook initqueue" '1:shortmem' '2+:mem' '3+:slab'
 getargs 'rd.break=initqueue' && emergency_shell -n initqueue "Break before initqueue"
 
-RDRETRY=$(getarg rd.retry -d 'rd_retry=')
+RDRETRY=$(getarg rd.retry)
 RDRETRY=${RDRETRY:-180}
 RDRETRY=$((RDRETRY * 2))
 export RDRETRY

--- a/modules.d/98dracut-systemd/dracut-mount.sh
+++ b/modules.d/98dracut-systemd/dracut-mount.sh
@@ -9,7 +9,7 @@ source_conf /etc/conf.d
 
 make_trace_mem "hook mount" '1:shortmem' '2+:mem' '3+:slab'
 
-getargs 'rd.break=mount' -d 'rdbreak=mount' && emergency_shell -n mount "Break before mount"
+getargs 'rd.break=mount' && emergency_shell -n mount "Break before mount"
 # mount scripts actually try to mount the root filesystem, and may
 # be sourced any number of times. As soon as one succeeds, no more are sourced.
 i=0

--- a/modules.d/98dracut-systemd/dracut-pre-mount.sh
+++ b/modules.d/98dracut-systemd/dracut-pre-mount.sh
@@ -11,7 +11,7 @@ source_conf /etc/conf.d
 make_trace_mem "hook pre-mount" '1:shortmem' '2+:mem' '3+:slab'
 # pre pivot scripts are sourced just before we doing cleanup and switch over
 # to the new root.
-getargs 'rd.break=pre-mount' -d 'rdbreak=pre-mount' && emergency_shell -n pre-mount "Break before pre-mount"
+getargs 'rd.break=pre-mount' && emergency_shell -n pre-mount "Break before pre-mount"
 source_hook pre-mount
 
 export -p > /dracut-state.sh

--- a/modules.d/98dracut-systemd/dracut-pre-pivot.sh
+++ b/modules.d/98dracut-systemd/dracut-pre-pivot.sh
@@ -11,14 +11,14 @@ source_conf /etc/conf.d
 make_trace_mem "hook pre-pivot" '1:shortmem' '2+:mem' '3+:slab'
 # pre pivot scripts are sourced just before we doing cleanup and switch over
 # to the new root.
-getargs 'rd.break=pre-pivot' -d 'rdbreak=pre-pivot' && emergency_shell -n pre-pivot "Break before pre-pivot"
+getargs 'rd.break=pre-pivot' && emergency_shell -n pre-pivot "Break before pre-pivot"
 source_hook pre-pivot
 
 # pre pivot cleanup scripts are sourced just before we switch over to the new root.
-getargs 'rd.break=cleanup' -d 'rdbreak=cleanup' && emergency_shell -n cleanup "Break before cleanup"
+getargs 'rd.break=cleanup' && emergency_shell -n cleanup "Break before cleanup"
 source_hook cleanup
 
-_bv=$(getarg rd.break -d rdbreak) && [ -z "$_bv" ] \
+_bv=$(getarg rd.break) && [ -z "$_bv" ] \
     && emergency_shell -n switch_root "Break before switch_root"
 unset _bv
 

--- a/modules.d/98dracut-systemd/dracut-pre-trigger.sh
+++ b/modules.d/98dracut-systemd/dracut-pre-trigger.sh
@@ -12,7 +12,7 @@ make_trace_mem "hook pre-trigger" '1:shortmem' '2+:mem' '3+:slab'
 
 source_hook pre-trigger
 
-getargs 'rd.break=pre-trigger' -d 'rdbreak=pre-trigger' && emergency_shell -n pre-trigger "Break before pre-trigger"
+getargs 'rd.break=pre-trigger' && emergency_shell -n pre-trigger "Break before pre-trigger"
 
 udevadm control --reload > /dev/null 2>&1 || :
 

--- a/modules.d/98dracut-systemd/dracut-pre-udev.sh
+++ b/modules.d/98dracut-systemd/dracut-pre-udev.sh
@@ -18,7 +18,7 @@ if [ ! -d $_modprobe_d ]; then
     mkdir -p $_modprobe_d
 fi
 
-for i in $(getargs rd.driver.pre -d rdloaddriver=); do
+for i in $(getargs rd.driver.pre); do
     (
         IFS=,
         for p in $i; do
@@ -27,7 +27,7 @@ for i in $(getargs rd.driver.pre -d rdloaddriver=); do
     )
 done
 
-for i in $(getargs rd.driver.blacklist -d rdblacklist=); do
+for i in $(getargs rd.driver.blacklist); do
     (
         IFS=,
         for p in $i; do
@@ -36,7 +36,7 @@ for i in $(getargs rd.driver.blacklist -d rdblacklist=); do
     )
 done
 
-for p in $(getargs rd.driver.post -d rdinsmodpost=); do
+for p in $(getargs rd.driver.post); do
     echo "blacklist $p" >> $_modprobe_d/initramfsblacklist.conf
     _do_insmodpost=1
 done

--- a/modules.d/98dracut-systemd/dracut-pre-udev.sh
+++ b/modules.d/98dracut-systemd/dracut-pre-udev.sh
@@ -10,7 +10,7 @@ source_conf /etc/conf.d
 make_trace_mem "hook pre-udev" '1:shortmem' '2+:mem' '3+:slab'
 # pre pivot scripts are sourced just before we doing cleanup and switch over
 # to the new root.
-getargs 'rd.break=pre-udev' -d 'rdbreak=pre-udev' && emergency_shell -n pre-udev "Break before pre-udev"
+getargs 'rd.break=pre-udev' && emergency_shell -n pre-udev "Break before pre-udev"
 source_hook pre-udev
 
 _modprobe_d=/run/modprobe.d

--- a/modules.d/99base/dracut-lib.sh
+++ b/modules.d/99base/dracut-lib.sh
@@ -975,7 +975,7 @@ emergency_shell() {
         && [ -e /run/initramfs/.die ] \
         && _emergency_action=poweroff
 
-    if getargbool 1 rd.shell -d -y rdshell || getarg rd.break -d rdbreak; then
+    if getargbool 1 rd.shell -d -y rdshell || getarg rd.break; then
         _emergency_shell "$_rdshell_name"
     else
         source_hook "$hook"

--- a/modules.d/99base/dracut-lib.sh
+++ b/modules.d/99base/dracut-lib.sh
@@ -371,7 +371,7 @@ setdebug() {
     if [ -z "$RD_DEBUG" ]; then
         if [ -e /proc/cmdline ]; then
             RD_DEBUG=no
-            if getargbool 0 rd.debug -d -y rdinitdebug -d -y rdnetdebug; then
+            if getargbool 0 rd.debug; then
                 RD_DEBUG=yes
                 [ -n "$BASH" ] \
                     && export PS4='${BASH_SOURCE}@${LINENO}(${FUNCNAME[0]-}): '
@@ -460,8 +460,8 @@ die() {
 check_quiet() {
     if [ -z "$DRACUT_QUIET" ]; then
         DRACUT_QUIET="yes"
-        getargbool 0 rd.info -d -y rdinfo && DRACUT_QUIET="no"
-        getargbool 0 rd.debug -d -y rdinitdebug && DRACUT_QUIET="no"
+        getargbool 0 rd.info && DRACUT_QUIET="no"
+        getargbool 0 rd.debug && DRACUT_QUIET="no"
         getarg quiet || DRACUT_QUIET="yes"
         a=$(getarg loglevel=)
         [ -n "$a" ] && [ "$a" -ge 28 ] && DRACUT_QUIET="yes"
@@ -923,7 +923,7 @@ _emergency_shell() {
         /sbin/rdsosreport
         echo 'You might want to save "/run/initramfs/rdsosreport.txt" to a USB stick or /boot'
         echo 'after mounting them and attach it to a bug report.'
-        if ! RD_DEBUG='' getargbool 0 rd.debug -d -y rdinitdebug -d -y rdnetdebug; then
+        if ! RD_DEBUG='' getargbool 0 rd.debug -d -y rdnetdebug; then
             echo
             echo 'To get more debug information in the report,'
             echo 'reboot with "rd.debug" added to the kernel command line.'
@@ -975,7 +975,7 @@ emergency_shell() {
         && [ -e /run/initramfs/.die ] \
         && _emergency_action=poweroff
 
-    if getargbool 1 rd.shell -d -y rdshell || getarg rd.break; then
+    if getargbool 1 rd.shell || getarg rd.break; then
         _emergency_shell "$_rdshell_name"
     else
         source_hook "$hook"

--- a/modules.d/99base/init.sh
+++ b/modules.d/99base/init.sh
@@ -125,7 +125,7 @@ fi
 
 # run scriptlets to parse the command line
 make_trace_mem "hook cmdline" '1+:mem' '1+:iomem' '3+:slab'
-getargs 'rd.break=cmdline' -d 'rdbreak=cmdline' && emergency_shell -n cmdline "Break before cmdline"
+getargs 'rd.break=cmdline' && emergency_shell -n cmdline "Break before cmdline"
 source_hook cmdline
 
 [ -z "$root" ] && die "No or empty root= argument"
@@ -135,7 +135,7 @@ export root rflags fstype netroot NEWROOT
 
 # pre-udev scripts run before udev starts, and are run only once.
 make_trace_mem "hook pre-udev" '1:shortmem' '2+:mem' '3+:slab'
-getargs 'rd.break=pre-udev' -d 'rdbreak=pre-udev' && emergency_shell -n pre-udev "Break before pre-udev"
+getargs 'rd.break=pre-udev' && emergency_shell -n pre-udev "Break before pre-udev"
 source_hook pre-udev
 
 UDEV_LOG=err
@@ -152,7 +152,7 @@ UDEV_QUEUE_EMPTY="udevadm settle --timeout=0"
 udevproperty "hookdir=$hookdir"
 
 make_trace_mem "hook pre-trigger" '1:shortmem' '2+:mem' '3+:slab'
-getargs 'rd.break=pre-trigger' -d 'rdbreak=pre-trigger' && emergency_shell -n pre-trigger "Break before pre-trigger"
+getargs 'rd.break=pre-trigger' && emergency_shell -n pre-trigger "Break before pre-trigger"
 source_hook pre-trigger
 
 udevadm control --reload > /dev/null 2>&1 || :
@@ -161,7 +161,7 @@ udevadm trigger --type=subsystems --action=add > /dev/null 2>&1
 udevadm trigger --type=devices --action=add > /dev/null 2>&1
 
 make_trace_mem "hook initqueue" '1:shortmem' '2+:mem' '3+:slab'
-getargs 'rd.break=initqueue' -d 'rdbreak=initqueue' && emergency_shell -n initqueue "Break before initqueue"
+getargs 'rd.break=initqueue' && emergency_shell -n initqueue "Break before initqueue"
 
 RDRETRY=$(getarg rd.retry -d 'rd_retry=')
 RDRETRY=${RDRETRY:-180}
@@ -227,10 +227,10 @@ unset RDRETRY
 # pre-mount happens before we try to mount the root filesystem,
 # and happens once.
 make_trace_mem "hook pre-mount" '1:shortmem' '2+:mem' '3+:slab'
-getargs 'rd.break=pre-mount' -d 'rdbreak=pre-mount' && emergency_shell -n pre-mount "Break before pre-mount"
+getargs 'rd.break=pre-mount' && emergency_shell -n pre-mount "Break before pre-mount"
 source_hook pre-mount
 
-getargs 'rd.break=mount' -d 'rdbreak=mount' && emergency_shell -n mount "Break before mount"
+getargs 'rd.break=mount' && emergency_shell -n mount "Break before mount"
 # mount scripts actually try to mount the root filesystem, and may
 # be sourced any number of times. As soon as one succeeds, no more are sourced.
 _i_mount=0
@@ -266,12 +266,12 @@ done
 # pre pivot scripts are sourced just before we doing cleanup and switch over
 # to the new root.
 make_trace_mem "hook pre-pivot" '1:shortmem' '2+:mem' '3+:slab'
-getargs 'rd.break=pre-pivot' -d 'rdbreak=pre-pivot' && emergency_shell -n pre-pivot "Break before pre-pivot"
+getargs 'rd.break=pre-pivot' && emergency_shell -n pre-pivot "Break before pre-pivot"
 source_hook pre-pivot
 
 make_trace_mem "hook cleanup" '1:shortmem' '2+:mem' '3+:slab'
 # pre pivot cleanup scripts are sourced just before we switch over to the new root.
-getargs 'rd.break=cleanup' -d 'rdbreak=cleanup' && emergency_shell -n cleanup "Break before cleanup"
+getargs 'rd.break=cleanup' && emergency_shell -n cleanup "Break before cleanup"
 source_hook cleanup
 
 # By the time we get here, the root filesystem should be mounted.
@@ -370,7 +370,7 @@ wait_for_loginit
 # remove helper symlink
 [ -h /dev/root ] && rm -f -- /dev/root
 
-bv=$(getarg rd.break -d rdbreak) && [ -z "$bv" ] \
+bv=$(getarg rd.break) && [ -z "$bv" ] \
     && emergency_shell -n switch_root "Break before switch_root"
 unset bv
 info "Switching root"

--- a/modules.d/99base/init.sh
+++ b/modules.d/99base/init.sh
@@ -163,7 +163,7 @@ udevadm trigger --type=devices --action=add > /dev/null 2>&1
 make_trace_mem "hook initqueue" '1:shortmem' '2+:mem' '3+:slab'
 getargs 'rd.break=initqueue' && emergency_shell -n initqueue "Break before initqueue"
 
-RDRETRY=$(getarg rd.retry -d 'rd_retry=')
+RDRETRY=$(getarg rd.retry)
 RDRETRY=${RDRETRY:-180}
 RDRETRY=$((RDRETRY * 2))
 export RDRETRY

--- a/test/TEST-98-GETARG/test.sh
+++ b/test/TEST-98-GETARG/test.sh
@@ -103,11 +103,11 @@ test_run() {
 
         # shellcheck disable=SC2317  # called later by getarg in dracut-lib.sh
         getcmdline() {
-            echo "rdbreak=cmdline rd.lvm rd.auto=0 rd.auto rd.retry=10"
+            echo "rd.break=cmdline rd.lvm rd.auto=0 rd.auto rd.retry=10"
         }
         RDRETRY=$(getarg rd.retry -d 'rd_retry=')
         [[ $RDRETRY == "10" ]] || ret=$((ret + 1))
-        getarg rd.break=cmdline -d rdbreak=cmdline || ret=$((ret + 1))
+        getarg rd.break=cmdline || ret=$((ret + 1))
         getargbool 1 rd.lvm || ret=$((ret + 1))
         getargbool 0 rd.auto || ret=$((ret + 1))
 
@@ -115,7 +115,7 @@ test_run() {
         getcmdline() {
             echo "rd.break=cmdlined rd.lvm=0 rd.auto rd.auto=1 rd.auto=0"
         }
-        getarg rd.break=cmdline -d rdbreak=cmdline && ret=$((ret + 1))
+        getarg rd.break=cmdline && ret=$((ret + 1))
         getargbool 1 rd.lvm && ret=$((ret + 1))
         getargbool 0 rd.auto && ret=$((ret + 1))
 

--- a/test/TEST-98-GETARG/test.sh
+++ b/test/TEST-98-GETARG/test.sh
@@ -108,7 +108,7 @@ test_run() {
         RDRETRY=$(getarg rd.retry -d 'rd_retry=')
         [[ $RDRETRY == "10" ]] || ret=$((ret + 1))
         getarg rd.break=cmdline -d rdbreak=cmdline || ret=$((ret + 1))
-        getargbool 1 rd.lvm -d -n rd_NO_LVM || ret=$((ret + 1))
+        getargbool 1 rd.lvm || ret=$((ret + 1))
         getargbool 0 rd.auto || ret=$((ret + 1))
 
         # shellcheck disable=SC2317  # called later by getarg in dracut-lib.sh
@@ -116,7 +116,7 @@ test_run() {
             echo "rd.break=cmdlined rd.lvm=0 rd.auto rd.auto=1 rd.auto=0"
         }
         getarg rd.break=cmdline -d rdbreak=cmdline && ret=$((ret + 1))
-        getargbool 1 rd.lvm -d -n rd_NO_LVM && ret=$((ret + 1))
+        getargbool 1 rd.lvm && ret=$((ret + 1))
         getargbool 0 rd.auto && ret=$((ret + 1))
 
         # shellcheck disable=SC2317  # called later by getarg in dracut-lib.sh

--- a/test/TEST-98-GETARG/test.sh
+++ b/test/TEST-98-GETARG/test.sh
@@ -105,7 +105,7 @@ test_run() {
         getcmdline() {
             echo "rd.break=cmdline rd.lvm rd.auto=0 rd.auto rd.retry=10"
         }
-        RDRETRY=$(getarg rd.retry -d 'rd_retry=')
+        RDRETRY=$(getarg rd.retry)
         [[ $RDRETRY == "10" ]] || ret=$((ret + 1))
         getarg rd.break=cmdline || ret=$((ret + 1))
         getargbool 1 rd.lvm || ret=$((ret + 1))


### PR DESCRIPTION
Remove handling for the following command line options

- rdbreak
- rd.ccw
- rd_CCW
- rd_DASD_MOD
- rd_DASD
- rdinitdebug rdnetdebug
- rd_DM_UUID
- rdblacklist
- rdinsmodpost
- rdloaddriver
- rd_NO_FSTAB
- rdinfo
- check
- rdlivedebug
- live_dir
- liveimg
- overlay
- readonly_overlay
- reset_overlay
- live_ram
- rd_NO_CRYPTTAB
- rd_LUKS_KEYDEV_UUID
- rd_LUKS_KEYPATH
- rd_NO_LUKS
- rd_LUKS_UUID
- rd_NO_LVMCONF
- rd_LVM_LV
- rd_NO_LVM
- rd_LVM_VG
- rd_NFS_DOMAIN
- rd_NO_PLYMOUTH
- rd_retry
- rdshell
- rd_NO_SPLASH
- rd_NO_ZFCPCONF
- rd_ZFCP
- rd_ZNET

## Checklist
- [ ] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it

Fixes #
