### PR TITLE
feat: config example for cloud provider uki vm

### DIFF
--- a/dracut.conf.d/50-uki-virt.conf.example
+++ b/dracut.conf.d/50-uki-virt.conf.example
@@ -1,0 +1,54 @@
+# EFI unified kernel image for virtual machines
+
+# generic
+hostonly="no"
+
+# unified kernel image
+uefi="yes"
+
+# VMs can't update microcode anyway
+early_microcode="no"
+
+# modules: basics
+dracutmodules+=" dracut-systemd shutdown "
+
+# modules: virtual consoles
+dracutmodules+=" i18n "
+
+# modules: encrypted block device
+dracutmodules+=" systemd-cryptsetup crypt-loop "
+
+# modules: logical volume management
+dracutmodules+=" lvm "
+
+# modules: measure boot phase into TPM2
+dracutmodules+=" systemd-pcrphase "
+
+# modules: support root on virtiofs
+dracutmodules+=" virtiofs "
+
+# modules: use sysext images (see 'man systemd-sysext')
+dracutmodules+=" systemd-sysext "
+
+# modules: root disk integrity protection
+dracutmodules+=" systemd-veritysetup "
+
+# drivers: virtual buses, pci
+drivers+=" virtio-pci virtio-mmio "      # qemu-kvm
+drivers+=" hv-vmbus pci-hyperv "         # hyperv
+drivers+=" xen-pcifront "                # xen
+
+# drivers: storage
+drivers+=" ahci nvme sd_mod sr_mod "     # generic
+drivers+=" virtio-blk virtio-scsi "      # qemu-kvm
+drivers+=" hv-storvsc "                  # hyperv
+drivers+=" xen-blkfront "                # xen
+
+# root encryption
+drivers+=" dm_crypt "
+
+# root disk integrity protection
+drivers+=" dm_verity overlay "
+
+# filesystems
+filesystems+=" vfat ext4 xfs overlay "

--- a/test/TEST-18-UEFI/test.sh
+++ b/test/TEST-18-UEFI/test.sh
@@ -41,7 +41,12 @@ test_setup() {
     mkdir -p "$TESTDIR"/dracut.*/initramfs/proc
     mksquashfs "$TESTDIR"/dracut.*/initramfs/ "$TESTDIR"/squashfs.img -quiet -no-progress
 
-    mkdir -p "$TESTDIR"/ESP/EFI/BOOT
+    mkdir -p "$TESTDIR"/ESP/EFI/BOOT /tmp/dracut.conf.d
+
+    # test with the reference uki config when systemd is available
+    if command -v systemctl &> /dev/null; then
+        cp "${basedir}/dracut.conf.d/50-uki-virt.conf.example" /tmp/dracut.conf.d/50-uki-virt.conf
+    fi
 
     test_dracut \
         --kernel-cmdline 'root=/dev/disk/by-id/scsi-0QEMU_QEMU_HARDDISK_root ro rd.skipfsck rootfstype=squashfs' \


### PR DESCRIPTION
This is an example configuration for a 'unified kernel image'.

The key benefit of a unified kernel is that its secure boot signature covers the initrd and cmdline contents, allowing a trustworthy measured boot process with attestation, which is not practical with locally generated initrds/cmdlines.

The initrd in this example only needs a very small set of block driver modules present, in order to be usable across KVM, Hyper-V and Xen hypervisors which will cover essentially all common public and private clouds.

Credit for most of this work goes to  @vittyvk  and @trungams . The example is not intended to be the exact latest copy that is used downstream. Instead the example is meant to be a superset of the downstream use-cases to provide a form of documentation of dracut (comments in the config file) and hopefully eventually used in the upstream CI as well as one important use-case.

## Changes

## Checklist
- [x] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [x] I am providing new code and test(s) for it

Fixes #
