### PR TITLE
ci: remove workarounds from openSUSE CI container

### DIFF
--- a/test/container/Dockerfile-opensuse
+++ b/test/container/Dockerfile-opensuse
@@ -41,7 +41,6 @@ RUN dnf -y install --setopt=install_weak_deps=False \
     procps \
     python3-pefile \
     qemu-kvm \
-    rng-tools \
     squashfs \
     swtpm \
     systemd-boot \
@@ -51,8 +50,3 @@ RUN dnf -y install --setopt=install_weak_deps=False \
     /usr/bin/qemu-system-$(uname -m) \
     util-linux-systemd \
     && dnf -y update && dnf clean all
-
-# configuration in the package is not compatible
-# with the upstream CI, lets remove it
-RUN \
-  rm -rf /usr/lib/dracut/dracut.conf.d


### PR DESCRIPTION
This change will result in tests running for openSUSE in hostonly mode (instead of non-hostonly).



## Checklist
- [ ] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it

Fixes #
