### PR TITLE
fix(dracut-functions.sh): check for modules in --kmoddir, not in --sysroot

### DIFF
--- a/dracut-functions.sh
+++ b/dracut-functions.sh
@@ -761,7 +761,7 @@ check_kernel_config() {
 # 0 if the kernel module is either built-in or available
 # 1 if the kernel module is not enabled
 check_kernel_module() {
-    modprobe -d "$dracutsysrootdir" -S "$kernel" --dry-run "$1" &> /dev/null || return 1
+    modprobe -d "$drivers_dir/../../" -S "$kernel" --dry-run "$1" &> /dev/null || return 1
 }
 
 # get_cpu_vendor


### PR DESCRIPTION
Modules are installed from the directory specified by `--kmoddir`, but currently the `check_kernel_module()` function is checking for the module in `--sysroot/lib/modules`. This is notably not the same when kernels packages are being built inside some docker container. We should check for the modules existence in the directory we are actually going to install it from.

## Changes

## Checklist
- [ ] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it

Fixes # Downstream discovered issue
