### PR TITLE
ci: test plymouth dracut module in more containers

### DIFF
--- a/test/container/Dockerfile-Fedora-latest
+++ b/test/container/Dockerfile-Fedora-latest
@@ -51,6 +51,7 @@ RUN dnf -y install --setopt=install_weak_deps=False \
     parted \
     pcsc-lite \
     pigz \
+    plymouth \
     qemu \
     qrencode \
     rng-tools \

--- a/test/container/Dockerfile-Gentoo
+++ b/test/container/Dockerfile-Gentoo
@@ -50,6 +50,7 @@ RUN emerge --quiet --deep --autounmask-continue=y --with-bdeps=n --noreplace \
     sys-block/open-iscsi \
     sys-block/parted \
     sys-block/tgt \
+    sys-boot/plymouth \
     sys-devel/bison \
     sys-devel/flex \
     sys-fs/btrfs-progs \

--- a/test/container/Dockerfile-Ubuntu
+++ b/test/container/Dockerfile-Ubuntu
@@ -58,7 +58,7 @@ RUN apt-get update -y -qq && apt-get upgrade -y -qq && \
     parted \
     pcscd \
     pigz \
-    plymouth \
+    plymouth-themes \
     pkg-config \
     procps \
     qemu-kvm \

--- a/test/container/Dockerfile-alpine
+++ b/test/container/Dockerfile-alpine
@@ -58,6 +58,7 @@ RUN apk add --no-cache \
     parted \
     partx \
     pigz \
+    plymouth \
     procps \
     qemu-img \
     qemu-system-x86_64 \


### PR DESCRIPTION
Add plymouth to the following containers:
 - Fedora
 - Gentoo
 - Alpine

## Checklist
- [ ] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it

Fixes #

CC @pvalena @AndrewAmmerlaan 