### PR TITLE
ci(alpine): add util-linux-login for sulogin

### DIFF
--- a/test/container/Dockerfile-alpine
+++ b/test/container/Dockerfile-alpine
@@ -63,4 +63,5 @@ if [ "$DISTRIBUTION" = "alpine:edge" ] ; then \
     procps \
     squashfs-tools \
     util-linux-misc \
+    util-linux-login \
 ; fi


### PR DESCRIPTION
This is required to test emergency shell for alpine.

## Checklist
- [ ] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it

Fixes #
