### PR TITLE
ci: move debian extended tests to extra to do less work on each PR

### DIFF
--- a/.github/workflows/integration-extra.yml
+++ b/.github/workflows/integration-extra.yml
@@ -26,10 +26,17 @@ jobs:
                 container: [
                         "alpine",
                         "alpine:edge",
-                        "centos:stream10-development",
-                        "fedora:rawhide",
+                        "arch",
+                        "debian",
                         "debian:sid",
+                        "fedora",
+                        "fedora:rawhide",
+                        "centos:stream10-development",
+                        "gentoo",
+                        "opensuse",
+                        "ubuntu",
                         "ubuntu:rolling",
+                        "void",
                 ]
                 test: [
                         "10",

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -76,7 +76,6 @@ jobs:
             matrix:
                 container: [
                         "arch",
-                        "debian",
                         "fedora",
                         "gentoo",
                         "opensuse",
@@ -119,7 +118,6 @@ jobs:
             matrix:
                 container: [
                         "arch",
-                        "debian",
                         "fedora",
                         "gentoo",
                         "opensuse",


### PR DESCRIPTION
Prefer testing on Ubuntu on each PR over Debian and delegate testing on Debian to Integration Tests (Extra) - that runs scheduled instead of each PR.

## Checklist
- [ ] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it

Fixes #
