### PR TITLE
fix(systemd, systemd-journal): only install libgcrypt where actually needed

### DIFF
--- a/modules.d/00systemd/module-setup.sh
+++ b/modules.d/00systemd/module-setup.sh
@@ -155,6 +155,5 @@ EOF
     # Install library file(s)
     _arch=${DRACUT_ARCH:-$(uname -m)}
     inst_libdir_file \
-        {"tls/$_arch/",tls/,"$_arch/",}"libgcrypt.so*" \
         {"tls/$_arch/",tls/,"$_arch/",}"libnss_*"
 }

--- a/modules.d/01systemd-journald/module-setup.sh
+++ b/modules.d/01systemd-journald/module-setup.sh
@@ -54,10 +54,17 @@ install() {
     # Install library file(s)
     _arch=${DRACUT_ARCH:-$(uname -m)}
     inst_libdir_file \
-        {"tls/$_arch/",tls/,"$_arch/",}"libgcrypt.so*" \
         {"tls/$_arch/",tls/,"$_arch/",}"liblz4.so.*" \
         {"tls/$_arch/",tls/,"$_arch/",}"liblzma.so.*" \
         {"tls/$_arch/",tls/,"$_arch/",}"libzstd.so.*"
+
+    # The journal forward secure sealing feature loads libgcrypt with dlopen
+    # rather than explicitly linking against it, so we need to explicitly
+    # install it. However, systemd can be built without any libgcrypt
+    # dependency, so check whether systemd-resolved explicitly links against it.
+    if $DRACUT_LDD "${dracutsysrootdir}${systemdutildir}/systemd-resolved" | grep -q libgcrypt; then
+        inst_libdir_file {"tls/$_arch/",tls/,"$_arch/",}"libgcrypt.so*"
+    fi
 
     # Install the hosts local user configurations if enabled.
     if [[ $hostonly ]]; then


### PR DESCRIPTION
systemd v256 started loading libgcrypt with dlopen, so the systemd module started installing it unconditionally. However, the only part of systemd that uses it without explicitly linking it is the journal forward secure sealing feature. This module does not install journald or anything else that is likely to need libgcrypt. Even if some other part did need it, it would be pulled in using the usual ldd mechanism.

This change also benefits older systemd versions because systemd can be built without any libgcrypt dependency at all.

Following that, the systemd-journal module should check whether libgcrypt is actually needed. systemd-resolved explicitly links against it, so check using ldd in a similar manner to the crypt-gpg module.

CC @aafeijoo-suse

## Changes

## Checklist
- [X] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it
