### PR TITLE
feat(configure): allow dracut-cpio to be disabled

### DIFF
--- a/configure
+++ b/configure
@@ -61,6 +61,7 @@ while (($# > 0)); do
         --systemdsystemunitdir) read_arg systemdsystemunitdir "$@" || shift ;;
         --bashcompletiondir) read_arg bashcompletiondir "$@" || shift ;;
         --enable-dracut-cpio) enable_dracut_cpio=yes ;;
+        --disable-dracut-cpio) enable_dracut_cpio=no ;;
         *) echo "Ignoring unknown option '$1'" ;;
     esac
     shift


### PR DESCRIPTION
Just because cargo is installed, doesn't mean we want to use it.

## Checklist
- [x] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it