### PR TITLE
fix(dracut): --list-modules should imply --no-kernel as well

### DIFF
--- a/dracut.sh
+++ b/dracut.sh
@@ -810,7 +810,11 @@ while :; do
         --no-compress) _no_compress_l="cat" ;;
         --gzip) compress_l="gzip" ;;
         --enhanced-cpio) enhanced_cpio_l="yes" ;;
-        --list-modules) do_list="yes" ;;
+        --list-modules)
+            do_list="yes"
+            kernel_only="no"
+            no_kernel="yes"
+            ;;
         -M | --show-modules)
             show_modules_l="yes"
             ;;


### PR DESCRIPTION
This will ensure that 'dracut --list-modules' works well in a container.

## Checklist
- [x] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it

Fixes #
