### PR TITLE
feat(dracut-systemd): install dracut-* into /usr/bin

### DIFF
--- a/modules.d/98dracut-systemd/dracut-cmdline-ask.service
+++ b/modules.d/98dracut-systemd/dracut-cmdline-ask.service
@@ -19,7 +19,7 @@ Conflicts=shutdown.target emergency.target
 Environment=DRACUT_SYSTEMD=1
 Environment=NEWROOT=/sysroot
 Type=oneshot
-ExecStart=-/bin/dracut-cmdline-ask
+ExecStart=-/usr/bin/dracut-cmdline-ask
 StandardInput=tty
 StandardOutput=inherit
 StandardError=inherit

--- a/modules.d/98dracut-systemd/dracut-cmdline.service
+++ b/modules.d/98dracut-systemd/dracut-cmdline.service
@@ -19,7 +19,7 @@ Conflicts=shutdown.target emergency.target
 Environment=DRACUT_SYSTEMD=1
 Environment=NEWROOT=/sysroot
 Type=oneshot
-ExecStart=-/bin/dracut-cmdline
+ExecStart=-/usr/bin/dracut-cmdline
 StandardInput=null
 StandardError=journal+console
 KillMode=process

--- a/modules.d/98dracut-systemd/dracut-emergency.service
+++ b/modules.d/98dracut-systemd/dracut-emergency.service
@@ -13,7 +13,7 @@ Environment=HOME=/
 Environment=DRACUT_SYSTEMD=1
 Environment=NEWROOT=/sysroot
 WorkingDirectory=/
-ExecStart=-/bin/dracut-emergency
+ExecStart=-/usr/bin/dracut-emergency
 ExecStopPost=-/bin/rm -f -- /.console_lock
 Type=oneshot
 StandardInput=tty-force

--- a/modules.d/98dracut-systemd/dracut-initqueue.service
+++ b/modules.d/98dracut-systemd/dracut-initqueue.service
@@ -17,7 +17,7 @@ Conflicts=shutdown.target emergency.target
 Environment=DRACUT_SYSTEMD=1
 Environment=NEWROOT=/sysroot
 Type=oneshot
-ExecStart=-/bin/dracut-initqueue
+ExecStart=-/usr/bin/dracut-initqueue
 StandardInput=null
 StandardError=journal+console
 KillMode=process

--- a/modules.d/98dracut-systemd/dracut-mount.service
+++ b/modules.d/98dracut-systemd/dracut-mount.service
@@ -15,7 +15,7 @@ Conflicts=shutdown.target emergency.target
 Environment=DRACUT_SYSTEMD=1
 Environment=NEWROOT=/sysroot
 Type=oneshot
-ExecStart=-/bin/dracut-mount
+ExecStart=-/usr/bin/dracut-mount
 StandardInput=null
 StandardError=journal+console
 KillMode=process

--- a/modules.d/98dracut-systemd/dracut-pre-mount.service
+++ b/modules.d/98dracut-systemd/dracut-pre-mount.service
@@ -15,7 +15,7 @@ Conflicts=shutdown.target emergency.target
 Environment=DRACUT_SYSTEMD=1
 Environment=NEWROOT=/sysroot
 Type=oneshot
-ExecStart=-/bin/dracut-pre-mount
+ExecStart=-/usr/bin/dracut-pre-mount
 StandardInput=null
 StandardError=journal+console
 KillMode=process

--- a/modules.d/98dracut-systemd/dracut-pre-pivot.service
+++ b/modules.d/98dracut-systemd/dracut-pre-pivot.service
@@ -23,7 +23,7 @@ Conflicts=shutdown.target emergency.target
 Environment=DRACUT_SYSTEMD=1
 Environment=NEWROOT=/sysroot
 Type=oneshot
-ExecStart=-/bin/dracut-pre-pivot
+ExecStart=-/usr/bin/dracut-pre-pivot
 StandardInput=null
 StandardError=journal+console
 KillMode=process

--- a/modules.d/98dracut-systemd/dracut-pre-trigger.service
+++ b/modules.d/98dracut-systemd/dracut-pre-trigger.service
@@ -16,7 +16,7 @@ Conflicts=shutdown.target emergency.target
 Environment=DRACUT_SYSTEMD=1
 Environment=NEWROOT=/sysroot
 Type=oneshot
