### PR TITLE
test(FULL-SYSTEMD): introduce optional_modules variable

### DIFF
--- a/test/TEST-41-FULL-SYSTEMD/test.sh
+++ b/test/TEST-41-FULL-SYSTEMD/test.sh
@@ -132,11 +132,15 @@ EOF
 
     grep -F -a -m 1 ID_FS_UUID "$TESTDIR"/marker.img > "$TESTDIR"/luks.uuid
 
-    # shellcheck disable=SC2046
+    local optional_modules
+    if [ -f /usr/lib/systemd/systemd-battery-check ]; then
+        optional_modules="$optional_modules systemd-battery-check"
+    fi
+    if [ -f /usr/lib/systemd/systemd-bsod ]; then
+        optional_modules="$optional_modules systemd-bsod"
+    fi
     test_dracut \
-        -a "resume dracut-systemd systemd-ac-power systemd-coredump systemd-creds systemd-cryptsetup systemd-integritysetup systemd-ldconfig systemd-pcrphase systemd-pstore systemd-repart systemd-sysext systemd-veritysetup" \
-        $(if [ -f /usr/lib/systemd/systemd-battery-check ]; then echo "-a systemd-battery-check"; fi) \
-        $(if [ -f /usr/lib/systemd/systemd-bsod ]; then echo "-a systemd-bsod"; fi) \
+        -a "resume dracut-systemd systemd-ac-power systemd-coredump systemd-creds systemd-cryptsetup systemd-integritysetup systemd-ldconfig systemd-pcrphase systemd-pstore systemd-repart systemd-sysext systemd-veritysetup $optional_modules" \
         --add-drivers "btrfs" \
         "$TESTDIR"/initramfs.testing
 


### PR DESCRIPTION
## Changes

Unfold the test_dracut call by constructing a optional_modules variable. This makes the code longer, but easier to read.
@jozzsi What do you think about that change?

## Checklist
- [ ] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it