### PR TITLE
fix(systemd-cryptsetup): include /etc/crypttab

### DIFF
--- a/modules.d/01systemd-cryptsetup/module-setup.sh
+++ b/modules.d/01systemd-cryptsetup/module-setup.sh
@@ -47,6 +47,7 @@ install() {
     # the cryptsetup targets are already pulled in by 00systemd, but not
     # the enablement symlinks
     inst_multiple -o \
+        /etc/crypttab \
         "$tmpfilesdir"/cryptsetup.conf \
         "$systemdutildir"/system-generators/systemd-cryptsetup-generator \
         "$systemdutildir"/systemd-cryptsetup \


### PR DESCRIPTION
This pull request changes...

## Changes

The configuration in `/etc/crypttab` is ignored when booting with systemd-cryptsetup:

```
$ cat /etc/crypttab
system_crypt   UUID=e1446dc1-f3d2-445f-96aa-09245ebe7bd5 none luks,discard
$ mount | grep " / "
/dev/mapper/luks-e1446dc1-f3d2-445f-96aa-09245ebe7bd5 on / type ext4 (rw,relatime,errors=remount-ro)
```

So include `/etc/crypttab` in case it is available. Then the setting will be honoured:

```
$ mount | grep " / "
/dev/mapper/system_crypt on / type ext4 (rw,relatime,discard,errors=remount-ro)
```

## Checklist
- [x] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it

Fixes Bug-Ubuntu: https://launchpad.net/bugs/2084809
