### PR TITLE
fix(systemd-networkd): Remove basename dependency

### DIFF
--- a/modules.d/01systemd-networkd/networkd-run.sh
+++ b/modules.d/01systemd-networkd/networkd-run.sh
@@ -3,7 +3,7 @@
 type source_hook > /dev/null 2>&1 || . /lib/dracut-lib.sh
 
 for ifpath in /sys/class/net/*; do
-    ifname="$(basename "$ifpath")"
+    ifname="${ifpath##*/}"
 
     # shellcheck disable=SC2015
     [ "$ifname" != "lo" ] && [ -e "$ifpath" ] && [ ! -e /tmp/networkd."$ifname".done ] || continue


### PR DESCRIPTION


This pull request changes...

## Changes


## Checklist
- [x] I have tested it locally
- [x] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it

## Fixes

The basename tool was not listed in the requirements and is also not needed.
Also see https://github.com/dracutdevs/dracut/commit/4c216b1db6a86373549e13b60250a7fcf94417b9