### PR TITLE
test(FULL-SYSTEM): remove non-systemd dracut modules from the test

### DIFF
--- a/test/TEST-04-FULL-SYSTEMD/test.sh
+++ b/test/TEST-04-FULL-SYSTEMD/test.sh
@@ -127,7 +127,8 @@ EOF
     echo -n test > /tmp/key
 
     test_dracut \
-        -m "btrfs dracut-systemd i18n systemd-ac-power systemd-coredump systemd-creds systemd-cryptsetup systemd-integritysetup systemd-ldconfig systemd-pcrphase systemd-pstore systemd-repart systemd-sysext systemd-veritysetup" \
+        -m "dracut-systemd systemd-ac-power systemd-coredump systemd-creds systemd-cryptsetup systemd-integritysetup systemd-ldconfig systemd-pcrphase systemd-pstore systemd-repart systemd-sysext systemd-veritysetup" \
+        --add-drivers "btrfs" \
         -i "/tmp/key" "/etc/key" \
         "$TESTDIR"/initramfs.testing
 


### PR DESCRIPTION
i18n is not longer required after 238378ad2b7367900a0050bb9fc5b9eab5294cba.

## Checklist
- [ ] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it

Fixes #
