### PR TITLE
ci: limit when Publish to GitHub Pages  needs to run

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,17 +1,26 @@
 name: Publish to GitHub Pages
+
 on:
   push:
     branches: [main]
+    paths-ignore:
+      - 'modules.d/**'
+      - 'test/**'
+      - 'src/**'
+
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:
+
 concurrency:
   group: github-pages
   cancel-in-progress: false
+
 # Sets permissions of the GITHUB_TOKEN to allow deployment to GitHub Pages
 permissions:
   contents: read
   pages: write
   id-token: write
+
 jobs:
   build:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Do not run the action if all changes are below the following directories:
 - 'modules.d/**'
 - 'test/**'
 - 'src/**'

CC @ianw 

## Checklist
- [ ] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it

Fixes #
