### PR TITLE
ci(debian): install dracut-network

### DIFF
--- a/test/container/Dockerfile-debian
+++ b/test/container/Dockerfile-debian
@@ -4,6 +4,7 @@
 # - mawk (instead of gawk)
 # - zstd compression
 # - verbose logging for tests
+# - console-setup dracut module
 
 # Not installed
 # - dmraid (no longer maintained, https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=1056944)
@@ -21,7 +22,7 @@ ARG DISTRIBUTION
 ENV V=2
 
 # Install dracut as a linux-initramfs-tool provider so that the default initramfs-tool package does not get installed
-RUN apt-get update -y -qq && apt-get upgrade -y -qq && apt-get install -y -qq --no-install-recommends dracut
+RUN apt-get update -y -qq && apt-get upgrade -y -qq && apt-get install -y -qq --no-install-recommends dracut-network
 
 # extra packages for sid, ubuntu
 RUN if [ "${DISTRIBUTION}" = "debian:sid" ] || [ "${DISTRIBUTION}" = "ubuntu:latest" ] ; then \


### PR DESCRIPTION
This should install more downstream dependencies and brings upstream closer to downstream.

CC @bdrung 

## Checklist
- [ ] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it

Fixes #
