### PR TITLE
fix: add bash dependency when bash scripts are used in the module

### DIFF
--- a/modules.d/01systemd-networkd/module-setup.sh
+++ b/modules.d/01systemd-networkd/module-setup.sh
@@ -22,7 +22,7 @@ check() {
 depends() {
 
     # This module has external dependency on other module(s).
-    echo net-lib kernel-network-modules systemd-sysusers systemd
+    echo net-lib kernel-network-modules systemd-sysusers systemd bash
     # Return 0 to include the dependent module(s) in the initramfs.
     return 0
 

--- a/modules.d/45plymouth/module-setup.sh
+++ b/modules.d/45plymouth/module-setup.sh
@@ -24,7 +24,7 @@ check() {
 
 # called by dracut
 depends() {
-    echo drm
+    echo drm bash
 }
 
 # called by dracut

--- a/modules.d/91zipl/module-setup.sh
+++ b/modules.d/91zipl/module-setup.sh
@@ -19,6 +19,11 @@ check() {
 }
 
 # called by dracut
+depends() {
+    echo bash
+}
+
+# called by dracut
 installkernel() {
     local _boot_zipl
 


### PR DESCRIPTION
The following dracut modules are impacted:
 - systemd-networkd
 - plymouth
 - zipl

## Checklist
- [ ] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it

Fixes #
