### PR TITLE
docs: switch to asciidoctor for man generation, with fallback

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -48,7 +48,7 @@ jobs:
       - name: Install dependencies
         run: |
           sudo apt -y update
-          sudo apt -y install asciidoc gcc libkmod-dev libsystemd-dev pkg-config
+          sudo apt -y install asciidoctor gcc libkmod-dev libsystemd-dev pkg-config
 
       - name: Autobuild
         uses: github/codeql-action/autobuild@v3

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -46,6 +46,20 @@ jobs:
                 uses: actions/checkout@v4
             -   name: "${{ matrix.container }} TEST-${{ matrix.test }}"
                 run: ./test/test-github.sh "TEST-${{ matrix.test }}" ${{ matrix.test }}
+
+    # Test deprecated asciidoc man generation path
+    doc_asciidoc:
+      name: asciidoc man generation
+      runs-on: ubuntu-latest
+      steps:
+        - name: "Checkout Repository"
+          uses: actions/checkout@v4
+        - run: |
+              sudo apt-get update
+              sudo apt -y install asciidoc gcc libkmod-dev libsystemd-dev pkg-config
+              ./configure --disable-asciidoctor
+              make doc
+
     extended:
         needs: basic
         name: ${{ matrix.test }} on ${{ matrix.container }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -41,7 +41,7 @@ jobs:
     - name: Install dependencies
       run: |
         sudo apt -y update
-        sudo apt -y install make asciidoc
+        sudo apt -y install make asciidoctor
     - name: Install Antora
       run: npm i antora
     - name: Generate Site

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,7 +25,7 @@ jobs:
       - name: Install dependencies
         run: |
           sudo apt -y update
-          sudo apt -y install asciidoc
+          sudo apt -y install asciidoctor
 
       - name: Build
         run: bash ${GITHUB_WORKSPACE}/tools/release.sh ${{ inputs.tag }}

--- a/Makefile
+++ b/Makefile
@@ -114,6 +114,8 @@ ifneq ($(enable_documentation),no)
 all: doc
 endif
 
+ifeq ($(disable_asciidoctor),yes)
+$(warning *** Building with asciidoc deprecated)
 %: %.xml
 	@rm -f -- "$@"
 	xsltproc -o "$@" -nonet http://docbook.sourceforge.net/release/xsl/current/manpages/docbook.xsl $<
@@ -121,6 +123,21 @@ endif
 %.xml: %.adoc
 	@rm -f -- "$@"
 	asciidoc -a "version=$(DRACUT_FULL_VERSION)" -d manpage -b docbook -o "$@" $<
+else
+define ASCIIDOC_MANPAGE
+	asciidoctor -a "version=$(DRACUT_FULL_VERSION)" -b manpage $<
+endef
+
+%.1: %.1.adoc
+	$(ASCIIDOC_MANPAGE)
+%.5: %.5.adoc
+	$(ASCIIDOC_MANPAGE)
+%.7: %.7.adoc
+	$(ASCIIDOC_MANPAGE)
+%.8: %.8.adoc
+	$(ASCIIDOC_MANPAGE)
+endif
+
 
 # If ANOTRA_BIN not set, default to look for "npx" to run "npx antora".  If we
 # end up with undefined ANTORA_BIN (i.e. not set and npx not found), we'll give

--- a/configure
+++ b/configure
@@ -50,6 +50,7 @@ while (($# > 0)); do
         --systemdsystemunitdir) read_arg systemdsystemunitdir "$@" || shift ;;
         --bashcompletiondir) read_arg bashcompletiondir "$@" || shift ;;
         --enable-dracut-cpio) enable_dracut_cpio=yes ;;
+        --disable-asciidoctor) disable_asciidoctor=yes ;;
         *) echo "Ignoring unknown option '$1'" ;;
     esac
     shift
@@ -173,6 +174,7 @@ sysconfdir ?= ${sysconfdir:-${prefix}/etc}
 sbindir ?= ${sbindir:-${prefix}/sbin}
 mandir ?= ${mandir:-${prefix}/share/man}
 enable_documentation ?= ${enable_documentation:-yes}
+disable_asciidoctor ?= ${disable_asciidoctor:-no}
 enable_dracut_cpio ?= ${enable_dracut_cpio}
 bindir ?= ${bindir:-${prefix}/bin}
 KMOD_CFLAGS ?= $(${PKG_CONFIG} --cflags " libkmod >= 23 ") ${KMOD_CFLAGS_EXTRA}

--- a/doc_site/modules/ROOT/pages/developer/hacking.adoc
+++ b/doc_site/modules/ROOT/pages/developer/hacking.adoc
@@ -320,8 +320,24 @@ $ make run
 
 == Documentation
 
