### PR TITLE
docs: warn against the usage of omit, drivers, dracutmodules

### DIFF
--- a/man/dracut.conf.5.adoc
+++ b/man/dracut.conf.5.adoc
@@ -44,12 +44,17 @@ Configuration files must have the extension .conf; other extensions are ignored.
 *omit_dracutmodules+=*" __<dracut modules>__ "::
     Omit a space-separated list of dracut modules to call when building the
     initramfs. Modules are located in _/usr/lib/dracut/modules.d_.
+    Warning: Avoid manually omitting dracut modules, as you may
+    inadvertently remove essential ones that dracut can't detect
+    or warn you about. Using this option is not recommended and is at
+    your own risk.
 
 *dracutmodules+=*" __<dracut modules>__ "::
     Specify a space-separated list of dracut modules to call when building the
     initramfs. Modules are located in _/usr/lib/dracut/modules.d_.
     This option forces dracut to only include the specified dracut modules.
     In most cases the "add_dracutmodules" option is what you want to use.
+    This option is not recomended to use (use at your own risk).
 
 *add_drivers+=*" __<kernel modules>__ "::
     Specify a space-separated list of kernel modules to add to the initramfs.
@@ -67,6 +72,9 @@ Configuration files must have the extension .conf; other extensions are ignored.
     Specify a space-separated list of kernel modules to exclusively include in
     the initramfs. The kernel modules have to be specified without the ".ko"
     suffix.
+    This option forces dracut to only include the specified kernel modules.
+    In most cases the "--add-drivers" option is what you want to use.
+    This option is not recomended to use (use at your own risk).
 
 *filesystems+=*" __<filesystem names>__ "::
     Specify a space-separated list of kernel filesystem modules to exclusively


### PR DESCRIPTION
These are common footguns. We should do a better job warning the users against these usually untested configurations.

Follow-up to eb1ae6c

## Checklist
- [ ] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it

Fixes #
