### PR TITLE
ci: resolve regression with void container

### DIFF
--- a/test/container/Dockerfile-debian
+++ b/test/container/Dockerfile-debian
@@ -1,6 +1,7 @@
 # Test coverage provided by this container:
 # - arm64
 # - dash default shell (instead of bash)
+# - mawk (instead of gawk)
 # - pigz compression
 # - verbose logging for tests
 

--- a/test/container/Dockerfile-ubuntu
+++ b/test/container/Dockerfile-ubuntu
@@ -1,6 +1,7 @@
 # Test coverage provided by this container:
 # - arm64
 # - dash default shell (instead of bash)
+# - mawk (instead of gawk)
 # - pigz compression
 # - verbose logging for tests
 

--- a/test/container/Dockerfile-void
+++ b/test/container/Dockerfile-void
@@ -25,6 +25,7 @@ RUN xbps-install -Syu xbps && xbps-install -yu \
     erofs-utils \
     eudev \
     gcc \
+    glibc \
     gnupg \
     iproute2 \
     iputils \
@@ -43,6 +44,5 @@ RUN xbps-install -Syu xbps && xbps-install -yu \
     qemu-system-amd64 \
     squashfs-tools \
     systemd-boot-efistub \
-    tgt \
     ukify \
     && rm -rf /var/cache/xbps


### PR DESCRIPTION
Re-install glibc into the void container.

## Checklist
- [ ] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it

Fixes #
