### PR TITLE
ci: test dash only on Debian/Ubuntu CI

### DIFF
--- a/test/container/Dockerfile-arch
+++ b/test/container/Dockerfile-arch
@@ -6,7 +6,6 @@ ENV TEST_FSTYPE=xfs
 RUN pacman --noconfirm -Syu \
     asciidoc \
     asciidoctor \
-    astyle \
     base-devel \
     bluez \
     btrfs-progs \
@@ -15,7 +14,6 @@ RUN pacman --noconfirm -Syu \
     cifs-utils \
     connman \
     cpio \
-    dash \
     dhclient \
     dhcp \
     dmraid \

--- a/test/container/Dockerfile-debian
+++ b/test/container/Dockerfile-debian
@@ -22,7 +22,6 @@ RUN \
     DEBIAN_FRONTEND=noninteractive apt-get install -y -qq --no-install-recommends -o Dpkg::Use-Pty=0 \
     asciidoc \
     asciidoctor \
-    astyle \
     bluez \
     btrfs-progs \
     busybox-static \

--- a/test/container/Dockerfile-fedora
+++ b/test/container/Dockerfile-fedora
@@ -12,10 +12,8 @@ if [ "${DISTRIBUTION}" = "centos:stream9" ]; then \
 else \
     dnf -y install --setopt=install_weak_deps=False \
     asciidoctor \
-    astyle \
     btrfs-progs \
     busybox \
-    dash \
     dmraid \
     erofs-utils \
     f2fs-tools \

--- a/test/container/Dockerfile-gentoo
+++ b/test/container/Dockerfile-gentoo
@@ -34,7 +34,6 @@ RUN emerge --quiet --deep --autounmask-continue=y --with-bdeps=n --noreplace \
     app-emulation/qemu \
     app-misc/jq \
     app-portage/gentoolkit \
-    app-shells/dash \
     app-text/asciidoc \
     app-text/docbook-xml-dtd \
     app-text/docbook-xsl-stylesheets \

--- a/test/container/Dockerfile-opensuse
+++ b/test/container/Dockerfile-opensuse
@@ -11,7 +11,6 @@ RUN dnf -y install --setopt=install_weak_deps=False \
     bzip2 \
     cargo \
     cryptsetup \
-    dash \
     dbus-broker \
     dhcp-client \
     dhcp-server \

--- a/test/container/Dockerfile-ubuntu
+++ b/test/container/Dockerfile-ubuntu
@@ -22,7 +22,6 @@ RUN \
     DEBIAN_FRONTEND=noninteractive apt-get install -y -qq --no-install-recommends -o Dpkg::Use-Pty=0 \
     asciidoc \
     asciidoctor \
-    astyle \
     bluez \
     btrfs-progs \
     busybox-static \

--- a/test/container/Dockerfile-void
+++ b/test/container/Dockerfile-void
@@ -2,7 +2,6 @@ FROM ghcr.io/void-linux/void-glibc-full
 
 RUN xbps-install -Syu xbps && xbps-install -yu \
     asciidoc \
-    astyle \
     base-devel \
     bash \
     binutils \
@@ -15,7 +14,6 @@ RUN xbps-install -Syu xbps && xbps-install -yu \
     cpio \
     cryptsetup \
     curl \
-    dash \
     dhclient \
     dhcp \
     dmraid \


### PR DESCRIPTION
dash is default on Debian/Ubuntu and no testcase requires dash anymore.

Removed astyle as well as it is was never needed to run the CI.

## Changes

## Checklist
- [ ] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it

Fixes #
