### PR TITLE
ci: address new yamllint warnings and errors

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -189,7 +189,7 @@ systemd-veritysetup:
 
 systemd-emergency:
   - changed-files:
-    - any-glob-to-any-file: 'modules.d/[0-9][0-9]systemd-emergency/*'
+      - any-glob-to-any-file: 'modules.d/[0-9][0-9]systemd-emergency/*'
 
 caps:
   - changed-files:

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -230,9 +230,9 @@ jobs:
                 test:
                     - "70"
                 include:
-                  - # on openSUSE run tests with network-legacy
-                    container: "opensuse"
-                    network: "network-legacy"
+                    # on openSUSE run tests with network-legacy
+                    - container: "opensuse"
+                      network: "network-legacy"
         container:
             image: ghcr.io/dracut-ng/${{ matrix.container }}
             options: '--device=/dev/kvm'


### PR DESCRIPTION
## Changes

Address all warnings and errors from yamllint except some of the line-length warnings:

```
yamllint -d "{extends: default, rules: {line-length: {max: 203}}}"  .
```

Fixes: be7e87fbb7d7 ("feat(systemd-emergency): install rescue and emergency targets")
Fixes: fa194671663d ("ci: reenable test 70 (only on openSUSE)")


## Checklist
- [ ] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it
