### PR TITLE
feat(systemd-emergency): install rescue and emergency targets

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -187,6 +187,10 @@ systemd-veritysetup:
   - changed-files:
       - any-glob-to-any-file: 'modules.d/[0-9][0-9]systemd-veritysetup/*'
 
+systemd-emergency:
+  - changed-files:
+    - any-glob-to-any-file: 'modules.d/[0-9][0-9]systemd-emergency/*'
+
 caps:
   - changed-files:
       - any-glob-to-any-file: 'modules.d/[0-9][0-9]caps/*'

--- a/modules.d/97systemd-emergency/module-setup.sh
+++ b/modules.d/97systemd-emergency/module-setup.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+# This file is part of dracut.
+# SPDX-License-Identifier: GPL-2.0-or-later
+
+check() {
+    require_binaries "$systemdutildir"/systemd-sulogin-shell || return 1
+
+    return 255
+}
+
+depends() {
+    echo systemd
+}
+
+install() {
+    inst_multiple -o \
+        "$systemdsystemunitdir"/emergency.target \
+        "$systemdsystemunitdir"/emergency.service \
+        "$systemdsystemunitdir"/rescue.target \
+        "$systemdsystemunitdir"/rescue.service \
+        "$systemdutildir"/systemd-sulogin-shell
+}


### PR DESCRIPTION
Systemd upstream natively provides emergency and rescue services. Give an option to install them instead of dracut provided versions.
    
Both mkinitcpio and mkosi installs these into the initrd. 

CC @mwilck @aafeijoo-suse

## Checklist
- [ ] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it

Fixes #
