### PR TITLE
test: call lvm lvcreate with --yes

### DIFF
--- a/test/TEST-20-RAID/create-root.sh
+++ b/test/TEST-20-RAID/create-root.sh
@@ -20,7 +20,7 @@ echo "The passphrase is test"
 cryptsetup luksOpen /dev/md0 dracut_crypt_test < /keyfile
 lvm pvcreate -ff -y /dev/mapper/dracut_crypt_test
 lvm vgcreate dracut /dev/mapper/dracut_crypt_test
-lvm lvcreate -l 100%FREE -n root dracut
+lvm lvcreate --yes -l 100%FREE -n root dracut
 lvm vgchange -ay
 mkfs.ext4 -q -L root /dev/dracut/root
 mkdir -p /sysroot

--- a/test/TEST-21-LVM/create-root.sh
+++ b/test/TEST-21-LVM/create-root.sh
@@ -16,7 +16,7 @@ for dev in /dev/disk/by-id/scsi-0QEMU_QEMU_HARDDISK_disk[123]; do
 done
 
 lvm vgcreate dracut /dev/disk/by-id/scsi-0QEMU_QEMU_HARDDISK_disk[123]
-lvm lvcreate -l 100%FREE -n root dracut
+lvm lvcreate --yes -l 100%FREE -n root dracut
 lvm vgchange -ay
 mkfs.ext4 -q /dev/dracut/root
 mkdir -p /sysroot

--- a/test/TEST-22-RAID-DEG/create-root.sh
+++ b/test/TEST-22-RAID-DEG/create-root.sh
@@ -20,7 +20,7 @@ echo "The passphrase is test"
 cryptsetup luksOpen /dev/md0 dracut_crypt_test < /keyfile
 lvm pvcreate -ff -y /dev/mapper/dracut_crypt_test
 lvm vgcreate dracut /dev/mapper/dracut_crypt_test
-lvm lvcreate -l 100%FREE -n root dracut
+lvm lvcreate --yes -l 100%FREE -n root dracut
 lvm vgchange -ay
 mkfs.ext4 -q -L root /dev/dracut/root
 mkdir -p /sysroot

--- a/test/TEST-23-IMSM/create-root.sh
+++ b/test/TEST-23-IMSM/create-root.sh
@@ -57,7 +57,7 @@ mdadm -W /dev/md0
 set -e
 lvm pvcreate -ff -y /dev/md0
 lvm vgcreate dracut /dev/md0
-lvm lvcreate -l 100%FREE -n root dracut
+lvm lvcreate --yes -l 100%FREE -n root dracut
 lvm vgchange -ay
 mkfs.ext4 -q -L root /dev/dracut/root
 mkdir -p /sysroot

--- a/test/TEST-25-LVM-THIN/create-root.sh
+++ b/test/TEST-25-LVM-THIN/create-root.sh
@@ -17,8 +17,8 @@ for dev in /dev/disk/by-id/scsi-0QEMU_QEMU_HARDDISK_disk[123]; do
 done
 
 lvm vgcreate dracut /dev/disk/by-id/scsi-0QEMU_QEMU_HARDDISK_disk[123]
-lvm lvcreate --ignoremonitoring -l 100%FREE -T dracut/mythinpool
-lvm lvcreate --ignoremonitoring -V100M -T dracut/mythinpool -n root
+lvm lvcreate --yes --ignoremonitoring -l 100%FREE -T dracut/mythinpool
+lvm lvcreate --yes --ignoremonitoring -V100M -T dracut/mythinpool -n root
 lvm vgchange --ignoremonitoring -ay
 mkfs.ext4 -q /dev/dracut/root
 mkdir -p /sysroot

--- a/test/TEST-26-ENC-RAID-LVM/create-root.sh
+++ b/test/TEST-26-ENC-RAID-LVM/create-root.sh
@@ -26,7 +26,7 @@ mdadm -W /dev/md0
 lvm pvcreate -ff -y /dev/md0
 lvm vgcreate dracut /dev/md0
 
-lvm lvcreate -l 100%FREE -n root dracut
+lvm lvcreate --yes -l 100%FREE -n root dracut
 lvm vgchange -ay
 mkfs.ext4 -q /dev/dracut/root
 mkdir -p /sysroot

--- a/test/TEST-70-ISCSI/create-client-root.sh
+++ b/test/TEST-70-ISCSI/create-client-root.sh
@@ -21,7 +21,7 @@ mdadm --create /dev/md0 --run --auto=yes --level=stripe --raid-devices=2 /dev/di
 mdadm -W /dev/md0 || :
 lvm pvcreate -ff -y /dev/md0
 lvm vgcreate dracut /dev/md0
-lvm lvcreate -l 100%FREE -n root dracut
+lvm lvcreate --yes -l 100%FREE -n root dracut
 lvm vgchange -ay
 mkfs.ext4 -q -j -L sysroot /dev/dracut/root
 mount -t ext4 /dev/dracut/root /sysroot

--- a/test/TEST-71-ISCSI-MULTI/create-client-root.sh
+++ b/test/TEST-71-ISCSI-MULTI/create-client-root.sh
@@ -21,7 +21,7 @@ mdadm --create /dev/md0 --run --auto=yes --level=stripe --raid-devices=2 /dev/di
 mdadm -W /dev/md0 || :
 lvm pvcreate -ff -y /dev/md0
 lvm vgcreate dracut /dev/md0
-lvm lvcreate -l 100%FREE -n root dracut
+lvm lvcreate --yes -l 100%FREE -n root dracut
 lvm vgchange -ay
 mkfs.ext4 -q -j -L sysroot /dev/dracut/root
 mount -t ext4 /dev/dracut/root /sysroot

--- a/test/TEST-72-NBD/create-encrypted-root.sh
+++ b/test/TEST-72-NBD/create-encrypted-root.sh
@@ -18,7 +18,7 @@ echo "The passphrase is test"
 cryptsetup luksOpen /dev/disk/by-id/scsi-0QEMU_QEMU_HARDDISK_root dracut_crypt_test < /keyfile
 lvm pvcreate -ff -y /dev/mapper/dracut_crypt_test
 lvm vgcreate dracut /dev/mapper/dracut_crypt_test
-lvm lvcreate -l 100%FREE -n root dracut
+lvm lvcreate --yes -l 100%FREE -n root dracut
 lvm vgchange -ay
 udevadm settle
 mkfs.ext4 -q -L dracut -j /dev/dracut/root


### PR DESCRIPTION
Avoid interactivity in CI. This change should prevent the following prompt waiting for interactions

```
WARNING: ext4 signature detected on /dev/dracut/root at offset 1080. Wipe it? [y/n]:
```

## Checklist
- [ ] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it

Fixes #
