### PR TITLE
ci(fedora): add ignition

### DIFF
--- a/test/container/Dockerfile-fedora
+++ b/test/container/Dockerfile-fedora
@@ -11,6 +11,7 @@
 # - libkcapi-hmaccalc (fido)
 # - nss-softokn, kdumpbase out of tree dracut modules
 # - fips
+# - ignition
 
 ARG DISTRIBUTION=fedora
 ARG REGISTRY=registry.fedoraproject.org
@@ -52,6 +53,7 @@ RUN dnf -y install --setopt=install_weak_deps=False \
     fcoe-utils \
     fuse3 \
     gcc \
+    ignition \
     iproute \
     iputils \
     iscsi-initiator-utils \


### PR DESCRIPTION
Ignition is a utility used to manipulate systems during the initramfs. This includes partitioning disks, formatting partitions, writing files (regular files, systemd units, etc.), and configuring users. On first boot, Ignition reads its configuration from a source of truth (remote URL, network metadata service, hypervisor bridge, etc.) and applies the configuration.

This is an important out-of tree dracut module that the upstream project should not regress.

## Checklist
- [ ] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it

Fixes #
