### PR TITLE
fix(dracut-systemd): check systemd-cryptsetup before including

### DIFF
--- a/modules.d/98dracut-systemd/module-setup.sh
+++ b/modules.d/98dracut-systemd/module-setup.sh
@@ -19,7 +19,10 @@ depends() {
     # systemd-cryptsetup is mandatory dependency
     # see https://github.com/dracut-ng/dracut-ng/issues/563
     if dracut_module_included "crypt"; then
-        deps+=" systemd-cryptsetup"
+        module_check systemd-cryptsetup > /dev/null 2>&1
+        if [[ $? == 255 ]]; then
+            deps+=" systemd-cryptsetup"
+        fi
     fi
 
     echo "$deps"


### PR DESCRIPTION
On Gentoo, depending on systemd-cryptsetup causes the dracut-systemd module to be excluded from the initrd when users have cryptsetup installed but systemd has been built with cryptsetup disabled.

This makes life harder for Gentoo users with a default dracut config.

Bug: https://bugs.gentoo.org/943035


## Checklist
- [ ] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it

Fixes #
