### PR TITLE
fix(plymouth): change severity of shutdown log messages

### DIFF
--- a/modules.d/99shutdown/shutdown.sh
+++ b/modules.d/99shutdown/shutdown.sh
@@ -43,7 +43,7 @@ getargs 'rd.break=pre-shutdown' && emergency_shell --shutdown pre-shutdown "Brea
 
 source_hook pre-shutdown
 
-warn "Killing all remaining processes"
+info "Killing all remaining processes"
 
 killall_proc_mountpoint /oldroot || sleep 0.2
 
@@ -78,7 +78,7 @@ umount_a() {
         local ret=$?
         if [ $ret -eq 0 ]; then
             _did_umount="y"
-            warn "Unmounted $mp."
+            info "Unmounted $mp."
         elif [ $ret -eq 137 ]; then
             _timed_out_umounts="$_timed_out_umounts $mp "
             warn "Unmounting $mp timed out."


### PR DESCRIPTION
## Changes

Right now, if someone is using plymouth and the "quiet" boot parameter, odds are that they do so in the hope of a more polished boot experience.

The shutdown module prints a couple of warnings and then shuts down plymouth, meaning that these warnings will flash briefly on screen before the actual reboot/shutdown.

None of the warnings qualify as warnings though:

1. Printing "Unmounted /oldroot" just means that unmounting /oldroot (an internal implementational detail) succeeded.
2. Printing "Killing all remaining processes" hardly qualifies as a warning since it's a quite expected result of a reboot.

So downgrade them to "info" (which will respect the "quiet" boot parameter), leading to a nice, quiet reboot.

## Checklist
- [x] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it
