### PR TITLE
test: replace qemu nic model e1000 by virtio

### DIFF
--- a/test/TEST-60-NFS/test.sh
+++ b/test/TEST-60-NFS/test.sh
@@ -28,7 +28,7 @@ run_server() {
     "$testdir"/run-qemu \
         "${disk_args[@]}" \
         -net socket,listen=127.0.0.1:12320 \
-        -net nic,macaddr=52:54:00:12:34:56,model=e1000 \
+        -net nic,macaddr=52:54:00:12:34:56,model=virtio \
         -serial "${SERIAL:-"file:$TESTDIR/server.log"}" \
         -append "panic=1 oops=panic softlockup_panic=1 root=LABEL=dracut rootfstype=ext4 rw console=ttyS0,115200n81 $SERVER_DEBUG" \
         -initrd "$TESTDIR"/initramfs.server \
@@ -69,7 +69,7 @@ client_test() {
 
     "$testdir"/run-qemu \
         "${disk_args[@]}" \
-        -net nic,macaddr="$mac",model=e1000 \
+        -net nic,macaddr="$mac",model=virtio \
         -net socket,connect=127.0.0.1:12320 \
         -append "$TEST_KERNEL_CMDLINE $cmdline ro" \
         -initrd "$TESTDIR"/initramfs.testing
@@ -422,7 +422,7 @@ test_setup() {
     # Make server's dracut image
     "$DRACUT" -i "$TESTDIR"/overlay / \
         -a "bash rootfs-block debug kernel-modules watchdog qemu network-legacy" \
-        -d "af_packet piix ide-gd_mod ata_piix ext4 sd_mod e1000 i6300esb" \
+        -d "af_packet piix ide-gd_mod ata_piix ext4 sd_mod i6300esb virtio_net" \
         --no-hostonly-cmdline -N \
         -f "$TESTDIR"/initramfs.server "$KVERSION" || return 1
 }

--- a/test/TEST-61-MULTINIC/test.sh
+++ b/test/TEST-61-MULTINIC/test.sh
@@ -29,7 +29,7 @@ run_server() {
     "$testdir"/run-qemu \
         "${disk_args[@]}" \
         -net socket,listen=127.0.0.1:12350 \
-        -net nic,macaddr=52:54:01:12:34:56,model=e1000 \
+        -net nic,macaddr=52:54:01:12:34:56,model=virtio \
         -serial "${SERIAL:-"file:$TESTDIR/server.log"}" \
         -append "panic=1 oops=panic softlockup_panic=1 systemd.crash_reboot root=LABEL=dracut rootfstype=ext4 rw console=ttyS0,115200n81" \
         -initrd "$TESTDIR"/initramfs.server \
@@ -74,13 +74,13 @@ client_test() {
     "$testdir"/run-qemu \
         "${disk_args[@]}" \
         -net socket,connect=127.0.0.1:12350 \
-        -net nic,macaddr=52:54:00:12:34:"$mac1",model=e1000 \
-        -net nic,macaddr=52:54:00:12:34:"$mac2",model=e1000 \
-        -net nic,macaddr=52:54:00:12:34:"$mac3",model=e1000 \
+        -net nic,macaddr=52:54:00:12:34:"$mac1",model=virtio \
+        -net nic,macaddr=52:54:00:12:34:"$mac2",model=virtio \
+        -net nic,macaddr=52:54:00:12:34:"$mac3",model=virtio \
         -netdev hubport,id=n1,hubid=1 \
         -netdev hubport,id=n2,hubid=2 \
-        -device e1000,netdev=n1,mac=52:54:00:12:34:98 \
-        -device e1000,netdev=n2,mac=52:54:00:12:34:99 \
+        -device virtio,netdev=n1,mac=52:54:00:12:34:98 \
+        -device virtio,netdev=n2,mac=52:54:00:12:34:99 \
         -append "$TEST_KERNEL_CMDLINE $cmdline ro init=/sbin/init systemd.log_target=console" \
         -initrd "$TESTDIR"/initramfs.testing || return 1
 
@@ -354,7 +354,7 @@ test_setup() {
     # Make server's dracut image
     "$DRACUT" -i "$TESTDIR"/overlay / \
         -m "bash rootfs-block debug kernel-modules watchdog qemu network-legacy" \
-        -d "af_packet piix ide-gd_mod ata_piix ext4 sd_mod nfsv2 nfsv3 nfsv4 nfs_acl nfs_layout_nfsv41_files nfsd e1000 i6300esb" \
+        -d "af_packet piix ide-gd_mod ata_piix ext4 sd_mod nfsv2 nfsv3 nfsv4 nfs_acl nfs_layout_nfsv41_files nfsd i6300esb virtio_net" \
         --no-hostonly-cmdline -N \
         -f "$TESTDIR"/initramfs.server "$KVERSION" || return 1
 

--- a/test/TEST-70-ISCSI/test.sh
+++ b/test/TEST-70-ISCSI/test.sh
@@ -21,8 +21,8 @@ run_server() {
     "$testdir"/run-qemu \
         "${disk_args[@]}" \
         -serial "${SERIAL:-"file:$TESTDIR/server.log"}" \
-        -net nic,macaddr=52:54:00:12:34:56,model=e1000 \
-        -net nic,macaddr=52:54:00:12:34:57,model=e1000 \
+        -net nic,macaddr=52:54:00:12:34:56,model=virtio \
+        -net nic,macaddr=52:54:00:12:34:57,model=virtio \
         -net socket,listen=127.0.0.1:12330 \
         -append "panic=1 oops=panic softlockup_panic=1 quiet root=/dev/disk/by-id/scsi-0QEMU_QEMU_HARDDISK_serverroot rw console=ttyS0,115200n81 $SERVER_DEBUG" \
         -initrd "$TESTDIR"/initramfs.server \
@@ -58,8 +58,8 @@ run_client() {
     test_marker_reset
     "$testdir"/run-qemu \
         "${disk_args[@]}" \
-        -net nic,macaddr=52:54:00:12:34:00,model=e1000 \
-        -net nic,macaddr=52:54:00:12:34:01,model=e1000 \
+        -net nic,macaddr=52:54:00:12:34:00,model=virtio \
+        -net nic,macaddr=52:54:00:12:34:01,model=virtio \
         -net socket,connect=127.0.0.1:12330 \
         -acpitable file=ibft.table \
         -append "$TEST_KERNEL_CMDLINE $*" \
@@ -215,7 +215,7 @@ test_setup() {
     # Make server's dracut image
     "$DRACUT" \
         -a "rootfs-block test kernel-modules network-legacy" \
-        -d "piix ide-gd_mod ata_piix ext4 sd_mod e1000 drbg virtio_pci virtio_scsi" \
+        -d "piix ide-gd_mod ata_piix ext4 sd_mod drbg virtio_net virtio_pci virtio_scsi" \
         -i "./server.link" "/etc/systemd/network/01-server.link" \
         -i ./wait-if-server.sh /lib/dracut/hooks/pre-mount/99-wait-if-server.sh \
         --no-hostonly-cmdline -N \

--- a/test/TEST-71-ISCSI-MULTI/test.sh
+++ b/test/TEST-71-ISCSI-MULTI/test.sh
@@ -21,8 +21,8 @@ run_server() {
     "$testdir"/run-qemu \
         "${disk_args[@]}" \
         -serial "${SERIAL:-"file:$TESTDIR/server.log"}" \
-        -net nic,macaddr=52:54:00:12:34:56,model=e1000 \
-        -net nic,macaddr=52:54:00:12:34:57,model=e1000 \
+        -net nic,macaddr=52:54:00:12:34:56,model=virtio \
+        -net nic,macaddr=52:54:00:12:34:57,model=virtio \
         -net socket,listen=127.0.0.1:12331 \
         -append "panic=1 oops=panic softlockup_panic=1 systemd.crash_reboot root=/dev/disk/by-id/scsi-0QEMU_QEMU_HARDDISK_serverroot rootfstype=ext4 rw console=ttyS0,115200n81 $SERVER_DEBUG" \
         -initrd "$TESTDIR"/initramfs.server \
@@ -57,8 +57,8 @@ run_client() {
     test_marker_reset
     "$testdir"/run-qemu \
         "${disk_args[@]}" \
-        -net nic,macaddr=52:54:00:12:34:00,model=e1000 \
-        -net nic,macaddr=52:54:00:12:34:01,model=e1000 \
+        -net nic,macaddr=52:54:00:12:34:00,model=virtio \
+        -net nic,macaddr=52:54:00:12:34:01,model=virtio \
         -net socket,connect=127.0.0.1:12331 \
         -append "$TEST_KERNEL_CMDLINE rw rd.auto $*" \
         -initrd "$TESTDIR"/initramfs.testing
@@ -237,7 +237,7 @@ test_setup() {
     # Make server's dracut image
     "$DRACUT" -i "$TESTDIR"/overlay / \
         -a "test rootfs-block debug kernel-modules network-legacy" \
-        -d "af_packet piix ide-gd_mod ata_piix ext4 sd_mod e1000 drbg" \
+        -d "af_packet piix ide-gd_mod ata_piix ext4 sd_mod drbg virtio_net" \
         -i "./server.link" "/etc/systemd/network/01-server.link" \
         -i "./wait-if-server.sh" "/lib/dracut/hooks/pre-mount/99-wait-if-server.sh" \
         --no-hostonly-cmdline -N \

--- a/test/TEST-72-NBD/test.sh
+++ b/test/TEST-72-NBD/test.sh
@@ -40,7 +40,7 @@ run_server() {
     "$testdir"/run-qemu \
         "${disk_args[@]}" \
         -serial "${SERIAL:-"file:$TESTDIR/server.log"}" \
-        -net nic,macaddr=52:54:00:12:34:56,model=e1000 \
+        -net nic,macaddr=52:54:00:12:34:56,model=virtio \
         -net socket,listen=127.0.0.1:12340 \
         -append "panic=1 oops=panic softlockup_panic=1 rd.luks=0 systemd.crash_reboot quiet root=/dev/disk/by-id/scsi-0QEMU_QEMU_HARDDISK_serverroot rootfstype=ext4 rw console=ttyS0,115200n81 $SERVER_DEBUG" \
         -initrd "$TESTDIR"/initramfs.server \
@@ -83,7 +83,7 @@ client_test() {
     test_marker_reset
     "$testdir"/run-qemu \
         "${disk_args[@]}" \
-        -net nic,macaddr="$mac",model=e1000 \
+        -net nic,macaddr="$mac",model=virtio \
         -net socket,connect=127.0.0.1:12340 \
         -append "$cmdline rd.auto ro console=ttyS0,115200n81" \
         -initrd "$TESTDIR"/initramfs.testing
@@ -344,7 +344,7 @@ test_setup() {
 
     "$DRACUT" -N -i "$TESTDIR"/overlay / \
         -a "test rootfs-block debug kernel-modules network-legacy" \
-        -d "af_packet piix ide-gd_mod ata_piix ext4 sd_mod e1000 drbg" \
+        -d "af_packet piix ide-gd_mod ata_piix ext4 sd_mod drbg virtio_net" \
         -i "./server.link" "/etc/systemd/network/01-server.link" \
         -i "./wait-if-server.sh" "/lib/dracut/hooks/pre-mount/99-wait-if-server.sh" \
         -f "$TESTDIR"/initramfs.server "$KVERSION" || return 1


### PR DESCRIPTION
## Changes

TEST-72-NBD fails on s390x with:

```
qemu-system-s390x: warning: hub port hub0port0 has no peer
qemu-system-s390x: warning: hub 0 with no nics
qemu-system-s390x: warning: netdev hub0port0 has no peer
qemu-system-s390x: warning: requested NIC (#net046, model e1000) was not created (not supported by this machine?)
```

The test uses the e1000 model, but s390x does not have it:

```
$ qemu-system-s390x -nic model=help
Available NIC models:
virtio
```

So replace the e1000 model by virtio, which is supported by most architectures.

## Checklist
- [ ] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it

Fixes #953
