### PR TITLE
fix(systemd-networkd): make sure default network is always last

### DIFF
--- a/modules.d/01systemd-networkd/module-setup.sh
+++ b/modules.d/01systemd-networkd/module-setup.sh
@@ -63,7 +63,7 @@ install() {
         "$systemdsystemunitdir"/systemd-networkd-wait-online.service.d/99-dracut.conf
 
     inst_simple "$moddir"/99-default.network \
-        "$systemdnetworkconfdir"/99-dracut-default.network
+        "$systemdnetworkconfdir"/zzzz-dracut-default.network
 
     inst_hook cmdline 99 "$moddir"/networkd-config.sh
     inst_hook initqueue/settled 99 "$moddir"/networkd-run.sh

--- a/modules.d/01systemd-networkd/networkd-config.sh
+++ b/modules.d/01systemd-networkd/networkd-config.sh
@@ -20,7 +20,7 @@ for f in /run/systemd/network/*.network; do
     } >> "$f"
 
     # Remove the default network if at least one was generated
-    rm -f "$systemdnetworkconfdir"/99-dracut-default.network
+    rm -f "$systemdnetworkconfdir"/zzzz-dracut-default.network
 done
 
 # Just in case networkd was already running


### PR DESCRIPTION
## Changes

Renames the default network file so it has 4 leading 'z', to make it as unlikely as possible for it to be anything but the last file, even if the user has files not following the common naming scheme of "00-abc.network".

## Checklist
- [ ] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it

Fixes #618 
