### PR TITLE
ci(alpine): use clang instead of gcc for more test coverage

### DIFF
--- a/test/container/Dockerfile-alpine
+++ b/test/container/Dockerfile-alpine
@@ -1,10 +1,11 @@
 FROM docker.io/alpine:latest
 
+# prefer running tests with clang
+ENV CC=clang
+
 # ovmf is not installed as systemd-boot-efistub is not available
 # see https://gitlab.alpinelinux.org/alpine/aports/-/merge_requests/61369
-
 RUN apk add --no-cache \
-    alpine-sdk \
     asciidoc \
     bash \
     binutils \
@@ -14,6 +15,7 @@ RUN apk add --no-cache \
     busybox \
     bzip2 \
     cargo \
+    clang \
     coreutils \
     cpio \
     cryptsetup \
@@ -28,6 +30,7 @@ RUN apk add --no-cache \
     erofs-utils \
     eudev \
     findmnt \
+    file \
     f2fs-tools \
     gawk \
     git \


### PR DESCRIPTION
CI container to reproduce clang build issues.

## Checklist
- [x] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it

Fixes #
