### PR TITLE
feat(fips): include openssl's fips.so and openssl.cnf

### DIFF
--- a/modules.d/01fips/module-setup.sh
+++ b/modules.d/01fips/module-setup.sh
@@ -62,4 +62,17 @@ install() {
     inst_multiple sha512hmac rmmod insmod mount uname umount grep sed cut find sort cat tail tr
 
     inst_simple /etc/system-fips
+
+    # if we have openssl we need to install their fips library and configuration
+    [ -x /usr/bin/openssl ] && {
+        read -r _ conf < <(openssl version -d)
+        conf=${conf#\"}
+        conf=${conf%\"}
+        inst_simple "${moddir}/openssl.cnf" "$conf/openssl.cnf"
+
+        read -r _ mod < <(openssl version -m)
+        mod=${mod#\"}
+        mod=${mod%\"}
+        inst_simple "$mod/fips.so"
+    }
 }

--- a/modules.d/01fips/openssl.cnf
+++ b/modules.d/01fips/openssl.cnf
@@ -1,0 +1,7 @@
+openssl_conf = openssl_init
+[openssl_init]
+providers = provider_sect
+[provider_sect]
+default = default_sect
+[default_sect]
+activate = 1


### PR DESCRIPTION
## Changes

Include default `openssl.cnf` and `fips.so` if openssl is detected.

Ref: https://github.com/redhat-plumbers/dracut-rhel9/pull/67

## Checklist
- [ ] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it