### PR TITLE
test(BASIC): enable testing in fips mode

### DIFF
--- a/test/TEST-10-BASIC/test.sh
+++ b/test/TEST-10-BASIC/test.sh
@@ -15,6 +15,8 @@ test_run() {
         TEST_KERNEL_CMDLINE+=" root=ZFS=dracut/root "
     else
         TEST_KERNEL_CMDLINE+=" root=LABEL=dracut "
+        # test fips mode
+        [ -f /usr/share/crypto-policies/default-fips-config ] && TEST_KERNEL_CMDLINE+=" fips=1 rd.fips.skipkernel boot=LABEL=dracut "
     fi
 
     test_marker_reset


### PR DESCRIPTION
This test will enable fips mode on Fedora CI.


## Checklist
- [ ] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it

Fixes #
