### PR TITLE
ci: upgrade GitHub actions to newer versions

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -24,7 +24,7 @@ jobs:
       with:
         fetch-depth: 0
     - name: Configure Pages
-      uses: actions/configure-pages@v3
+      uses: actions/configure-pages@v5
     - name: Install Node.js
       uses: actions/setup-node@v4
       with:
@@ -38,9 +38,9 @@ jobs:
     - name: Generate Site
       run: make doc_site
     - name: Upload Artifacts
-      uses: actions/upload-pages-artifact@v2
+      uses: actions/upload-pages-artifact@v3
       with:
         path: build/site
     - name: Deploy to GitHub Pages
       id: deployment
-      uses: actions/deploy-pages@v2
+      uses: actions/deploy-pages@v4


### PR DESCRIPTION
Goal is to get rid of the following warning:

```
The following actions use a deprecated Node.js version and will be forced to run on node20: 
actions/configure-pages@v3, actions/upload-artifact@v3, actions/deploy-pages@v2.

The following artifacts were uploaded using a version of actions/upload-artifact that is scheduled for 
deprecation:  "github-pages".
Please update your workflow to use v4 of the artifact actions.
```

See https://github.blog/changelog/2024-03-07-github-actions-all-actions-will-run-on-node20-instead-of-node16-by-default/

CC @ianw 

## Checklist
- [ ] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it

Fixes #
