### PR TITLE
test(BASIC): add support for zfs TEST_FSTYPE

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -48,7 +48,7 @@ jobs:
             -   name: "Checkout Repository"
                 uses: actions/checkout@v4
             -   name: "${{ matrix.container }} TEST-${{ matrix.test }}"
-                run: ./test/test-github.sh "TEST-${{ matrix.test }}" ${{ matrix.test }}
+                run:  TARGETS='all install check' DRACUT=dracut ./test/test-github.sh "TEST-${{ matrix.test }}" ${{ matrix.test }}
 
     # syncheck
     syncheck:

--- a/Makefile
+++ b/Makefile
@@ -171,6 +171,7 @@ install: all
 	ln -fs dracut-functions.sh $(DESTDIR)$(pkglibdir)/dracut-functions
 	install -m 0755 dracut-logger.sh $(DESTDIR)$(pkglibdir)/dracut-logger.sh
 	install -m 0755 dracut-initramfs-restore.sh $(DESTDIR)$(pkglibdir)/dracut-initramfs-restore
+	rm -rf $(DESTDIR)$(pkglibdir)/modules.d/80test*
 	cp -arx modules.d dracut.conf.d $(DESTDIR)$(pkglibdir)
 ifneq ($(enable_test),no)
 	cp -arx test $(DESTDIR)$(pkglibdir)

--- a/test/TEST-10-BASIC/create-root.sh
+++ b/test/TEST-10-BASIC/create-root.sh
@@ -6,11 +6,31 @@ set -ex
 # populate TEST_FSTYPE
 . /env
 
-eval "mkfs.${TEST_FSTYPE} -q -L dracut /dev/disk/by-id/scsi-0QEMU_QEMU_HARDDISK_root"
+if [ "$TEST_FSTYPE" = "zfs" ]; then
+    zpool create dracut /dev/disk/by-id/scsi-0QEMU_QEMU_HARDDISK_root
+    zfs create dracut/root
+else
+    eval "mkfs.${TEST_FSTYPE} -q -L dracut /dev/disk/by-id/scsi-0QEMU_QEMU_HARDDISK_root"
+fi
+
 mkdir -p /root
-mount -t "${TEST_FSTYPE}" /dev/disk/by-id/scsi-0QEMU_QEMU_HARDDISK_root /root
+
+if [ "$TEST_FSTYPE" = "zfs" ]; then
+    zfs set mountpoint=/root dracut/root
+    zfs get mounted dracut/root
+else
+    mount -t "${TEST_FSTYPE}" /dev/disk/by-id/scsi-0QEMU_QEMU_HARDDISK_root /root
+fi
+
 cp -a -t /root /source/*
 mkdir -p /root/run
-umount /root
+
+if [ "$TEST_FSTYPE" = "zfs" ]; then
+    zfs unmount /root
+    zfs set mountpoint=/ dracut/root
+else
+    umount /root
+fi
+
 echo "dracut-root-block-created" | dd oflag=direct,dsync status=none of=/dev/disk/by-id/scsi-0QEMU_QEMU_HARDDISK_marker
 poweroff -f


### PR DESCRIPTION
Basic tests now installs the upstream version of dracut modules on top of the dracut modules that comes with the downstream distribution or other dowstream out of tree dracut modules.

## Checklist
- [ ] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it

Fixes #
