### PR TITLE
ci: install asciidoc into Gentoo container

### DIFF
--- a/test/container/Dockerfile-gentoo
+++ b/test/container/Dockerfile-gentoo
@@ -35,8 +35,12 @@ RUN emerge --quiet --deep --autounmask-continue=y --with-bdeps=n --noreplace \
     app-misc/jq \
     app-portage/gentoolkit \
     app-shells/dash \
+    app-text/asciidoc \
+    app-text/docbook-xml-dtd \
+    app-text/docbook-xsl-stylesheets \
     dev-lang/perl \
     dev-lang/rust-bin \
+    dev-libs/libxslt \
     dev-libs/openssl \
     net-fs/cifs-utils \
     net-fs/nfs-utils \


### PR DESCRIPTION
All other CI containers have asciidoc installed.

This enable testing document generation upstream.

CC @Nowa-Ammerlaan

## Checklist
- [ ] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it

Fixes #
