### PR TITLE
perf(systemd-initrd): do not depend on base module

### DIFF
--- a/modules.d/01systemd-initrd/module-setup.sh
+++ b/modules.d/01systemd-initrd/module-setup.sh
@@ -10,11 +10,16 @@ check() {
 
 # called by dracut
 depends() {
-    echo base systemd-udevd systemd-journald systemd-tmpfiles
+    echo systemd-udevd systemd-journald systemd-tmpfiles
 }
 
 # called by dracut
 install() {
+    # The existence of this file is required
+    if ! [[ -e "$initdir/etc/initrd-release" ]]; then
+        : > "$initdir/etc/initrd-release"
+    fi
+
     inst_multiple -o \
         "$systemdsystemunitdir"/initrd.target \
         "$systemdsystemunitdir"/initrd-fs.target \


### PR DESCRIPTION
Make sure /etc/initrd exist without depending on the base module.

Test SYSTEMD-INITRD confirms no regression as this tests now no longer includes the base module and it still passes the boot tests with systemd (hence the perf tag).

## Checklist
- [X] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [X] I am providing new code and test(s) for it

Fixes #
