### PR TITLE
ci(void): set zfs as preferred fstype for testing

### DIFF
--- a/test/container/Dockerfile-void
+++ b/test/container/Dockerfile-void
@@ -8,6 +8,9 @@
 
 FROM ghcr.io/void-linux/void-glibc-full
 
+# prefer running tests with zfs
+ENV TEST_FSTYPE=zfs
+
 RUN xbps-install -Syu xbps && xbps-install -yu \
     asciidoc \
     bash \
@@ -45,6 +48,7 @@ RUN xbps-install -Syu xbps && xbps-install -yu \
     qemu-system-amd64 \
     squashfs-tools \
     systemd-boot-efistub \
+    ncurses-base \
     ukify \
     zfs \
     && rm -rf /var/cache/xbps


### PR DESCRIPTION
Use this as an opportunity to also install ncurses-base package to get rid of terminfo dracut module warnings.

## Checklist
- [ ] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it

Fixes #
