### PR TITLE
fix(systemd): fix typo in the dracut module name

### DIFF
--- a/modules.d/00systemd/module-setup.sh
+++ b/modules.d/00systemd/module-setup.sh
@@ -142,7 +142,7 @@ EOF
         90-vconsole.rules \
         99-systemd.rules
 
-    if dracut_module_included "10i18n" && [[ -e "$systemdsystemunitdir"/systemd-vconsole-setup.service ]]; then
+    if dracut_module_included "i18n" && [[ -e "$systemdsystemunitdir"/systemd-vconsole-setup.service ]]; then
         inst_multiple -o \
             "$systemdutildir"/systemd-vconsole-setup \
             "$systemdsystemunitdir"/systemd-vconsole-setup.service \


### PR DESCRIPTION
Follow-up 5551746088633116a28f3ded9d7003f378b6cd17.

## Checklist
- [ ] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it

Fixes #709
