### PR TITLE
test: decrease default VM memory size to 1 GiB

### DIFF
--- a/test/run-qemu
+++ b/test/run-qemu
@@ -36,7 +36,7 @@ case "$ARCH" in
 esac
 
 # Provide rng device sourcing the hosts /dev/urandom and other standard parameters
-ARGS+=(-smp 2 -m 2048 -nodefaults -vga none -display none -no-reboot -watchdog-action poweroff -device virtio-rng-pci)
+ARGS+=(-smp 2 -m "${MEMORY-1024}" -nodefaults -vga none -display none -no-reboot -watchdog-action poweroff -device virtio-rng-pci)
 
 if ! [[ $* == *-daemonize* ]] && ! [[ $* == *-daemonize* ]]; then
     ARGS+=(-serial stdio)


### PR DESCRIPTION
## Changes

Commit a0442b777820("test: increase VM memory size to pass test 40 on more VMs") increased the VM memory from 1 to 2 GiB for TEST-72-NBD, because the test ran out of memory on Arch and openSUSE.

Running the tests on armhf fails with:

```
qemu-system-armhf: at most 2047 MB RAM can be simulated
```

Decrease the default memory back to 1 GiB. Dracut should work on systems and VMs with not much memory.

## Checklist
- [ ] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it

Fixes #
