### PR TITLE
fix(dracut-init): add compatibility with Debian/Ubuntu for libdirs detection

### DIFF
--- a/dracut-init.sh
+++ b/dracut-init.sh
@@ -91,7 +91,10 @@ if ! [[ $libdirs ]]; then
         && [[ -d $dracutsysrootdir/lib64 ]]; then
         libdirs+=" /lib64"
         [[ -d $dracutsysrootdir/usr/lib64 ]] && libdirs+=" /usr/lib64"
-    else
+
+    fi
+
+    if [[ -d $dracutsysrootdir/lib ]]; then
         libdirs+=" /lib"
         [[ -d $dracutsysrootdir/usr/lib ]] && libdirs+=" /usr/lib"
     fi

--- a/test/TEST-41-FULL-SYSTEMD/test.sh
+++ b/test/TEST-41-FULL-SYSTEMD/test.sh
@@ -138,9 +138,8 @@ EOF
 
     grep -F -a -m 1 ID_FS_UUID "$TESTDIR"/marker.img > "$TESTDIR"/luks.uuid
 
-    # TODO switch back to -a from -m after https://github.com/dracut-ng/dracut-ng/issues/685 is fixed, otherwise this test fails on Ubuntu
     test_dracut \
-        -m "resume dracut-systemd systemd-ac-power systemd-battery-check systemd-bsod systemd-coredump systemd-creds systemd-cryptsetup systemd-integritysetup systemd-ldconfig systemd-pcrphase systemd-pstore systemd-repart systemd-sysext systemd-veritysetup" \
+        -a "resume dracut-systemd systemd-ac-power systemd-battery-check systemd-bsod systemd-coredump systemd-creds systemd-cryptsetup systemd-integritysetup systemd-ldconfig systemd-pcrphase systemd-pstore systemd-repart systemd-sysext systemd-veritysetup" \
         --add-drivers "btrfs" \
         "$TESTDIR"/initramfs.testing
 


### PR DESCRIPTION
Make sure if /lib/ is included in libdirs when needed.                                                                                                                                                                                
                                                                                                                                                                                                                                      
This change is required for multipath dracut module to work properly on Debian/Ubuntu based distributions.    

libdir before this PR
- Ubuntu 
`/lib64 /usr/lib64 /lib/x86_64-linux-gnu`

- Fedora
`/lib64 /usr/lib64 /usr/lib64/iscsi`

- openSUSE
`/lib64 /usr/lib64`

libdir after this PR
- Ubuntu
`/lib64 /usr/lib64 /lib /usr/lib /lib/x86_64-linux-gnu`

- Fedora
`/lib64 /usr/lib64 /lib /usr/lib /usr/lib64/iscsi`

- openSUSE
`/lib64 /usr/lib64 /lib /usr/lib`

## Checklist
- [ ] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it

Fixes #685

CC @bdrung @mwilck @zeha