### PR TITLE
fix(systemd): add vmw_vsock_virtio_transport kernel module

### DIFF
--- a/modules.d/00systemd/module-setup.sh
+++ b/modules.d/00systemd/module-setup.sh
@@ -15,7 +15,7 @@ check() {
 }
 
 installkernel() {
-    hostonly='' instmods autofs4 ipv6 dmi-sysfs
+    hostonly='' instmods autofs4 ipv6 dmi-sysfs vmw_vsock_virtio_transport
     instmods -s efivarfs
 }
 


### PR DESCRIPTION
NotifyAccess through sd-notify

As an example [multipathd.service](https://github.com/dracut-ng/dracut-ng/blob/main/modules.d/90multipath/multipathd.service) is using NotifyAccess .

Systemd PR: https://github.com/systemd/systemd/pull/27806

CC @mwilck 

## Checklist
- [ ] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it

Fixes #
