### PR TITLE
test(BTRFSRAID): make the test more reliable

### DIFF
--- a/test/TEST-24-BTRFSRAID/test.sh
+++ b/test/TEST-24-BTRFSRAID/test.sh
@@ -23,7 +23,7 @@ test_run() {
     test_marker_reset
     "$testdir"/run-qemu \
         "${disk_args[@]}" \
-        -append "$TEST_KERNEL_CMDLINE root=LABEL=root" \
+        -append "$TEST_KERNEL_CMDLINE root=LABEL=root ro" \
         -initrd "$TESTDIR"/initramfs.testing
     test_marker_check || return 1
 }
@@ -41,8 +41,7 @@ test_setup() {
     # devices, volume groups, encrypted partitions, etc.
     "$DRACUT" -N -i "$TESTDIR"/overlay / \
         --add-confdir test-makeroot \
-        -a "bash btrfs" \
-        -d "piix ide-gd_mod ata_piix btrfs sd_mod" \
+        -d "btrfs piix ide-gd_mod ata_piix btrfs sd_mod" \
         -I "mkfs.btrfs" \
         -i ./create-root.sh /lib/dracut/hooks/initqueue/01-create-root.sh \
         -f "$TESTDIR"/initramfs.makeroot "$KVERSION" || return 1
@@ -64,7 +63,7 @@ test_setup() {
 
     test_marker_check dracut-root-block-created || return 1
 
-    test_dracut \
+    test_dracut --nofscks \
         -d "btrfs" \
         "$TESTDIR"/initramfs.testing
 }


### PR DESCRIPTION
Currently the tests sometimes fials with the following error message

```
Dependency failed for systemd-fsck…m Check on /dev/disk/by-label/root.
```

## Checklist
- [ ] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it

Fixes #
