### PR TITLE
ci: add erofs-utils to the centos stream container

### DIFF
--- a/test/container/Dockerfile-fedora
+++ b/test/container/Dockerfile-fedora
@@ -17,13 +17,8 @@ else \
     dhcp-client \
     dhcp-server \
     dmraid \
-    erofs-utils \
-    f2fs-tools \
-    jfsutils \
     mkosi \
     nbd \
-    ntfs-3g \
-    ntfsprogs \
     /usr/bin/qemu-system-$(uname -m) \
     qrencode \
     sbsigntools \
@@ -42,6 +37,7 @@ RUN dnf -y install --setopt=install_weak_deps=False \
     dbus-daemon \
     device-mapper-multipath \
     e2fsprogs \
+    erofs-utils \
     fcoe-utils \
     fuse3 \
     gcc \


### PR DESCRIPTION
Remove some filesystem-util packages that currently not used by the CI to minimize the difference between fedora and centos stream containers

## Checklist
- [ ] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it

Fixes #
