### PR TITLE
fix(rngd): do not include the module if we can not start the service

### DIFF
--- a/modules.d/06rngd/module-setup.sh
+++ b/modules.d/06rngd/module-setup.sh
@@ -21,6 +21,7 @@
 check() {
     # if there's no rngd binary, no go.
     require_binaries rngd || return 1
+    require_binaries "${systemdsystemunitdir}/rngd.service" || return 1
 
     return 0
 }


### PR DESCRIPTION
Some distributions do not have this service file present (e.g. openSUSE).

Follow-up to a952820 and https://github.com/dracut-ng/dracut-ng/pull/290

## Checklist
- [ ] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it

Fixes #
