### PR TITLE
ci(gentoo): force hostonly mode as is recommended by Gentoo wiki

### DIFF
--- a/test/container/Dockerfile-gentoo
+++ b/test/container/Dockerfile-gentoo
@@ -85,6 +85,10 @@ if [ "$OPTION" = "systemd" ] ; then \
 ; fi
 
 # cleanup
+# force hostonly mode as this is the config recommended by Gentoo wiki
+# https://wiki.gentoo.org/wiki/Dracut
 RUN \
     rm -rf /var/cache/* /usr/share/doc/* /usr/share/man/* ;\
-    emerge --depclean --with-bdeps=n
+    emerge --depclean --with-bdeps=n ;\
+    mkdir -p /usr/lib/dracut/dracut.conf.d/ ;\
+    echo 'hostonly="yes"' > /usr/lib/dracut/dracut.conf.d/50-hostonly.conf


### PR DESCRIPTION
See https://wiki.gentoo.org/wiki/Dracut.

Following the discussion at https://github.com/dracut-ng/dracut-ng/issues/674 - with permission from @Nowa-Ammerlaan  - I'd like to propose switching the CI for Gentoo to run in hostonly mode to increase confidence that this mode is well supported on Gentoo.

CC @Nowa-Ammerlaan 

## Checklist
- [ ] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it

Fixes #
