### PR TITLE
ci: re-enable one workaround to handle enable-split-usr

### DIFF
--- a/test/container/Dockerfile-alpine
+++ b/test/container/Dockerfile-alpine
@@ -74,3 +74,9 @@ RUN apk add --no-cache \
     util-linux-misc \
     xfsprogs \
     xz
+
+# workaround for --enable-split-usr
+# see https://github.com/eudev-project/eudev/pull/246
+# needed to run RAID tests
+RUN \
+  cp /usr/lib/udev/rules.d/* /lib/udev/rules.d/


### PR DESCRIPTION
See https://gitlab.alpinelinux.org/alpine/aports/-/issues/14610

## Checklist
- [ ] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it

Fixes #
