### PR TITLE
ci: remove branch name that triggered a workflow_run

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -4,7 +4,6 @@ on:
   workflow_run:
     workflows: [Labeler]
     types: [completed]
-    branches: [ main ]
     paths-ignore:
       - antora-playbook.yaml
       - 'doc_site/**'


### PR DESCRIPTION
branch name is not populated for workflow_runs.

This PR restores lint GitHub Action. Sorry for the churn @LaszloGombos 

## Changes

## Checklist
- [ ] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it

Fixes #
