### PR TITLE
ci: add swtpm for TPM emulation

### DIFF
--- a/test/container/Dockerfile-alpine
+++ b/test/container/Dockerfile-alpine
@@ -29,8 +29,8 @@ RUN apk add --no-cache \
     e2fsprogs \
     erofs-utils \
     eudev \
-    findmnt \
     file \
+    findmnt \
     f2fs-tools \
     gawk \
     git \
@@ -40,9 +40,9 @@ RUN apk add --no-cache \
     jfsutils \
     jq \
     kbd \
+    keyutils \
     kmod \
     kmod-dev \
-    keyutils \
     libcap-utils \
     linux-virt \
     losetup \
@@ -70,6 +70,7 @@ RUN apk add --no-cache \
     sfdisk \
     squashfs-tools \
     sudo \
+    swtpm \
     util-linux-misc \
     xfsprogs \
     xz

--- a/test/container/Dockerfile-arch
+++ b/test/container/Dockerfile-arch
@@ -49,12 +49,9 @@ RUN pacman --noconfirm -Syu \
     shellcheck \
     shfmt \
     squashfs-tools \
-    strace \
     swtpm \
     systemd-ukify \
-    tcpdump \
     tgt \
     tpm2-tools \
-    vi \
     xfsprogs \
     && yes | pacman -Scc

--- a/test/container/Dockerfile-arch
+++ b/test/container/Dockerfile-arch
@@ -50,10 +50,11 @@ RUN pacman --noconfirm -Syu \
     shfmt \
     squashfs-tools \
     strace \
+    swtpm \
     systemd-ukify \
     tcpdump \
     tgt \
     tpm2-tools \
-    xfsprogs \
     vi \
+    xfsprogs \
     && yes | pacman -Scc

--- a/test/container/Dockerfile-debian
+++ b/test/container/Dockerfile-debian
@@ -40,7 +40,6 @@ RUN apt-get update -y -qq && apt-get upgrade -y -qq && apt-get install -y -qq --
     jfsutils \
     jq \
     kmod \
-    less \
     libkmod-dev \
     linux-image-generic \
     lvm2 \
@@ -67,19 +66,15 @@ RUN apt-get update -y -qq && apt-get upgrade -y -qq && apt-get install -y -qq --
     sbsigntool \
     shellcheck \
     squashfs-tools \
-    strace \
     swtpm \
     systemd-boot-efi \
     systemd-container \
     systemd-coredump \
     systemd-resolved \
     systemd-timesyncd \
-    tcpdump \
     tgt \
     thin-provisioning-tools \
     tpm2-tools \
-    vim \
-    wget \
     xfsprogs \
     zstd \
     && apt-get clean

--- a/test/container/Dockerfile-debian
+++ b/test/container/Dockerfile-debian
@@ -24,10 +24,10 @@ RUN apt-get update -y -qq && apt-get upgrade -y -qq && apt-get install -y -qq --
     docbook-xml \
     docbook-xsl \
     erofs-utils \
+    f2fs-tools \
     fcoe-utils \
     fdisk \
     file \
-    f2fs-tools \
     g++ \
     gawk \
     git \
@@ -59,8 +59,8 @@ RUN apt-get update -y -qq && apt-get upgrade -y -qq && apt-get install -y -qq --
     parted \
     pcscd \
     pigz \
-    plymouth \
     pkg-config \
+    plymouth \
     procps \
     qemu-kvm \
     rng-tools5 \
@@ -68,6 +68,7 @@ RUN apt-get update -y -qq && apt-get upgrade -y -qq && apt-get install -y -qq --
     shellcheck \
     squashfs-tools \
     strace \
+    swtpm \
     systemd-boot-efi \
     systemd-container \
     systemd-coredump \

--- a/test/container/Dockerfile-fedora
+++ b/test/container/Dockerfile-fedora
@@ -61,16 +61,13 @@ RUN dnf -y install --setopt=install_weak_deps=False \
     ShellCheck \
     shfmt \
     squashfs-tools \
-    strace \
     swtpm \
     systemd-boot-unsigned \
     systemd-networkd \
     systemd-resolved \
     systemd-ukify \
     tar \
-    tcpdump \
     tpm2-tools \
-    wget \
     xfsprogs \
     xz \
     && dnf -y update && dnf clean all

--- a/test/container/Dockerfile-fedora
+++ b/test/container/Dockerfile-fedora
@@ -62,6 +62,7 @@ RUN dnf -y install --setopt=install_weak_deps=False \
     shfmt \
     squashfs-tools \
     strace \
+    swtpm \
     systemd-boot-unsigned \
     systemd-networkd \
     systemd-resolved \

--- a/test/container/Dockerfile-gentoo
+++ b/test/container/Dockerfile-gentoo
@@ -25,17 +25,18 @@ RUN emerge --quiet --update --deep --newuse --autounmask-continue=y --with-bdeps
 
 RUN emerge --quiet --deep --autounmask-continue=y --with-bdeps=n --noreplace \
     app-admin/rsyslog \
