### PR TITLE
feat(test-root): only include debug module if V is set to 2

### DIFF
--- a/modules.d/80test-root/module-setup.sh
+++ b/modules.d/80test-root/module-setup.sh
@@ -6,7 +6,11 @@ check() {
 }
 
 depends() {
-    echo debug
+    if [[ $V == "2" ]]; then
+        echo debug
+    fi
+
+    return 0
 }
 
 install() {
@@ -19,7 +23,7 @@ install() {
 
     inst_simple /etc/os-release
 
-    inst_multiple mkdir ln dd stty mount poweroff umount setsid sync
+    inst_multiple mkdir ln dd stty mount poweroff umount setsid sync cat grep
 
     for _terminfodir in /lib/terminfo /etc/terminfo /usr/share/terminfo; do
         [ -f "${_terminfodir}/l/linux" ] && break


### PR DESCRIPTION
This PR enables CI to run faster by default (V=1).

When debugging (V=2) debug module will be included as before.

Follow-up to https://github.com/dracut-ng/dracut-ng/pull/607 .

## Checklist
- [ ] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it

Fixes #

CC @bdrung 