### PR TITLE
chore: improve portability for calling `cp`

### DIFF
--- a/dracut-init.sh
+++ b/dracut-init.sh
@@ -20,9 +20,9 @@
 export LC_MESSAGES=C
 
 if [[ $EUID == "0" ]] && ! [[ $DRACUT_NO_XATTR ]]; then
-    export DRACUT_CP="cp --sparse=auto --preserve=mode,timestamps,xattr,links -dfr"
+    export DRACUT_CP="cp --preserve=mode,timestamps,xattr,links -dfr"
 else
-    export DRACUT_CP="cp --sparse=auto --preserve=mode,timestamps,links -dfr"
+    export DRACUT_CP="cp --preserve=mode,timestamps,links -dfr"
 fi
 
 # is_func <command>

--- a/dracut-init.sh
+++ b/dracut-init.sh
@@ -20,9 +20,9 @@
 export LC_MESSAGES=C
 
 if [[ $EUID == "0" ]] && ! [[ $DRACUT_NO_XATTR ]]; then
-    export DRACUT_CP="cp --reflink=auto --sparse=auto --preserve=mode,timestamps,xattr,links -dfr"
+    export DRACUT_CP="cp --sparse=auto --preserve=mode,timestamps,xattr,links -dfr"
 else
-    export DRACUT_CP="cp --reflink=auto --sparse=auto --preserve=mode,timestamps,links -dfr"
+    export DRACUT_CP="cp --sparse=auto --preserve=mode,timestamps,links -dfr"
 fi
 
 # is_func <command>

--- a/dracut.sh
+++ b/dracut.sh
@@ -2599,7 +2599,7 @@ if [[ $uefi == yes ]]; then
                 exit 1
             fi
         else
-            if cp --reflink=auto "${uefi_outdir}/linux.efi" "$outfile"; then
+            if cp "${uefi_outdir}/linux.efi" "$outfile"; then
                 dinfo "*** Creating UEFI image file '$outfile' done ***"
             else
                 rm -f -- "$outfile"
@@ -2613,7 +2613,7 @@ if [[ $uefi == yes ]]; then
         exit 1
     fi
 else
-    if cp --reflink=auto "${DRACUT_TMPDIR}/initramfs.img" "$outfile"; then
+    if cp "${DRACUT_TMPDIR}/initramfs.img" "$outfile"; then
         dinfo "*** Creating initramfs image file '$outfile' done ***"
     else
         rm -f -- "$outfile"

--- a/install.d/50-dracut.install
+++ b/install.d/50-dracut.install
@@ -35,7 +35,7 @@ if [[ -f ${KERNEL_IMAGE%/*}/$IMAGE ]]; then
     # use this and don't generate a new one
     [[ $KERNEL_INSTALL_VERBOSE == 1 ]] && echo \
         "There is an $IMAGE image at the same place as the kernel, skipping generating a new one"
-    cp --reflink=auto "${KERNEL_IMAGE%/*}/$IMAGE" "$KERNEL_INSTALL_STAGING_AREA/$IMAGE" \
+    cp "${KERNEL_IMAGE%/*}/$IMAGE" "$KERNEL_INSTALL_STAGING_AREA/$IMAGE" \
         && chown root:root "$KERNEL_INSTALL_STAGING_AREA/$IMAGE" \
         && chmod 0600 "$KERNEL_INSTALL_STAGING_AREA/$IMAGE" \
         && exit 0

--- a/install.d/51-dracut-rescue.install
+++ b/install.d/51-dracut-rescue.install
@@ -125,7 +125,7 @@ case "$COMMAND" in
 
         [[ -d $BOOT_DIR_ABS ]] || mkdir -p "$BOOT_DIR_ABS"
 
-        if ! cp --reflink=auto "$KERNEL_IMAGE" "$BOOT_DIR_ABS/$KERNEL"; then
+        if ! cp "$KERNEL_IMAGE" "$BOOT_DIR_ABS/$KERNEL"; then
             echo "Can't copy '$KERNEL_IMAGE to '$BOOT_DIR_ABS/$KERNEL'!" >&2
         fi
 

--- a/src/install/dracut-install.c
+++ b/src/install/dracut-install.c
@@ -409,7 +409,7 @@ normal_copy:
         const char *preservation = (geteuid() == 0
                                     && no_xattr == false) ? "--preserve=mode,xattr,timestamps,ownership" : "--preserve=mode,timestamps,ownership";
         if (pid == 0) {
-                execlp("cp", "cp", "--reflink=auto", "--sparse=auto", preservation, "-fL", src, dst, NULL);
+                execlp("cp", "cp", "--sparse=auto", preservation, "-fL", src, dst, NULL);
                 _exit(errno == ENOENT ? 127 : 126);
         }
 
@@ -421,7 +421,7 @@ normal_copy:
         }
         ret = WIFSIGNALED(ret) ? 128 + WTERMSIG(ret) : WEXITSTATUS(ret);
         if (ret != 0)
-                log_error("ERROR: 'cp --reflink=auto --sparse=auto %s -fL %s %s' failed with %d", preservation, src, dst, ret);
+                log_error("ERROR: 'cp --sparse=auto %s -fL %s %s' failed with %d", preservation, src, dst, ret);
         log_debug("cp ret = %d", ret);
         return ret;
 }

--- a/src/install/dracut-install.c
+++ b/src/install/dracut-install.c
@@ -409,7 +409,7 @@ normal_copy:
         const char *preservation = (geteuid() == 0
                                     && no_xattr == false) ? "--preserve=mode,xattr,timestamps,ownership" : "--preserve=mode,timestamps,ownership";
         if (pid == 0) {
-                execlp("cp", "cp", "--sparse=auto", preservation, "-fL", src, dst, NULL);
+                execlp("cp", "cp", preservation, "-fL", src, dst, NULL);
                 _exit(errno == ENOENT ? 127 : 126);
         }
 
@@ -421,7 +421,7 @@ normal_copy:
         }
         ret = WIFSIGNALED(ret) ? 128 + WTERMSIG(ret) : WEXITSTATUS(ret);
         if (ret != 0)
-                log_error("ERROR: 'cp --sparse=auto %s -fL %s %s' failed with %d", preservation, src, dst, ret);
+                log_error("ERROR: 'cp %s -fL %s %s' failed with %d", preservation, src, dst, ret);
         log_debug("cp ret = %d", ret);
         return ret;
 }

--- a/src/install/dracut-install.c
+++ b/src/install/dracut-install.c
@@ -407,7 +407,7 @@ static int cp(const char *src, const char *dst)
 normal_copy:
         pid = fork();
         const char *preservation = (geteuid() == 0
-                                    && no_xattr == false) ? "--preserve=mode,xattr,timestamps,ownership" : "--preserve=mode,timestamps,ownership";
+                                    && no_xattr == false) ? "--preserve=mode,xattr,timestamps,ownership" : "-p";
         if (pid == 0) {
                 execlp("cp", "cp", preservation, "-fL", src, dst, NULL);
                 _exit(errno == ENOENT ? 127 : 126);


### PR DESCRIPTION
`--sparse=auto` is the default behavior in coreutils.
`--reflink=auto` is the default behavior in coreutils since v9.0.  
All CI containers are using newer versions of cp than v9.0.

## Checklist
- [ ] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it

Fixes #379 (partially) 
