### PR TITLE
test(MULTINIC): fix virtio regression

### DIFF
--- a/test/TEST-61-MULTINIC/test.sh
+++ b/test/TEST-61-MULTINIC/test.sh
@@ -75,8 +75,8 @@ client_test() {
         -net nic,macaddr=52:54:00:12:34:"$mac3",model=virtio \
         -netdev hubport,id=n1,hubid=1 \
         -netdev hubport,id=n2,hubid=2 \
-        -device virtio,netdev=n1,mac=52:54:00:12:34:98 \
-        -device virtio,netdev=n2,mac=52:54:00:12:34:99 \
+        -device virtio-net-pci,netdev=n1,mac=52:54:00:12:34:98 \
+        -device virtio-net-pci,netdev=n2,mac=52:54:00:12:34:99 \
         -append "$TEST_KERNEL_CMDLINE $cmdline ro init=/sbin/init systemd.log_target=console" \
         -initrd "$TESTDIR"/initramfs.testing || return 1
 


### PR DESCRIPTION
Currently it is skipped on all containers, as none of the containers have `/etc/sysconfig/network-scripts` directory any more.

Since the tests do not run on CI, they are easily regress - seems https://github.com/dracut-ng/dracut-ng/issues/953 already caused a bit of regression.

This is just a bit of patch work - someone with more networking knowledge should take a look at how to stabilize all the networking tests on all distros.

CC @bdrung 

## Checklist
- [ ] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it

Fixes #
