### PR TITLE
test(RAID-DEG): reenable systemd for this test

### DIFF
--- a/test/TEST-22-RAID-DEG/test.sh
+++ b/test/TEST-22-RAID-DEG/test.sh
@@ -97,7 +97,8 @@ test_setup() {
     chmod 0600 /tmp/key
 
     test_dracut \
-        -m "crypt lvm mdraid kernel-modules" \
+        -a "crypt lvm mdraid kernel-modules" \
+        -o network \
         -i "./cryptroot-ask.sh" "/sbin/cryptroot-ask" \
         -i "/tmp/mdadm.conf" "/etc/mdadm.conf" \
         -i "/tmp/crypttab" "/etc/crypttab" \


### PR DESCRIPTION
Omitting network module is required for the test to pass on Ubuntu. 

## Checklist
- [ ] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it

Fixes #
