### PR TITLE
revert(dracut-systemd): include systemd-cryptsetup module when needed

### DIFF
--- a/modules.d/98dracut-systemd/module-setup.sh
+++ b/modules.d/98dracut-systemd/module-setup.sh
@@ -12,17 +12,7 @@ check() {
 
 # called by dracut
 depends() {
-    local deps
-    deps="systemd-initrd systemd-ask-password"
-
-    # when systemd and crypt are both included
-    # systemd-cryptsetup is mandatory dependency
-    # see https://github.com/dracut-ng/dracut-ng/issues/563
-    if dracut_module_included "crypt"; then
-        deps+=" systemd-cryptsetup"
-    fi
-
-    echo "$deps"
+    echo "systemd-initrd systemd-ask-password"
     return 0
 }
 


### PR DESCRIPTION
This reverts commit e0e5424a7b5e387ccb70e47ffea5a59716bf7b76.

Depending on systemd-cryptsetup causes the dracut-systemd module to be excluded from the initrd when users have cryptsetup installed but systemd has been built with cryptsetup disabled.

This makes life harder for users with a default dracut config.

Bug: https://bugs.gentoo.org/943035