### PR TITLE
ci: only run linting when it is useful

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,10 +1,12 @@
 name: Lint
 
 on:
-  push:
-    branches: [ main ]
   pull_request:
     branches: [ main ]
+      paths-ignore:
+        - antora-playbook.yaml
+        - 'doc_site/**'
+        - 'man/**'
 
 jobs:
   lint-shell:


### PR DESCRIPTION
No need to run lint on commit again, as it is running on each PR.

## Checklist
- [ ] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it

