### PR TITLE
fix(udev-rules): remove systemd-specific rules

### DIFF
--- a/modules.d/95udev-rules/module-setup.sh
+++ b/modules.d/95udev-rules/module-setup.sh
@@ -48,9 +48,6 @@ install() {
         70-memory.rules \
         70-mouse.rules \
         70-touchpad.rules \
-        70-uaccess.rules \
-        71-seat.rules \
-        73-seat-late.rules \
         75-net-description.rules \
         75-probe_mtd.rules \
         78-sound-card.rules \


### PR DESCRIPTION
These rules are already present in the systemd dracut module, see https://github.com/dracut-ng/dracut-ng/blob/main/modules.d/00systemd/module-setup.sh#L147

## Checklist
- [ ] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it

Fixes #
