### PR TITLE
fix(kernel-network-modules): if running inside vm, include qemu-net

### DIFF
--- a/modules.d/40network/module-setup.sh
+++ b/modules.d/40network/module-setup.sh
@@ -7,8 +7,6 @@ check() {
 
 # called by dracut
 depends() {
-    is_qemu_virtualized && echo -n "qemu-net "
-
     for module in network-manager systemd-networkd connman network-legacy; do
         if dracut_module_included "$module"; then
             echo "$module"

--- a/modules.d/90kernel-network-modules/module-setup.sh
+++ b/modules.d/90kernel-network-modules/module-setup.sh
@@ -6,6 +6,11 @@ check() {
 }
 
 # called by dracut
+depends() {
+    is_qemu_virtualized && echo -n "qemu-net "
+}
+
+# called by dracut
 installkernel() {
     # Include wired net drivers, excluding wireless
     local _arch=${DRACUT_ARCH:-$(uname -m)}


### PR DESCRIPTION
This change also allows to make the network meta module simply just make a decision on which netowkring module to use.

## Checklist
- [ ] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it

Fixes #
