### PR TITLE
ci: add more packages to Debian and Ubuntu containers

### DIFF
--- a/test/container/Dockerfile-Debian
+++ b/test/container/Dockerfile-Debian
@@ -15,6 +15,7 @@ RUN apt-get update -y -qq && apt-get upgrade -y -qq && apt-get install -y -qq --
     bzip2 \
     ca-certificates \
     cargo \
+    cifs-utils \
     console-setup \
     cpio \
     cryptsetup \
@@ -23,15 +24,19 @@ RUN apt-get update -y -qq && apt-get upgrade -y -qq && apt-get install -y -qq --
     docbook-xml \
     docbook-xsl \
     erofs-utils \
+    fcoe-utils \
     fdisk \
+    file \
     g++ \
     gawk \
     git \
+    gpg \
     iputils-arping \
     iputils-ping \
     isc-dhcp-client \
     isc-dhcp-server \
     iscsiuio \
+    jq \
     kmod \
     less \
     libkmod-dev \
@@ -45,24 +50,32 @@ RUN apt-get update -y -qq && apt-get upgrade -y -qq && apt-get install -y -qq --
     network-manager \
     nfs-kernel-server \
     ntfs-3g \
+    nvme-cli \
     open-iscsi \
+    openssh-client \
     ovmf \
     parted \
+    pcscd \
     pigz \
+    plymouth \
     pkg-config \
     procps \
     qemu-kvm \
     rng-tools5 \
-    shellcheck \
     sbsigntool \
+    shellcheck \
     squashfs-tools \
     strace \
     systemd-boot-efi \
+    systemd-container \
     systemd-coredump \
+    systemd-resolved \
+    systemd-timesyncd \
     tcpdump \
     tgt \
     thin-provisioning-tools \
     tpm2-tools \
     vim \
     wget \
+    zstd \
     && apt-get clean

--- a/test/container/Dockerfile-Ubuntu
+++ b/test/container/Dockerfile-Ubuntu
@@ -12,6 +12,7 @@ RUN apt-get update -y -qq && apt-get upgrade -y -qq && \
     bzip2 \
     ca-certificates \
     cargo \
+    cifs-utils \
     console-setup \
     cpio \
     cryptsetup \
@@ -21,15 +22,19 @@ RUN apt-get update -y -qq && apt-get upgrade -y -qq && \
     docbook-xml \
     docbook-xsl \
     erofs-utils \
+    fcoe-utils \
     fdisk \
+    file \
     g++ \
     gawk \
     git \
+    gpg \
     iputils-arping \
     iputils-ping \
     isc-dhcp-client \
     isc-dhcp-server \
     iscsiuio \
+    jq \
     kmod \
     less \
     libdmraid-dev \
@@ -44,10 +49,14 @@ RUN apt-get update -y -qq && apt-get upgrade -y -qq && \
     network-manager \
     nfs-kernel-server \
     ntfs-3g \
+    nvme-cli \
     open-iscsi \
+    openssh-client \
     ovmf \
     parted \
+    pcscd \
     pigz \
+    plymouth \
     pkg-config \
     procps \
     qemu-kvm \
@@ -57,7 +66,10 @@ RUN apt-get update -y -qq && apt-get upgrade -y -qq && \
     squashfs-tools \
     strace \
     systemd-boot-efi \
+    systemd-container \
     systemd-coredump \
+    systemd-resolved \
+    systemd-timesyncd \
     systemd-ukify \
     tcpdump \
     tgt \
@@ -65,5 +77,6 @@ RUN apt-get update -y -qq && apt-get upgrade -y -qq && \
     tpm2-tools \
     vim \
     wget \
+    zstd \
     && apt-get clean \
     && chmod a+r /boot/vmlinu*


### PR DESCRIPTION
Increase test coverage. Some of the newly added packages are needed to to install some dracut modules and are already installed for other CI containers.

## Checklist
- [ ] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it

Fixes #
