### PR TITLE
ci: remove dracut modules from the ci containers that are being tested

### DIFF
--- a/test/test-github.sh
+++ b/test/test-github.sh
@@ -9,6 +9,14 @@ if [ "$V" = "2" ]; then set -x; fi
 
 [[ -d ${0%/*} ]] && cd "${0%/*}"/../
 
+# remove dracut modules that are being tested
+(
+    cd modules.d
+    for dir in *; do
+        rm -rf /usr/lib/dracut/modules.d/[0-9][0-9]"${dir/#[0-9][0-9]/}"
+    done
+)
+
 # disable building documentation by default
 [ -z "$enable_documentation" ] && export enable_documentation=no
 


### PR DESCRIPTION
As an example, when a module ordering gets changed, without this PR the module would be available twice under modules.d - once with the old order number that gets installed with the package manager and once with the new order number that gets overlaid.

## Checklist
- [ ] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it

Fixes #
