### PR TITLE
fix(nvmf): require NVMeoF modules

### DIFF
--- a/modules.d/95nvmf/module-setup.sh
+++ b/modules.d/95nvmf/module-setup.sh
@@ -2,7 +2,10 @@
 
 # called by dracut
 check() {
+    local -A nvmf_trtypes
+
     require_binaries nvme jq || return 1
+    require_kernel_modules nvme_fabrics || return 1
 
     # shellcheck disable=SC2317  # called later by for_each_host_dev_and_slaves
     is_nvmf() {
@@ -21,7 +24,12 @@ check() {
                 break
             fi
         done
-        [[ $trtype == "fc" ]] || [[ $trtype == "tcp" ]] || [[ $trtype == "rdma" ]]
+        if [[ $trtype == "fc" ]] || [[ $trtype == "tcp" ]] || [[ $trtype == "rdma" ]]; then
+            nvmf_trtypes["nvme_${trtype}"]=1
+            return 0
+        else
+            return 1
+        fi
     }
 
     has_nbft() {
@@ -42,6 +50,7 @@ check() {
         local _is_nvmf=$?
         popd > /dev/null || exit
         [[ $_is_nvmf == 0 ]] || return 255
+        require_kernel_modules "${!nvmf_trtypes[@]}" || return 1
         if [ ! -f /sys/class/fc/fc_udev_device/nvme_discovery ] \
             && [ ! -f /etc/nvme/discovery.conf ] \
             && [ ! -f /etc/nvme/config.json ] && ! has_nbft; then


### PR DESCRIPTION
Make sure the necessary kernel modules for NVMeoF boot support are included.

## Changes

## Checklist
- [x] I have tested it locally
- [x] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it

cc: @aafeijoo-suse @tbzatek @johnmeneghini @Douglas-Farley