### PR TITLE
test(FULL-SYSTEMD): make systemd-pcrphase module optional

### DIFF
--- a/test/TEST-41-FULL-SYSTEMD/test.sh
+++ b/test/TEST-41-FULL-SYSTEMD/test.sh
@@ -139,8 +139,11 @@ EOF
     if [ -f /usr/lib/systemd/systemd-bsod ]; then
         optional_modules="$optional_modules systemd-bsod"
     fi
+    if [ -f /usr/lib/systemd/systemd-pcrextend ]; then
+        optional_modules="$optional_modules systemd-pcrphase"
+    fi
     test_dracut \
-        -a "resume dracut-systemd systemd-ac-power systemd-coredump systemd-creds systemd-cryptsetup systemd-integritysetup systemd-ldconfig systemd-pcrphase systemd-pstore systemd-repart systemd-sysext systemd-veritysetup $optional_modules" \
+        -a "resume dracut-systemd systemd-ac-power systemd-coredump systemd-creds systemd-cryptsetup systemd-integritysetup systemd-ldconfig systemd-pstore systemd-repart systemd-sysext systemd-veritysetup $optional_modules" \
         --add-drivers "btrfs" \
         "$TESTDIR"/initramfs.testing
 


### PR DESCRIPTION
## Changes

TEST-04-FULL-SYSTEMD fails on s390x:

```
dracut[E]: Module 'systemd-pcrphase' cannot be installed.
```

systemd ships `systemd-pcrphase.service` only on amd64, arm64, armhf, riscv64 on Ubuntu and Debian. So make `systemd-pcrphase` an optional modules in the test.

## Checklist
- [ ] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it

Fixes #958