-To build the documentation site run `make doc_site`.  This will be built and
-published by CI on commit.
+=== Man pages
+
+Runtime documentation is largely in `man` pages shipped by distributions.  The
+man pages are built from link:https://asciidoc.org/[AsciiDoc] sources by
+link:https://asciidoctor.org/[Asciidoctor].
+
+To disable man page generation run `configure` with `--disable-documentation`
+
+WARNING: The flag `--disable-asciidoctor` is provided to build the manual pages
+with the `asciidoc` and `docbook` toolchain.  As the documentation site
+generator Antora is based on Asciidoctor, this flag is deprecated to enable a
+single Asciidoctor-based toolchain for manual pages and the generated site in a
+future release.
+
+=== Documentation site
+
+To build this documentation site run `make doc_site`.  The site is built and
+published by CI on commits.
 
 The documentation site is based on https://antora.org/[Antora].  By default
 it will build via `npx` (install `nodejs`) or if you have Antora installed in

--- a/test/container/Dockerfile-alpine
+++ b/test/container/Dockerfile-alpine
@@ -6,7 +6,6 @@ ENV CC=clang
 # ovmf is not installed as systemd-boot-efistub is not available
 # see https://gitlab.alpinelinux.org/alpine/aports/-/merge_requests/61369
 RUN apk add --no-cache \
-    asciidoc \
     asciidoctor \
     bash \
     binutils \

--- a/test/container/Dockerfile-arch
+++ b/test/container/Dockerfile-arch
@@ -4,7 +4,6 @@ FROM docker.io/archlinux
 ENV TEST_FSTYPE=xfs
 
 RUN pacman --noconfirm -Syu \
-    asciidoc \
     asciidoctor \
     astyle \
     base-devel \

--- a/test/container/Dockerfile-debian
+++ b/test/container/Dockerfile-debian
@@ -8,7 +8,6 @@ FROM docker.io/${DISTRIBUTION}
 # Install dracut as a linux-initramfs-tool provider so that the default initramfs-tool package does not get installed
 RUN apt-get update -y -qq && apt-get upgrade -y -qq && apt-get install -y -qq --no-install-recommends dracut && \
     DEBIAN_FRONTEND=noninteractive apt-get install -y -qq --no-install-recommends -o Dpkg::Use-Pty=0 \
-    asciidoc \
     asciidoctor \
     astyle \
     bluez \

--- a/test/container/Dockerfile-fedora
+++ b/test/container/Dockerfile-fedora
@@ -3,7 +3,6 @@ FROM registry.fedoraproject.org/${DISTRIBUTION}
 
 # Install needed packages for the dracut CI container
 RUN dnf -y install --setopt=install_weak_deps=False \
-    asciidoc \
     asciidoctor \
     astyle \
     bash-completion \

--- a/test/container/Dockerfile-gentoo
+++ b/test/container/Dockerfile-gentoo
@@ -35,9 +35,6 @@ RUN emerge --quiet --deep --autounmask-continue=y --with-bdeps=n --noreplace \
     app-misc/jq \
     app-portage/gentoolkit \
     app-shells/dash \
-    app-text/asciidoc \
-    app-text/docbook-xml-dtd \
-    app-text/docbook-xsl-stylesheets \
     dev-lang/perl \
     dev-lang/rust-bin \
     dev-libs/libxslt \

--- a/test/container/Dockerfile-opensuse
+++ b/test/container/Dockerfile-opensuse
@@ -5,7 +5,6 @@ ENV TEST_FSTYPE=btrfs
 
 # Install needed packages for the dracut CI container
 RUN dnf -y install --setopt=install_weak_deps=False \
-    asciidoc \
     bash-completion \
     btrfsprogs \
     bzip2 \

--- a/test/container/Dockerfile-ubuntu
+++ b/test/container/Dockerfile-ubuntu
@@ -8,7 +8,6 @@ ENV V=2
 # The Linux kernel is only readable by root. See https://launchpad.net/bugs/759725
 RUN apt-get update -y -qq && apt-get upgrade -y -qq && \
     DEBIAN_FRONTEND=noninteractive apt-get install -y -qq --no-install-recommends -o Dpkg::Use-Pty=0 \
-    asciidoc \
     asciidoctor \
     astyle \
     bluez \

--- a/test/container/Dockerfile-void
+++ b/test/container/Dockerfile-void
@@ -1,7 +1,6 @@
 FROM ghcr.io/void-linux/void-glibc-full
 
 RUN xbps-install -Syu xbps && xbps-install -yu \
-    asciidoc \
     astyle \
     base-devel \
     bash \


### PR DESCRIPTION
## Changes

This switches the man page generator to asciidoctor, with a fallback option to configure to use the existing asciidoc/docbook path.

The reason to do this is to consolidate the published site generation and man page generation around asciidoctor.  With that in place, we can use some asciidoctor features like extensions to better link the man pages together, or provide other tweaks to the documentation.

This switches the default generation to asciidoctor, but adds a --disable-asciidoctor switch as a temporary escape hatch for packagers.

The testing is converted to asciidoctor, with an additional test of the asciidoc toolchain just to avoid major regressions there.

Documentation is updated.

## Checklist
- [x] I have tested it locally
- [x] I have reviewed and updated any documentation if relevant
- [x] I am providing new code and test(s) for it
