### PR TITLE
fix: make sure both /lib64 and /lib are included

### DIFF
--- a/dracut-init.sh
+++ b/dracut-init.sh
@@ -87,7 +87,7 @@ DRACUT_LDCONFIG=${DRACUT_LDCONFIG:-ldconfig}
 
 # Detect lib paths
 if ! [[ $libdirs ]]; then
-    if [[ $("$DRACUT_LDD" "$dracutsysrootdir$DRACUT_TESTBIN") == */lib64/* ]] &> /dev/null \
+    if [[ $("$DRACUT_LDD" "$dracutsysrootdir$DRACUT_TESTBIN") == *"=> "*/lib64/* ]] &> /dev/null \
         && [[ -d $dracutsysrootdir/lib64 ]]; then
         libdirs+=" /lib64"
         [[ -d $dracutsysrootdir/usr/lib64 ]] && libdirs+=" /usr/lib64"


### PR DESCRIPTION
Fixes https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=1078545

This PR resolves the warning seen on CI (e.g. test 01-BASIC) both for Debian and Ubuntu containers.

```
[FAILED] Failed to start multipathd.service…Mapper Multipath Device Controller.
```

## Checklist
- [X] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it

Fixes #
