### PR TITLE
revert(systemd): trigger systemd-vconsole-setup.service only on demand

### DIFF
--- a/modules.d/00systemd/module-setup.sh
+++ b/modules.d/00systemd/module-setup.sh
@@ -154,14 +154,8 @@ EOF
     if dracut_module_included "10i18n" && [[ -e "$systemdsystemunitdir"/systemd-vconsole-setup.service ]]; then
         inst_multiple -o \
             "$systemdutildir"/systemd-vconsole-setup \
-            "$systemdsystemunitdir"/systemd-vconsole-setup.service
-
-        for i in \
-            emergency.target \
-            rescue.target; do
-            [[ -f "$systemdsystemunitdir"/$i ]] || continue
-            $SYSTEMCTL -q --root "$initdir" add-wants "$i" systemd-vconsole-setup.service
-        done
+            "$systemdsystemunitdir"/systemd-vconsole-setup.service \
+            "$systemdsystemunitdir"/sysinit.target.wants/systemd-vconsole-setup.service
     fi
 
     mkdir -p "$initdir/etc/systemd"

--- a/modules.d/01systemd-ask-password/module-setup.sh
+++ b/modules.d/01systemd-ask-password/module-setup.sh
@@ -48,10 +48,6 @@ install() {
         systemd-ask-password \
         systemd-tty-ask-password-agent
 
-    if [ -e "$systemdsystemunitdir"/systemd-vconsole-setup.service ]; then
-        $SYSTEMCTL -q --root "$initdir" add-wants systemd-ask-password-console.service systemd-vconsole-setup.service
-    fi
-
     # Enable the systemd type service unit for systemd-ask-password.
     $SYSTEMCTL -q --root "$initdir" enable systemd-ask-password-console.service
 
@@ -60,10 +56,6 @@ install() {
         inst_multiple -o \
             "$systemdsystemunitdir"/systemd-ask-password-plymouth.path \
             "$systemdsystemunitdir"/systemd-ask-password-plymouth.service
-
-        if [ -e "$systemdsystemunitdir"/systemd-vconsole-setup.service ]; then
-            $SYSTEMCTL -q --root "$initdir" add-wants systemd-ask-password-plymouth.service systemd-vconsole-setup.service
-        fi
 
         $SYSTEMCTL -q --root "$initdir" enable systemd-ask-password-plymouth.service
     fi


### PR DESCRIPTION
Revert 6b095274fb935ffb7639d1ea7e51f9bd0f487726.

Enable systemd-vconsole-setup.service always when it is avaiable as it usually gets triggered by udev rules anyways.

## Checklist
- [ ] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it

Fixes #620
