### PR TITLE
fix(dracut-install): revert add fw_devlink suppliers as module dependencies

### DIFF
--- a/src/install/dracut-install.c
+++ b/src/install/dracut-install.c
@@ -1616,7 +1616,7 @@ static int install_dependent_module(struct kmod_module *mod, int *err)
                 if (*err == 0) {
                         *err = kmod_module_get_weakdeps(mod, &modweak);
                         if (*err == 0)
-                                *err = install_dependent_modules(ctx, modweak, NULL);
+                                *err = install_dependent_modules(modweak);
                 }
 #endif
         } else {
@@ -1710,7 +1710,7 @@ static int install_module(struct kmod_module *mod)
         if (ret == 0) {
                 ret = kmod_module_get_weakdeps(mod, &modweak);
                 if (ret == 0)
-                        ret = install_dependent_modules(ctx, modweak, NULL);
+                        ret = install_dependent_modules(modweak);
         }
 #endif
 


### PR DESCRIPTION
Original discussion - https://github.com/dracutdevs/dracut/pull/2075

see also https://github.com/dracut-ng/dracut-ng/issues/316 and #722

Void Linux reverted these changes downstream: see https://raw.githubusercontent.com/void-linux/void-packages/refs/heads/master/srcpkgs/dracut/patches/revert-fw_devlink.patch .

There is a history of performance and regression concern around this area of code. Note that many distributions (except of course Void) are shipping this change - including Fedora, Gentoo, Arch and Debian. 

It would be useful to have some kind of test scenario where the impact of this change could be better understood. The project should not have a fragmentation between distributions in a core area like this without understanding the benefit and having a test case if possible.

The CI now has some basic arm64 test infrastructure (not just amd64). 

This reverts commit 8de0258d71dc5600d715d7534471e35b2b75c7be. 
This reverts commit 07e2c4926780b672922563a6ea0bf1bd4bcfcd9f. 
This reverts commit d71bec4aa444d92820e428c0629d0e75e268c815. 
This reverts commit 6500e95494175819b382acbac8eafcdf72fabd6d. 
This reverts commit 131822e26d76a3ce2028e9a545be2af066805629. 
This reverts commit 3de4c7313260fb600507c9b87f780390b874c870.

## Changes

## Checklist
- [ ] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it

CC @classabbyamp @bdrung @alpernebbi 
