### PR TITLE
docs: update NEWS.md and AUTHORS for release 104

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -4,6 +4,7 @@ Victor Lowther <victor.lowther@gmail.com>
 Antonio Alvarez Feijoo <antonio.feijoo@suse.com>
 Jóhann B. Guðmundsson <johannbg@gmail.com>
 Amadeusz Żołnowski <aidecoe@aidecoe.name>
+Jo Zzsi <jozzsicsataban@gmail.com>
 Daniel Molkentin <daniel.molkentin@suse.com>
 Hannes Reinecke <hare@suse.com>
 Kairui Song <kasong@redhat.com>
@@ -11,8 +12,8 @@ Will Woods <wwoods@redhat.com>
 Philippe Seewer <philippe.seewer@bfh.ch>
 Warren Togami <wtogami@redhat.com>
 Benjamin Drung <benjamin.drung@canonical.com>
-Dave Young <dyoung@redhat.com>
 Martin Wilck <mwilck@suse.de>
+Dave Young <dyoung@redhat.com>
 Jeremy Katz <katzj@redhat.com>
 Lukas Nykryn <lnykryn@redhat.com>
 David Dillow <dave@thedillows.org>
@@ -25,41 +26,42 @@ Thomas Renninger <trenn@suse.com>
 Frederick Grose <fgrose@sugarlabs.org>
 Alexander Tsoy <alexander@tsoy.me>
 Beniamino Galvani <bgalvani@redhat.com>
+Pavel Valena <pvalena@redhat.com>
 наб <nabijaczleweli@nabijaczleweli.xyz>
 Jonathan Lebon <jonathan@jlebon.com>
 Steffen Maier <maier@linux.ibm.com>
 WANG Chao <chaowang@redhat.com>
 David Tardon <dtardon@redhat.com>
 Yu Watanabe <watanabe.yu+github@gmail.com>
+Andrew Ammerlaan <andrewammerlaan@gentoo.org>
 Andrey Borzenkov <arvidjaar@gmail.com>
 David Disseldorp <ddiss@suse.de>
 Frantisek Sumsal <frantisek@sumsal.cz>
-Pavel Valena <pvalena@redhat.com>
+Marcos Mello <marcosfrm@gmail.com>
 Peter Robinson <pbrobinson@fedoraproject.org>
 Thomas Blume <thomas.blume@suse.com>
 Brian C. Lane <bcl@redhat.com>
 Hans de Goede <hdegoede@redhat.com>
 Peter Jones <pjones@redhat.com>
+Philipp Rudo <prudo@redhat.com>
 Andreas Thienemann <andreas@bawue.net>
-Andrew Ammerlaan <andrewammerlaan@gentoo.org>
-Marcos Mello <marcosfrm@gmail.com>
 Renaud Métrich <rmetrich@redhat.com>
 Tomasz Paweł Gajc <tpgxyz@gmail.com>
 Fabian Vogt <fvogt@suse.com>
 Nicolas Chauvet <kwizart@gmail.com>
 Zoltán Böszörményi <zboszor@pr.hu>
 Colin Walters <walters@verbum.org>
+David Teigland <teigland@redhat.com>
 Dusty Mabe <dusty@dustymabe.com>
 John Reiser <jreiser@bitwagon.com>
+Kairui Song <kasong@tencent.com>
 Luca Berra <bluca@vodka.it>
 Shreenidhi Shedi <sshedi@vmware.com>
 Xunlei Pang <xlpang@redhat.com>
 Daniel Drake <drake@endlessm.com>
-David Teigland <teigland@redhat.com>
-Kairui Song <kasong@tencent.com>
+Mike Gilbert <floppym@gentoo.org>
 Angelo "pallotron" Failla <pallotron@fb.com>
 Dan Horák <dhorak@redhat.com>
-Mike Gilbert <floppym@gentoo.org>
 Ville Skyttä <ville.skytta@iki.fi>
 Adrien Thierry <athierry@redhat.com>
 Böszörményi Zoltán <zboszor@pr.hu>
@@ -119,10 +121,12 @@ Juan RP <xtraeme@gmail.com>
 Lance Albertson <lance@osuosl.org>
 Marian Ganisin <mganisin@redhat.com>
 Matt Coleman <matt@datto.com>
+Matteo Croce <teknoraver@meta.com>
 Matthias Gerstner <matthias.gerstner@suse.de>
 Max Resch <resch.max@gmail.com>
 Michael Ploujnikov <plouj@somanetworks.com>
 Michal Koutný <mkoutny@suse.com>
+Neal Gompa <neal@gompa.dev>
 Nicolas Porcel <nicolasporcel06@gmail.com>
 Pratyush Anand <panand@redhat.com>
 Sam James <sam@gentoo.org>
@@ -133,6 +137,7 @@ Stig Telfer <stelfer@cray.com>
 Thomas Backlund <tmb@mageia.org>
 Topi Miettinen <toiwoton@gmail.com>
 Vasiliy Tolstov <v.tolstov@selfip.ru>
+Vitaly Kuznetsov <vkuznets@redhat.com>
 Wim Muskee <wimmuskee@gmail.com>
 keentux <valentin.lefebvre@suse.com>
 Alan Jenkins <alan-jenkins@tuffmail.co.uk>
@@ -157,6 +162,7 @@ Denis Silakov <dsilakov@virtuozzo.com>
 Dimitri John Ledkov <dimitri.j.ledkov@intel.com>
 Erwan Velu <erwan.velu@enovance.com>
 Evgeny Vereshchagin <evvers@ya.ru>
+Fabian Vogt <fvogt@suse.de>
 Federico Vaga <federico.vaga@cern.ch>
 Frederick Grose <4335897+FGrose@users.noreply.github.com>
 German Maglione <gmaglione@redhat.com>
@@ -185,8 +191,8 @@ Marko Myllynen <myllynen@redhat.com>
 Matthew Thode <mthode@mthode.org>
 Mike Snitzer <snitzer@redhat.com>
 Minfei Huang <mhuang@redhat.com>
-Neal Gompa <neal@gompa.dev>
 Nikoli <nikoli@gmx.us>
+Ondrej Kubik <ondrej.kubik@canonical.com>
 Patrick Talbert <ptalbert@redhat.com>
 Pedro Monreal <pmgdeb@gmail.com>
 Petr Pavlu <petr.pavlu@suse.com>
@@ -197,7 +203,7 @@ Stefan Berger <stefanb@us.ibm.com>
 Thomas Lange <lange@informatik.uni-koeln.de>
 Tianhao Chai <cth451@gmail.com>
 Till Maas <opensource@till.name>
-Vitaly Kuznetsov <vkuznets@redhat.com>
+Timo Rothenpieler <timo@rothenpieler.org>
 Vivek Goyal <vgoyal@redhat.com>
 Vladislav Bogdanov <bubble@hoster-ok.com>
 Wenchao Hao <haowenchao@huawei.com>
@@ -243,6 +249,7 @@ Carlo Caione <carlo@endlessm.com>
 Chad Dupuis <chad.dupuis@cavium.com>
 Charles Rose <charles.rose@dell.com>
 Christian Heinz <christian.ch.heinz@gmail.com>
+Clemens Lang <cllang@redhat.com>
 Cole Robinson <crobinso@redhat.com>
 Cong Wang <amwang@redhat.com>
 Conrad Hoffmann <ch@bitfehler.net>
@@ -260,6 +267,7 @@ Derek Higgins <derekh@redhat.com>
 Dirk Müller <dirk@dmllr.de>
 Dmitry Klochkov <dmitry.klochkov@bell-sw.com>
 Donovan Tremura <neurognostic@protonmail.ch>
+Dorina Kovacs <princessdorinakovacs@gmail.com>
 Duane Griffin <duaneg@dghda.com>
 Elan Ruusamäe <glen@delfi.ee>
 Emanuele Giuseppe Esposito <eesposit@redhat.com>
@@ -268,7 +276,7 @@ Enzo Matsumiya <ematsumiya@suse.de>
 Eugene S. Sobolev <sobolev@protei.ru>
 Eugene Syromiatnikov <esyr@redhat.com>
 Evgeni Golov <evgeni@golov.de>
-Fabian Vogt <fvogt@suse.de>
+Fabian Henze <1144183+flyser@users.noreply.github.com>
 Florian Albrechtskirchinger <falbrechtskirchinger@gmail.com>
 Florian Gamböck <mail@floga.de>
 Frank Deng <frank.deng@oracle.com>
@@ -299,6 +307,7 @@ Jeremy Linton <jeremy.linton@arm.com>
 Jeremy Linton <jlinton@redhat.com>
 Jeremy Linton <lintonrjeremy@gmail.com>
 Jiri Pirko <jiri@resnulli.us>
+Jochen Sprickerhof <git@jochen.sprickerhof.de>
 Joe Lawrence <Joe.Lawrence@stratus.com>
 Johannes Thumshirn <jthumshirn@suse.com>
 John Meneghini <jmeneghi@redhat.com>
@@ -316,6 +325,7 @@ Lennart Poettering <lennart@poettering.net>
 Lennert Buytenhek <buytenh@wantstofly.org>
 Lev Veyde <lveyde@redhat.com>
 Lianbo Jiang <lijiang@redhat.com>
+Lichen Liu <lichliu@redhat.com>
 Louis Sautier <sautier.louis@gmail.com>
 Luca BRUNO <luca.bruno@coreos.com>
 Lucas C. Villa Real <lucasvr@gmail.com>
@@ -336,6 +346,7 @@ Michal Schmidt <mschmidt@redhat.com>
 Michal Sekletar <msekleta@redhat.com>
 Michał Zegan <webczat@outlook.com>
 Mike Gorse <mgorse@suse.com>
+Mike Schwarz <xurubezi@gmail.com>
 Moritz 'Morty' Strübe <morty@gmx.net>
 Morten Linderud <morten@linderud.pw>
 Munehiro Matsuda <haro@kgt.co.jp>
@@ -378,7 +389,6 @@ Thierry Vignaud <thierry.vignaud@gmail.com>
 Thilo Bangert <thilo.bangert@gmx.net>
 Thomas Abraham <tabraham@suse.com>
 Thomas Haller <thaller@redhat.com>
