### PR TITLE
ci: use apt-get instead of apt for

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -47,8 +47,8 @@ jobs:
 
       - name: Install dependencies
         run: |
-          sudo apt -y update
-          sudo apt -y install asciidoc gcc libkmod-dev libsystemd-dev pkg-config
+          sudo apt-get -y update
+          sudo apt-get -y install asciidoc gcc libkmod-dev libsystemd-dev pkg-config
 
       - name: Autobuild
         uses: github/codeql-action/autobuild@v3

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -56,7 +56,7 @@ jobs:
           uses: actions/checkout@v4
         - run: |
               sudo apt-get update
-              sudo apt -y install shellcheck shfmt
+              sudo apt-get -y install shellcheck shfmt
               make syncheck
 
     extended:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -40,8 +40,8 @@ jobs:
         node-version: '18'
     - name: Install dependencies
       run: |
-        sudo apt -y update
-        sudo apt -y install make asciidoc
+        sudo apt-get -y update
+        sudo apt-get -y install make asciidoc
     - name: Install Antora
       run: npm i antora
     - name: Generate Site

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,8 +24,8 @@ jobs:
 
       - name: Install dependencies
         run: |
-          sudo apt -y update
-          sudo apt -y install asciidoc
+          sudo apt-get -y update
+          sudo apt-get -y install asciidoc
 
       - name: Build
         run: bash ${GITHUB_WORKSPACE}/tools/release.sh ${{ inputs.tag }}


### PR DESCRIPTION
This resolves a warning from apt and provides greater compatibility.

## Checklist
- [ ] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it

Fixes #
