### PR TITLE
perf(systemd): remove crypto API kernel modules

### DIFF
--- a/modules.d/00systemd/module-setup.sh
+++ b/modules.d/00systemd/module-setup.sh
@@ -15,12 +15,13 @@ check() {
 }
 
 installkernel() {
-    hostonly='' instmods autofs4 ipv6 algif_hash hmac sha256 dmi-sysfs
+    hostonly='' instmods autofs4 ipv6 dmi-sysfs
     instmods -s efivarfs
 }
 
 # called by dracut
 install() {
+
     if [[ $prefix == /run/* ]]; then
         dfatal 'systemd does not work with a prefix, which contains "/run"!!'
         exit 1


### PR DESCRIPTION
See https://github.com/systemd/systemd/commit/2c3794f4228162c9bfd9e10886590d9f5b1920d7

This change was made in systemd v252.

## Checklist
- [ ] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it

Fixes #
