### PR TITLE
test(FULL-SYSTEMD): add test coverage for mkinitcpio

### DIFF
--- a/test/container/Dockerfile-arch
+++ b/test/container/Dockerfile-arch
@@ -35,6 +35,7 @@ RUN pacman --noconfirm -Syu \
     lvm2 \
     make \
     mdadm \
+    mkinitcpio \
     mkosi \
     multipath-tools \
     nbd \


### PR DESCRIPTION
Print systemd units included in initrd from mkinitcpio but not from dracut.

## Checklist
- [ ] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it

Fixes #
