### PR TITLE
test: include debug module in server only when debugging

### DIFF
--- a/test/TEST-60-NFS/test.sh
+++ b/test/TEST-60-NFS/test.sh
@@ -421,7 +421,7 @@ test_setup() {
     )
     # Make server's dracut image
     "$DRACUT" -i "$TESTDIR"/overlay / \
-        -a "bash rootfs-block debug kernel-modules watchdog qemu network-legacy" \
+        -a "bash rootfs-block kernel-modules watchdog qemu network-legacy ${SERVER_DEBUG:+debug}" \
         -d "af_packet piix ide-gd_mod ata_piix ext4 sd_mod i6300esb virtio_net" \
         --no-hostonly-cmdline -N \
         -f "$TESTDIR"/initramfs.server "$KVERSION" || return 1

--- a/test/TEST-61-MULTINIC/test.sh
+++ b/test/TEST-61-MULTINIC/test.sh
@@ -5,6 +5,7 @@ TEST_DESCRIPTION="root filesystem on NFS with multiple nics with $USE_NETWORK"
 
 # Uncomment this to debug failures
 #DEBUGFAIL="loglevel=7 rd.shell rd.break"
+#SERVER_DEBUG="rd.debug loglevel=7"
 #SERIAL="tcp:127.0.0.1:9999"
 
 # skip the test if ifcfg dracut module can not be installed
@@ -31,7 +32,7 @@ run_server() {
         -net socket,listen=127.0.0.1:12350 \
         -net nic,macaddr=52:54:01:12:34:56,model=virtio \
         -serial "${SERIAL:-"file:$TESTDIR/server.log"}" \
-        -append "panic=1 oops=panic softlockup_panic=1 systemd.crash_reboot root=LABEL=dracut rootfstype=ext4 rw console=ttyS0,115200n81" \
+        -append "panic=1 oops=panic softlockup_panic=1 systemd.crash_reboot root=LABEL=dracut rootfstype=ext4 rw console=ttyS0,115200n81 $SERVER_DEBUG" \
         -initrd "$TESTDIR"/initramfs.server \
         -pidfile "$TESTDIR"/server.pid -daemonize || return 1
 
@@ -353,7 +354,7 @@ test_setup() {
     )
     # Make server's dracut image
     "$DRACUT" -i "$TESTDIR"/overlay / \
-        -m "bash rootfs-block debug kernel-modules watchdog qemu network-legacy" \
+        -m "bash rootfs-block kernel-modules watchdog qemu network-legacy ${SERVER_DEBUG:+debug}" \
         -d "af_packet piix ide-gd_mod ata_piix ext4 sd_mod nfsv2 nfsv3 nfsv4 nfs_acl nfs_layout_nfsv41_files nfsd i6300esb virtio_net" \
         --no-hostonly-cmdline -N \
         -f "$TESTDIR"/initramfs.server "$KVERSION" || return 1

--- a/test/TEST-62-BONDBRIDGEVLAN/test.sh
+++ b/test/TEST-62-BONDBRIDGEVLAN/test.sh
@@ -7,6 +7,7 @@ TEST_DESCRIPTION="root filesystem on NFS with bridging/bonding/vlan with $USE_NE
 
 # Uncomment this to debug failures
 #DEBUGFAIL="rd.shell rd.break"
+#SERVER_DEBUG="rd.debug loglevel=7"
 #SERIAL="tcp:127.0.0.1:9999"
 
 # skip the test if ifcfg dracut module can not be installed
@@ -373,7 +374,7 @@ test_setup() {
     # Make client's dracut image
     test_dracut \
         --no-hostonly --no-hostonly-cmdline \
-        -a "debug ${USE_NETWORK} ifcfg" \
+        -a "${USE_NETWORK} ifcfg ${DEBUGFAIL:+debug}" \
         "$TESTDIR"/initramfs.testing
 
     (
@@ -388,7 +389,7 @@ test_setup() {
     # Make server's dracut image
     "$DRACUT" -i "$TESTDIR"/overlay / \
         --no-early-microcode \
-        -m "rootfs-block debug kernel-modules watchdog qemu network network-legacy" \
+        -m "rootfs-block kernel-modules watchdog qemu network network-legacy ${SERVER_DEBUG:+debug}" \
         -d "ipvlan macvlan af_packet piix ide-gd_mod ata_piix ext4 sd_mod nfsv2 nfsv3 nfsv4 nfs_acl nfs_layout_nfsv41_files nfsd virtio-net i6300esb" \
         --no-hostonly-cmdline -N \
         -f "$TESTDIR"/initramfs.server "$KVERSION" || return 1

--- a/test/TEST-71-ISCSI-MULTI/test.sh
+++ b/test/TEST-71-ISCSI-MULTI/test.sh
@@ -236,7 +236,7 @@ test_setup() {
 
     # Make server's dracut image
     "$DRACUT" -i "$TESTDIR"/overlay / \
-        -a "test rootfs-block debug kernel-modules network-legacy" \
+        -a "test rootfs-block kernel-modules network-legacy ${SERVER_DEBUG:+debug}" \
         -d "af_packet piix ide-gd_mod ata_piix ext4 sd_mod drbg virtio_net" \
         -i "./server.link" "/etc/systemd/network/01-server.link" \
         -i "./wait-if-server.sh" "/lib/dracut/hooks/pre-mount/99-wait-if-server.sh" \

--- a/test/TEST-72-NBD/test.sh
+++ b/test/TEST-72-NBD/test.sh
@@ -6,6 +6,7 @@ TEST_DESCRIPTION="root filesystem on NBD with $USE_NETWORK"
 # Uncomment this to debug failures
 # DEBUGFAIL="rd.debug systemd.log_target=console loglevel=7"
 #DEBUGFAIL="rd.shell rd.break rd.debug systemd.log_target=console loglevel=7 systemd.log_level=debug"
+#SERVER_DEBUG="rd.debug loglevel=7"
 #SERIAL="tcp:127.0.0.1:9999"
 
 test_check() {
@@ -343,7 +344,7 @@ test_setup() {
         "$TESTDIR"/initramfs.testing
 
     "$DRACUT" -N -i "$TESTDIR"/overlay / \
-        -a "test rootfs-block debug kernel-modules network-legacy" \
+        -a "test rootfs-block kernel-modules network-legacy ${SERVER_DEBUG:+debug}" \
         -d "af_packet piix ide-gd_mod ata_piix ext4 sd_mod drbg virtio_net" \
         -i "./server.link" "/etc/systemd/network/01-server.link" \
         -i "./wait-if-server.sh" "/lib/dracut/hooks/pre-mount/99-wait-if-server.sh" \


### PR DESCRIPTION
This pull request changes...

## Changes

Including the `debug` module in the server's dracut image is not needed for the normal test case run. Only include it when the user sets `SERVER_DEBUG` to debug the test case.

## Checklist
- [ ] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it
