### PR TITLE
ci: test clang with Void instead of Alpine

### DIFF
--- a/test/container/Dockerfile-alpine
+++ b/test/container/Dockerfile-alpine
@@ -23,15 +23,12 @@ FROM docker.io/${DISTRIBUTION}
 # export ARG
 ARG DISTRIBUTION
 
-ENV CC=clang
-
 # Packages to pass the BASIC test
 RUN apk add --no-cache \
     asciidoc \
     bash \
     binutils \
     blkid \
-    clang \
     coreutils \
     dracut \
     dracut-tests \

--- a/test/container/Dockerfile-void
+++ b/test/container/Dockerfile-void
@@ -5,11 +5,14 @@
 # - elogind (instead of logind)
 # - uki (without systemd)
 # - zfs and zfs out of tree dracut module
+# - gzip compression
+# - clang
 
 FROM ghcr.io/void-linux/void-glibc-full
 
-# prefer running tests with zfs
+# prefer running tests with zfs and clang
 ENV TEST_FSTYPE=zfs
+ENV CC=clang
 
 RUN xbps-install -Syu xbps && xbps-install -yu \
     asciidoc \
@@ -17,6 +20,7 @@ RUN xbps-install -Syu xbps && xbps-install -yu \
     binutils \
     btrfs-progs \
     cargo \
+    clang \
     cpio \
     cryptsetup \
     dhclient \


### PR DESCRIPTION
Now that alpine is less tested, let's use Void Linux instead for clang.

## Checklist
- [ ] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it

Fixes #
