### PR TITLE
test(MULTINIC): avoid /usr/bin/env in server initrd

### DIFF
--- a/test/TEST-61-MULTINIC/server-init.sh
+++ b/test/TEST-61-MULTINIC/server-init.sh
@@ -1,4 +1,4 @@
-#!/usr/bin/env bash
+#!/bin/bash
 exec < /dev/console > /dev/console 2>&1
 set -x
 export PATH=/usr/sbin:/usr/bin:/sbin:/bin


### PR DESCRIPTION
The MULTINIC test fails to start the server on Ubuntu:

```
/usr/bin/env: 'bash': No such file or directory
[    8.026059] Kernel panic - not syncing: Attempted to kill init! exitcode=0x00007f00
```

This is caused by missing `/usr/bin/env` in the server initrd. So just rely on bash being present in the initrd.

Fixes: 4f0a784186e5 ("chore(tests): search for bash in $PATH to improve portability")

@jozzsi 