### PR TITLE
test: fail test if server has terminated

### DIFF
--- a/test/TEST-60-NFS/test.sh
+++ b/test/TEST-60-NFS/test.sh
@@ -39,10 +39,7 @@ run_server() {
     tty -s && stty sane
 
     if ! [[ $SERIAL ]]; then
-        while ! grep -q Serving "$TESTDIR"/server.log; do
-            echo "Waiting for the server to startup"
-            sleep 1
-        done
+        wait_for_server_startup || return 1
     else
         echo Sleeping 10 seconds to give the server a head start
         sleep 10

--- a/test/TEST-61-MULTINIC/test.sh
+++ b/test/TEST-61-MULTINIC/test.sh
@@ -42,12 +42,7 @@ run_server() {
     tty -s && stty sane
 
     if ! [[ $SERIAL ]]; then
-        while :; do
-            grep Serving "$TESTDIR"/server.log && break
-            echo "Waiting for the server to startup"
-            tail "$TESTDIR"/server.log
-            sleep 1
-        done
+        wait_for_server_startup || return 1
     else
         echo Sleeping 10 seconds to give the server a head start
         sleep 10

--- a/test/TEST-62-BONDBRIDGEVLAN/test.sh
+++ b/test/TEST-62-BONDBRIDGEVLAN/test.sh
@@ -64,12 +64,7 @@ run_server() {
     tty -s && stty sane
 
     if ! [[ $SERIAL ]]; then
-        echo "Waiting for the server to startup"
-        while :; do
-            grep Serving "$TESTDIR"/server.log && break
-            tail "$TESTDIR"/server.log
-            sleep 1
-        done
+        wait_for_server_startup || return 1
     else
         echo Sleeping 10 seconds to give the server a head start
         sleep 10

--- a/test/TEST-70-ISCSI/test.sh
+++ b/test/TEST-70-ISCSI/test.sh
@@ -33,12 +33,7 @@ run_server() {
     tty -s && stty sane
 
     if ! [[ $SERIAL ]]; then
-        while :; do
-            grep Serving "$TESTDIR"/server.log && break
-            echo "Waiting for the server to startup"
-            tail "$TESTDIR"/server.log
-            sleep 1
-        done
+        wait_for_server_startup || return 1
     else
         echo Sleeping 10 seconds to give the server a head start
         sleep 10

--- a/test/TEST-71-ISCSI-MULTI/test.sh
+++ b/test/TEST-71-ISCSI-MULTI/test.sh
@@ -33,12 +33,7 @@ run_server() {
     tty -s && stty sane
 
     if ! [[ $SERIAL ]]; then
-        while :; do
-            grep Serving "$TESTDIR"/server.log && break
-            echo "Waiting for the server to startup"
-            tail "$TESTDIR"/server.log
-            sleep 1
-        done
+        wait_for_server_startup || return 1
     else
         echo Sleeping 10 seconds to give the server a head start
         sleep 10

--- a/test/TEST-72-NBD/test.sh
+++ b/test/TEST-72-NBD/test.sh
@@ -52,12 +52,7 @@ run_server() {
     tty -s && stty sane
 
     if ! [[ $SERIAL ]]; then
-        echo "Waiting for the server to startup"
-        while :; do
-            grep Serving "$TESTDIR"/server.log && break
-            tail "$TESTDIR"/server.log
-            sleep 1
-        done
+        wait_for_server_startup || return 1
     else
         echo Sleeping 10 seconds to give the server a head start
         sleep 10

--- a/test/test-functions
+++ b/test/test-functions
@@ -63,6 +63,16 @@ test_dracut() {
         "$@" || return 1
 }
 
+# Wait for the server QEMU has been started up.
+# It should print "Serving" in the server.log in that case.
+wait_for_server_startup() {
+    while ! grep -q Serving "$TESTDIR"/server.log; do
+        echo "Waiting for the server to startup"
+        tail "$TESTDIR"/server.log
+        sleep 1
+    done
+}
+
 ovmf_code() {
     for path in \
         "/usr/share/OVMF/OVMF_CODE.fd" \

--- a/test/test-functions
+++ b/test/test-functions
@@ -66,9 +66,16 @@ test_dracut() {
 # Wait for the server QEMU has been started up.
 # It should print "Serving" in the server.log in that case.
 wait_for_server_startup() {
+    local server_pid
+    server_pid=$(cat "$TESTDIR"/server.pid)
+
     while ! grep -q Serving "$TESTDIR"/server.log; do
         echo "Waiting for the server to startup"
         tail "$TESTDIR"/server.log
+        if ! test -f "/proc/$server_pid/status"; then
+            echo "Error: Server QEMU process $server_pid is gone. Please check $TESTDIR/server.log for failures." >&2
+            return 1
+        fi
         sleep 1
     done
 }


### PR DESCRIPTION
## Changes

The server might shutdown on error. When waiting for the server to startup, check if the server QEMU process has vanished and abort the test in that case.

## Checklist
- [x] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it