### PR TITLE
perf(systemd-initrd): initrd.target is already the default target

### DIFF
--- a/modules.d/01systemd-initrd/module-setup.sh
+++ b/modules.d/01systemd-initrd/module-setup.sh
@@ -26,6 +26,4 @@ install() {
         "$systemdsystemunitdir"/initrd-cleanup.service \
         "$systemdsystemunitdir"/initrd-udevadm-cleanup-db.service \
         "$systemdsystemunitdir"/initrd-parse-etc.service
-
-    $SYSTEMCTL -q --root "$initdir" set-default initrd.target
 }


### PR DESCRIPTION
Avoid creating an extra symlink under /etc inside the generated initrd.

initrd.target is already the default target.

## Checklist
- [ ] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it

Fixes #
