### PR TITLE
ci: make sure downstream dracut package is installed in ci containers

### DIFF
--- a/test/container/Dockerfile-arch
+++ b/test/container/Dockerfile-arch
@@ -26,6 +26,7 @@ RUN pacman --noconfirm -Syu \
     dhclient \
     dhcp \
     dmraid \
+    dracut \
     elfutils \
     erofs-utils \
     gcc \

--- a/test/container/Dockerfile-gentoo
+++ b/test/container/Dockerfile-gentoo
@@ -68,6 +68,7 @@ RUN emerge --quiet --deep --autounmask-continue=y --with-bdeps=n --noreplace \
     sys-fs/mdadm \
     sys-fs/multipath-tools \
     sys-fs/squashfs-tools \
+    sys-kernel/dracut \
     sys-kernel/gentoo-kernel-bin \
     sys-libs/glibc \
     sys-libs/libxcrypt \


### PR DESCRIPTION
The CI test suite now able to handle and pick up dowstream dracut configuration.

All other CI containers have dracut installed - except Arch and Gentoo.

## Checklist
- [ ] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it

Fixes #
