### PR TITLE
test(RAID-DEG): workaround of omitting network is no longer needed

### DIFF
--- a/test/TEST-22-RAID-DEG/test.sh
+++ b/test/TEST-22-RAID-DEG/test.sh
@@ -101,7 +101,6 @@ test_setup() {
 
     test_dracut \
         -a "crypt lvm mdraid kernel-modules" \
-        -o network \
         -i "./cryptroot-ask.sh" "/sbin/cryptroot-ask" \
         -i "/tmp/mdadm.conf" "/etc/mdadm.conf" \
         -i "/tmp/crypttab" "/etc/crypttab" \


### PR DESCRIPTION
Likely https://github.com/dracut-ng/dracut-ng/pull/950 allows us to remove this workaround as well. 

## Checklist
- [ ] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it

Fixes #
