### PR TITLE
fix(docs): correct spelling mistake of recommended

### DIFF
--- a/man/dracut.8.adoc
+++ b/man/dracut.8.adoc
@@ -116,7 +116,7 @@ example:
     parameter can be specified multiple times.
     This option forces dracut to only include the specified dracut modules.
     In most cases the "--add" option is what you want to use.
-    This option is not recomended to use (use at your own risk).
+    This option is not recommended to use (use at your own risk).
 +
 [NOTE]
 ===============================
@@ -133,7 +133,7 @@ example:
     suffix. This parameter can be specified multiple times.
     This option forces dracut to only include the specified kernel modules.
     In most cases the "--add-drivers" option is what you want to use.
-    This option is not recomended to use (use at your own risk).
+    This option is not recommended to use (use at your own risk).
 +
 [NOTE]
 ===============================

--- a/man/dracut.conf.5.adoc
+++ b/man/dracut.conf.5.adoc
@@ -53,7 +53,7 @@ Specify a space-separated list of dracut modules to call when building the
 initramfs. Modules are located in _/usr/lib/dracut/modules.d_.
 This option forces dracut to only include the specified dracut modules.
 In most cases the "add_dracutmodules" option is what you want to use.
-This option is not recomended to use (use at your own risk).
+This option is not recommended to use (use at your own risk).
 
 *add_drivers+=*" __<kernel modules>__ "::
 Specify a space-separated list of kernel modules to add to the initramfs.
@@ -73,7 +73,7 @@ the initramfs. The kernel modules have to be specified without the ".ko"
 suffix.
 This option forces dracut to only include the specified kernel modules.
 In most cases the "--add-drivers" option is what you want to use.
-This option is not recomended to use (use at your own risk).
+This option is not recommended to use (use at your own risk).
 
 *filesystems+=*" __<filesystem names>__ "::
 Specify a space-separated list of kernel filesystem modules to exclusively


### PR DESCRIPTION
## Changes

correct spelling mistake of recommended

## Checklist
- [ ] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it

Fixes: eb1ae6c4f836 ("docs: warn against the usage of -m, -o, -d")
Fixes: f6983159fa0b ("docs: warn against the usage of omit, drivers, dracutmodules")
