### PR TITLE
feat(dmsquash-live): add support for rd.live.overlay.nouserconfirmprompt

### DIFF
--- a/man/dracut.cmdline.7.adoc
+++ b/man/dracut.cmdline.7.adoc
@@ -1272,6 +1272,11 @@ of the base root filesystem and the persistent overlay, or
 root filesystem, and `/run/overlayfs` becomes the temporary, writable, upper
 directory overlay, to complete the bootable root filesystem.
 
+**rd.live.overlay.nouserconfirmprompt=**::
+Suppresses the 'Using temporary overlay' blocking prompt that asks for a
+user confirmation before proceeding to boot. This allows the boot process
+to continue to completion without user interation.
+
 **rd.live.overlay.reset=**1::
 Specifies that a persistent overlay should be reset on boot.  All previous root
 filesystem changes are vacated by this action.

--- a/modules.d/90dmsquash-live/dmsquash-live-root.sh
+++ b/modules.d/90dmsquash-live/dmsquash-live-root.sh
@@ -26,6 +26,7 @@ squash_image=$(getarg rd.live.squashimg)
 getargbool 0 rd.live.ram && live_ram="yes"
 getargbool 0 rd.live.overlay.reset && reset_overlay="yes"
 getargbool 0 rd.live.overlay.readonly && readonly_overlay="--readonly" || readonly_overlay=""
+getargbool 0 rd.live.overlay.nouserconfirmprompt && overlay_no_user_confirm_prompt="--noprompt" || overlay_no_user_confirm_prompt=""
 overlay=$(getarg rd.live.overlay)
 getargbool 0 rd.writable.fsimg && writable_fsimg="yes"
 overlay_size=$(getarg rd.live.overlay.size=)
@@ -219,7 +220,7 @@ do_live_overlay() {
     fi
 
     if [ -z "$setup" ] || [ -n "$readonly_overlay" ]; then
-        if [ -n "$setup" ]; then
+        if [ -n "$setup" ] || [ -n "$overlay_no_user_confirm_prompt" ]; then
             warn "Using temporary overlay."
         elif [ -n "$devspec" ] && [ -n "$pathspec" ]; then
             [ -z "$m" ] \


### PR DESCRIPTION
From: @gmileka

Dracut allows the creation of a LiveOS using a read-only squashfs and a read-write overlay on top.

If the read-write overlay is backed by a ramdisk, Dracut halts and prompts the user to confirm whether to continue or not.

This interaction during the boot process is not desired in all cases.

This change introduces a new flag (rd.live.overlay.nouserconfirmprompt) that when defined, it suppresses the prompt and allows the boot process to continue to completion without user interation.

There is no impact to existing configurations and their associated behavior. The new behavior only takes effect only when the new switch is explicitly defined by the image build as a kernel parameter.
