### PR TITLE
ci: remove git from CI containers

### DIFF
--- a/test/container/Dockerfile-alpine
+++ b/test/container/Dockerfile-alpine
@@ -1,7 +1,7 @@
 ARG DISTRIBUTION=alpine
 FROM docker.io/${DISTRIBUTION}
 
-# prefer running tests with clang
+# run tests with clang
 ENV CC=clang
 
 # ovmf is not installed as systemd-boot-efistub is not available
@@ -22,7 +22,6 @@ RUN apk add --no-cache \
     bash \
     binutils \
     blkid \
-    bluez \
     btrfs-progs \
     busybox \
     bzip2 \
@@ -42,7 +41,6 @@ RUN apk add --no-cache \
     file \
     findmnt \
     f2fs-tools \
-    git \
     gpg \
     grep \
     iputils \

--- a/test/container/Dockerfile-arch
+++ b/test/container/Dockerfile-arch
@@ -19,7 +19,6 @@ RUN pacman --noconfirm -Syu \
     elfutils \
     erofs-utils \
     f2fs-tools \
-    git \
     glibc \
     jfsutils \
     jq \

--- a/test/container/Dockerfile-debian
+++ b/test/container/Dockerfile-debian
@@ -40,8 +40,7 @@ RUN \
     fcoe-utils \
     fdisk \
     file \
-    g++ \
-    git \
+    gcc \
     gpg \
     iputils-arping \
     iputils-ping \

--- a/test/container/Dockerfile-fedora
+++ b/test/container/Dockerfile-fedora
@@ -40,7 +40,6 @@ RUN dnf -y install --setopt=install_weak_deps=False \
     fcoe-utils \
     fuse3 \
     gcc \
-    git \
     iproute \
     iputils \
     iscsi-initiator-utils \

--- a/test/container/Dockerfile-opensuse
+++ b/test/container/Dockerfile-opensuse
@@ -18,7 +18,6 @@ RUN dnf -y install --setopt=install_weak_deps=False \
     e2fsprogs \
     erofs-utils \
     gcc \
-    git \
     hmaccalc \
     iproute \
     iputils \

--- a/test/container/Dockerfile-ubuntu
+++ b/test/container/Dockerfile-ubuntu
@@ -40,8 +40,7 @@ RUN \
     fcoe-utils \
     fdisk \
     file \
-    g++ \
-    git \
+    gcc \
     gpg \
     iputils-arping \
     iputils-ping \

--- a/test/container/Dockerfile-void
+++ b/test/container/Dockerfile-void
@@ -2,15 +2,11 @@ FROM ghcr.io/void-linux/void-glibc-full
 
 RUN xbps-install -Syu xbps && xbps-install -yu \
     asciidoc \
-    base-devel \
     bash \
     binutils \
-    bluez \
     btrfs-progs \
-    busybox \
     cargo \
     cifs-utils \
-    connman \
     cpio \
     cryptsetup \
     curl \
@@ -25,9 +21,10 @@ RUN xbps-install -Syu xbps && xbps-install -yu \
     erofs-utils \
     eudev \
     f2fs-tools \
-    git \
+    gcc \
     glibc \
     gnupg \
+    iproute2 \
     iputils \
     jfsutils \
     jq \
@@ -40,7 +37,6 @@ RUN xbps-install -Syu xbps && xbps-install -yu \
     mdadm \
     mtools \
     nbd \
-    NetworkManager \
     nfs-utils \
     ntfs-3g \
     nvme-cli \
@@ -48,9 +44,9 @@ RUN xbps-install -Syu xbps && xbps-install -yu \
     openssh \
     parted \
     pigz \
+    pkg-config \
     plymouth \
     qemu-system-amd64 \
-    rng-tools \
     sbsigntool \
     squashfs-tools \
     swtpm \


### PR DESCRIPTION
`git` is not required to build dracut or run the tests. 
Remove some other packages that are not used during the CI run anyways.

## Checklist
- [ ] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it

Fixes #
