### PR TITLE
ci: do not log how sysroot is constructed

### DIFF
--- a/test/dracut.conf.d/test-makeroot/test-makeroot.conf
+++ b/test/dracut.conf.d/test-makeroot/test-makeroot.conf
@@ -5,3 +5,4 @@ do_strip="no"
 do_hardlink="no"
 early_microcode="no"
 hostonly_cmdline="no"
+stdloglvl=1

--- a/test/dracut.conf.d/test-root/test-root.conf
+++ b/test/dracut.conf.d/test-root/test-root.conf
@@ -5,3 +5,4 @@ do_strip="no"
 do_hardlink="no"
 early_microcode="no"
 hostonly_cmdline="no"
+stdloglvl=1


### PR DESCRIPTION
It is confusing to see dracut invoked 3 times for each use-case for the uninitiated. Only log for the dracut invocation that is under test.

## Checklist
- [ ] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it

Fixes #
