### PR TITLE
ci: switch from musl:openrc to glibc:openrc

### DIFF
--- a/.github/workflows/container-extra.yml
+++ b/.github/workflows/container-extra.yml
@@ -37,7 +37,7 @@ jobs:
                     - { dockerfile: 'Dockerfile-ubuntu', tag: 'ubuntu:rolling', platform: 'linux/amd64' }
                     - { dockerfile: 'Dockerfile-alpine', tag: 'alpine:edge',    platform: 'linux/amd64' }
                     - { dockerfile: 'Dockerfile-gentoo', tag: 'gentoo:latest',  platform: 'linux/amd64', option: 'systemd' }
-                    - { dockerfile: 'Dockerfile-gentoo', tag: 'gentoo:musl',    platform: 'linux/amd64', option: 'musl' }
+                    - { dockerfile: 'Dockerfile-gentoo', tag: 'gentoo:amd64-openrc', platform: 'linux/amd64', option: 'amd64-openrc' }
                     - { dockerfile: 'Dockerfile-fedora', tag: 'fedora:rawhide', platform: 'linux/amd64', registry: 'registry.fedoraproject.org' }
                     - { dockerfile: 'Dockerfile-fedora', tag: 'centos:stream10-development', platform: 'linux/amd64', registry: 'quay.io/centos' }
         steps:

--- a/.github/workflows/integration-extra.yml
+++ b/.github/workflows/integration-extra.yml
@@ -33,7 +33,7 @@ jobs:
                         "fedora:rawhide",
                         "centos:stream10-development",
                         "gentoo",
-                        "gentoo:musl"
+                        "gentoo:amd64-openrc",
                         "opensuse",
                         "ubuntu",
                         "ubuntu:rolling",


### PR DESCRIPTION
The goal is to test some common non-systemd configuration.
glibc:openrc is probably a better option for this goal, and
GitHub Action (node) fails to run tests on the Gentoo based musl container.

CC @Nowa-Ammerlaan 


## Checklist
- [ ] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it

Fixes #
