### PR TITLE
test: set rd.timeout for the test runs

### DIFF
--- a/test/test-functions
+++ b/test/test-functions
@@ -21,7 +21,7 @@ if [[ -z $basedir ]]; then basedir="$(realpath ../..)"; fi
 DRACUT=${DRACUT-${basedir}/dracut.sh}
 PKGLIBDIR=${PKGLIBDIR-$basedir}
 
-TEST_KERNEL_CMDLINE+=" rd.retry=10 rd.info rd.shell=0 panic=1 oops=panic softlockup_panic=1 systemd.crash_reboot console=ttyS0,115200n81 $DEBUGFAIL "
+TEST_KERNEL_CMDLINE+=" rd.retry=10 rd.timeout=30 rd.info rd.shell=0 panic=1 oops=panic softlockup_panic=1 systemd.crash_reboot console=ttyS0,115200n81 $DEBUGFAIL "
 if [[ $V != "1" && $V != "2" ]]; then
     TEST_KERNEL_CMDLINE+="quiet "
 fi


### PR DESCRIPTION
The goal is to make sure test do not get stuck forever and instead they timeout (and fail).

## Checklist
- [ ] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it

Fixes #
