### PR TITLE
ci(Gentoo): fix docker warning

### DIFF
--- a/test/container/Dockerfile-Gentoo
+++ b/test/container/Dockerfile-Gentoo
@@ -1,4 +1,4 @@
-FROM docker.io/gentoo/portage:latest as portage
+FROM docker.io/gentoo/portage:latest AS portage
 
 FROM docker.io/gentoo/stage3:systemd
 COPY --from=portage /var/db/repos/gentoo /var/db/repos/gentoo


### PR DESCRIPTION
See for syntax rules
https://docs.docker.com/reference/build-checks/from-as-casing/ .

## Checklist
- [ ] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it

Fixes #
