### PR TITLE
fix: typo in variable name

### DIFF
--- a/dracut.sh
+++ b/dracut.sh
@@ -929,8 +929,8 @@ if [[ -n $add_confdir ]]; then
     # Check if it exists under $confdir.
     elif [[ -d $confdir/$add_confdir ]]; then
         add_confdir="$confdir/$add_confdir"
-    elif [[ -d $dracutbasdir/dracut.conf.d/$add_confdir ]]; then
-        add_confdir="$dracutbasdir/dracut.conf.d/$add_confdir"
+    elif [[ -d $dracutbasedir/dracut.conf.d/$add_confdir ]]; then
+        add_confdir="$dracutbasedir/dracut.conf.d/$add_confdir"
     else
         printf "%s\n" "dracut[F]: Configuration directory '$add_confdir' not found." >&2
         exit 1


### PR DESCRIPTION
Follow-up fix for https://github.com/dracut-ng/dracut-ng/commit/6107f5e54fb82f1c00285a4cc709b04f29eee460

CC @licliu 

## Checklist
- [ ] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it

Fixes #
