### PR TITLE
ci: switch from ubuntu:rolling to ubuntu:devel

### DIFF
--- a/.github/workflows/container-extra.yml
+++ b/.github/workflows/container-extra.yml
@@ -36,7 +36,7 @@ jobs:
             matrix:
                 config:
                     - {dockerfile: 'Dockerfile-debian', tag: 'debian:sid', platform: 'linux/amd64'}
-                    - {dockerfile: 'Dockerfile-debian', tag: 'ubuntu:rolling', platform: 'linux/amd64'}
+                    - {dockerfile: 'Dockerfile-debian', tag: 'ubuntu:devel', platform: 'linux/amd64'}
                     - {dockerfile: 'Dockerfile-alpine', tag: 'alpine:edge', platform: 'linux/amd64'}
                     - {dockerfile: 'Dockerfile-gentoo', tag: 'gentoo:latest', platform: 'linux/amd64', option: 'systemd'}
                     - {dockerfile: 'Dockerfile-gentoo', tag: 'gentoo:amd64-openrc', platform: 'linux/amd64', option: 'amd64-openrc'}

--- a/.github/workflows/integration-extra.yml
+++ b/.github/workflows/integration-extra.yml
@@ -37,7 +37,7 @@ jobs:
                     - gentoo:amd64-openrc
                     - opensuse
                     - ubuntu
-                    - ubuntu:rolling
+                    - ubuntu:devel
                     - void
                 test:
                     - "10"

--- a/.github/workflows/manualtest.yml
+++ b/.github/workflows/manualtest.yml
@@ -22,7 +22,7 @@ on:  # yamllint disable-line rule:truthy
                     - "debian"
                     - "debian:sid"
                     - "ubuntu"
-                    - "ubuntu:rolling"
+                    - "ubuntu:devel"
                     - "opensuse"
                     - "gentoo"
                     - "void"

--- a/test/container/Dockerfile-debian
+++ b/test/container/Dockerfile-debian
@@ -24,14 +24,14 @@ ENV V=2
 RUN apt-get update -y -qq && apt-get upgrade -y -qq && apt-get install -y -qq --no-install-recommends dracut
 
 # extra packages for sid, ubuntu
-RUN if [ "${DISTRIBUTION}" = "debian:sid" ] || [ "${DISTRIBUTION}" = "ubuntu:latest" ] ; then \
+RUN if [ "${DISTRIBUTION}" ! = "debian:latest" ] ; then \
     DEBIAN_FRONTEND=noninteractive apt-get install -y -qq --no-install-recommends -o Dpkg::Use-Pty=0 \
     network-manager \
     systemd-ukify \
     ; fi
 
-# extra packages for sid, rolling
-RUN if [ "$DISTRIBUTION" = "debian:sid" ] || [ "${DISTRIBUTION}" = "ubuntu:rolling" ] ; then \
+# extra packages for sid, rolling, devel
+RUN if [ "$DISTRIBUTION" = "debian:sid" ] || [ "${DISTRIBUTION}" = "ubuntu:rolling" ] || [ "${DISTRIBUTION}" = "ubuntu:devel" ] ; then \
     DEBIAN_FRONTEND=noninteractive apt-get install -y -qq --no-install-recommends -o Dpkg::Use-Pty=0 \
     systemd-cryptsetup \
     systemd-repart \


### PR DESCRIPTION
The goal is to test with latest Ubuntu before a dracut release.

When I enabled ubuntu:rolling I simply missed that :devel is the latest version not :rolling.

CC @bdrung 

## Checklist
- [ ] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it

Fixes #
