### PR TITLE
ci: remove gawk dependency from alpine container

### DIFF
--- a/test/container/Dockerfile-alpine
+++ b/test/container/Dockerfile-alpine
@@ -33,7 +33,6 @@ RUN apk add --no-cache \
     file \
     findmnt \
     f2fs-tools \
-    gawk \
     git \
     gpg \
     grep \


### PR DESCRIPTION
This change switches awk to the busybox implementation.

Follow-up to https://github.com/dracut-ng/dracut-ng/pull/734 

## Checklist
- [ ] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it

Fixes #
