### PR TITLE
ci: run syncheck job only after basic test passed

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -52,15 +52,16 @@ jobs:
 
     # syncheck
     syncheck:
-      name: syncheck
-      runs-on: ubuntu-latest
-      steps:
-        - name: "Checkout Repository"
-          uses: actions/checkout@v4
-        - run: |
-              sudo apt-get update
-              sudo apt-get -y install shellcheck shfmt
-              make syncheck
+        needs: basic
+        name: syncheck
+        runs-on: ubuntu-latest
+        steps:
+            - name: "Checkout Repository"
+              uses: actions/checkout@v4
+            - run: |
+                  sudo apt-get update
+                  sudo apt-get -y install shellcheck shfmt
+                  make syncheck
 
     extended:
         needs: basic


### PR DESCRIPTION
Prioritize running basic tests over syncheck.

## Checklist
- [ ] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it

Fixes #
