### PR TITLE
ci: force openSUSE CI container non-hostonly

### DIFF
--- a/test/container/Dockerfile-opensuse
+++ b/test/container/Dockerfile-opensuse
@@ -50,3 +50,7 @@ RUN dnf -y install --setopt=install_weak_deps=False \
     /usr/bin/qemu-system-$(uname -m) \
     util-linux-systemd \
     && dnf -y update && dnf clean all
+
+# force non-hostonly mode, but keep all the other config
+RUN \
+  echo 'hostonly="no"' > /usr/lib/dracut/dracut.conf.d/02-dist.conf


### PR DESCRIPTION
The hostonly config passed locally but fails on the CI.

Follow-up to 2c09b1d. Sorry for the churn @LaszloGombos 

## Checklist
- [ ] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it

Fixes #