+    app-alternatives/bc \
     app-alternatives/cpio \
-	app-alternatives/bc \
     app-arch/cpio \
-    app-crypt/tpm2-tools \
     app-crypt/sbsigntools \
+    app-crypt/swtpm \
+    app-crypt/tpm2-tools \
     app-emulation/qemu \
     app-misc/jq \
     app-portage/gentoolkit \
     app-shells/dash \
-    dev-lang/rust-bin \
     dev-lang/perl \
+    dev-lang/rust-bin \
     dev-libs/openssl \
     net-fs/cifs-utils \
     net-fs/nfs-utils \
@@ -64,8 +65,8 @@ RUN emerge --quiet --deep --autounmask-continue=y --with-bdeps=n --noreplace \
     sys-fs/squashfs-tools \
     sys-fs/xfsprogs \
     sys-kernel/gentoo-kernel-bin \
-    sys-libs/libxcrypt \
     sys-libs/glibc \
+    sys-libs/libxcrypt \
     virtual/libelf \
     virtual/pkgconfig \
     && rm -rf /var/cache/* /usr/share/doc/* /usr/share/man/*

--- a/test/container/Dockerfile-opensuse
+++ b/test/container/Dockerfile-opensuse
@@ -47,6 +47,7 @@ RUN dnf -y install --setopt=install_weak_deps=False \
     shfmt \
     squashfs \
     strace \
+    swtpm \
     systemd-boot \
     systemd-experimental \
     tar \

--- a/test/container/Dockerfile-opensuse
+++ b/test/container/Dockerfile-opensuse
@@ -46,17 +46,14 @@ RUN dnf -y install --setopt=install_weak_deps=False \
     ShellCheck \
     shfmt \
     squashfs \
-    strace \
     swtpm \
     systemd-boot \
     systemd-experimental \
     tar \
-    tcpdump \
     tgt \
     tpm2.0-tools \
     /usr/bin/qemu-system-$(uname -m) \
     util-linux-systemd \
-    wget \
     xz \
     && dnf -y update && dnf clean all
 

--- a/test/container/Dockerfile-ubuntu
+++ b/test/container/Dockerfile-ubuntu
@@ -41,7 +41,6 @@ RUN apt-get update -y -qq && apt-get upgrade -y -qq && \
     jfsutils \
     jq \
     kmod \
-    less \
     libdmraid-dev \
     libkmod-dev \
     linux-image-generic \
@@ -69,7 +68,6 @@ RUN apt-get update -y -qq && apt-get upgrade -y -qq && \
     sbsigntool \
     shellcheck \
     squashfs-tools \
-    strace \
     swtpm \
     systemd-boot-efi \
     systemd-container \
@@ -77,12 +75,9 @@ RUN apt-get update -y -qq && apt-get upgrade -y -qq && \
     systemd-resolved \
     systemd-timesyncd \
     systemd-ukify \
-    tcpdump \
     tgt \
     thin-provisioning-tools \
     tpm2-tools \
-    vim \
-    wget \
     xfsprogs \
     zstd \
     && apt-get clean \

--- a/test/container/Dockerfile-ubuntu
+++ b/test/container/Dockerfile-ubuntu
@@ -25,10 +25,10 @@ RUN apt-get update -y -qq && apt-get upgrade -y -qq && \
     docbook-xml \
     docbook-xsl \
     erofs-utils \
+    f2fs-tools \
     fcoe-utils \
     fdisk \
     file \
-    f2fs-tools \
     g++ \
     gawk \
     git \
@@ -61,8 +61,8 @@ RUN apt-get update -y -qq && apt-get upgrade -y -qq && \
     parted \
     pcscd \
     pigz \
-    plymouth-themes \
     pkg-config \
+    plymouth-themes \
     procps \
     qemu-kvm \
     rng-tools5 \
@@ -70,6 +70,7 @@ RUN apt-get update -y -qq && apt-get upgrade -y -qq && \
     shellcheck \
     squashfs-tools \
     strace \
+    swtpm \
     systemd-boot-efi \
     systemd-container \
     systemd-coredump \

--- a/test/container/Dockerfile-void
+++ b/test/container/Dockerfile-void
@@ -56,10 +56,8 @@ RUN xbps-install -Syu xbps && xbps-install -yu \
     shellcheck \
     shfmt \
     squashfs-tools \
-    strace \
     swtpm \
     systemd-boot-efistub \
-    tcpdump \
     tgt \
     tpm2-tools \
     ukify \

--- a/test/container/Dockerfile-void
+++ b/test/container/Dockerfile-void
@@ -57,6 +57,7 @@ RUN xbps-install -Syu xbps && xbps-install -yu \
     shfmt \
     squashfs-tools \
     strace \
+    swtpm \
     systemd-boot-efistub \
     tcpdump \
     tgt \


### PR DESCRIPTION
Add swtpm for TPM emulation
Also remove unused interactive debugging tools (vi, strace, tcpdump, wget, less)

## Checklist
- [ ] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it

Fixes #
