### PR TITLE
ci: increase GitHub Action timeout to 20 min

### DIFF
--- a/.github/workflows/integration-extra.yml
+++ b/.github/workflows/integration-extra.yml
@@ -16,7 +16,7 @@ jobs:
         # run this test on all containers
         name: ${{ matrix.test }} on ${{ matrix.container }}
         runs-on: ubuntu-latest
-        timeout-minutes: 10
+        timeout-minutes: 20
         concurrency:
             group: basic-${{ github.workflow }}-${{ github.ref }}-${{ matrix.container }}-${{ matrix.test }}
             cancel-in-progress: true

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -21,7 +21,7 @@ jobs:
         # run this test on all containers
         name: ${{ matrix.test }} on ${{ matrix.container }}
         runs-on: ubuntu-latest
-        timeout-minutes: 10
+        timeout-minutes: 20
         concurrency:
             group: basic-${{ github.workflow }}-${{ github.ref }}-${{ matrix.container }}-${{ matrix.test }}
             cancel-in-progress: true
@@ -67,7 +67,7 @@ jobs:
         needs: basic
         name: ${{ matrix.test }} on ${{ matrix.container }}
         runs-on: ubuntu-latest
-        timeout-minutes: 10
+        timeout-minutes: 20
         concurrency:
             group: extended-${{ github.workflow }}-${{ github.ref }}-${{ matrix.container }}-${{ matrix.test }}
             cancel-in-progress: true
@@ -109,7 +109,7 @@ jobs:
         needs: basic
         name: ${{ matrix.test }} on ${{ matrix.container }}
         runs-on: ubuntu-latest
-        timeout-minutes: 10
+        timeout-minutes: 20
         concurrency:
             group: extended-systemd-${{ github.workflow }}-${{ github.ref }}-${{ matrix.container }}-${{ matrix.test }}
             cancel-in-progress: true
@@ -140,7 +140,7 @@ jobs:
         needs: basic
         name: ${{ matrix.test }} on ${{ matrix.container }}
         runs-on: ubuntu-latest
-        timeout-minutes: 10
+        timeout-minutes: 20
         concurrency:
             group: dracut-cpio-${{ github.workflow }}-${{ github.ref }}-${{ matrix.container }}-${{ matrix.test }}
             cancel-in-progress: true
@@ -165,7 +165,7 @@ jobs:
         needs: basic
         name: ${{ matrix.test }} on ${{ matrix.container }} on arm64
         runs-on: ubuntu-latest
-        timeout-minutes: 10
+        timeout-minutes: 20
         concurrency:
             group: arm64-${{ github.workflow }}-${{ github.ref }}-${{ matrix.container }}-${{ matrix.test }}
             cancel-in-progress: true
@@ -193,7 +193,7 @@ jobs:
         # all nfs based on default networking
         name: ${{ matrix.test }} on ${{ matrix.container }}
         runs-on: ubuntu-latest
-        timeout-minutes: 10
+        timeout-minutes: 20
         concurrency:
             group: network-${{ github.workflow }}-${{ github.ref }}-${{ matrix.container }}-${{ matrix.test }}-${{ matrix.network }}
             cancel-in-progress: true
@@ -232,7 +232,7 @@ jobs:
 #    network-advanced:
 #        name: ${{ matrix.test }} on ${{ matrix.container }}
 #        runs-on: ubuntu-latest
-#        timeout-minutes: 10
+#        timeout-minutes: 20
 #        concurrency:
 #            group: network-iscsi-${{ github.workflow }}-${{ github.ref }}-${{ matrix.container }}-${{ matrix.test }}-${{ matrix.network }}
 #            cancel-in-progress: true

--- a/.github/workflows/manualtest.yml
+++ b/.github/workflows/manualtest.yml
@@ -58,7 +58,7 @@ jobs:
     test:
         needs: matrix
         runs-on: ubuntu-latest
-        timeout-minutes: 10
+        timeout-minutes: 20
         concurrency:
             group: ${{ github.workflow }}-${{ github.ref }}-${{ matrix.container }}-${{ matrix.test }}
             cancel-in-progress: true


### PR DESCRIPTION
Sadly, the timeout includes not only the time it takes to run the test, but also the time it takes to allocate a machine on GitHub to run the job, which is unpredicatable.

Increase the timeout to account for this new information.

## Checklist
- [ ] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it

Fixes #