-ExecStart=-/bin/dracut-pre-trigger
+ExecStart=-/usr/bin/dracut-pre-trigger
 StandardInput=null
 StandardError=journal+console
 KillMode=process

--- a/modules.d/98dracut-systemd/dracut-pre-udev.service
+++ b/modules.d/98dracut-systemd/dracut-pre-udev.service
@@ -20,7 +20,7 @@ Conflicts=shutdown.target emergency.target
 Environment=DRACUT_SYSTEMD=1
 Environment=NEWROOT=/sysroot
 Type=oneshot
-ExecStart=-/bin/dracut-pre-udev
+ExecStart=-/usr/bin/dracut-pre-udev
 StandardInput=null
 StandardError=journal+console
 KillMode=process

--- a/modules.d/98dracut-systemd/emergency.service
+++ b/modules.d/98dracut-systemd/emergency.service
@@ -14,7 +14,7 @@ Environment=HOME=/
 Environment=DRACUT_SYSTEMD=1
 Environment=NEWROOT=/sysroot
 WorkingDirectory=/
-ExecStart=/bin/dracut-emergency
+ExecStart=/usr/bin/dracut-emergency
 ExecStopPost=-/usr/bin/systemctl --fail --no-block default
 Type=idle
 StandardInput=tty-force

--- a/modules.d/98dracut-systemd/module-setup.sh
+++ b/modules.d/98dracut-systemd/module-setup.sh
@@ -31,21 +31,21 @@ depends() {
 
 # called by dracut
 install() {
-    inst_script "$moddir/dracut-emergency.sh" /bin/dracut-emergency
+    inst_script "$moddir/dracut-emergency.sh" /usr/bin/dracut-emergency
     inst_simple "$moddir/emergency.service" "${systemdsystemunitdir}"/emergency.service
     inst_simple "$moddir/dracut-emergency.service" "${systemdsystemunitdir}"/dracut-emergency.service
     inst_simple "$moddir/emergency.service" "${systemdsystemunitdir}"/rescue.service
 
     ln_r "${systemdsystemunitdir}/initrd.target" "${systemdsystemunitdir}/default.target"
 
-    inst_script "$moddir/dracut-cmdline.sh" /bin/dracut-cmdline
-    inst_script "$moddir/dracut-cmdline-ask.sh" /bin/dracut-cmdline-ask
-    inst_script "$moddir/dracut-pre-udev.sh" /bin/dracut-pre-udev
-    inst_script "$moddir/dracut-pre-trigger.sh" /bin/dracut-pre-trigger
-    inst_script "$moddir/dracut-initqueue.sh" /bin/dracut-initqueue
-    inst_script "$moddir/dracut-pre-mount.sh" /bin/dracut-pre-mount
-    inst_script "$moddir/dracut-mount.sh" /bin/dracut-mount
-    inst_script "$moddir/dracut-pre-pivot.sh" /bin/dracut-pre-pivot
+    inst_script "$moddir/dracut-cmdline.sh" /usr/bin/dracut-cmdline
+    inst_script "$moddir/dracut-cmdline-ask.sh" /usr/bin/dracut-cmdline-ask
+    inst_script "$moddir/dracut-pre-udev.sh" /usr/bin/dracut-pre-udev
+    inst_script "$moddir/dracut-pre-trigger.sh" /usr/bin/dracut-pre-trigger
+    inst_script "$moddir/dracut-initqueue.sh" /usr/bin/dracut-initqueue
+    inst_script "$moddir/dracut-pre-mount.sh" /usr/bin/dracut-pre-mount
+    inst_script "$moddir/dracut-mount.sh" /usr/bin/dracut-mount
+    inst_script "$moddir/dracut-pre-pivot.sh" /usr/bin/dracut-pre-pivot
 
     inst_script "$moddir/rootfs-generator.sh" "$systemdutildir"/system-generators/dracut-rootfs-generator
 


### PR DESCRIPTION
## Changes

Modern systems have /usr merged and `/bin` pointing to `/usr/bin`. So install all `dracut-*` scripts into `/usr/bin` instead of `/bin`.

## Checklist
- [ ] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it

Fixes #
