### PR TITLE
feat(dmsquash-live): add support for rd.live.overlay.nouserconfirmprompt

### DIFF
--- a/man/dracut.cmdline.7.adoc
+++ b/man/dracut.cmdline.7.adoc
@@ -1272,6 +1272,11 @@ of the base root filesystem and the persistent overlay, or
 root filesystem, and `/run/overlayfs` becomes the temporary, writable, upper
 directory overlay, to complete the bootable root filesystem.
 
+**rd.live.overlay.nouserconfirmprompt=**::
+Supresses the 'Using temporary overlay' blocking prompt that asks for a
+user confirmation before proceeding during boot time. This is to allow
+the boot process to continue to completion without user interation.
+
 **rd.live.overlay.reset=**1::
 Specifies that a persistent overlay should be reset on boot.  All previous root
 filesystem changes are vacated by this action.

--- a/modules.d/90dmsquash-live/dmsquash-live-root.sh
+++ b/modules.d/90dmsquash-live/dmsquash-live-root.sh
@@ -26,6 +26,7 @@ squash_image=$(getarg rd.live.squashimg)
 getargbool 0 rd.live.ram && live_ram="yes"
 getargbool 0 rd.live.overlay.reset && reset_overlay="yes"
 getargbool 0 rd.live.overlay.readonly && readonly_overlay="--readonly" || readonly_overlay=""
+getargbool 0 rd.live.overlay.nouserconfirmprompt && overlay_no_user_confirm_prompt="--noprompt" || overlay_no_user_confirm_prompt=""
 overlay=$(getarg rd.live.overlay)
 getargbool 0 rd.writable.fsimg && writable_fsimg="yes"
 overlay_size=$(getarg rd.live.overlay.size=)
@@ -219,7 +220,7 @@ do_live_overlay() {
     fi
 
     if [ -z "$setup" ] || [ -n "$readonly_overlay" ]; then
-        if [ -n "$setup" ]; then
+        if [ -n "$setup" ] || [ -n "$overlay_no_user_confirm_prompt" ]; then
             warn "Using temporary overlay."
         elif [ -n "$devspec" ] && [ -n "$pathspec" ]; then
             [ -z "$m" ] \


### PR DESCRIPTION
From https://github.com/microsoft/azurelinux/blob/3.0/SPECS/dracut/allow-liveos-overlay-no-user-confirmation-prompt.patch

It seems useful for all Linux distributions . 

CC @gmileka 

## Checklist
- [ ] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it

Fixes #
