### PR TITLE
fix(base): remove fallback for shell selection

### DIFF
--- a/modules.d/99base/module-setup.sh
+++ b/modules.d/99base/module-setup.sh
@@ -19,11 +19,6 @@ install() {
     ln -s dracut-util "${initdir}/usr/bin/dracut-getarg"
     ln -s dracut-util "${initdir}/usr/bin/dracut-getargs"
 
-    if [ ! -e "${initdir}/bin/sh" ]; then
-        inst_multiple bash
-        (ln -s bash "${initdir}/bin/sh" || :)
-    fi
-
     # add common users in /etc/passwd, it will be used by nfs/ssh currently
     # use password for hostonly images to facilitate secure sulogin in emergency console
     [[ $hostonly ]] && pwshadow='x'


### PR DESCRIPTION
This fallback is no longer needed after the introduction of the shell-interpreter dracut module.

## Checklist
- [ ] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it

Fixes #
