### PR TITLE
fix: initqueue -> /sbin/initqueue

### DIFF
--- a/modules.d/90crypt/cryptroot-ask.sh
+++ b/modules.d/90crypt/cryptroot-ask.sh
@@ -157,7 +157,7 @@ else
             fi
             sleep 1
             info "No key found for $device.  Will try $numtries time(s) more later."
-            initqueue --unique --onetime --settled \
+            /sbin/initqueue --unique --onetime --settled \
                 --name cryptroot-ask-"$luksname" \
                 "$(command -v cryptroot-ask)" "$device" "$luksname" "$is_keysource" "$((numtries - 1))"
             exit 0

--- a/modules.d/90kernel-modules/parse-kernel.sh
+++ b/modules.d/90kernel-modules/parse-kernel.sh
@@ -28,5 +28,5 @@ for p in $(getargs rd.driver.post); do
     _do_insmodpost=1
 done
 
-[ -n "$_do_insmodpost" ] && initqueue --settled --unique --onetime insmodpost.sh
+[ -n "$_do_insmodpost" ] && /sbin/initqueue --settled --unique --onetime insmodpost.sh
 unset _do_insmodpost _modprobe_d

--- a/modules.d/95fcoe/parse-fcoe.sh
+++ b/modules.d/95fcoe/parse-fcoe.sh
@@ -27,7 +27,7 @@ if ! [ -e /sys/bus/fcoe/ctlr_create ] && ! modprobe -b fcoe && ! modprobe -b lib
     die "FCoE requested but kernel/initrd does not support FCoE"
 fi
 
-initqueue --onetime modprobe -b -q bnx2fc
+/sbin/initqueue --onetime modprobe -b -q bnx2fc
 
 parse_fcoe_opts() {
     local fcoe_interface

--- a/modules.d/95iscsi/parse-iscsiroot.sh
+++ b/modules.d/95iscsi/parse-iscsiroot.sh
@@ -85,9 +85,9 @@ if [ -n "$iscsi_firmware" ]; then
     modprobe -b -q iscsi_ibft
     # if no ip= is given, but firmware
     echo "${DRACUT_SYSTEMD+systemctl is-active initrd-root-device.target || }[ -f '/tmp/iscsistarted-firmware' ]" > "$hookdir"/initqueue/finished/iscsi_started.sh
-    initqueue --unique --online /sbin/iscsiroot online "iscsi:" "$NEWROOT"
-    initqueue --unique --onetime --timeout /sbin/iscsiroot timeout "iscsi:" "$NEWROOT"
-    initqueue --unique --onetime --settled /sbin/iscsiroot online "iscsi:" "'$NEWROOT'"
+    /sbin/initqueue --unique --online /sbin/iscsiroot online "iscsi:" "$NEWROOT"
+    /sbin/initqueue --unique --onetime --timeout /sbin/iscsiroot timeout "iscsi:" "$NEWROOT"
+    /sbin/initqueue --unique --onetime --settled /sbin/iscsiroot online "iscsi:" "'$NEWROOT'"
 fi
 
 # ISCSI actually supported?
@@ -103,7 +103,7 @@ modprobe -b -q be2iscsi
 
 if [ -n "$netroot" ] && [ "$root" != "/dev/root" ] && [ "$root" != "dhcp" ]; then
     if ! getargbool 1 rd.neednet > /dev/null || ! getarg "ip="; then
-        initqueue --unique --onetime --settled /sbin/iscsiroot dummy "'$netroot'" "'$NEWROOT'"
+        /sbin/initqueue --unique --onetime --settled /sbin/iscsiroot dummy "'$netroot'" "'$NEWROOT'"
     fi
 fi
 
@@ -142,7 +142,7 @@ if [ -z "$netroot" ] || ! [ "${netroot%%:*}" = "iscsi" ]; then
     return 1
 fi
 
-initqueue --unique --onetime --timeout /sbin/iscsiroot timeout "$netroot" "$NEWROOT"
+/sbin/initqueue --unique --onetime --timeout /sbin/iscsiroot timeout "$netroot" "$NEWROOT"
 
 for nroot in $(getargs netroot); do
     [ "${nroot%%:*}" = "iscsi" ] || continue

--- a/modules.d/95nvmf/parse-nvmf-boot-connections.sh
+++ b/modules.d/95nvmf/parse-nvmf-boot-connections.sh
@@ -236,9 +236,9 @@ if ! getargbool 0 rd.nvmf.nonbft; then
     done
 fi
 
-initqueue --onetime modprobe -b -q nvme_tcp
-initqueue --onetime modprobe -b -q nvme_core
-initqueue --onetime modprobe -b -q nvme_fabrics
+/sbin/initqueue --onetime modprobe -b -q nvme_tcp
+/sbin/initqueue --onetime modprobe -b -q nvme_core
+/sbin/initqueue --onetime modprobe -b -q nvme_fabrics
 
 parse_nvmf_discover() {
     traddr="none"

--- a/modules.d/98dracut-systemd/dracut-pre-udev.sh
+++ b/modules.d/98dracut-systemd/dracut-pre-udev.sh
@@ -41,7 +41,7 @@ for p in $(getargs rd.driver.post); do
     _do_insmodpost=1
 done
 
-[ -n "$_do_insmodpost" ] && initqueue --settled --unique --onetime insmodpost.sh
+[ -n "$_do_insmodpost" ] && /sbin/initqueue --settled --unique --onetime insmodpost.sh
 unset _do_insmodpost _modprobe_d
 unset i
 


### PR DESCRIPTION
Use full path for initqueue.

Inspired by https://github.com/aafeijoo-suse/dracut-core/commit/d339ae05f388c3e5aefe523d35be981a0d69ff5a 

## Checklist
- [ ] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it

Fixes #
