### PR TITLE
docs: do not run integration tests for docs only changes

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -3,7 +3,11 @@ name: Integration Test
 on:
     pull_request:
         branches: [ main ]
-
+        paths-ignore:
+          - antora-playbook.yaml
+          - 'doc_site/**'
+          - 'man/**'
+x
 env:
     # set V to 2 when re-running jobs with debug logging enabled
     # see https://docs.github.com/en/actions/monitoring-and-troubleshooting-workflows/troubleshooting-workflows/enabling-debug-logging


### PR DESCRIPTION
## Changes

In the integration workflow, add paths-ignore so that if any changes only match these filters, the integration tests will be skipped.

Discussion @ https://github.com/dracut-ng/dracut-ng/issues/723#issuecomment-2418317960

## Checklist
- [ ] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it
