### PR TITLE
fix(dracut-functions.sh): check_kernel_module go one dir further up

### DIFF
--- a/dracut-functions.sh
+++ b/dracut-functions.sh
@@ -761,7 +761,7 @@ check_kernel_config() {
 # 0 if the kernel module is either built-in or available
 # 1 if the kernel module is not enabled
 check_kernel_module() {
-    modprobe -d "$drivers_dir/../../" -S "$kernel" --dry-run "$1" &> /dev/null || return 1
+    modprobe -d "$drivers_dir/../../../" -S "$kernel" --dry-run "$1" &> /dev/null || return 1
 }
 
 # get_cpu_vendor


### PR DESCRIPTION
Since `$drivers_dir` contains the `$kernel` as well we have to go up one level more.

This pull request changes...

## Changes

## Checklist
- [ ] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it

Fixes #
