### PR TITLE
feat: default config profile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -173,6 +173,9 @@ install: all
 	install -m 0755 dracut-initramfs-restore.sh $(DESTDIR)$(pkglibdir)/dracut-initramfs-restore
 	rm -rf $(DESTDIR)$(pkglibdir)/modules.d/80test*
 	cp -arx modules.d dracut.conf.d $(DESTDIR)$(pkglibdir)
+	for i in $(configprofile) ; do \
+		cp -arx dracut.conf.d/$$i/* $(DESTDIR)$(pkglibdir)/dracut.conf.d/ ;\
+	done
 ifneq ($(enable_test),no)
 	cp -arx test $(DESTDIR)$(pkglibdir)
 else

--- a/configure
+++ b/configure
@@ -62,6 +62,7 @@ while (($# > 0)); do
         --bashcompletiondir) read_arg bashcompletiondir "$@" || shift ;;
         --enable-dracut-cpio) enable_dracut_cpio=yes ;;
         --disable-dracut-cpio) enable_dracut_cpio=no ;;
+        --configprofile) read_arg configprofile "$@" || shift ;;
         *) echo "Ignoring unknown option '$1'" ;;
     esac
     shift
@@ -202,6 +203,7 @@ EOF
     [[ $infodir ]] && echo "infodir ?= ${infodir}"
     [[ $systemdsystemunitdir ]] && echo "systemdsystemunitdir ?= ${systemdsystemunitdir}"
     [[ $bashcompletiondir ]] && echo "bashcompletiondir ?= ${bashcompletiondir}"
+    [[ $configprofile ]] && echo "configprofile ?= ${configprofile}"
 } >> Makefile.inc.$$
 
 mv Makefile.inc.$$ Makefile.inc


### PR DESCRIPTION
## Changes

During packaging - at configure stage - allow setting the default dracut configuration from the predefined list of of "profiles".                                                                                                                                                                                                                
                                                                                                                                                                                                                                      
As an example Ubuntu packaging can call ` ./confgure --configprofile "generic" `

## Checklist
- [ ] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it
