### PR TITLE
test: print skip logs in V=1 or V=2 mode

### DIFF
--- a/test/test-functions
+++ b/test/test-functions
@@ -237,6 +237,9 @@ while (($# > 0)); do
             ;;
         --all)
             if ! test_check 2 &> test${TEST_RUN_ID:+-$TEST_RUN_ID}.log; then
+                if [ "$V" -ge 1 ]; then
+                    cat test${TEST_RUN_ID:+-$TEST_RUN_ID}.log
+                fi
                 echo -e "TEST: $TEST_DESCRIPTION " "$COLOR_WARNING" "[SKIPPED]" "$COLOR_NORMAL"
                 exit 0
             else


### PR DESCRIPTION
## Changes

In case a test is skipped, print the log in V=1 or V=2 mode to give a hint why the test was skipped.

## Checklist
- [ ] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it
