### PR TITLE
ci: add a test container with no dhclient installed

### DIFF
--- a/test/container/Dockerfile-Fedora-latest
+++ b/test/container/Dockerfile-Fedora-latest
@@ -15,7 +15,6 @@ RUN dnf -y install --setopt=install_weak_deps=False \
     dash \
     dbus-daemon \
     device-mapper-multipath \
-    dhcp-client \
     dhcp-server \
     dmraid \
     e2fsprogs \

--- a/test/container/Dockerfile-Ubuntu
+++ b/test/container/Dockerfile-Ubuntu
@@ -31,7 +31,6 @@ RUN apt-get update -y -qq && apt-get upgrade -y -qq && \
     gpg \
     iputils-arping \
     iputils-ping \
-    isc-dhcp-client \
     isc-dhcp-server \
     iscsiuio \
     jq \


### PR DESCRIPTION
Currently all test containers (including even alpine and void) has dhclient installed, so the non-dhclient path is not tested.

Picked Ubuntu and Fedora as both expressed interest not supporting isc-dhcp-client much longer. 

See https://blueprints.launchpad.net/ubuntu/noble/amd64/isc-dhcp-client
> Please, consider using an alternative for isc-dhcp-client

and https://src.fedoraproject.org/rpms/dracut/c/a1ebaf27b616010bc672be9409ff42b8234b008d

## Checklist
- [ ] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it

Fixes #
