### PR TITLE
fix(systemd-journald): install libaudit

### DIFF
--- a/modules.d/01systemd-journald/module-setup.sh
+++ b/modules.d/01systemd-journald/module-setup.sh
@@ -54,6 +54,7 @@ install() {
     # Install library file(s)
     _arch=${DRACUT_ARCH:-$(uname -m)}
     inst_libdir_file \
+        {"tls/$_arch/",tls/,"$_arch/",}"libaudit.so*" \
         {"tls/$_arch/",tls/,"$_arch/",}"libgcrypt.so*" \
         {"tls/$_arch/",tls/,"$_arch/",}"liblz4.so.*" \
         {"tls/$_arch/",tls/,"$_arch/",}"liblzma.so.*" \


### PR DESCRIPTION
Fix the following error

```
/init: error while loading shared libraries: libaudit.so.1: cannot open shared object file: No such file or directory
audit-libs
```

## Checklist
- [ ] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it

Fixes #
