### PR TITLE
docs: small cleanup of main landing page

### DIFF
--- a/doc_site/modules/ROOT/pages/index.adoc
+++ b/doc_site/modules/ROOT/pages/index.adoc
@@ -4,18 +4,19 @@
 :revnumber: {version}
 :language: bash
 
-== Introduction
-This section is a modified version of
-http://en.wikipedia.org/wiki/Initrd which is licensed under the
-Creative Commons Attribution/Share-Alike License.
+dracut is a tool to create an initial image used by the kernel for loading
+necessary drivers and performing other configuration required to enabling
+booting of the main system.
 
-=== Definition
+== initrd and initramfs
+
 An _initial ramdisk_ is a temporary file system used in the boot process of the
 Linux kernel. _initrd_ and _initramfs_ refer to slightly different schemes for
 loading this file system into memory. Both are commonly used to make
 preparations before the real root file system can be mounted.
 
-=== Rationale
+== Rationale
+
 Many Linux distributions ship a single, generic kernel image that is intended to
 boot as wide a variety of hardware as possible. The device drivers for this
 generic kernel image are included as loadable modules, as it is not possible to
@@ -42,7 +43,7 @@ an initial boot stage with a temporary root file system
 user-space helpers that would do the hardware detection, module loading and
 device discovery necessary to get the real root file system mounted.
 
-=== Implementation
+== Implementation
 An image of this initial root file system (along with the kernel image) must be
 stored somewhere accessible by the Linux bootloader or the boot firmware of the
 computer. This can be:
@@ -59,7 +60,7 @@ memory and then start the kernel, passing in the memory address of the image.
 Depending on which algorithms were compiled statically into it, the kernel can
 currently unpack initrd/initramfs images compressed with gzip, bzip2 and LZMA.
 
-=== Mount preparations
+== Mount preparations
 dracut can generate a customized initramfs image which contains only whatever is
 necessary to boot some particular computer, such as ATA, SCSI and filesystem
 kernel modules (host-only mode).
@@ -120,28 +121,44 @@ rotated away. Instead, it is simply emptied and the final root file system
 mounted over the top.
 
 If the systemd module is used in the initramfs, the ordering of the services
-started looks like <<dracutbootup7>>.
+started looks like xref:man/dracut.bootup.7.adoc[].
 
-=== Dracut on shutdown
+== Dracut on shutdown
 
 On a systemd driven system, the dracut initramfs is also used for the shutdown
-procedure.  See :xref:man/dracut-shutdown.service.8.adoc[] for details.
+procedure.  See xref:man/dracut-shutdown.service.8.adoc[] for details.
 
-== User Manual Pages
+== Resources
+
+=== Manual pages
+
+Documentation is most in the form of manual pages for the various dracut
+components.
+
+==== User Manual Pages
 
 * xref:man/dracut.8.adoc[]
 * xref:man/dracut.conf.5.adoc[]
 * xref:man/dracut.cmdline.7.adoc[]
 * xref:man/lsinitrd.1.adoc[]
 
-== Developer Manual Pages
+==== Developer Manual Pages
 
 * xref:man/dracut.modules.7.adoc[]
 * xref:man/dracut.bootup.7.adoc[]
 
+=== Development
+
+Issues and merge requests can be found at the GitHub development page at
+link:https://github.com/dracut-ng//dracut-ng[]
+
 == License
 
-This work is licensed under the Creative Commons Attribution/Share-Alike
-License. To view a copy of this license, visit
-http://creativecommons.org/licenses/by-sa/3.0/ or send a letter to Creative
-Commons, 559 Nathan Abbott Way, Stanford, California 94305, USA.
+dracut is licensed under the GNU General Public License (GPL) v2; see
+link:https://github.com/dracut-ng/dracut-ng/blob/main/COPYING[COPYING]
+
+Parts of this documentation site are taken from work licensed under the
+Creative Commons Attribution/Share-Alike License. To view a copy of this
+license, visit link:http://creativecommons.org/licenses/by-sa/3.0/[] or send a
+letter to Creative Commons, 559 Nathan Abbott Way, Stanford, California
+94305, USA.


### PR DESCRIPTION
## Changes

This is a few small cleanups.  The message about the license first up makes it seem like dracut itself is under creative commons license, which isn't true. I've moved this down to the bottom, and added a note that dracut is gpl2 but some parts of the docs are CC.

I've added a shorter introduction and de-dented things.  I've also linked in the development site along with the other man pages.

## Checklist
- [x] I have tested it locally
- [x] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it