### PR TITLE
fix(dracut-systemd): consult SYSTEMD_SULOGIN_FORCE before allowing passwordless logins

### DIFF
--- a/modules.d/98dracut-systemd/dracut-emergency.sh
+++ b/modules.d/98dracut-systemd/dracut-emergency.sh
@@ -32,7 +32,13 @@ if getargbool 1 rd.shell || getarg rd.break; then
     done < /proc/consoles
     [ -f /etc/profile ] && . /etc/profile
     [ -z "$PS1" ] && export PS1="$_name:\${PWD}# "
-    exec sulogin -e
+
+    if getargbool 0 SYSTEMD_SULOGIN_FORCE; then
+        # allows passwordless logins if root account is locked.
+        exec sulogin -e
+    else
+        exec sulogin
+    fi
 else
     export hook="shutdown-emergency"
     warn "$action has failed. To debug this issue add \"rd.shell rd.debug\" to the kernel command line."


### PR DESCRIPTION
Follow-up to https://github.com/dracutdevs/dracut/commit/32f68c1

This PR would make the default configuration of dracut more secure.

This functionality matches default systemd (and as such mkosi, mkinitcpio) - see https://github.com/systemd/systemd/blob/main/src/sulogin-shell/sulogin-shell.c

## Checklist
- [ ] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it

Fixes #979
