### PR TITLE
fix(dracut.sh): do not add cmdline for force_drivers if --kernel-only

### DIFF
--- a/dracut.sh
+++ b/dracut.sh
@@ -2044,10 +2044,12 @@ if [[ $no_kernel != yes ]]; then
     if [[ $force_drivers ]]; then
         # shellcheck disable=SC2086
         hostonly='' instmods -c $force_drivers
-        rm -f "$initdir"/etc/cmdline.d/20-force_driver.conf
-        for mod in $force_drivers; do
-            echo "rd.driver.pre=$mod" >> "$initdir"/etc/cmdline.d/20-force_drivers.conf
-        done
+        if [[ $kernel_only != yes ]]; then
+            rm -f "$initdir"/etc/cmdline.d/20-force_driver.conf
+            for mod in $force_drivers; do
+                echo "rd.driver.pre=$mod" >> "$initdir"/etc/cmdline.d/20-force_drivers.conf
+            done
+        fi
     fi
     if [[ $filesystems ]]; then
         # shellcheck disable=SC2086


### PR DESCRIPTION
From https://github.com/openSUSE/dracut/pull/384/commits/4e681447f64236422606af7f4ca2877e727c0294

## Checklist
- [ ] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it

Fixes #