-Timo Rothenpieler <timo@rothenpieler.org>
 Tobias Geerinckx <tobias.geerinckx@gmail.com>
 Tobias Klauser <tklauser@distanz.ch>
 Tom Gundersen <teg@jklm.no>

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,176 @@
 [Rendered view](https://github.com/dracut-ng/dracut-ng/blob/master/NEWS.md)
 
+dracut-ng-104
+=============
+
+New dracut modules:
+* shell-interpreter: meta package for improved shell selection
+* fips-crypto-policies: make c-p follow FIPS mode automatically
+* squash-lib: code shared by 95squash-{squashfs,erofs}
+
+Removed dracut modules:
+* ifcfg: no longer needed for networking
+* mksh: lack of interest to maintain
+
+Notable new features:
+* add --add-confdir option to dracut
+* new dracut configuration profiles under dracut.conf.d/ (e.g. for uki)
+* systemd-udevd: make systemd-sysctl, systemd-modules-load optional
+
+Notable bug fixes:
+* crypt: include systemd-cryptsetup module when needed
+* udev-rules: move installation of libkmod to udev-rules module
+* busybox: install busybox symlinks later in the generation process
+* nvmf: install (only) required nvmf modules
+* systemd: include systemd config files from /usr/lib/systemd
+* systemd: trigger systemd-vconsole-setup.service only on demand
+* multipath: include module with "find_multipaths strict"
+* nfs: include also entries from /usr/lib/{passwd,group}
+* network: handle '-m network'
+* systemd-networkd: remove basename dependency
+* remove obsolete syntax for many command line options without the rd. prefix
+
+The project builds test containers daily for the following Linux distributions:
+
+Alpine, Arch, Debian (amd64 and arm64), Fedora (amd64 and arm64), Gentoo, openSUSE, Ubuntu, Void
+These Linux distributions test dracut in various configurations (systemd/OpenRC/runit, glibc/musl, dhclient/NetworkManager/systemd-networkd).
+
+#### Features
+
+*   config example for cloud provider uki vm ([cc0a0e42](https://github.com/dracut-ng/dracut-ng/commit/cc0a0e420df6120fa81b8c12b47865dc7825d1f4))
+*   add common config when networking is not desired ([9ffabd59](https://github.com/dracut-ng/dracut-ng/commit/9ffabd5916605be5052faa1256f29feafbc83b1e))
+* **busybox:**  use busybox --install to install itself ([3975e26a](https://github.com/dracut-ng/dracut-ng/commit/3975e26a84cd8645b15d0a863263a63da93650e0))
+* **dracut:**  detect kernel initrd support ([b41c2401](https://github.com/dracut-ng/dracut-ng/commit/b41c24019321232a22062955254bd3eb2f002b4a))
+* **dracut-functions:**  check more paths ([ede2a05a](https://github.com/dracut-ng/dracut-ng/commit/ede2a05a6e44f6c73eca79e1fd4803927d334511))
+* **dracut-init.sh:**  allow changing the destination directory for inst et al ([3ad7e6c2](https://github.com/dracut-ng/dracut-ng/commit/3ad7e6c23bdcac7c7f6adc8a2cb31bab3c37038a))
+* **dracut-initramfs-restore:**  unpack erofs images ([ce83d38d](https://github.com/dracut-ng/dracut-ng/commit/ce83d38dfa30507382b00219f9e009dbb10e3c72))
+* **dracut.sh:**  add --add-confdir option ([6107f5e5](https://github.com/dracut-ng/dracut-ng/commit/6107f5e54fb82f1c00285a4cc709b04f29eee460))
+* **fips:**  add support for UKIs ([1000265a](https://github.com/dracut-ng/dracut-ng/commit/1000265a185c5156e0e0ba218bca23a9f1031f60))
+* **fips-crypto-policies:**  make c-p follow FIPS mode automatically ([bd3c1e1c](https://github.com/dracut-ng/dracut-ng/commit/bd3c1e1cc2f656f7ee4ff47e00ca716d52a86a3d))
+* **lsinitrd:**  add support for erofs images ([2a3bc5af](https://github.com/dracut-ng/dracut-ng/commit/2a3bc5af412929a638559a9e530c00a53932a606))
+* **pcmcia:**  only include when another module requires it ([ea4199b3](https://github.com/dracut-ng/dracut-ng/commit/ea4199b38c097fa4dc059dd52740af91111145b5))
+* **rescue:**  move command line arguments to 50-rescue.conf ([d24917fa](https://github.com/dracut-ng/dracut-ng/commit/d24917fa1907d67d3e422139a2bf0866bf0dc26d))
+* **shell-interpreter:**  meta package for improved shell selection ([e1fcfe64](https://github.com/dracut-ng/dracut-ng/commit/e1fcfe64fb439ae71fc6babcaac3c6bc834b00a9))
+* **squash:**
+  *  add module 95squash-erofs ([ebc9e84d](https://github.com/dracut-ng/dracut-ng/commit/ebc9e84dd3bdcb3fc2899431cb46bc12bd986294))
+  *  split 95squash-squashfs from 99squash ([5d03cc3b](https://github.com/dracut-ng/dracut-ng/commit/5d03cc3be869268ec07cf2c2ec74f008dde3e110))
+  *  move mksquashfs to 99squash/modules-setup ([b5482f07](https://github.com/dracut-ng/dracut-ng/commit/b5482f0726e02e6c6484377725345109c204fb03))
+* **systemd:**  always install libsystemd libraries ([921792f2](https://github.com/dracut-ng/dracut-ng/commit/921792f201e954de461d3b551e01b5369d666db8))
+* **systemd:**  include systemd config files from /usr/lib/systemd ([6c99c073](https://github.com/dracut-ng/dracut-ng/commit/6c99c07327b9600f18fcf97564f427610453a771))
+* **test-root:**  only include debug module if V is set to 2 ([8974fea2](https://github.com/dracut-ng/dracut-ng/commit/8974fea2f92a63a10e48ad9aee9ccc02c5e78883))
+
+#### Bug Fixes
+
+*   install test infrastructure ([a0d12aa7](https://github.com/dracut-ng/dracut-ng/commit/a0d12aa7dd6d4304955de1407a35dda87ee86b54))
+*   typo in variable name ([76b2f1a9](https://github.com/dracut-ng/dracut-ng/commit/76b2f1a9b52afd4203c1d0e6afb57314bbfe8407))
+* **Dockerfile-Gentoo:**  explicitly pull in all build dependencies ([2f8ea1c9](https://github.com/dracut-ng/dracut-ng/commit/2f8ea1c90175b3fbe8c98621776a7d3456c78c56))
+* **Makefile:**  install dracut config examples under /usr ([0d369e3e](https://github.com/dracut-ng/dracut-ng/commit/0d369e3e30935dffe48dfff1e90463868e7f804a))
+* **base:**
+  *  init from base is not needed when systemd is enabled ([ae94b24f](https://github.com/dracut-ng/dracut-ng/commit/ae94b24f2370db490593dd35b2cfea57aa7dbfe5))
+  *  remove the undocumented real_init, realinitpath and rd.distroinit ([b1dbe859](https://github.com/dracut-ng/dracut-ng/commit/b1dbe859a9b6ca4bc60a0bf94ace660414207b51))
+* **busybox:**
+  *  install busybox symlinks later in the generation process ([4e78a870](https://github.com/dracut-ng/dracut-ng/commit/4e78a8705e19562f5659e352612e50905c4be12a))
+  *  install busybox symlinks manually ([95ba0327](https://github.com/dracut-ng/dracut-ng/commit/95ba03270eb3297103cba276c2925ecc1b762926))
+* **crypt:**
+  *  include systemd-cryptsetup module when needed ([8907ba12](https://github.com/dracut-ng/dracut-ng/commit/8907ba124e9dcd57049c2ccb4fd20b98b3bd83c2))
+  *  install dm_crypt module in non-hostonly mode as well ([59af2fff](https://github.com/dracut-ng/dracut-ng/commit/59af2fff515539e4b47ddc955d0c61a3829c85c4))
+* **dracut:**
+  *  --list-modules should imply --no-kernel as well ([bd7736e9](https://github.com/dracut-ng/dracut-ng/commit/bd7736e9823d3be580d6320e2cefad97d0b33edd))
+  *  don't apply aggressive strip to kernel modules ([a1c51af1](https://github.com/dracut-ng/dracut-ng/commit/a1c51af1bf5809a8f6deb246ef6ae3f25608d6a3))
+  *  do not add all lib subdirs to `LD_LIBRARY_PATH` with `--sysroot` ([d0c82322](https://github.com/dracut-ng/dracut-ng/commit/d0c82322ce1b44e72539b6dd537711afb68f081e))
+  *  ldd output borked with `--sysroot` ([e0b87682](https://github.com/dracut-ng/dracut-ng/commit/e0b876823d9c608db7132cab9e5edd62543a27ae))
+  *  re-enable extended attributes in containers ([c964a56f](https://github.com/dracut-ng/dracut-ng/commit/c964a56fde168212422fdf37ecb835dfe409f4a7))
+* **dracut-fuctions.sh:**  avoid reading the wrong kconfig ([d8fb0ef8](https://github.com/dracut-ng/dracut-ng/commit/d8fb0ef8d9d6c0bada3e21e7a3801e5ba9fc2cdb))
+* **dracut-functions:**  allow for \ in get_maj_min file path ([91b1574c](https://github.com/dracut-ng/dracut-ng/commit/91b1574c4a19be297b893791192049612467694b))
+* **dracut-functions.sh:**  only return block devices from get_persistent_dev ([6611c6e4](https://github.com/dracut-ng/dracut-ng/commit/6611c6e4a0166bec50cc567b708ec7265dc82682))
+* **dracut-init.sh:**  add module to mods_to_load before checking dependencies ([d0f8fde5](https://github.com/dracut-ng/dracut-ng/commit/d0f8fde5668cfd7fda1d15824e268b4949b4fd04))
+* **dracut-install:**
+  *  use correct data type for pid ([36dc45ca](https://github.com/dracut-ng/dracut-ng/commit/36dc45ca74ba675ac6a331459d850a15fdcbb2d6))
+  *  handle correctly sysrootdir with trailing '/' ([1c44cd71](https://github.com/dracut-ng/dracut-ng/commit/1c44cd71a87967c5d8094a3d37ab2598dbd1ef12))
+  *  do not assume handled path starts with sysrootdir ([7bc1f538](https://github.com/dracut-ng/dracut-ng/commit/7bc1f5383df58ed93ad4827634042f92ade4b20a))
+  *  resolve -Wextra warnings ([8de0258d](https://github.com/dracut-ng/dracut-ng/commit/8de0258d71dc5600d715d7534471e35b2b75c7be))
+  *  refuse empty DRACUT_LDD environment variable ([a9e11447](https://github.com/dracut-ng/dracut-ng/commit/a9e1144713056248c8ca0e0e4a2f3a08a12b89b2))
+* **dracut-systemd:**  include systemd-cryptsetup module when needed ([e0e5424a](https://github.com/dracut-ng/dracut-ng/commit/e0e5424a7b5e387ccb70e47ffea5a59716bf7b76))
+* **dracut.sh:**
+  *  exit when installing the squash loader fails ([abac41d0](https://github.com/dracut-ng/dracut-ng/commit/abac41d0fa3c69dd4dc717fedd61502affa2799e))
+  *  use only compressor that kernel supports ([cc17951e](https://github.com/dracut-ng/dracut-ng/commit/cc17951ec350d0e3a8f95550579d4515c18a4649))
+  *  account for the kernel being named kernel ([c520f3a4](https://github.com/dracut-ng/dracut-ng/commit/c520f3a49ddb7b7225cdac4dd3c4d9f68e7d105c))
+* **fips-crypto-policies:**  make it depend on fips dracut module ([a2096daf](https://github.com/dracut-ng/dracut-ng/commit/a2096dafdbfc88eed91ce34b1f4d27e7eb7ca839))
+* **hwdb:**  only install /etc/udev/udev.hwdb in hostonly mode ([f2b1491f](https://github.com/dracut-ng/dracut-ng/commit/f2b1491f8461c331f501680291d6ceed6c2a718e))
+* **lsinitrd:**  check skipcpio file directly ([2815f021](https://github.com/dracut-ng/dracut-ng/commit/2815f021fd7947364c4344da479803983ffaba25))
+* **lvm:**  clean up whitespace in messages ([5e9cb283](https://github.com/dracut-ng/dracut-ng/commit/5e9cb2832f5b129dbbfdd3e9c040da978e960f56))
+* **man:**  update description of the --gzip option ([206b5448](https://github.com/dracut-ng/dracut-ng/commit/206b54481ccc031763714052545c6e7779ea3c5e))
+* **multipath:**  include module with "find_multipaths strict" ([1e802f15](https://github.com/dracut-ng/dracut-ng/commit/1e802f15fee3d6402d83e0efefef8bb88c5a33e3))
+* **network:**
+  *  call both check_module and module_check ([c81c9552](https://github.com/dracut-ng/dracut-ng/commit/c81c9552650971717f99118a295c3c3840da3209))
+  *  handle '-m network' ([c4b57722](https://github.com/dracut-ng/dracut-ng/commit/c4b57722fbe65dce49105ad264dde2c2bbfc8a41))
+* **nfs:**  include also entries from /usr/lib/{passwd,group} ([d954e3a9](https://github.com/dracut-ng/dracut-ng/commit/d954e3a9e83c28e1509186c6a668a6f6c0bd4591))
+* **nvmf:**
+  *  install (only) required nvmf modules ([3748ed4d](https://github.com/dracut-ng/dracut-ng/commit/3748ed4db5255c516cd60c2d710532d79878a498))
+  *  require NVMeoF modules ([41332702](https://github.com/dracut-ng/dracut-ng/commit/4133270236f99d2196b2c1d05dfab76aae2f8092))
+* **release:**  improve commit message ([267d002c](https://github.com/dracut-ng/dracut-ng/commit/267d002cbb63a59d47a2d7273d62757f9763b4d2))
+* **rescue:**  make rescue always no-hostonly ([224c0091](https://github.com/dracut-ng/dracut-ng/commit/224c00914bfb4ba1dee48e094ebb137facfd5947))
+* **rngd:**  install system service file ([a9528201](https://github.com/dracut-ng/dracut-ng/commit/a9528201bea5182c72556731ef7944259fbe3fc8))
+* **squash:**
+  *  remove cyclic dependency ([5f6b6fa4](https://github.com/dracut-ng/dracut-ng/commit/5f6b6fa4dc0b2f6a174e98f557fd595bdd92d361))
+  *  use 99busybox instead of installing it manually ([69ebcb58](https://github.com/dracut-ng/dracut-ng/commit/69ebcb5850b5ceb27d5fd5fee6a5d2857d38b828))
+  *  explicitly create required directories ([d23b0eea](https://github.com/dracut-ng/dracut-ng/commit/d23b0eeaa6a985b60b3a7f278f8e8fb1a63a0ae3))
+* **squash-erofs:**  properly exclude $squashdir ([323af181](https://github.com/dracut-ng/dracut-ng/commit/323af1817405b64a154ae1b01f5aca180a2801fa))
+* **squash-lib:**  harden against empty $initdir ([924e2e85](https://github.com/dracut-ng/dracut-ng/commit/924e2e85d9731b4e1d3852bc3a4a5d045024051a))
+* **systemd:**
+  *  do not set unused target as the default ([982735c7](https://github.com/dracut-ng/dracut-ng/commit/982735c790cabade82f520ddda8e6c3733cb6571))
+  *  /sbin/init is not required inside initrd ([a066b07f](https://github.com/dracut-ng/dracut-ng/commit/a066b07fbdc5cad5c3cb9873d987a432cbed14e2))
+  *  systemd-vconsole-setup has a dependency on loadkeys ([55517460](https://github.com/dracut-ng/dracut-ng/commit/5551746088633116a28f3ded9d7003f378b6cd17))
+  *  remove duplicate systemd cryptsetup targets ([ad520855](https://github.com/dracut-ng/dracut-ng/commit/ad520855113d99d7551a7ab6c19870736f72cbc4))
+  *  make nologin optional ([953b48a7](https://github.com/dracut-ng/dracut-ng/commit/953b48a7e7a4057c7d694c29cc30ea993b946e55))
+  *  move installation of libkmod to udev-rules module ([ef0972fe](https://github.com/dracut-ng/dracut-ng/commit/ef0972fe5349bdf6e821cb79a47cf412caf99059))
+* **systemd-cryptsetup:**  install cryptsetup-pre.target ([181e1f11](https://github.com/dracut-ng/dracut-ng/commit/181e1f116b74d1e4ee400f72f7440b78a4c4d1f1))
+* **systemd-initrd:**  add base as dependency ([56c84cde](https://github.com/dracut-ng/dracut-ng/commit/56c84cdece4bff04ed9db213f49d052d994df04d))
+* **systemd-networkd:**
+  *  remove basename dependency ([2bb74448](https://github.com/dracut-ng/dracut-ng/commit/2bb7444850b57893a6c6c875da69109b83da5090))
+  *  make sure default network is always last ([e1dfdaca](https://github.com/dracut-ng/dracut-ng/commit/e1dfdaca22d5074a6a3d8fcf6df080752b84803d), closes [#618](https://github.com/dracut-ng/dracut-ng/issues/618))
+* **systemd-sysctl:**  systemd-modules-load is not a dependency ([4fb67460](https://github.com/dracut-ng/dracut-ng/commit/4fb6746085aaceed4822bf7c8ee13193e2ef46fe))
+* **systemd-udevd:**  make systemd-sysctl, systemd-modules-load optional ([1de08390](https://github.com/dracut-ng/dracut-ng/commit/1de083908d5065af585c0a657c43f8ad16a19868))
+* **test:**  always install kernel modules ([9c79e226](https://github.com/dracut-ng/dracut-ng/commit/9c79e22694332a0e6b59f92391fe7e05919de485))
+* **udev-rules:**
+  *  remove systemd-specific rules ([6243b7b6](https://github.com/dracut-ng/dracut-ng/commit/6243b7b623680aa1f431c962832a6f877b60afdb))
+  *  move *-persistent-storage.rules to rootfs-block ([d67251aa](https://github.com/dracut-ng/dracut-ng/commit/d67251aaa5529e521e0a0ca4d28dc938a98a6226))
+  *  install dropins for udev.conf ([bdaa4e5b](https://github.com/dracut-ng/dracut-ng/commit/bdaa4e5b0145214fa154465a92a80783a46aba9a))
+* **watchdog:**  change the priority of watchdog kernel modules ([0097ded1](https://github.com/dracut-ng/dracut-ng/commit/0097ded1de21f8a7f9453a5e1c03195f985a053f))
+
+#### Performance
+
+* **systemd-initrd:**
+  *  do not depend on base module ([06074459](https://github.com/dracut-ng/dracut-ng/commit/06074459b9536a03f67bc6b6e09da0b2b510bd67))
+  *  initrd.target is already the default ([b7b4f039](https://github.com/dracut-ng/dracut-ng/commit/b7b4f03987a0ffbd2b8ee585b84f852e512f000d))
+
+#### Contributors
+
+- Jo Zzsi <jozzsicsataban@gmail.com>
+- Laszlo Gombos <laszlo.gombos@gmail.com>
+- Philipp Rudo <prudo@redhat.com>
+- Antonio Alvarez Feijoo <antonio.feijoo@suse.com>
+- Pavel Valena <pvalena@redhat.com>
+- Andrew Ammerlaan <andrewammerlaan@gentoo.org>
+- Marcos Mello <marcosfrm@gmail.com>
+- Martin Wilck <mwilck@suse.de>
+- Matteo Croce <teknoraver@meta.com>
+- Ondrej Kubik <ondrej.kubik@canonical.com>
+- Alexander Tsoy <alexander@tsoy.me>
+- Clemens Lang <cllang@redhat.com>
+- David Teigland <teigland@redhat.com>
+- Dorina Kovacs <princessdorinakovacs@gmail.com>
+- Fabian Henze <1144183+flyser@users.noreply.github.com>
+- Fabian Vogt <fvogt@suse.de>
+- Jochen Sprickerhof <git@jochen.sprickerhof.de>
+- Kairui Song <kasong@tencent.com>
+- Lichen Liu <lichliu@redhat.com>
+- Mike Gilbert <floppym@gentoo.org>
+- Mike Schwarz <xurubezi@gmail.com>
+- Neal Gompa <neal@gompa.dev>
+- Timo Rothenpieler <timo@rothenpieler.org>
+- Vitaly Kuznetsov <vkuznets@redhat.com>
+
 dracut-ng-103
 =============
 

--- a/dracut-version.sh
+++ b/dracut-version.sh
@@ -1,3 +1,3 @@
 #!/bin/sh
 # shellcheck disable=SC2034
-DRACUT_VERSION=103
+DRACUT_VERSION=104

--- a/dracut.html
+++ b/dracut.html
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd"><html xmlns="http://www.w3.org/1999/xhtml"><head><meta http-equiv="Content-Type" content="text/html; charset=UTF-8" /><title>dracut 103</title><style type="text/css">
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd"><html xmlns="http://www.w3.org/1999/xhtml"><head><meta http-equiv="Content-Type" content="text/html; charset=UTF-8" /><title>dracut 104</title><style type="text/css">
 
 body, h1, h2, h3, h4, h5, h6, pre, li, div {
 	line-height: 1.29em;
@@ -1117,7 +1117,7 @@ table tr.even td {
 	color: #3c6eb4;
 }
 
-</style><meta name="generator" content="DocBook XSL Stylesheets Vsnapshot" /></head><body><div xml:lang="en" class="book" lang="en"><div class="titlepage"><div><div><h1 class="title"><a id="idm1"></a>dracut 103</h1></div><div><div class="author"><h3 class="author"><span class="firstname">Harald</span> <span class="surname">Hoyer</span></h3><code class="email">&lt;<a class="email" href="mailto:harald@profian.com">harald@profian.com</a>&gt;</code></div></div></div><hr /></div><div class="toc"><p><strong>Table of Contents</strong></p><dl class="toc"><dt><span class="part"><a href="#_introduction">I. Introduction</a></span></dt><dd><dl><dt><span class="chapter"><a href="#_definition">1. Definition</a></span></dt><dt><span class="chapter"><a href="#_rationale">2. Rationale</a></span></dt><dt><span class="chapter"><a href="#_implementation">3. Implementation</a></span></dt><dt><span class="chapter"><a href="#_mount_preparations">4. Mount preparations</a></span></dt><dt><span class="chapter"><a href="#_dracut_on_shutdown">5. Dracut on shutdown</a></span></dt></dl></dd><dt><span class="part"><a href="#_user_manual">II. User Manual</a></span></dt><dd><dl><dt><span class="chapter"><a href="#_dracut_8">6. DRACUT(8)</a></span></dt><dd><dl><dt><span class="section"><a href="#_name">NAME</a></span></dt><dt><span class="section"><a href="#_synopsis">SYNOPSIS</a></span></dt><dt><span class="section"><a href="#_description">DESCRIPTION</a></span></dt><dt><span class="section"><a href="#_usage">USAGE</a></span></dt><dd><dl><dt><span class="section"><a href="#_inspecting_the_contents">Inspecting the Contents</a></span></dt><dt><span class="section"><a href="#_adding_dracut_modules">Adding dracut Modules</a></span></dt><dt><span class="section"><a href="#_omitting_dracut_modules">Omitting dracut Modules</a></span></dt><dt><span class="section"><a href="#_adding_kernel_modules">Adding Kernel Modules</a></span></dt><dt><span class="section"><a href="#_boot_parameters">Boot parameters</a></span></dt><dt><span class="section"><a href="#Injecting">Injecting custom Files</a></span></dt><dt><span class="section"><a href="#NetworkBoot">Network Boot</a></span></dt></dl></dd><dt><span class="section"><a href="#_troubleshooting">Troubleshooting</a></span></dt><dd><dl><dt><span class="section"><a href="#identifying-your-problem-area">Identifying your problem area</a></span></dt><dt><span class="section"><a href="#information-to-include-in-your-report">Information to include in your report</a></span></dt><dt><span class="section"><a href="#debugging-dracut">Debugging dracut</a></span></dt></dl></dd><dt><span class="section"><a href="#_options">OPTIONS</a></span></dt><dt><span class="section"><a href="#_environment">ENVIRONMENT</a></span></dt><dt><span class="section"><a href="#_files">FILES</a></span></dt><dd><dl><dt><span class="section"><a href="#_configuration_in_the_initramfs">Configuration in the initramfs</a></span></dt></dl></dd><dt><span class="section"><a href="#_availability">AVAILABILITY</a></span></dt><dt><span class="section"><a href="#_authors">AUTHORS</a></span></dt><dt><span class="section"><a href="#_see_also">SEE ALSO</a></span></dt></dl></dd><dt><span class="chapter"><a href="#dracutconf5">7. DRACUT.CONF(5)</a></span></dt><dd><dl><dt><span class="section"><a href="#_name_2">NAME</a></span></dt><dt><span class="section"><a href="#_synopsis_2">SYNOPSIS</a></span></dt><dt><span class="section"><a href="#_description_2">Description</a></span></dt><dt><span class="section"><a href="#_files_2">Files</a></span></dt><dt><span class="section"><a href="#_author">AUTHOR</a></span></dt><dt><span class="section"><a href="#_see_also_2">See Also</a></span></dt></dl></dd><dt><span class="chapter"><a href="#dracutcmdline7">8. DRACUT.CMDLINE(7)</a></span></dt><dd><dl><dt><span class="section"><a href="#_name_3">NAME</a></span></dt><dt><span class="section"><a href="#_description_3">DESCRIPTION</a></span></dt><dd><dl><dt><span class="section"><a href="#_standard">Standard</a></span></dt><dt><span class="section"><a href="#_iso_scan_filename">iso-scan/filename</a></span></dt><dt><span class="section"><a href="#_misc">Misc</a></span></dt><dt><span class="section"><a href="#dracutkerneldebug">Debug</a></span></dt><dt><span class="section"><a href="#_i18n">I18N</a></span></dt><dt><span class="section"><a href="#_lvm">LVM</a></span></dt><dt><span class="section"><a href="#_crypto_luks">crypto LUKS</a></span></dt><dt><span class="section"><a href="#_crypto_luks_key_on_removable_device_support">crypto LUKS - key on removable device support</a></span></dt><dt><span class="section"><a href="#_md_raid">MD RAID</a></span></dt><dt><span class="section"><a href="#_dm_raid">DM RAID</a></span></dt><dt><span class="section"><a href="#_multipath">MULTIPATH</a></span></dt><dt><span class="section"><a href="#_fips">FIPS</a></span></dt><dt><span class="section"><a href="#_network">Network</a></span></dt><dt><span class="section"><a href="#_nfs">NFS</a></span></dt><dt><span class="section"><a href="#_cifs">CIFS</a></span></dt><dt><span class="section"><a href="#_iscsi">iSCSI</a></span></dt><dt><span class="section"><a href="#_fcoe">FCoE</a></span></dt><dt><span class="section"><a href="#_nvmf">NVMf</a></span></dt><dt><span class="section"><a href="#_nbd">NBD</a></span></dt><dt><span class="section"><a href="#_virtiofs">VIRTIOFS</a></span></dt><dt><span class="section"><a href="#_dasd">DASD</a></span></dt><dt><span class="section"><a href="#_zfcp">ZFCP</a></span></dt><dt><span class="section"><a href="#_znet">ZNET</a></span></dt><dt><span class="section"><a href="#_booting_live_images">Booting live images</a></span></dt><dt><span class="section"><a href="#_zipl">ZIPL</a></span></dt><dt><span class="section"><a href="#_cio_ignore">CIO_IGNORE</a></span></dt><dt><span class="section"><a href="#_plymouth_boot_splash">Plymouth Boot Splash</a></span></dt><dt><span class="section"><a href="#_kernel_keys">Kernel keys</a></span></dt><dt><span class="section"><a href="#_deprecated_renamed_options">Deprecated, renamed Options</a></span></dt><dt><span class="section"><a href="#_configuration_in_the_initramfs_2">Configuration in the Initramfs</a></span></dt></dl></dd><dt><span class="section"><a href="#_author_2">AUTHOR</a></span></dt><dt><span class="section"><a href="#_see_also_3">SEE ALSO</a></span></dt></dl></dd><dt><span class="chapter"><a href="#lsinitrd1">9. LSINITRD(1)</a></span></dt><dd><dl><dt><span class="section"><a href="#_name_4">NAME</a></span></dt><dt><span class="section"><a href="#_synopsis_3">SYNOPSIS</a></span></dt><dt><span class="section"><a href="#_description_4">DESCRIPTION</a></span></dt><dt><span class="section"><a href="#_options_2">OPTIONS</a></span></dt><dt><span class="section"><a href="#_availability_2">AVAILABILITY</a></span></dt><dt><span class="section"><a href="#_authors_2">AUTHORS</a></span></dt><dt><span class="section"><a href="#_see_also_4">SEE ALSO</a></span></dt></dl></dd><dt><span class="chapter"><a href="#_developer_manual">10. Developer Manual</a></span></dt><dt><span class="chapter"><a href="#dracutmodules7">11. DRACUT.MODULES(7)</a></span></dt><dd><dl><dt><span class="section"><a href="#_name_5">NAME</a></span></dt><dt><span class="section"><a href="#_description_5">DESCRIPTION</a></span></dt><dt><span class="section"><a href="#stages">Boot Process Stages</a></span></dt><dd><dl><dt><span class="section"><a href="#_hook_cmdline">Hook: cmdline</a></span></dt><dt><span class="section"><a href="#_hook_pre_udev">Hook: pre-udev</a></span></dt><dt><span class="section"><a href="#_start_udev">Start Udev</a></span></dt><dt><span class="section"><a href="#_hook_pre_trigger">Hook: pre-trigger</a></span></dt><dt><span class="section"><a href="#_trigger_udev">Trigger Udev</a></span></dt><dt><span class="section"><a href="#_main_loop">Main Loop</a></span></dt><dt><span class="section"><a href="#_hook_pre_mount">Hook: pre-mount</a></span></dt><dt><span class="section"><a href="#_hook_mount">Hook: mount</a></span></dt><dt><span class="section"><a href="#_hook_pre_pivot">Hook: pre-pivot</a></span></dt><dt><span class="section"><a href="#_hook_cleanup">Hook: cleanup</a></span></dt><dt><span class="section"><a href="#_cleanup_and_switch_root">Cleanup and switch_root</a></span></dt></dl></dd><dt><span class="section"><a href="#_network_infrastructure">Network Infrastructure</a></span></dt><dt><span class="section"><a href="#_writing_a_module">Writing a Module</a></span></dt><dd><dl><dt><span class="section"><a href="#_module_setup_sh_check">module-setup.sh: check()</a></span></dt><dt><span class="section"><a href="#_module_setup_sh_depends">module-setup.sh: depends()</a></span></dt><dt><span class="section"><a href="#_module_setup_sh_cmdline">module-setup.sh: cmdline()</a></span></dt><dt><span class="section"><a href="#_module_setup_sh_install">module-setup.sh: install()</a></span></dt><dt><span class="section"><a href="#_module_setup_sh_installkernel">module-setup.sh: installkernel()</a></span></dt><dt><span class="section"><a href="#_anchor_id_creation_xreflabel_creation_creation_functions">Creation Functions</a></span></dt><dt><span class="section"><a href="#_initramfs_functions">Initramfs Functions</a></span></dt><dt><span class="section"><a href="#_network_modules">Network Modules</a></span></dt></dl></dd><dt><span class="section"><a href="#_author_3">AUTHOR</a></span></dt><dt><span class="section"><a href="#_see_also_5">SEE ALSO</a></span></dt></dl></dd><dt><span class="chapter"><a href="#dracutbootup7">12. DRACUT.BOOTUP(7)</a></span></dt><dd><dl><dt><span class="section"><a href="#_name_6">NAME</a></span></dt><dt><span class="section"><a href="#_description_6">DESCRIPTION</a></span></dt><dt><span class="section"><a href="#_author_4">AUTHOR</a></span></dt><dt><span class="section"><a href="#_see_also_6">SEE ALSO</a></span></dt></dl></dd><dt><span class="appendix"><a href="#_license">A. License</a></span></dt></dl></dd></dl></div><div class="part"><div class="titlepage"><div><div><h1 class="title"><a id="_introduction"></a>Part I. Introduction</h1></div></div></div><div class="toc"><p><strong>Table of Contents</strong></p><dl class="toc"><dt><span class="chapter"><a href="#_definition">1. Definition</a></span></dt><dt><span class="chapter"><a href="#_rationale">2. Rationale</a></span></dt><dt><span class="chapter"><a href="#_implementation">3. Implementation</a></span></dt><dt><span class="chapter"><a href="#_mount_preparations">4. Mount preparations</a></span></dt><dt><span class="chapter"><a href="#_dracut_on_shutdown">5. Dracut on shutdown</a></span></dt></dl></div><p>This section is a modified version of
+</style><meta name="generator" content="DocBook XSL Stylesheets Vsnapshot" /></head><body><div xml:lang="en" class="book" lang="en"><div class="titlepage"><div><div><h1 class="title"><a id="idm1"></a>dracut 104</h1></div><div><div class="author"><h3 class="author"><span class="firstname">Harald</span> <span class="surname">Hoyer</span></h3><code class="email">&lt;<a class="email" href="mailto:harald@profian.com">harald@profian.com</a>&gt;</code></div></div></div><hr /></div><div class="toc"><p><strong>Table of Contents</strong></p><dl class="toc"><dt><span class="part"><a href="#_introduction">I. Introduction</a></span></dt><dd><dl><dt><span class="chapter"><a href="#_definition">1. Definition</a></span></dt><dt><span class="chapter"><a href="#_rationale">2. Rationale</a></span></dt><dt><span class="chapter"><a href="#_implementation">3. Implementation</a></span></dt><dt><span class="chapter"><a href="#_mount_preparations">4. Mount preparations</a></span></dt><dt><span class="chapter"><a href="#_dracut_on_shutdown">5. Dracut on shutdown</a></span></dt></dl></dd><dt><span class="part"><a href="#_user_manual">II. User Manual</a></span></dt><dd><dl><dt><span class="chapter"><a href="#_dracut_8">6. DRACUT(8)</a></span></dt><dd><dl><dt><span class="section"><a href="#_name">NAME</a></span></dt><dt><span class="section"><a href="#_synopsis">SYNOPSIS</a></span></dt><dt><span class="section"><a href="#_description">DESCRIPTION</a></span></dt><dt><span class="section"><a href="#_usage">USAGE</a></span></dt><dd><dl><dt><span class="section"><a href="#_inspecting_the_contents">Inspecting the Contents</a></span></dt><dt><span class="section"><a href="#_adding_dracut_modules">Adding dracut Modules</a></span></dt><dt><span class="section"><a href="#_omitting_dracut_modules">Omitting dracut Modules</a></span></dt><dt><span class="section"><a href="#_adding_kernel_modules">Adding Kernel Modules</a></span></dt><dt><span class="section"><a href="#_boot_parameters">Boot parameters</a></span></dt><dt><span class="section"><a href="#Injecting">Injecting custom Files</a></span></dt><dt><span class="section"><a href="#NetworkBoot">Network Boot</a></span></dt></dl></dd><dt><span class="section"><a href="#_troubleshooting">Troubleshooting</a></span></dt><dd><dl><dt><span class="section"><a href="#identifying-your-problem-area">Identifying your problem area</a></span></dt><dt><span class="section"><a href="#information-to-include-in-your-report">Information to include in your report</a></span></dt><dt><span class="section"><a href="#debugging-dracut">Debugging dracut</a></span></dt></dl></dd><dt><span class="section"><a href="#_options">OPTIONS</a></span></dt><dt><span class="section"><a href="#_environment">ENVIRONMENT</a></span></dt><dt><span class="section"><a href="#_files">FILES</a></span></dt><dd><dl><dt><span class="section"><a href="#_configuration_in_the_initramfs">Configuration in the initramfs</a></span></dt></dl></dd><dt><span class="section"><a href="#_availability">AVAILABILITY</a></span></dt><dt><span class="section"><a href="#_authors">AUTHORS</a></span></dt><dt><span class="section"><a href="#_see_also">SEE ALSO</a></span></dt></dl></dd><dt><span class="chapter"><a href="#dracutconf5">7. DRACUT.CONF(5)</a></span></dt><dd><dl><dt><span class="section"><a href="#_name_2">NAME</a></span></dt><dt><span class="section"><a href="#_synopsis_2">SYNOPSIS</a></span></dt><dt><span class="section"><a href="#_description_2">Description</a></span></dt><dt><span class="section"><a href="#_files_2">Files</a></span></dt><dt><span class="section"><a href="#_author">AUTHOR</a></span></dt><dt><span class="section"><a href="#_see_also_2">See Also</a></span></dt></dl></dd><dt><span class="chapter"><a href="#dracutcmdline7">8. DRACUT.CMDLINE(7)</a></span></dt><dd><dl><dt><span class="section"><a href="#_name_3">NAME</a></span></dt><dt><span class="section"><a href="#_description_3">DESCRIPTION</a></span></dt><dd><dl><dt><span class="section"><a href="#_standard">Standard</a></span></dt><dt><span class="section"><a href="#_iso_scan_filename">iso-scan/filename</a></span></dt><dt><span class="section"><a href="#_misc">Misc</a></span></dt><dt><span class="section"><a href="#dracutkerneldebug">Debug</a></span></dt><dt><span class="section"><a href="#_i18n">I18N</a></span></dt><dt><span class="section"><a href="#_lvm">LVM</a></span></dt><dt><span class="section"><a href="#_crypto_luks">crypto LUKS</a></span></dt><dt><span class="section"><a href="#_crypto_luks_key_on_removable_device_support">crypto LUKS - key on removable device support</a></span></dt><dt><span class="section"><a href="#_md_raid">MD RAID</a></span></dt><dt><span class="section"><a href="#_dm_raid">DM RAID</a></span></dt><dt><span class="section"><a href="#_multipath">MULTIPATH</a></span></dt><dt><span class="section"><a href="#_fips">FIPS</a></span></dt><dt><span class="section"><a href="#_network">Network</a></span></dt><dt><span class="section"><a href="#_nfs">NFS</a></span></dt><dt><span class="section"><a href="#_cifs">CIFS</a></span></dt><dt><span class="section"><a href="#_iscsi">iSCSI</a></span></dt><dt><span class="section"><a href="#_fcoe">FCoE</a></span></dt><dt><span class="section"><a href="#_nvmf">NVMf</a></span></dt><dt><span class="section"><a href="#_nbd">NBD</a></span></dt><dt><span class="section"><a href="#_virtiofs">VIRTIOFS</a></span></dt><dt><span class="section"><a href="#_dasd">DASD</a></span></dt><dt><span class="section"><a href="#_zfcp">ZFCP</a></span></dt><dt><span class="section"><a href="#_znet">ZNET</a></span></dt><dt><span class="section"><a href="#_booting_live_images">Booting live images</a></span></dt><dt><span class="section"><a href="#_zipl">ZIPL</a></span></dt><dt><span class="section"><a href="#_cio_ignore">CIO_IGNORE</a></span></dt><dt><span class="section"><a href="#_plymouth_boot_splash">Plymouth Boot Splash</a></span></dt><dt><span class="section"><a href="#_kernel_keys">Kernel keys</a></span></dt><dt><span class="section"><a href="#_deprecated_renamed_options">Deprecated, renamed Options</a></span></dt><dt><span class="section"><a href="#_configuration_in_the_initramfs_2">Configuration in the Initramfs</a></span></dt></dl></dd><dt><span class="section"><a href="#_author_2">AUTHOR</a></span></dt><dt><span class="section"><a href="#_see_also_3">SEE ALSO</a></span></dt></dl></dd><dt><span class="chapter"><a href="#lsinitrd1">9. LSINITRD(1)</a></span></dt><dd><dl><dt><span class="section"><a href="#_name_4">NAME</a></span></dt><dt><span class="section"><a href="#_synopsis_3">SYNOPSIS</a></span></dt><dt><span class="section"><a href="#_description_4">DESCRIPTION</a></span></dt><dt><span class="section"><a href="#_options_2">OPTIONS</a></span></dt><dt><span class="section"><a href="#_availability_2">AVAILABILITY</a></span></dt><dt><span class="section"><a href="#_authors_2">AUTHORS</a></span></dt><dt><span class="section"><a href="#_see_also_4">SEE ALSO</a></span></dt></dl></dd><dt><span class="chapter"><a href="#_developer_manual">10. Developer Manual</a></span></dt><dt><span class="chapter"><a href="#dracutmodules7">11. DRACUT.MODULES(7)</a></span></dt><dd><dl><dt><span class="section"><a href="#_name_5">NAME</a></span></dt><dt><span class="section"><a href="#_description_5">DESCRIPTION</a></span></dt><dt><span class="section"><a href="#stages">Boot Process Stages</a></span></dt><dd><dl><dt><span class="section"><a href="#_hook_cmdline">Hook: cmdline</a></span></dt><dt><span class="section"><a href="#_hook_pre_udev">Hook: pre-udev</a></span></dt><dt><span class="section"><a href="#_start_udev">Start Udev</a></span></dt><dt><span class="section"><a href="#_hook_pre_trigger">Hook: pre-trigger</a></span></dt><dt><span class="section"><a href="#_trigger_udev">Trigger Udev</a></span></dt><dt><span class="section"><a href="#_main_loop">Main Loop</a></span></dt><dt><span class="section"><a href="#_hook_pre_mount">Hook: pre-mount</a></span></dt><dt><span class="section"><a href="#_hook_mount">Hook: mount</a></span></dt><dt><span class="section"><a href="#_hook_pre_pivot">Hook: pre-pivot</a></span></dt><dt><span class="section"><a href="#_hook_cleanup">Hook: cleanup</a></span></dt><dt><span class="section"><a href="#_cleanup_and_switch_root">Cleanup and switch_root</a></span></dt></dl></dd><dt><span class="section"><a href="#_network_infrastructure">Network Infrastructure</a></span></dt><dt><span class="section"><a href="#_writing_a_module">Writing a Module</a></span></dt><dd><dl><dt><span class="section"><a href="#_module_setup_sh_check">module-setup.sh: check()</a></span></dt><dt><span class="section"><a href="#_module_setup_sh_depends">module-setup.sh: depends()</a></span></dt><dt><span class="section"><a href="#_module_setup_sh_cmdline">module-setup.sh: cmdline()</a></span></dt><dt><span class="section"><a href="#_module_setup_sh_install">module-setup.sh: install()</a></span></dt><dt><span class="section"><a href="#_module_setup_sh_installkernel">module-setup.sh: installkernel()</a></span></dt><dt><span class="section"><a href="#_anchor_id_creation_xreflabel_creation_creation_functions">Creation Functions</a></span></dt><dt><span class="section"><a href="#_initramfs_functions">Initramfs Functions</a></span></dt><dt><span class="section"><a href="#_network_modules">Network Modules</a></span></dt></dl></dd><dt><span class="section"><a href="#_author_3">AUTHOR</a></span></dt><dt><span class="section"><a href="#_see_also_5">SEE ALSO</a></span></dt></dl></dd><dt><span class="chapter"><a href="#dracutbootup7">12. DRACUT.BOOTUP(7)</a></span></dt><dd><dl><dt><span class="section"><a href="#_name_6">NAME</a></span></dt><dt><span class="section"><a href="#_description_6">DESCRIPTION</a></span></dt><dt><span class="section"><a href="#_author_4">AUTHOR</a></span></dt><dt><span class="section"><a href="#_see_also_6">SEE ALSO</a></span></dt></dl></dd><dt><span class="appendix"><a href="#_license">A. License</a></span></dt></dl></dd></dl></div><div class="part"><div class="titlepage"><div><div><h1 class="title"><a id="_introduction"></a>Part I. Introduction</h1></div></div></div><div class="toc"><p><strong>Table of Contents</strong></p><dl class="toc"><dt><span class="chapter"><a href="#_definition">1. Definition</a></span></dt><dt><span class="chapter"><a href="#_rationale">2. Rationale</a></span></dt><dt><span class="chapter"><a href="#_implementation">3. Implementation</a></span></dt><dt><span class="chapter"><a href="#_mount_preparations">4. Mount preparations</a></span></dt><dt><span class="chapter"><a href="#_dracut_on_shutdown">5. Dracut on shutdown</a></span></dt></dl></div><p>This section is a modified version of
 <a class="ulink" href="http://en.wikipedia.org/wiki/Initrd" target="_top">http://en.wikipedia.org/wiki/Initrd</a> which is licensed under the
 Creative Commons Attribution/Share-Alike License.</p><div class="chapter"><div class="titlepage"><div><div><h2 class="title"><a id="_definition"></a>Chapter 1. Definition</h2></div></div></div><p>An <span class="emphasis"><em>initial ramdisk</em></span> is a temporary file system used in the boot process of the
 Linux kernel. <span class="emphasis"><em>initrd</em></span> and <span class="emphasis"><em>initramfs</em></span> refer to slightly different schemes for
@@ -1583,7 +1583,8 @@ example:</p><pre class="screen"># dracut --libdirs "dir1 dir2"  ...</pre></div><
 </dd><dt><span class="term">
 <span class="strong"><strong>--print-cmdline</strong></span>
 </span></dt><dd>
-    Print the kernel command line for the current disk layout.
+    Print part of the kernel command line required to boot for the current disk layout.
+    This option does not return all kernel command line options that dracut might add to the initrd.
 </dd><dt><span class="term">
 <span class="strong"><strong>--mdadmconf</strong></span>
 </span></dt><dd>
@@ -1671,6 +1672,12 @@ example:</p><pre class="screen"># dracut --fscks "fsck.foo barfsck"  ...</pre></
     Specify configuration directory to use.
 </p><p class="simpara">Default:
    <span class="emphasis"><em>/etc/dracut.conf.d</em></span></p></dd><dt><span class="term">
+<span class="strong"><strong>--add-confdir</strong></span> <span class="emphasis"><em>&lt;configuration directory&gt;</em></span>
+</span></dt><dd><p class="simpara">
+    Add an extra configuration directory to use *.conf files from. If the
+    directory is not existed, will look for subdirectory under confdir.
+</p><p class="simpara">Default:
+    <span class="emphasis"><em>empty</em></span></p></dd><dt><span class="term">
 <span class="strong"><strong>--tmpdir</strong></span> <span class="emphasis"><em>&lt;temporary directory&gt;</em></span>
 </span></dt><dd><p class="simpara">
     Specify temporary directory to use.
@@ -1802,11 +1809,10 @@ example:</p><pre class="screen"># dracut --install "/bin/foo /sbin/bar"  ...</pr
     Install the space separated list of files into the initramfs, if they exist.
 </dd><dt><span class="term">
 <span class="strong"><strong>--gzip</strong></span>
-</span></dt><dd>
-    Compress the generated initramfs using gzip. This will be done by default,
-    unless another compression option or --no-compress is passed. Equivalent to
-    "--compress=gzip -9".
-</dd><dt><span class="term">
+</span></dt><dd><p class="simpara">
+    Compress the generated initramfs using gzip.
+</p><div class="warning" style="margin-left: 0.5in; margin-right: 0.5in;"><h3 class="title">Warning</h3><p>Make sure your kernel has gzip decompression support compiled in, otherwise you
+will not be able to boot. Equivalent to "--compress=gzip -9".</p></div></dd><dt><span class="term">
 <span class="strong"><strong>--bzip2</strong></span>
 </span></dt><dd><p class="simpara">
     Compress the generated initramfs using bzip2.
@@ -2285,7 +2291,7 @@ provide a valid <span class="emphasis"><em>/etc/fstab</em></span>.</p></div><div
 </span></dt><dd>
     Add a space-separated list of fsck tools. If nothing is specified, the
     default is: "umount mount /sbin/fsck* xfs_db xfs_check xfs_repair e2fsck
-    jfs_fsck reiserfsck btrfsck". The installation is opportunistic
+    jfs_fsck btrfsck". The installation is opportunistic
     (non-existing tools are ignored).
 </dd><dt><span class="term">
 <span class="strong"><strong>nofscks=</strong></span>"<span class="emphasis"><em>{yes|no}</em></span>"
@@ -3684,125 +3690,9 @@ been implemented through the multiple lower layers feature of OverlayFS.</p></dd
 </p><p><strong>Example. </strong>
 </p><pre class="screen">ecryptfskey=/etc/keys/ecryptfs-trusted.blob</pre><p>
 </p></dd></dl></div></div><div class="section"><div class="titlepage"><div><div><h3 class="title"><a id="_deprecated_renamed_options"></a>Deprecated, renamed Options</h3></div></div></div><p>Here is a list of options and their new replacement.</p><div class="variablelist"><dl class="variablelist"><dt><span class="term">
-rdbreak
-</span></dt><dd>
-rd.break
-</dd><dt><span class="term">
-rd.ccw
-</span></dt><dd>
-rd.znet
-</dd><dt><span class="term">
-rd_CCW
-</span></dt><dd>
-rd.znet
-</dd><dt><span class="term">
-rd_DASD_MOD
-</span></dt><dd>
-rd.dasd
-</dd><dt><span class="term">
-rd_DASD
-</span></dt><dd>
-rd.dasd
-</dd><dt><span class="term">
-rdinitdebug rdnetdebug
-</span></dt><dd>
-rd.debug
-</dd><dt><span class="term">
 rd_NO_DM
 </span></dt><dd>
 rd.dm=0
-</dd><dt><span class="term">
-rd_DM_UUID
-</span></dt><dd>
-rd.dm.uuid
-</dd><dt><span class="term">
-rdblacklist
-</span></dt><dd>
-rd.driver.blacklist
-</dd><dt><span class="term">
-rdinsmodpost
-</span></dt><dd>
-rd.driver.post
-</dd><dt><span class="term">
-rdloaddriver
-</span></dt><dd>
-rd.driver.pre
-</dd><dt><span class="term">
-rd_NO_FSTAB
-</span></dt><dd>
-rd.fstab=0
-</dd><dt><span class="term">
-rdinfo
-</span></dt><dd>
-rd.info
-</dd><dt><span class="term">
-check
-</span></dt><dd>
-rd.live.check
-</dd><dt><span class="term">
-rdlivedebug
-</span></dt><dd>
-rd.live.debug
-</dd><dt><span class="term">
-live_dir
-</span></dt><dd>
-rd.live.dir
-</dd><dt><span class="term">
-liveimg
-</span></dt><dd>
-rd.live.image
-</dd><dt><span class="term">
-overlay
-</span></dt><dd>
-rd.live.overlay
-</dd><dt><span class="term">
-readonly_overlay
-</span></dt><dd>
-rd.live.overlay.readonly
-</dd><dt><span class="term">
-reset_overlay
-</span></dt><dd>
-rd.live.overlay.reset
-</dd><dt><span class="term">
-live_ram
-</span></dt><dd>
-rd.live.ram
-</dd><dt><span class="term">
-rd_NO_CRYPTTAB
-</span></dt><dd>
-rd.luks.crypttab=0
-</dd><dt><span class="term">
-rd_LUKS_KEYDEV_UUID
-</span></dt><dd>
-rd.luks.keydev.uuid
-</dd><dt><span class="term">
-rd_LUKS_KEYPATH
-</span></dt><dd>
-rd.luks.keypath
-</dd><dt><span class="term">
-rd_NO_LUKS
-</span></dt><dd>
-rd.luks=0
-</dd><dt><span class="term">
-rd_LUKS_UUID
-</span></dt><dd>
-rd.luks.uuid
-</dd><dt><span class="term">
-rd_NO_LVMCONF
-</span></dt><dd>
-rd.lvm.conf
-</dd><dt><span class="term">
-rd_LVM_LV
-</span></dt><dd>
-rd.lvm.lv
-</dd><dt><span class="term">
-rd_NO_LVM
-</span></dt><dd>
-rd.lvm=0
-</dd><dt><span class="term">
-rd_LVM_VG
-</span></dt><dd>
-rd.lvm.vg
 </dd><dt><span class="term">
 rd_NO_MDADMCONF
 </span></dt><dd>
@@ -3820,10 +3710,6 @@ rd_MD_UUID
 </span></dt><dd>
 rd.md.uuid
 </dd></dl></div><p>rd_NO_MULTIPATH: rd.multipath=0</p><div class="variablelist"><dl class="variablelist"><dt><span class="term">
-rd_NFS_DOMAIN
-</span></dt><dd>
-rd.nfs.domain
-</dd><dt><span class="term">
 iscsi_initiator
 </span></dt><dd>
 rd.iscsi.initiator
@@ -3864,22 +3750,6 @@ iscsi_firmware
 </span></dt><dd>
 rd.iscsi.firmware=0
 </dd><dt><span class="term">
-rd_NO_PLYMOUTH
-</span></dt><dd>
-rd.plymouth=0
-</dd><dt><span class="term">
-rd_retry
-</span></dt><dd>
-rd.retry
-</dd><dt><span class="term">
-rdshell
-</span></dt><dd>
-rd.shell
-</dd><dt><span class="term">
-rd_NO_SPLASH
-</span></dt><dd>
-rd.splash
-</dd><dt><span class="term">
 rdudevdebug
 </span></dt><dd>
 rd.udev.udev_log=debug
@@ -3895,18 +3765,6 @@ rd.udev.udev_log=debug
 rd.udev.info
 </span></dt><dd>
 rd.udev.udev_log=info
-</dd><dt><span class="term">
-rd_NO_ZFCPCONF
-</span></dt><dd>
-rd.zfcp.conf=0
-</dd><dt><span class="term">
-rd_ZFCP
-</span></dt><dd>
-rd.zfcp
-</dd><dt><span class="term">
-rd_ZNET
-</span></dt><dd>
-rd.znet
 </dd><dt><span class="term">
 KEYMAP
 </span></dt><dd>
@@ -4086,18 +3944,55 @@ current machine setup. It should start with a space and should not print a
 newline.</p></div><div class="section"><div class="titlepage"><div><div><h3 class="title"><a id="_module_setup_sh_install"></a>module-setup.sh: install()</h3></div></div></div><p>The install() function is called to install everything non-kernel related.
 To install binaries, scripts, and other files, you can use the functions
 mentioned in <a class="xref" href="#creation">[creation]</a>.</p><p>To address a file in the current module directory, use the variable "$moddir".</p></div><div class="section"><div class="titlepage"><div><div><h3 class="title"><a id="_module_setup_sh_installkernel"></a>module-setup.sh: installkernel()</h3></div></div></div><p>In installkernel() all kernel related files should be installed. You can use all
-of the functions mentioned in <a class="xref" href="#creation">[creation]</a> to install files.</p></div><div class="section"><div class="titlepage"><div><div><h3 class="title"><a id="_anchor_id_creation_xreflabel_creation_creation_functions"></a><a id="creation"></a>Creation Functions</h3></div></div></div><div class="section"><div class="titlepage"><div><div><h4 class="title"><a id="_inst_multiple_o_lt_file_gt_lt_file_gt_8230"></a>inst_multiple [-o] &lt;file&gt; [ &lt;file&gt; …]</h4></div></div></div><p>installs multiple binaries and files. If executables are specified without a
+of the functions mentioned in <a class="xref" href="#creation">[creation]</a> to install files.</p></div><div class="section"><div class="titlepage"><div><div><h3 class="title"><a id="_anchor_id_creation_xreflabel_creation_creation_functions"></a><a id="creation"></a>Creation Functions</h3></div></div></div><div class="section"><div class="titlepage"><div><div><h4 class="title"><a id="_inst_dir_lt_dir_gt"></a>inst_dir &lt;dir&gt;</h4></div></div></div><p>installs a directory &lt;dir&gt; (but not its content) to the same place in the
+initramfs image.</p></div><div class="section"><div class="titlepage"><div><div><h4 class="title"><a id="_inst_h_lt_src_gt_lt_dst_gt"></a>inst [-H] &lt;src&gt; [&lt;dst&gt;]</h4></div></div></div></div><div class="section"><div class="titlepage"><div><div><h4 class="title"><a id="_inst_binary_lt_src_gt_lt_dst_gt"></a>inst_binary &lt;src&gt; [&lt;dst&gt;]</h4></div></div></div></div><div class="section"><div class="titlepage"><div><div><h4 class="title"><a id="_inst_script_lt_src_gt_lt_dst_gt"></a>inst_script &lt;src&gt; [&lt;dst&gt;]</h4></div></div></div><p>installs <span class="emphasis"><em>one</em></span> file &lt;src&gt; either to the same place in the initramfs or to an
+optional &lt;dst&gt;, and also its dependencies and .hmac file (if it exists). inst
+with more than two arguments is treated the same as inst_multiple, all arguments
+are treated as files to install and none as install destinations.</p><p>options:</p><div class="variablelist"><dl class="variablelist"><dt><span class="term">
+-H
+</span></dt><dd>
+log all installed files to <span class="emphasis"><em>/lib/dracut/hostonly-files</em></span>, so they can be
+removed if <span class="strong"><strong>rd.hostonly</strong></span> is passed on the kernel command line.
+</dd></dl></div></div><div class="section"><div class="titlepage"><div><div><h4 class="title"><a id="_inst_simple_h_lt_src_gt_lt_dst_gt"></a>inst_simple [-H] &lt;src&gt; [&lt;dst&gt;]</h4></div></div></div><p>installs <span class="emphasis"><em>one</em></span> file &lt;src&gt; either to the same place in the initramfs or to an
+optional &lt;dst&gt;, but without installing its dependencies or .hmac file.</p><p>options:</p><div class="variablelist"><dl class="variablelist"><dt><span class="term">
+-H
+</span></dt><dd>
+log all installed files to <span class="emphasis"><em>/lib/dracut/hostonly-files</em></span>, so they can be
+removed if <span class="strong"><strong>rd.hostonly</strong></span> is passed on the kernel command line.
+</dd></dl></div></div><div class="section"><div class="titlepage"><div><div><h4 class="title"><a id="_inst_multiple_h_o_lt_file_gt_lt_file_gt_8230"></a>inst_multiple [-H] [-o] &lt;file&gt; [ &lt;file&gt; …]</h4></div></div></div><p>installs multiple binaries and files. If executables are specified without a
 path, dracut will search the path PATH=/usr/sbin:/sbin:/usr/bin:/bin for the
-binary. If the option "-o" is given as the first parameter, a missing file does
-not lead to an error.</p></div><div class="section"><div class="titlepage"><div><div><h4 class="title"><a id="_inst_lt_src_gt_lt_dst_gt"></a>inst &lt;src&gt; [&lt;dst&gt;]</h4></div></div></div><p>installs <span class="emphasis"><em>one</em></span> file &lt;src&gt; either to the same place in the initramfs or to an
-optional &lt;dst&gt;. inst with more than two arguments is treated the same as
-inst_multiple, all arguments are treated as files to install and none as
-install destinations.</p></div><div class="section"><div class="titlepage"><div><div><h4 class="title"><a id="_inst_hook_lt_hookdir_gt_lt_prio_gt_lt_src_gt"></a>inst_hook &lt;hookdir&gt; &lt;prio&gt; &lt;src&gt;</h4></div></div></div><p>installs an executable/script &lt;src&gt; in the dracut hook &lt;hookdir&gt; with priority
+binary.</p><p>options:</p><div class="variablelist"><dl class="variablelist"><dt><span class="term">
+-H
+</span></dt><dd>
+log all installed files to <span class="emphasis"><em>/lib/dracut/hostonly-files</em></span>, so they can be
+removed if <span class="strong"><strong>rd.hostonly</strong></span> is passed on the kernel command line.
+</dd><dt><span class="term">
+-o
+</span></dt><dd>
+optional, a missing file does not lead to an error.
+</dd></dl></div></div><div class="section"><div class="titlepage"><div><div><h4 class="title"><a id="_inst_hook_lt_hookdir_gt_lt_prio_gt_lt_src_gt"></a>inst_hook &lt;hookdir&gt; &lt;prio&gt; &lt;src&gt;</h4></div></div></div><p>installs an executable/script &lt;src&gt; in the dracut hook &lt;hookdir&gt; with priority
 &lt;prio&gt;.</p></div><div class="section"><div class="titlepage"><div><div><h4 class="title"><a id="_inst_rules_lt_udevrule_gt_lt_udevrule_gt_8230"></a>inst_rules &lt;udevrule&gt; [ &lt;udevrule&gt; …]</h4></div></div></div><p>installs one or more udev rules. Non-existent udev rules are reported, but do
-not let dracut fail.</p></div><div class="section"><div class="titlepage"><div><div><h4 class="title"><a id="_instmods_lt_kernelmodule_gt_lt_kernelmodule_gt_8230"></a>instmods &lt;kernelmodule&gt; [ &lt;kernelmodule&gt; … ]</h4></div></div></div><p>instmods should be used only in the installkernel() function.</p><p>instmods installs one or more kernel modules in the initramfs. &lt;kernelmodule&gt;
+not let dracut fail.</p></div><div class="section"><div class="titlepage"><div><div><h4 class="title"><a id="_inst_libdir_dir_lt_dir_gt_lt_dir_gt_8230"></a>inst_libdir_dir &lt;dir&gt; [&lt;dir&gt;…]</h4></div></div></div><p>installs multiple directories (but not their content) located on a library
+directory to the initramfs image.</p></div><div class="section"><div class="titlepage"><div><div><h4 class="title"><a id="_inst_libdir_file_n_lt_pattern_gt_o_lt_file_gt_lt_file_gt_8230"></a>inst_libdir_file [-n &lt;pattern&gt;] [-o] &lt;file&gt; [&lt;file&gt;…]</h4></div></div></div><p>installs multiple files located on a library directory to the initramfs image.</p><p>options:</p><div class="variablelist"><dl class="variablelist"><dt><span class="term">
+-n &lt;pattern&gt;
+</span></dt><dd>
+install all library files matching a pattern.
+</dd><dt><span class="term">
+-o
+</span></dt><dd>
+optional, a missing library does not lead to an error.
+</dd></dl></div></div><div class="section"><div class="titlepage"><div><div><h4 class="title"><a id="_instmods_c_s_lt_kernelmodule_gt_lt_kernelmodule_gt_8230"></a>instmods [-c] [-s] &lt;kernelmodule&gt; [ &lt;kernelmodule&gt; … ]</h4></div></div></div><p>instmods should be used only in the installkernel() function.</p><p>instmods installs one or more kernel modules in the initramfs. &lt;kernelmodule&gt;
 can also be a whole subsystem, if prefixed with a "=", like "=drivers/net/team".</p><p>instmods will not install the kernel module, if $hostonly is set and the kernel
 module is not currently needed by any /sys/<span class="strong"><strong>…</strong></span>/uevent MODALIAS.
-To install a kernel module regardless of the hostonly mode use the form:</p><pre class="screen">hostonly='' instmods &lt;kernelmodule&gt;</pre></div></div><div class="section"><div class="titlepage"><div><div><h3 class="title"><a id="_initramfs_functions"></a>Initramfs Functions</h3></div></div></div><p>FIXME</p></div><div class="section"><div class="titlepage"><div><div><h3 class="title"><a id="_network_modules"></a>Network Modules</h3></div></div></div><p>FIXME</p></div></div><div class="section"><div class="titlepage"><div><div><h2 class="title" style="clear: both"><a id="_author_3"></a>AUTHOR</h2></div></div></div><p>Harald Hoyer</p></div><div class="section"><div class="titlepage"><div><div><h2 class="title" style="clear: both"><a id="_see_also_5"></a>SEE ALSO</h2></div></div></div><p><span class="strong"><strong>dracut</strong></span>(8)</p></div></div><div class="chapter"><div class="titlepage"><div><div><h2 class="title"><a id="dracutbootup7"></a>Chapter 12. DRACUT.BOOTUP(7)</h2></div></div></div><div class="toc"><p><strong>Table of Contents</strong></p><dl class="toc"><dt><span class="section"><a href="#_name_6">NAME</a></span></dt><dt><span class="section"><a href="#_description_6">DESCRIPTION</a></span></dt><dt><span class="section"><a href="#_author_4">AUTHOR</a></span></dt><dt><span class="section"><a href="#_see_also_6">SEE ALSO</a></span></dt></dl></div><div class="section"><div class="titlepage"><div><div><h2 class="title" style="clear: both"><a id="_name_6"></a>NAME</h2></div></div></div><p>dracut.bootup - boot ordering in the initramfs</p></div><div class="section"><div class="titlepage"><div><div><h2 class="title" style="clear: both"><a id="_description_6"></a>DESCRIPTION</h2></div></div></div><p>This flow chart illustrates the ordering of the services, if systemd is used in
+To install a kernel module regardless of the hostonly mode use the form:</p><pre class="screen">hostonly='' instmods &lt;kernelmodule&gt;</pre><p>options:</p><div class="variablelist"><dl class="variablelist"><dt><span class="term">
+-c
+</span></dt><dd>
+check that kernel modules exists and can be installed (i.e., not optional).
+</dd><dt><span class="term">
+-s
+</span></dt><dd>
+reduce verbosity.
+</dd></dl></div></div></div><div class="section"><div class="titlepage"><div><div><h3 class="title"><a id="_initramfs_functions"></a>Initramfs Functions</h3></div></div></div><p>FIXME</p></div><div class="section"><div class="titlepage"><div><div><h3 class="title"><a id="_network_modules"></a>Network Modules</h3></div></div></div><p>FIXME</p></div></div><div class="section"><div class="titlepage"><div><div><h2 class="title" style="clear: both"><a id="_author_3"></a>AUTHOR</h2></div></div></div><p>Harald Hoyer</p></div><div class="section"><div class="titlepage"><div><div><h2 class="title" style="clear: both"><a id="_see_also_5"></a>SEE ALSO</h2></div></div></div><p><span class="strong"><strong>dracut</strong></span>(8)</p></div></div><div class="chapter"><div class="titlepage"><div><div><h2 class="title"><a id="dracutbootup7"></a>Chapter 12. DRACUT.BOOTUP(7)</h2></div></div></div><div class="toc"><p><strong>Table of Contents</strong></p><dl class="toc"><dt><span class="section"><a href="#_name_6">NAME</a></span></dt><dt><span class="section"><a href="#_description_6">DESCRIPTION</a></span></dt><dt><span class="section"><a href="#_author_4">AUTHOR</a></span></dt><dt><span class="section"><a href="#_see_also_6">SEE ALSO</a></span></dt></dl></div><div class="section"><div class="titlepage"><div><div><h2 class="title" style="clear: both"><a id="_name_6"></a>NAME</h2></div></div></div><p>dracut.bootup - boot ordering in the initramfs</p></div><div class="section"><div class="titlepage"><div><div><h2 class="title" style="clear: both"><a id="_description_6"></a>DESCRIPTION</h2></div></div></div><p>This flow chart illustrates the ordering of the services, if systemd is used in
 the dracut initramfs.</p><pre class="screen">                                    systemd-journal.socket
                                                |
                                                v


### PR DESCRIPTION
New dracut modules:                                                                                                                                                                                                                   
* shell-interpreter: meta package for improved shell selection                                                                                                                                                                        
* fips-crypto-policies: make c-p follow FIPS mode automatically                                                                                                                                                                       
* squash-lib: code shared by 95squash-{squashfs,erofs}                                                                                                                                                                                
                                                                                                                                                                                                                                      
Removed dracut modules:                                                                                                                                                                                                               
* ifcfg: no longer needed for networking                                                                                                                                                                                              
* mksh: lack of interest to maintain                                                                                                                                                                                                  
                                                                                                                                                                                                                                      
Notable new features:                                                                                                                                                                                                                 
* add --add-confdir option to dracut                                                                                                                                                                                                  
* new dracut configuration profiles under dracut.conf.d/ (e.g. for uki)                                                                                                                                                                     
* systemd-udevd: make systemd-sysctl, systemd-modules-load optional                                                                                                                                                                   
                                                                                                                                                                                                                                      
Notable bug fixes:                                                                                                                                                                                                                    
* crypt: include systemd-cryptsetup module when needed                                                                                                                                                                                
* udev-rules: move installation of libkmod to udev-rules module                                                                                                                                                                       
* busybox: install busybox symlinks later in the generation process                                                                                                                                                                   
* nvmf: install (only) required nvmf modules                                                                                                                                                                                          
* systemd: include systemd config files from /usr/lib/systemd                                                                                                                                                                         
* systemd: trigger systemd-vconsole-setup.service only on demand                                                                                                                                                                      
* multipath: include module with "find_multipaths strict"                                                                                                                                                                             
* nfs: include also entries from /usr/lib/{passwd,group}                                                                                                                                                                              
* network: handle '-m network'                                                                                                                                                                                                        
* systemd-networkd: remove basename dependency                                                                                                                                                                                        
* remove obsolete syntax for many command line options without the rd. prefix                                                                                                                                                         
                                                                                                                                                                                                                                      
The project builds test containers daily for the following Linux distributions:                                                                                                                                                       
                                                                                                                                                                                                                                      
Alpine, Arch, Debian (amd64 and arm64), Fedora (amd64 and arm64), Gentoo, openSUSE, Ubuntu, Void                                                                                                                                      
These Linux distributions test dracut in various configurations (systemd/OpenRC/runit, glibc/musl, dhclient/NetworkManager/systemd-networkd). 
