### PR TITLE
fix(dracut): don't apply aggressive strip to kernel modules

### DIFF
--- a/dracut.sh
+++ b/dracut.sh
@@ -2177,6 +2177,7 @@ if [[ $do_strip == yes ]]; then
         fi
     done
 
+    kstrip_args=(-g)
     if [[ $aggressive_strip == yes ]]; then
         # `eu-strip` and `strip` both strips all unneeded parts by default
         strip_args=(-p)
@@ -2325,7 +2326,7 @@ if [[ $do_strip == yes ]] && ! [[ $DRACUT_FIPS_MODE ]]; then
         | while read -r -d $'\0' f || [ -n "$f" ]; do
             SIG=$(tail -c 28 "$f" | tr -d '\000')
             [[ $SIG == '~Module signature appended~' ]] || { printf "%s\000" "$f"; }
-        done | xargs -r -0 "$strip_cmd" "${strip_args[@]}"
+        done | xargs -r -0 "$strip_cmd" "${kstrip_args[@]}"
     dinfo "*** Stripping files done ***"
 fi
 


### PR DESCRIPTION
Unlike ordinary binaries, kernel module will be unusable if stripped with "-p". Fix this by always use "-g" only.

So far it didn't cause many issues since most kernels have their modules signed or compressed so this is skipped.

Signed-off-by: Kairui Song <kasong@tencent.com>

## Changes

## Checklist
- [x] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it

Fixes #
