### PR TITLE
ci: improve CI containers

### DIFF
--- a/test/container/Dockerfile-arch
+++ b/test/container/Dockerfile-arch
@@ -3,6 +3,7 @@
 # - mkinitcpio, mkosi
 # - sbsigntools
 # - qrencode (systemd-bsod)
+# - rdma out of tree dracut module
 
 # Not installed
 # - busybox (no need, tested elsewhere)
@@ -43,6 +44,7 @@ RUN pacman --noconfirm -Syu \
     nvme-cli \
     open-iscsi \
     parted \
+    pciutils \
     pkgconf \
     plymouth \
     qemu \

--- a/test/container/Dockerfile-fedora
+++ b/test/container/Dockerfile-fedora
@@ -9,6 +9,7 @@
 # - openssh (ssh-client)
 # - rsyslog (syslog)
 # - libkcapi-hmaccalc (fido)
+# - nss-softokn out of tree dracut module
 
 ARG DISTRIBUTION=fedora
 ARG REGISTRY=registry.fedoraproject.org

--- a/test/container/Dockerfile-opensuse
+++ b/test/container/Dockerfile-opensuse
@@ -1,6 +1,7 @@
 # Test coverage provided by this container:
 # - network-legacy
 # - hmaccalc (fido)
+# - rdma out of tree dracut module
 
 FROM registry.opensuse.org/opensuse/tumbleweed-dnf:latest
 
@@ -36,6 +37,7 @@ RUN dnf -y install --setopt=install_weak_deps=False \
     nfs-utils \
     open-iscsi \
     parted \
+    pciutils \
     procps \
     python3-pefile \
     qemu-kvm \

--- a/test/container/Dockerfile-void
+++ b/test/container/Dockerfile-void
@@ -4,6 +4,7 @@
 # - eudev (instead of systemd-udev)
 # - elogind (instead of logind)
 # - uki (without systemd)
+# - zfs and zfs out of tree dracut module
 
 FROM ghcr.io/void-linux/void-glibc-full
 
@@ -45,4 +46,5 @@ RUN xbps-install -Syu xbps && xbps-install -yu \
     squashfs-tools \
     systemd-boot-efistub \
     ukify \
+    zfs \
     && rm -rf /var/cache/xbps


### PR DESCRIPTION
Add pciutils for those containers that have the rdma out of tree dracut module installed (pulled in by tgt package).

Add zfs and zfs out of tree dracut module as a preparation for zfs testing.

## Checklist
- [ ] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it

Fixes #
