### PR TITLE
ci: remove rpm-build

### DIFF
--- a/test/container/Dockerfile-fedora
+++ b/test/container/Dockerfile-fedora
@@ -72,7 +72,6 @@ RUN dnf -y install --setopt=install_weak_deps=False \
     plymouth \
     qemu-kvm \
     rng-tools \
-    rpm-build \
     squashfs-tools \
     swtpm \
     systemd-boot-unsigned \

--- a/test/container/Dockerfile-opensuse
+++ b/test/container/Dockerfile-opensuse
@@ -41,7 +41,6 @@ RUN dnf -y install --setopt=install_weak_deps=False \
     python3-pefile \
     qemu-kvm \
     rng-tools \
-    rpm-build \
     ruby3.3-rubygem-asciidoctor \
     sbsigntools \
     squashfs \


### PR DESCRIPTION
CI no longer need to package for rpm. 

## Checklist
- [ ] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it

Fixes #
