### PR TITLE
feat(nvmf): enable other shells (dash) not just bash

### DIFF
--- a/modules.d/95nvmf/module-setup.sh
+++ b/modules.d/95nvmf/module-setup.sh
@@ -63,7 +63,7 @@ check() {
 
 # called by dracut
 depends() {
-    echo bash rootfs-block network
+    echo rootfs-block network
     return 0
 }
 


### PR DESCRIPTION
I do not see anywhere where bash would be required for the `nvmf` module.

@bdrung @mwilck what do you think ? Am I missing something ? 

## Checklist
- [ ] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it

Fixes #
