### PR TITLE
ci: test both opensuse leap and tumbleweed

### DIFF
--- a/.github/workflows/container-extra.yml
+++ b/.github/workflows/container-extra.yml
@@ -37,6 +37,7 @@ jobs:
                     - { dockerfile: 'Dockerfile-fedora', tag: 'fedora:rawhide', platform: 'linux/amd64' }
                     - { dockerfile: 'Dockerfile-ubuntu', tag: 'ubuntu:rolling', platform: 'linux/amd64' }
                     - { dockerfile: 'Dockerfile-gentoo', tag: 'gentoo:latest',  platform: 'linux/amd64' }
+                    - { dockerfile: 'Dockerfile-opensuse', tag: 'tumbleweed-dnf', platform: 'linux/amd64' }
         steps:
             -   name: Check out the repo
                 uses: actions/checkout@v4

--- a/test/container/Dockerfile-opensuse
+++ b/test/container/Dockerfile-opensuse
@@ -1,4 +1,5 @@
-FROM registry.opensuse.org/opensuse/tumbleweed-dnf:latest
+ARG DISTRIBUTION=leap-dnf:latest
+FROM registry.opensuse.org/opensuse/${DISTRIBUTION}
 
 # prefer running tests with btrfs
 ENV TEST_FSTYPE=btrfs


### PR DESCRIPTION
For Fedora (Rawhide), Debian (sid), Ubuntu (rolling) we have both a stable and next-stable container available - see https://github.com/dracut-ng/dracut-ng/blob/main/.github/workflows/container-extra.yml#L36 .

This PR makes a similar change for openSUSE.

## Checklist
- [ ] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it

Fixes #
