### PR TITLE
docs: build sample docs site on merge requests

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,7 +1,11 @@
 name: Publish to GitHub Pages
 on:
   push:
-    branches: [main]
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:
 concurrency:
@@ -40,5 +44,6 @@ jobs:
       with:
         path: build/site
     - name: Deploy to GitHub Pages
+      if: github.event_name == 'push'
       id: deployment
       uses: actions/deploy-pages@v2


### PR DESCRIPTION
## Changes

To enable testing of the docs site, build on merge requests.  Only publish the site on push events.

## Checklist
- [ ] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it