### PR TITLE
ci: install newly created systemd-cryptsetup into Debian/Ubuntu containers

### DIFF
--- a/test/container/Dockerfile-debian
+++ b/test/container/Dockerfile-debian
@@ -1,12 +1,23 @@
 ARG DISTRIBUTION=debian
 FROM docker.io/${DISTRIBUTION}
 
+# export ARG
+ARG DISTRIBUTION
+
 # dmraid is no longer installed
 # see https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=1056944
 
 # Install needed packages for the dracut CI container
 # Install dracut as a linux-initramfs-tool provider so that the default initramfs-tool package does not get installed
-RUN apt-get update -y -qq && apt-get upgrade -y -qq && apt-get install -y -qq --no-install-recommends dracut && \
+RUN apt-get update -y -qq && apt-get upgrade -y -qq && apt-get install -y -qq --no-install-recommends dracut
+
+# extra packages for sid
+RUN if [ "$DISTRIBUTION" = "debian:sid" ] ; then \
+    DEBIAN_FRONTEND=noninteractive apt-get install -y -qq --no-install-recommends -o Dpkg::Use-Pty=0 \
+    systemd-cryptsetup \
+    ; fi
+
+RUN \
     DEBIAN_FRONTEND=noninteractive apt-get install -y -qq --no-install-recommends -o Dpkg::Use-Pty=0 \
     asciidoc \
     asciidoctor \

--- a/test/container/Dockerfile-ubuntu
+++ b/test/container/Dockerfile-ubuntu
@@ -1,12 +1,23 @@
 ARG DISTRIBUTION=ubuntu
 FROM docker.io/${DISTRIBUTION}
 
+# export ARG
+ARG DISTRIBUTION
+
 # prefer running tests in verbose mode
 ENV V=2
 
 # Install needed packages for the dracut CI container
 # The Linux kernel is only readable by root. See https://launchpad.net/bugs/759725
-RUN apt-get update -y -qq && apt-get upgrade -y -qq && \
+RUN apt-get update -y -qq && apt-get upgrade -y -qq
+
+# extra packages for rolling
+RUN if [ "${DISTRIBUTION}" = "ubuntu:rolling" ] ; then \
+    DEBIAN_FRONTEND=noninteractive apt-get install -y -qq --no-install-recommends -o Dpkg::Use-Pty=0 \
+    systemd-cryptsetup \
+    ; fi
+
+RUN \
     DEBIAN_FRONTEND=noninteractive apt-get install -y -qq --no-install-recommends -o Dpkg::Use-Pty=0 \
     asciidoc \
     asciidoctor \


### PR DESCRIPTION

## Checklist
- [ ] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it

Fixes #
