### PR TITLE
fix(dracut-lib): initialize getcmdline/getarg local variables

### DIFF
--- a/modules.d/99base/dracut-lib.sh
+++ b/modules.d/99base/dracut-lib.sh
@@ -125,9 +125,9 @@ killall_proc_mountpoint() {
 getcmdline() {
     local _line
     local _i
-    local CMDLINE_ETC_D
-    local CMDLINE_ETC
-    local CMDLINE_PROC
+    local CMDLINE_ETC_D=''
+    local CMDLINE_ETC=''
+    local CMDLINE_PROC=''
     unset _line
 
     if [ -e /etc/cmdline ]; then
@@ -152,7 +152,7 @@ getcmdline() {
 
 getarg() {
     debug_off
-    local _deprecated _newoption
+    local _deprecated='' _newoption=''
     CMDLINE=$(getcmdline)
     export CMDLINE
     while [ $# -gt 0 ]; do


### PR DESCRIPTION
## Changes

Re-generate initrd without the systemd module with dracut 102-3.fc41:

```
dracut --omit systemd --regenerate-all --force -v
```

The resulting initrd fails to boot, and prints some errors:

```
dracut Warning: Signal caught
/lib/dracut-lib.sh: line 147: CMDLINE_PROC: unbound variable
/lib/dracut-lib.sh: line 198: _newoption: unbound variable
```

This failure can be explained when calling `getcmdline` or `getarg` with `set -u`. Initialize the local variables.

## Checklist
- [ ] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it

Fixes: #997
