### PR TITLE
fix(01fips-crypto-policies): use /bin in shebang

### DIFF
--- a/modules.d/01fips-crypto-policies/fips-crypto-policies.sh
+++ b/modules.d/01fips-crypto-policies/fips-crypto-policies.sh
@@ -1,4 +1,4 @@
-#!/usr/bin/sh
+#!/bin/sh
 
 type getarg > /dev/null 2>&1 || . /lib/dracut-lib.sh
 

--- a/modules.d/01fips-crypto-policies/module-setup.sh
+++ b/modules.d/01fips-crypto-policies/module-setup.sh
@@ -1,4 +1,4 @@
-#!/usr/bin/bash
+#!/bin/bash
 
 # called by dracut
 check() {


### PR DESCRIPTION
## Changes

lintian complaints on Debian/Ubuntu:

```
E: dracut-core: wrong-path-for-interpreter /usr/bin/bash != /bin/bash [usr/lib/dracut/modules.d/01fips-crypto-policies/module-setup.sh]
E: dracut-core: wrong-path-for-interpreter /usr/bin/sh != /bin/sh [usr/lib/dracut/modules.d/01fips-crypto-policies/fips-crypto-policies.sh]
```

Even for usr-merged setup, the shells should be found in `/bin`.

## Checklist
- [ ] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it
