### PR TITLE
ci: make sure systemd-sysv is installed in Debian/Ubuntu containers

### DIFF
--- a/test/container/Dockerfile-debian
+++ b/test/container/Dockerfile-debian
@@ -82,6 +82,7 @@ RUN \
     systemd-container \
     systemd-coredump \
     systemd-resolved \
+    systemd-sysv \
     systemd-timesyncd \
     tgt \
     thin-provisioning-tools \

--- a/test/container/Dockerfile-ubuntu
+++ b/test/container/Dockerfile-ubuntu
@@ -83,6 +83,7 @@ RUN \
     systemd-container \
     systemd-coredump \
     systemd-resolved \
+    systemd-sysv \
     systemd-timesyncd \
     systemd-ukify \
     tgt \


### PR DESCRIPTION
Resolves CI regression introduced by 7e3e547

## Checklist
- [ ] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it

Fixes #
