### PR TITLE
fix(dmsquash-live): checkisomd5 is installed into /usr/bin

### DIFF
--- a/modules.d/90dmsquash-live/checkisomd5@.service
+++ b/modules.d/90dmsquash-live/checkisomd5@.service
@@ -6,7 +6,7 @@ Before=shutdown.target
 [Service]
 Type=oneshot
 RemainAfterExit=no
-ExecStart=/bin/checkisomd5 --verbose %f
+ExecStart=/usr/bin/checkisomd5 --verbose %f
 StandardInput=tty-force
 StandardOutput=inherit
 StandardError=inherit


### PR DESCRIPTION
From https://abf.io/import/dracut/blob/rosa2023.1/0012-fix-dmsquash-live-set-correct-path-to-checkisomd5.patch

CC @mikhailnov @pvalena 

## Checklist
- [ ] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it
