### PR TITLE
test: only set VMLINUZ if it is not already set

### DIFF
--- a/test/test-functions
+++ b/test/test-functions
@@ -66,7 +66,7 @@ ovmf_code() {
     done
 }
 
-VMLINUZ="/lib/modules/${KVERSION}/vmlinuz"
+VMLINUZ=${VMLINUZ-"/lib/modules/${KVERSION}/vmlinuz"}
 if ! [ -f "$VMLINUZ" ]; then
     VMLINUZ="/lib/modules/${KVERSION}/vmlinux"
 fi


### PR DESCRIPTION
Make it consistent with KVERSION and only set it if it is not already set.

## Checklist
- [ ] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it

Fixes #
