### PR TITLE
ci: run the extended tests the same way as basic tests

### DIFF
--- a/.github/workflows/integration-extra.yml
+++ b/.github/workflows/integration-extra.yml
@@ -51,4 +51,4 @@ jobs:
             -   name: "Checkout Repository"
                 uses: actions/checkout@v4
             -   name: "${{ matrix.container }} TEST-${{ matrix.test }}"
-                run: ./test/test-github.sh "TEST-${{ matrix.test }}" ${{ matrix.test }}
+                run: TARGETS='all install cleaninstall check' DRACUT=dracut ./test/test-github.sh "TEST-${{ matrix.test }}" ${{ matrix.test }}

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -140,7 +140,7 @@ jobs:
             -   name: "Checkout Repository"
                 uses: actions/checkout@v4
             -   name: "${{ matrix.container }} TEST-${{ matrix.test }}"
-                run: ./test/test-github.sh "TEST-${{ matrix.test }}" ${{ matrix.test }}
+                run: TARGETS='all install cleaninstall check' DRACUT=dracut ./test/test-github.sh "TEST-${{ matrix.test }}" ${{ matrix.test }}
     dracut-cpio:
         needs: basic
         name: ${{ matrix.test }} on ${{ matrix.container }}

--- a/test/TEST-10-BASIC/test.sh
+++ b/test/TEST-10-BASIC/test.sh
@@ -44,7 +44,6 @@ test_setup() {
     # shellcheck disable=SC2046
     "$DRACUT" -N -l -i "$TESTDIR"/overlay / \
         --add-confdir test-makeroot \
-        -i /bin/dd /usr/sbin/dd \
         $(if [ "$TEST_FSTYPE" = "zfs" ]; then echo "-a zfs"; else echo "-I mkfs.${TEST_FSTYPE}"; fi) \
         -i ./create-root.sh /lib/dracut/hooks/initqueue/01-create-root.sh \
         -f "$TESTDIR"/initramfs.makeroot "$KVERSION" || return 1

--- a/test/TEST-11-USR-MOUNT/test.sh
+++ b/test/TEST-11-USR-MOUNT/test.sh
@@ -67,8 +67,8 @@ test_setup() {
     declare -a disk_args=()
     declare -i disk_index=0
     qemu_add_drive disk_index disk_args "$TESTDIR"/marker.img marker 1
-    qemu_add_drive disk_index disk_args "$TESTDIR"/root.btrfs root 160
-    qemu_add_drive disk_index disk_args "$TESTDIR"/usr.btrfs usr 160
+    qemu_add_drive disk_index disk_args "$TESTDIR"/root.btrfs root 320
+    qemu_add_drive disk_index disk_args "$TESTDIR"/usr.btrfs usr 320
 
     # Invoke KVM and/or QEMU to actually create the target filesystem.
     "$testdir"/run-qemu \

--- a/test/TEST-21-LVM/test.sh
+++ b/test/TEST-21-LVM/test.sh
@@ -45,9 +45,9 @@ test_setup() {
     # shellcheck disable=SC2034
     declare -i disk_index=0
     qemu_add_drive disk_index disk_args "$TESTDIR"/marker.img marker 1
-    qemu_add_drive disk_index disk_args "$TESTDIR"/disk-1.img disk1 40
-    qemu_add_drive disk_index disk_args "$TESTDIR"/disk-2.img disk2 40
-    qemu_add_drive disk_index disk_args "$TESTDIR"/disk-3.img disk3 40
+    qemu_add_drive disk_index disk_args "$TESTDIR"/disk-1.img disk1 80
+    qemu_add_drive disk_index disk_args "$TESTDIR"/disk-2.img disk2 80
+    qemu_add_drive disk_index disk_args "$TESTDIR"/disk-3.img disk3 80
 
     "$testdir"/run-qemu \
         "${disk_args[@]}" \

--- a/test/TEST-23-IMSM/create-root.sh
+++ b/test/TEST-23-IMSM/create-root.sh
@@ -20,9 +20,9 @@ udevadm settle
 sfdisk -g /dev/mapper/isw*Test0
 sfdisk --no-reread /dev/mapper/isw*Test0 << EOF
 ,4M
-,56M
-,56M
-,56M
+,112M
+,112M
+,112M
 EOF
 
 set -x

--- a/test/TEST-23-IMSM/test.sh
+++ b/test/TEST-23-IMSM/test.sh
@@ -75,8 +75,8 @@ test_setup() {
     declare -a disk_args=()
     declare -i disk_index=0
     qemu_add_drive disk_index disk_args "$TESTDIR"/marker.img marker 1
-    qemu_add_drive disk_index disk_args "$TESTDIR"/disk-1.img disk1 200
-    qemu_add_drive disk_index disk_args "$TESTDIR"/disk-2.img disk2 200
+    qemu_add_drive disk_index disk_args "$TESTDIR"/disk-1.img disk1 420
+    qemu_add_drive disk_index disk_args "$TESTDIR"/disk-2.img disk2 420
 
     # Invoke KVM and/or QEMU to actually create the target filesystem.
     "$testdir"/run-qemu \

--- a/test/TEST-25-LVM-THIN/create-root.sh
+++ b/test/TEST-25-LVM-THIN/create-root.sh
@@ -9,7 +9,7 @@ done
 
 lvm vgcreate dracut /dev/disk/by-id/scsi-0QEMU_QEMU_HARDDISK_disk[123]
 lvm lvcreate --yes --ignoremonitoring -l 100%FREE -T dracut/mythinpool
-lvm lvcreate --yes --ignoremonitoring -V100M -T dracut/mythinpool -n root
+lvm lvcreate --yes --ignoremonitoring -V200M -T dracut/mythinpool -n root
 lvm vgchange --ignoremonitoring -ay
 mkfs.ext4 -q /dev/dracut/root
 mkdir -p /sysroot

--- a/test/TEST-25-LVM-THIN/test.sh
+++ b/test/TEST-25-LVM-THIN/test.sh
@@ -46,9 +46,9 @@ test_setup() {
     # shellcheck disable=SC2034
     declare -i disk_index=0
     qemu_add_drive disk_index disk_args "$TESTDIR"/marker.img marker 1
-    qemu_add_drive disk_index disk_args "$TESTDIR"/disk-1.img disk1 40
-    qemu_add_drive disk_index disk_args "$TESTDIR"/disk-2.img disk2 40
-    qemu_add_drive disk_index disk_args "$TESTDIR"/disk-3.img disk3 40
+    qemu_add_drive disk_index disk_args "$TESTDIR"/disk-1.img disk1 80
+    qemu_add_drive disk_index disk_args "$TESTDIR"/disk-2.img disk2 80
+    qemu_add_drive disk_index disk_args "$TESTDIR"/disk-3.img disk3 80
 
     "$testdir"/run-qemu \
         "${disk_args[@]}" \

--- a/test/TEST-26-ENC-RAID-LVM/test.sh
+++ b/test/TEST-26-ENC-RAID-LVM/test.sh
@@ -73,9 +73,9 @@ test_setup() {
     declare -a disk_args=()
     declare -i disk_index=0
     qemu_add_drive disk_index disk_args "$TESTDIR"/marker.img marker 1
-    qemu_add_drive disk_index disk_args "$TESTDIR"/disk-1.img disk1 80
-    qemu_add_drive disk_index disk_args "$TESTDIR"/disk-2.img disk2 80
-    qemu_add_drive disk_index disk_args "$TESTDIR"/disk-3.img disk3 80
+    qemu_add_drive disk_index disk_args "$TESTDIR"/disk-1.img disk1 160
+    qemu_add_drive disk_index disk_args "$TESTDIR"/disk-2.img disk2 160
+    qemu_add_drive disk_index disk_args "$TESTDIR"/disk-3.img disk3 160
 
     "$testdir"/run-qemu \
         "${disk_args[@]}" \

--- a/test/TEST-30-DMSQUASH/create-root.sh
+++ b/test/TEST-30-DMSQUASH/create-root.sh
@@ -5,7 +5,7 @@ set -e
 
 # create a single partition using 50% of the capacity of the image file created by test_setup() in test.sh
 sfdisk /dev/disk/by-id/scsi-0QEMU_QEMU_HARDDISK_root << EOF
-2048,161792
+2048,452688
 EOF
 
 udevadm settle

--- a/test/TEST-30-DMSQUASH/test.sh
+++ b/test/TEST-30-DMSQUASH/test.sh
@@ -121,13 +121,13 @@ test_setup() {
     declare -a disk_args=()
     declare -i disk_index=0
     qemu_add_drive disk_index disk_args "$TESTDIR"/marker.img marker 1
-    qemu_add_drive disk_index disk_args "$TESTDIR"/root.img root 160
+    qemu_add_drive disk_index disk_args "$TESTDIR"/root.img root 512
 
     # erofs drive
-    qemu_add_drive disk_index disk_args "$TESTDIR"/root_erofs.img root_erofs 160
+    qemu_add_drive disk_index disk_args "$TESTDIR"/root_erofs.img root_erofs 512
 
     # NTFS drive
-    dd if=/dev/zero of="$TESTDIR"/root_ntfs.img bs=1MiB count=160
+    dd if=/dev/zero of="$TESTDIR"/root_ntfs.img bs=1MiB count=512
     qemu_add_drive disk_index disk_args "$TESTDIR"/root_ntfs.img root_ntfs
 
     # Invoke KVM and/or QEMU to actually create the target filesystem.
@@ -156,6 +156,7 @@ EOF
         --omit "systemd" \
         --drivers "ntfs3" \
         --install "mkfs.ext4" \
+        -a bash \
         --include /tmp/ntfs3.rules /lib/udev/rules.d/ntfs3.rules \
         "$TESTDIR"/initramfs.testing
 
@@ -164,6 +165,7 @@ EOF
         --add "dmsquash-live-autooverlay qemu" \
         --omit "systemd" \
         --install "mkfs.ext4" \
+        -a bash \
         "$TESTDIR"/initramfs.testing-autooverlay
 }
 

--- a/test/modules.d/80test-makeroot/module-setup.sh
+++ b/test/modules.d/80test-makeroot/module-setup.sh
@@ -14,6 +14,10 @@ installkernel() {
 }
 
 install() {
-    inst_multiple poweroff cp umount sync dd mkfs.ext4
+    inst_multiple poweroff cp umount sync mkfs.ext4
+
+    # prefer the coreutils version of dd over the busybox version for testing
+    inst /bin/dd /usr/sbin/dd
+
     inst_hook initqueue/finished 01 "$moddir/finished-false.sh"
 }


### PR DESCRIPTION
To increase test coverage install the upstream version of dracut as an overlay on top of the distribution CI containers.

Void dracut configuration always includes the drm dracut module, so test case storage sizes needed an increase.

## Checklist
- [ ] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it

Fixes #
