### PR TITLE
ci: extended integration tests

### DIFF
--- a/.github/workflows/integration-extra.yml
+++ b/.github/workflows/integration-extra.yml
@@ -1,0 +1,54 @@
+name: Integration Test  (extra)
+
+on:
+    schedule:
+        -  cron: '30 23 * * *'   # every day at 23:30 UTC
+
+    # Allows you to run this workflow manually from the Actions tab
+    workflow_dispatch:
+
+jobs:
+    basic:
+        # run this test on all containers
+        name: ${{ matrix.test }} on ${{ matrix.container }}
+        runs-on: ubuntu-latest
+        timeout-minutes: 10
+        concurrency:
+            group: basic-${{ github.workflow }}-${{ github.ref }}-${{ matrix.container }}-${{ matrix.test }}
+            cancel-in-progress: true
+        strategy:
+            fail-fast: false
+            matrix:
+                container: [
+                        "alpine:edge",
+                        "centos:stream10-development",
+                        "fedora:rawhide",
+                        "debian:sid",
+                        "ubuntu:rolling",
+                ]
+                test: [
+                        "10",
+                        "11",
+                        "12",
+                        "20",
+                        "21",
+                        "22",
+                        "23",
+                        "24",
+                        "25",
+                        "26",
+                        "30",
+                        "40",
+                        "41",
+                        "42",
+                        "80",
+                        "81",
+                ]
+        container:
+            image: ghcr.io/dracut-ng/${{ matrix.container }}
+            options: '--device=/dev/kvm --privileged'
+        steps:
+            -   name: "Checkout Repository"
+                uses: actions/checkout@v4
+            -   name: "${{ matrix.container }} TEST-${{ matrix.test }}"
+                run: ./test/test-github.sh "TEST-${{ matrix.test }}" ${{ matrix.test }}

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -8,6 +8,9 @@ on:
           - 'doc_site/**'
           - 'man/**'
 
+    # Allows you to run this workflow manually from the Actions tab
+    workflow_dispatch:
+
 env:
     # set V to 2 when re-running jobs with debug logging enabled
     # see https://docs.github.com/en/actions/monitoring-and-troubleshooting-workflows/troubleshooting-workflows/enabling-debug-logging


### PR DESCRIPTION
Allow the test to run manually. It also scheduled to runs once a day.

Extended tests run on the following containers
 - alpine:edge
 - centos:stream10-development
 - fedora:rawhide
 - debian:sid
 - ubuntu:rolling

The following tests seems to be failing
 - 20, 22, 26 (on centos), 10 (on alpine:edge)

## Checklist
- [ ] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it

Fixes #
