### PR TITLE
fix(hwdb): only install /etc/udev/udev.hwdb in hostonly mode

### DIFF
--- a/modules.d/95hwdb/module-setup.sh
+++ b/modules.d/95hwdb/module-setup.sh
@@ -5,7 +5,6 @@
 # called by dracut
 install() {
     inst_multiple -o \
-        /etc/udev/udev.hwdb \
         "${udevdir}"/hwdb.bin
 
     # Install the hosts local user configurations if enabled.


### PR DESCRIPTION
"$udevconfdir"/hwdb.bin already grabs /etc/udev/udev.hwdb in hostonly mode.

## Checklist
- [x] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it

Fixes #
