### PR TITLE
fix(systemd-sysext): make non-hostonly non-host

### DIFF
--- a/modules.d/01systemd-sysext/module-setup.sh
+++ b/modules.d/01systemd-sysext/module-setup.sh
@@ -36,9 +36,6 @@ install() {
 
     inst_multiple -o \
         "/usr/lib/confexts/*.raw" \
-        "/var/lib/confexts/*.raw" \
-        "/var/lib/extensions/*.raw" \
-        "/etc/extension-release.d/extension-release.*" \
         "/usr/lib/extension-release.d/extension-release.*" \
         "$systemdsystemunitdir"/systemd-confext${_suffix}.service \
         "$systemdsystemunitdir/systemd-confext${_suffix}.service.d/*.conf" \
@@ -57,6 +54,9 @@ install() {
     if [[ $hostonly ]]; then
         inst_multiple -H -o \
             "/etc/extensions/*.raw" \
+            "/etc/extension-release.d/extension-release.*" \
+            "/var/lib/confexts/*.raw" \
+            "/var/lib/extensions/*.raw" \
             "$systemdsystemconfdir"/systemd-confext${_suffix}.service \
             "$systemdsystemconfdir/systemd-confext${_suffix}.service.d/*.conf" \
             "$systemdsystemconfdir"/systemd-sysext${_suffix}.service \


### PR DESCRIPTION
Follow-up to https://github.com/dracut-ng/dracut-ng/pull/125

Not sure about the policy of picking up host extensions and automatically assuming that they are needed in the initrd, but regardless extensions under /etc and /var by definition are host specific.

## Checklist
- [ ] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it

Fixes #
