### PR TITLE
ci: install plymouth theme into alpine container

### DIFF
--- a/test/container/Dockerfile-alpine
+++ b/test/container/Dockerfile-alpine
@@ -62,7 +62,7 @@ RUN apk add --no-cache \
     parted \
     partx \
     pigz \
-    plymouth \
+    plymouth-themes \
     procps \
     qemu-img \
     qemu-system-x86_64 \


### PR DESCRIPTION
This PR resolves the following error

```
dracut[I]: *** Including module: plymouth ***
grep: /usr/share/plymouth/themes/text/text.plymouth: No such file or directory grep:
/usr/share/plymouth/themes/text/text.plymouth: No such file or directory grep:
/usr/share/plymouth/themes/text/text.plymouth: No such file or directory grep:
/usr/share/plymouth/themes/text/text.plymouth: No such file or directory grep:
/usr/share/plymouth/themes/text/text.plymouth: No such file or directory The default plymouth plugin () doesn't exist
```

## Checklist
- [ ] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it

Fixes #
