### PR TITLE
fix(udev-rules): move relevant rules from systemd

### DIFF
--- a/modules.d/00systemd/module-setup.sh
+++ b/modules.d/00systemd/module-setup.sh
@@ -139,9 +139,6 @@ EOF
     ln_r "$(find_binary true)" "/usr/bin/loginctl"
     ln_r "$(find_binary true)" "/bin/loginctl"
     inst_rules \
-        70-uaccess.rules \
-        71-seat.rules \
-        73-seat-late.rules \
         90-vconsole.rules \
         99-systemd.rules
 

--- a/modules.d/95udev-rules/module-setup.sh
+++ b/modules.d/95udev-rules/module-setup.sh
@@ -48,6 +48,9 @@ install() {
         70-memory.rules \
         70-mouse.rules \
         70-touchpad.rules \
+        70-uaccess.rules \
+        71-seat.rules \
+        73-seat-late.rules \
         75-net-description.rules \
         75-probe_mtd.rules \
         78-sound-card.rules \

--- a/test/container/Dockerfile-alpine
+++ b/test/container/Dockerfile-alpine
@@ -27,6 +27,7 @@ RUN apk add --no-cache \
     dosfstools \
     dracut \
     e2fsprogs \
+    elogind \
     erofs-utils \
     eudev \
     file \

--- a/test/container/Dockerfile-void
+++ b/test/container/Dockerfile-void
@@ -23,6 +23,7 @@ RUN xbps-install -Syu xbps && xbps-install -yu \
     e2fsprogs \
     edk2-ovmf \
     elfutils \
+    elogind \
     erofs-utils \
     eudev \
     f2fs-tools \


### PR DESCRIPTION
Also install elogind into Alpine and Void containers.

Follow-up to https://github.com/dracut-ng/dracut-ng/pull/628

## Checklist
- [ ] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it

Fixes #
