### PR TITLE
feat(configure): let's build dracut-cpio if cargo is installed

### DIFF
--- a/configure
+++ b/configure
@@ -6,7 +6,13 @@ echo \#buildapi-variable-no-builddir > /dev/null
 prefix=/usr
 
 enable_documentation=yes
-enable_dracut_cpio=no
+
+# if is cargo installed, let's build dracut-cpio
+if command -v cargo > /dev/null; then
+    enable_dracut_cpio=yes
+else
+    enable_dracut_cpio=no
+fi
 
 CC="${CC:-cc}"
 PKG_CONFIG="${PKG_CONFIG:-pkg-config}"

--- a/test/test-github.sh
+++ b/test/test-github.sh
@@ -14,11 +14,6 @@ if [ "$2" != "10" ]; then
     CONFIGURE_ARG+=" --disable-documentation"
 fi
 
-# if is cargo installed, let's build and test dracut-cpio
-if command -v cargo > /dev/null; then
-    CONFIGURE_ARG+=" --enable-dracut-cpio"
-fi
-
 # shellcheck disable=SC2086
 ./configure $CONFIGURE_ARG
 


### PR DESCRIPTION
dracut-cpio is now enabled on many distributions (openSUSE, Arch, Fedora), so let's make it the default.

## Checklist
- [ ] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it

Fixes #
