### PR TITLE
fix(dmsquash-live-root.sh): support images with non-existing /proc

### DIFF
--- a/modules.d/90dmsquash-live/dmsquash-live-root.sh
+++ b/modules.d/90dmsquash-live/dmsquash-live-root.sh
@@ -344,7 +344,7 @@ if [ -e "$SQUASHED" ]; then
         elif [ -f /run/initramfs/squashfs/LiveOS/ext3fs.img ]; then
             FSIMG="/run/initramfs/squashfs/LiveOS/ext3fs.img"
         fi
-    elif [ -d /run/initramfs/squashfs/proc ]; then
+    elif [ -d /run/initramfs/squashfs/usr ]; then
         FSIMG=$SQUASHED
         if [ -z "$overlayfs" ] && [ -n "$DRACUT_SYSTEMD" ]; then
             reloadsysrootmountunit=":>/xor_overlayfs;"


### PR DESCRIPTION
Change folder existence test from /run/initramfs/squashfs/proc to /run/initramfs/squashfs/usr.

## Changes

## Checklist
- [ ] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it

Fixes #244
