### PR TITLE
test: network dracut package needs to be added with '-a'

### DIFF
--- a/test/TEST-30-ISCSI/test.sh
+++ b/test/TEST-30-ISCSI/test.sh
@@ -173,7 +173,7 @@ test_setup() {
 
     # Create what will eventually be the server root filesystem onto an overlay
     "$DRACUT" -N -l --keep --tmpdir "$TESTDIR" \
-        -m "test-root ${USE_NETWORK}" \
+        -m "test-root" -a "${USE_NETWORK}" \
         -d "iscsi_tcp crc32c ipv6" \
         -i "${PKGLIBDIR}/modules.d/99base/dracut-lib.sh" "/lib/dracut-lib.sh" \
         -i "${PKGLIBDIR}/modules.d/99base/dracut-dev-lib.sh" "/lib/dracut-dev-lib.sh" \

--- a/test/TEST-35-ISCSI-MULTI/test.sh
+++ b/test/TEST-35-ISCSI-MULTI/test.sh
@@ -187,7 +187,7 @@ test_setup() {
 
     rm -rf -- "$TESTDIR"/overlay
     "$DRACUT" -N -l --keep --tmpdir "$TESTDIR" \
-        -m "test-root ${USE_NETWORK} iscsi" \
+        -m "test-root" -a "${USE_NETWORK} iscsi" \
         -d "iscsi_tcp crc32c ipv6 af_packet" \
         -I "ip grep sleep setsid chmod modprobe pidof tgtd tgtadm" \
         -i "${basedir}/modules.d/99base/dracut-lib.sh" "/lib/dracut-lib.sh" \

--- a/test/TEST-40-NBD/test.sh
+++ b/test/TEST-40-NBD/test.sh
@@ -297,7 +297,7 @@ EOF
     # We do it this way so that we do not risk trashing the host mdraid
     # devices, volume groups, encrypted partitions, etc.
     "$DRACUT" -N -l -i "$TESTDIR"/overlay / \
-        -m "test-makeroot ${USE_NETWORK}" \
+        -m "test-makeroot" -a "${USE_NETWORK}" \
         -i ./create-server-root.sh /lib/dracut/hooks/initqueue/01-create-server-root.sh \
         --nomdadmconf \
         --no-hostonly-cmdline -N \

--- a/test/TEST-50-MULTINIC/test.sh
+++ b/test/TEST-50-MULTINIC/test.sh
@@ -355,7 +355,7 @@ test_setup() {
     )
     # Make server's dracut image
     "$DRACUT" -l -i "$TESTDIR"/overlay / \
-        -m "bash rootfs-block debug kernel-modules watchdog qemu ${USE_NETWORK}" \
+        -m "bash rootfs-block debug kernel-modules watchdog qemu" -a "${USE_NETWORK}" \
         -d "af_packet piix ide-gd_mod ata_piix ext4 sd_mod nfsv2 nfsv3 nfsv4 nfs_acl nfs_layout_nfsv41_files nfsd e1000 i6300esb" \
         --no-hostonly-cmdline -N \
         -f "$TESTDIR"/initramfs.server "$KVERSION" || return 1


### PR DESCRIPTION
'-m network' does not really work as it is not able to include the actual networking backend as [`check_module`](https://github.com/dracut-ng/dracut-ng/blob/main/modules.d/40network/module-setup.sh#L20) call with always fail.

## Checklist
- [ ] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it

Fixes #
