### PR TITLE
fix(memstrack): change memstrack way of report

### DIFF
--- a/modules.d/99memstrack/memstrack-report.sh
+++ b/modules.d/99memstrack/memstrack-report.sh
@@ -14,4 +14,10 @@ else
     done
 fi
 
-cat /.memstrack
+if ! [ -e /proc/vmcore ]; then
+    if [ -e /.memstrack ]; then
+        IFS= vwarn < /.memstrack
+    else
+        warn 'No memstrack log generated!'
+    fi
+fi


### PR DESCRIPTION
If memstrack works in 1st kernel, we will use vwarn instead of cat to output the content of /.memstrack, because it is a wrapper of stderr, and more stable to have outputs in console.

If memstrack works in 2nd kernel, aka in kdump case, we will not print /.memstrack here, the output will be handled in kexec-tools side [1]. The reason is, for example in fedora, after vmcore dumping, kdump will use 'reboot -f' by default, which leaves no stable target to print /.memstrack. So the output is better handled in kexec-tools side.

[1]: https://lists.fedoraproject.org/archives/list/kexec@lists.fedoraproject.org/thread/ZOK7DY2VSYGVA3P2RTXJAFDWY72TPDCW/

From https://github.com/dracutdevs/dracut/pull/2322

CC @liutgnu

## Checklist
- [ ] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it

Fixes #
