### PR TITLE
test(BASIC): allow to run the test with various fstypes

### DIFF
--- a/test/TEST-01-BASIC/create-root.sh
+++ b/test/TEST-01-BASIC/create-root.sh
@@ -15,7 +15,7 @@ set -ex
 # populate TEST_FSTYPE
 . /env
 
-eval "mkfs.${TEST_FSTYPE} -q -L '  rdinit=/bin/sh' /dev/disk/by-id/scsi-0QEMU_QEMU_HARDDISK_root"
+eval "mkfs.${TEST_FSTYPE} -q -L dracut /dev/disk/by-id/scsi-0QEMU_QEMU_HARDDISK_root"
 mkdir -p /root
 mount -t "${TEST_FSTYPE}" /dev/disk/by-id/scsi-0QEMU_QEMU_HARDDISK_root /root
 cp -a -t /root /source/*

--- a/test/TEST-01-BASIC/create-root.sh
+++ b/test/TEST-01-BASIC/create-root.sh
@@ -12,9 +12,12 @@ udevadm settle
 
 set -ex
 
-mkfs.ext4 -q -L '  rdinit=/bin/sh' /dev/disk/by-id/scsi-0QEMU_QEMU_HARDDISK_root
+# populate TEST_FSTYPE
+. /env
+
+eval "mkfs.${TEST_FSTYPE} -q -L '  rdinit=/bin/sh' /dev/disk/by-id/scsi-0QEMU_QEMU_HARDDISK_root"
 mkdir -p /root
-mount -t ext4 /dev/disk/by-id/scsi-0QEMU_QEMU_HARDDISK_root /root
+mount -t "${TEST_FSTYPE}" /dev/disk/by-id/scsi-0QEMU_QEMU_HARDDISK_root /root
 cp -a -t /root /source/*
 mkdir -p /root/run
 umount /root

--- a/test/TEST-01-BASIC/test.sh
+++ b/test/TEST-01-BASIC/test.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 # shellcheck disable=SC2034
-TEST_DESCRIPTION="root filesystem on a ext4 filesystem"
+TEST_DESCRIPTION="root filesystem on ${TEST_FSTYPE} filesystem"
 
 # Uncomment this to debug failures
 # DEBUGFAIL="rd.shell rd.break"
@@ -27,12 +27,16 @@ test_setup() {
         -f "$TESTDIR"/initramfs.root "$KVERSION" || return 1
     mkdir -p "$TESTDIR"/overlay/source && mv "$TESTDIR"/dracut.*/initramfs/* "$TESTDIR"/overlay/source && rm -rf "$TESTDIR"/dracut.*
 
+    # pass enviroment variables to make the root filesystem
+    echo "TEST_FSTYPE=${TEST_FSTYPE}" > "$TESTDIR"/overlay/env
+
     # second, install the files needed to make the root filesystem
     # create an initramfs that will create the target root filesystem.
     # We do it this way so that we do not risk trashing the host mdraid
     # devices, volume groups, encrypted partitions, etc.
     "$DRACUT" -N -l -i "$TESTDIR"/overlay / \
         -m "test-makeroot" \
+        -I "mkfs.${TEST_FSTYPE}" \
         -i ./create-root.sh /lib/dracut/hooks/initqueue/01-create-root.sh \
         -f "$TESTDIR"/initramfs.makeroot "$KVERSION" || return 1
     rm -rf -- "$TESTDIR"/overlay
@@ -40,12 +44,12 @@ test_setup() {
     declare -a disk_args=()
     declare -i disk_index=0
     qemu_add_drive disk_index disk_args "$TESTDIR"/marker.img marker 1
-    qemu_add_drive disk_index disk_args "$TESTDIR"/root.img root 80
+    qemu_add_drive disk_index disk_args "$TESTDIR"/root.img root 160
 
     # Invoke KVM and/or QEMU to actually create the target filesystem.
     "$testdir"/run-qemu \
         "${disk_args[@]}" \
-        -append "root=/dev/dracut/root rw rootfstype=ext4 quiet console=ttyS0,115200n81" \
+        -append "root=/dev/dracut/root rw rootfstype=${TEST_FSTYPE} quiet console=ttyS0,115200n81" \
         -initrd "$TESTDIR"/initramfs.makeroot || return 1
     test_marker_check dracut-root-block-created || return 1
     rm -- "$TESTDIR"/marker.img

--- a/test/TEST-01-BASIC/test.sh
+++ b/test/TEST-01-BASIC/test.sh
@@ -14,7 +14,7 @@ test_run() {
     test_marker_reset
     "$testdir"/run-qemu \
         "${disk_args[@]}" \
-        -append "$TEST_KERNEL_CMDLINE rw \"root=LABEL=  rdinit=/bin/sh\" rd.retry=3" \
+        -append "$TEST_KERNEL_CMDLINE rw root=LABEL=dracut rd.retry=3" \
         -initrd "$TESTDIR"/initramfs.testing || return 1
 
     test_marker_check || return 1
@@ -44,7 +44,7 @@ test_setup() {
     declare -a disk_args=()
     declare -i disk_index=0
     qemu_add_drive disk_index disk_args "$TESTDIR"/marker.img marker 1
-    qemu_add_drive disk_index disk_args "$TESTDIR"/root.img root 160
+    qemu_add_drive disk_index disk_args "$TESTDIR"/root.img root 300
 
     # Invoke KVM and/or QEMU to actually create the target filesystem.
     "$testdir"/run-qemu \

--- a/test/TEST-02-SYSTEMD/create-root.sh
+++ b/test/TEST-02-SYSTEMD/create-root.sh
@@ -11,7 +11,7 @@ udevadm control --reload
 set -e
 
 udevadm settle
-mkfs.ext4 -q -L dracut /dev/disk/by-id/scsi-0QEMU_QEMU_HARDDISK_root
+mkfs.ext4 -q -L '  rdinit=/bin/sh' /dev/disk/by-id/scsi-0QEMU_QEMU_HARDDISK_root
 mkdir -p /root
 mount -t ext4 /dev/disk/by-id/scsi-0QEMU_QEMU_HARDDISK_root /root
 cp -a -t /root /source/*

--- a/test/TEST-02-SYSTEMD/test.sh
+++ b/test/TEST-02-SYSTEMD/test.sh
@@ -17,7 +17,7 @@ test_run() {
     test_marker_reset
     "$testdir"/run-qemu \
         "${disk_args[@]}" \
-        -append "$TEST_KERNEL_CMDLINE root=LABEL=dracut rw systemd.log_target=console rd.retry=3 init=/sbin/init" \
+        -append "$TEST_KERNEL_CMDLINE \"root=LABEL=  rdinit=/bin/sh\" rw systemd.log_target=console rd.retry=3 init=/sbin/init" \
         -initrd "$TESTDIR"/initramfs.testing || return 1
 
     test_marker_check || return 1

--- a/test/container/Dockerfile-Arch
+++ b/test/container/Dockerfile-Arch
@@ -1,5 +1,8 @@
 FROM docker.io/archlinux
 
+# prefer running tests with xfs
+ENV TEST_FSTYPE=xfs
+
 RUN pacman --noconfirm -Syu \
     asciidoc \
     astyle \

--- a/test/container/Dockerfile-OpenSuse-latest
+++ b/test/container/Dockerfile-OpenSuse-latest
@@ -1,5 +1,8 @@
 FROM registry.opensuse.org/opensuse/tumbleweed-dnf:latest
 
+# prefer running tests with btrfs
+ENV TEST_FSTYPE=btrfs
+
 # Install needed packages for the dracut CI container
 RUN dnf -y install --setopt=install_weak_deps=False \
     asciidoc \

--- a/test/test-functions
+++ b/test/test-functions
@@ -14,6 +14,8 @@ KVERSION=${KVERSION-$(uname -r)}
 
 [ -z "$USE_NETWORK" ] && USE_NETWORK="network"
 
+[ -z "$TEST_FSTYPE" ] && TEST_FSTYPE="ext4"
+
 if [[ -z $basedir ]]; then basedir="$(realpath ../..)"; fi
 
 DRACUT=${DRACUT-${basedir}/dracut.sh}


### PR DESCRIPTION
Default fstype (when test allows it) is now xfs for Arch and btrfs for openSUSE.   

Tested with the following fstypes:
 - ext2
 - ext3
 - ext4
 - btrfs
 - jfs
 - xfs
 
XFS filesystem labels can be at most 12 characters long, so move the test case for the '  rdinit=/bin/sh' label to TEST-02 instead and keep TEST-01 simple.

XFS filesystem must be larger than 300MB.

## Checklist
- [X] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [X] I am providing new code and test(s) for it

Fixes #
