### PR TITLE
fix(pcsc): add libpcsclite_real.so.*

### DIFF
--- a/modules.d/91pcsc/module-setup.sh
+++ b/modules.d/91pcsc/module-setup.sh
@@ -51,7 +51,8 @@ install() {
         {"tls/$_arch/",tls/,"$_arch/",}"pcsc/drivers/ifd-ccid.bundle/Contents/Info.plist" \
         {"tls/$_arch/",tls/,"$_arch/",}"pcsc/drivers/ifd-ccid.bundle/Contents/Linux/libccid.so" \
         {"tls/$_arch/",tls/,"$_arch/",}"pcsc/drivers/serial/libccidtwin.so" \
-        {"tls/$_arch/",tls/,"$_arch/",}"libpcsclite.so.*"
+        {"tls/$_arch/",tls/,"$_arch/",}"libpcsclite.so.*" \
+        {"tls/$_arch/",tls/,"$_arch/",}"libpcsclite_real.so.*"
 
     # Install the hosts local user configurations if enabled.
     if [[ $hostonly ]]; then


### PR DESCRIPTION
systemd-cryptsetup requires libpcsclite_real.so.1

Without it you get the following error:

`systemd-cryptsetup[697]: loading "libpcsclite_real.so.1" failed: libpcsclite_real.so.1: cannot open shared object file: No such file or directory`

## Changes

Adds libpcsclite_real.so.* to pcsc module

## Checklist
- [x] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it