### PR TITLE
fix(35network-manager): install nft binary during module installation

### DIFF
--- a/modules.d/35network-manager/module-setup.sh
+++ b/modules.d/35network-manager/module-setup.sh
@@ -27,7 +27,7 @@ install() {
     inst NetworkManager
     inst_multiple -o /usr/{lib,libexec}/nm-initrd-generator
     inst_multiple -o /usr/{lib,libexec}/nm-daemon-helper
-    inst_multiple -o teamd dhclient
+    inst_multiple -o teamd dhclient nft
     inst_hook cmdline 99 "$moddir/nm-config.sh"
     if dracut_module_included "systemd"; then
 


### PR DESCRIPTION
NetworkManager has a new bonding mode called balance-slb. This mode is used in environments where NICs are connected to switches without LACP. In order to work, NetworkManager configures a set of nftables rules.

The 'nft' binary is required to work.

This pull request changes...

## Changes

NetworkManager dracut module now installs nft during installation.

## Checklist
- [ ] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it
