### PR TITLE
chore: add recently introduced dracut modules

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -62,6 +62,10 @@ fips:
   - changed-files:
     - any-glob-to-any-file: 'modules.d/[0-9][0-9]fips/*'
 
+fips-crypto-policies:
+  - changed-files:
+    - any-glob-to-any-file: 'modules.d/[0-9][0-9]fips-crypto-policies/*'
+
 systemd-ac-power:
   - changed-files:
     - any-glob-to-any-file: 'modules.d/[0-9][0-9]systemd-ac-power/*'
@@ -527,6 +531,18 @@ shutdown:
     - any-glob-to-any-file: 'modules.d/[0-9][0-9]shutdown/*'
 
 squash:
+  - changed-files:
+    - any-glob-to-any-file: 'modules.d/[0-9][0-9]squash/*'
+
+squash-lib:
+  - changed-files:
+    - any-glob-to-any-file: 'modules.d/[0-9][0-9]squash-lib/*'
+
+squash-erofs:
+  - changed-files:
+    - any-glob-to-any-file: 'modules.d/[0-9][0-9]squash/*'
+
+squash-squashfs:
   - changed-files:
     - any-glob-to-any-file: 'modules.d/[0-9][0-9]squash/*'
 

--- a/doc_site/modules/ROOT/pages/modules/core.adoc
+++ b/doc_site/modules/ROOT/pages/modules/core.adoc
@@ -12,7 +12,7 @@ code, there are no specific types or categories for dracut modules.
 * utils (no kernel module, only user-space utilities)
 * meta (only for making decision which other modules to include)
 
-== local
+== core
 
 |===
 | Module | Description | Type
@@ -97,6 +97,10 @@ code, there are no specific types or categories for dracut modules.
 | Enforces FIPS security standard regulations
 |
 
+| fips-crypto-policies
+| crypto-policies
+| utils
+
 | fs-lib
 | filesystem tools (including fsck.* and mount)
 | library
@@ -104,6 +108,10 @@ code, there are no specific types or categories for dracut modules.
 | fstab-sys
 | Arranges for arbitrary partitions to be mounted before rootfs
 |
+
+| hwdb
+| Includes hardware database
+| utils
 
 | i18n
 | Includes keymaps, console fonts, etc.

--- a/doc_site/modules/ROOT/pages/modules/systemd.adoc
+++ b/doc_site/modules/ROOT/pages/modules/systemd.adoc
@@ -1,4 +1,4 @@
-== Systemd dracut modules
+= Systemd dracut modules
 
 These modules would require including a version of systemd into initramfs.
 
@@ -39,6 +39,15 @@ These modules would require including a version of systemd into initramfs.
 | Starts random generator serive on early boot
 
 | squash
+| Squash meta module
+
+| squash-erofs
+| Builds EroFS initramfs
+
+| squash-lib
+| Library for building Squash initramfs
+
+| squash-squashfs
 | Builds SquashFS initramfs
 
 | systemd


### PR DESCRIPTION
- squash-erofs
- squash-lib
- squash-squashfs
- hwdb
- fips-crypto-policies

