### PR TITLE
test(FULL-SYSTEMD): skip test on debian:stable for now

### DIFF
--- a/test/TEST-41-FULL-SYSTEMD/test.sh
+++ b/test/TEST-41-FULL-SYSTEMD/test.sh
@@ -9,6 +9,12 @@ test_check() {
         return 1
     fi
 
+    # TODO this check can be removed after CI switched to debian:13
+    if ! [ -f /usr/lib/systemd/systemd-battery-check ]; then
+        echo "Test needs systemd-battery-check.. Skipping"
+        return 1
+    fi
+
     command -v systemctl &> /dev/null
 }
 
@@ -132,6 +138,7 @@ EOF
 
     grep -F -a -m 1 ID_FS_UUID "$TESTDIR"/marker.img > "$TESTDIR"/luks.uuid
 
+    # TODO switch back to -a from -m after https://github.com/dracut-ng/dracut-ng/issues/685 is fixed, otherwise this test fails on Ubuntu
     test_dracut \
         -m "resume dracut-systemd systemd-ac-power systemd-battery-check systemd-bsod systemd-coredump systemd-creds systemd-cryptsetup systemd-integritysetup systemd-ldconfig systemd-pcrphase systemd-pstore systemd-repart systemd-sysext systemd-veritysetup" \
         --add-drivers "btrfs" \


### PR DESCRIPTION
This should make the Daily Integration test to finally fully green.

## Checklist
- [ ] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it

Fixes #
