### PR TITLE
fix(fips-crypto-policies): improve check for module inclusion

### DIFF
--- a/modules.d/01fips-crypto-policies/module-setup.sh
+++ b/modules.d/01fips-crypto-policies/module-setup.sh
@@ -3,7 +3,7 @@
 # called by dracut
 check() {
     # only enable on systems that use crypto-policies
-    [ -d "$dracutsysrootdir/etc/crypto-policies" ] && return 0
+    [ -f "$dracutsysrootdir/usr/share/crypto-policies/default-fips-config" ] && return 0
 
     # include when something else depends on it or it is explicitly requested
     return 255


### PR DESCRIPTION
Checking files under /etc in non-hostonly (generic mode) is not recommended. Test files under /usr instead.

Based on the discussion at https://github.com/dracut-ng/dracut-ng/pull/959#discussion_r1842124799

CC @neverpanic 

## Checklist
- [ ] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it

Fixes #
