### PR TITLE
ci: run publish after labeler

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -8,7 +8,7 @@ github:
 
 docs:
   - changed-files:
-    - any-glob-to-any-file: ['README.*', 'doc_site/*', 'doc_site/**/*', 'doc_site/**/**/*', 'doc_site/**/**/**/*', 'doc_site/**/**/**/**/*']
+    - any-glob-to-any-file: ['antora-playbook.yaml', 'README.*', 'man/*', 'doc_site/*', 'doc_site/**/*', 'doc_site/**/**/*', 'doc_site/**/**/**/*', 'doc_site/**/**/**/**/*']
 
 man:
   - changed-files:

--- a/.github/workflows/labels.yml
+++ b/.github/workflows/labels.yml
@@ -1,6 +1,8 @@
-name: "Pull Request Labeler"
+name: "Labeler"
 
-on: pull_request_target
+on:
+    pull_request:
+        branches: [ main ]
 
 jobs:
     triage:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,7 +1,9 @@
 name: Publish to GitHub Pages
 
 on:
-  push:
+  workflow_run:
+    workflows: [Labeler]
+    types: [completed]
     branches: [main]
     paths-ignore:
       - 'modules.d/**'

--- a/README.md
+++ b/README.md
@@ -2,9 +2,9 @@
 
 dracut-ng is an event driven initramfs infrastructure.
 
+[![distributions](https://repology.org/badge/tiny-repos/dracut.svg)](https://repology.org/project/dracut/versions)
+[![version(s)](https://repology.org/badge/latest-versions/dracut.svg)](https://repology.org/project/dracut/versions)
 [![Contributor Covenant](https://img.shields.io/badge/Contributor%20Covenant-v2.0%20adopted-ff69b4.svg)](https://dracut-ng.github.io/dracut-ng/developer/code_of_conduct.html)
-[![Packaging status](https://repology.org/badge/tiny-repos/dracut.svg)](https://repology.org/project/dracut/versions)
-[![latest packaged version(s)](https://repology.org/badge/latest-versions/dracut.svg)](https://repology.org/project/dracut/versions)
 
 dracut creates an initrd image by copying tools and files from an installed
 system and combining it with dracut modules, usually found in


### PR DESCRIPTION
The ultimate goal is to use GitHub Labels to trigger additional GitHub Actions. This is first step towards this idea.

In this PR, we want to trigger publishing to GitHub Pages only after PR labeling is finished, so that PR labels are available when we determine if we want to run the GitHub Action or not.

README has a trivial change to satisfy the requirement for the docs label.

## Checklist
- [ ] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it

Fixes #
