### PR TITLE
test: make the install dracut the default to run tests

### DIFF
--- a/test/test-functions
+++ b/test/test-functions
@@ -26,7 +26,7 @@ export TESTDIR
 
 if [[ -z $basedir ]]; then basedir="$(realpath ../..)"; fi
 
-DRACUT=${DRACUT-${basedir}/dracut.sh}
+DRACUT=${DRACUT-dracut}
 PKGLIBDIR=${PKGLIBDIR-$basedir}
 
 TEST_KERNEL_CMDLINE+=" rd.retry=10 rd.timeout=30 rd.info rd.shell=0 panic=1 oops=panic softlockup_panic=1 systemd.crash_reboot console=ttyS0,115200n81 $DEBUGFAIL "

--- a/test/test-github.sh
+++ b/test/test-github.sh
@@ -7,8 +7,6 @@
 set -e
 if [ "$V" = "2" ]; then set -x; fi
 
-export DRACUT=dracut
-
 [[ -d ${0%/*} ]] && cd "${0%/*}"/../
 
 # disable building documentation by default

--- a/test/test.sh
+++ b/test/test.sh
@@ -19,7 +19,7 @@ fi
 # clear previous test run
 TARGETS='clean all install check' "$PODMAN" run --rm -it \
     --device=/dev/kvm \
-    -e V -e TESTS -e TEST_RUN_ID -e TARGETS -e DRACUT \
+    -e V -e TESTS -e TEST_RUN_ID -e TARGETS \
     -v "$PWD"/:/z \
     "ghcr.io/dracut-ng/$CONTAINER" \
     /z/test/test-github.sh


### PR DESCRIPTION
After the --local flag is removed, using the local copy of dracut.sh for running tests is no longer possible, so change the default.

Related: https://github.com/dracut-ng/dracut-ng/pull/910

## Checklist
- [ ] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it

Fixes #
