### PR TITLE
test: do not redirect /dev/null to stdin

### DIFF
--- a/test/test-functions
+++ b/test/test-functions
@@ -249,7 +249,7 @@ while (($# > 0)); do
                     rm -fr -- "$TESTDIR"
                     rm -f -- .testdir${TEST_RUN_ID:+-$TEST_RUN_ID}
                     exit $ret
-                ) < /dev/null 2>&1 | "$tee_command" "test${TEST_RUN_ID:+-$TEST_RUN_ID}.log"
+                ) 2>&1 | "$tee_command" "test${TEST_RUN_ID:+-$TEST_RUN_ID}.log"
             else
                 (
                     test_setup && test_run
@@ -258,7 +258,7 @@ while (($# > 0)); do
                     rm -fr -- "$TESTDIR"
                     rm -f -- .testdir${TEST_RUN_ID:+-$TEST_RUN_ID}
                     exit $ret
-                ) < /dev/null > test${TEST_RUN_ID:+-$TEST_RUN_ID}.log 2>&1
+                ) > test${TEST_RUN_ID:+-$TEST_RUN_ID}.log 2>&1
             fi
             ret=$?
             set +o pipefail


### PR DESCRIPTION
## Changes

The test cases have comments saying "Uncomment this to debug failures", but uncommenting `DEBUGFAIL` is not enough. The initrd will not take any keyboard presses, because /dev/null is redirected to stdin.

To ease debugging, do not redirect /dev/null to stdin.

## Checklist
- [ ] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it