### PR TITLE
ci: remove remaining workarounds from the alpine container

### DIFF
--- a/test/container/Dockerfile-alpine
+++ b/test/container/Dockerfile-alpine
@@ -74,8 +74,3 @@ RUN apk add --no-cache \
     util-linux-misc \
     xfsprogs \
     xz
-
-RUN \
-  cp /usr/lib/udev/rules.d/* /lib/udev/rules.d/ && \
-  ln -sf /sbin/poweroff /sbin/shutdown && \
-  ln -sf /boot/vmlinuz-virt /boot/vmlinuz-$(cd /lib/modules; ls -1 | tail -1)

--- a/test/test-functions
+++ b/test/test-functions
@@ -71,8 +71,6 @@ if ! [ -f "$VMLINUZ" ]; then
     VMLINUZ="/lib/modules/${KVERSION}/vmlinux"
 fi
 
-[ -z "$VMLINUZ" ] && VMLINUZ=$(find /boot/vmlinuz-* -type f 2> /dev/null | tail -1)
-
 if ! [ -f "$VMLINUZ" ]; then
     [[ -f /etc/machine-id ]] && read -r MACHINE_ID < /etc/machine-id
 
@@ -84,11 +82,17 @@ if ! [ -f "$VMLINUZ" ]; then
         VMLINUZ="/boot/vmlinux-${KVERSION}"
     elif [ -f "/boot/kernel-${KVERSION}" ]; then
         VMLINUZ="/boot/kernel-${KVERSION}"
-    else
-        echo "Could not find a Linux kernel version $KVERSION to test with!" >&2
-        echo "Please install linux." >&2
-        exit 1
     fi
+fi
+
+if ! [ -f "$VMLINUZ" ]; then
+    VMLINUZ=$(find /boot/vmlinuz-* -type f 2> /dev/null | tail -1)
+fi
+
+if ! [ -f "$VMLINUZ" ]; then
+    echo "Could not find a Linux kernel version $KVERSION to test with!" >&2
+    echo "Please install linux." >&2
+    exit 1
 fi
 
 export VMLINUZ


### PR DESCRIPTION
Reorganize VMLINUZ detection to make the test pass again on alpine after the container change.

## Checklist
- [ ] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it

Fixes #
