### PR TITLE
fix(dracut-functions): do not assume btrfs is installed

### DIFF
--- a/dracut-functions.sh
+++ b/dracut-functions.sh
@@ -813,12 +813,14 @@ lvm_internal_dev() {
 
 btrfs_devs() {
     local _mp="$1"
-    btrfs device usage "$_mp" \
-        | while read -r _dev _; do
-            str_starts "$_dev" "/" || continue
-            _dev=${_dev%,}
-            printf -- "%s\n" "$_dev"
-        done
+    if command -v btrfs > /dev/null; then
+        btrfs device usage "$_mp" \
+            | while read -r _dev _; do
+                str_starts "$_dev" "/" || continue
+                _dev=${_dev%,}
+                printf -- "%s\n" "$_dev"
+            done
+    fi
 }
 
 zfs_devs() {


### PR DESCRIPTION
Fix the following warning

```
dracut-functions.sh: line 816: btrfs: command not found
```

## Checklist
- [ ] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it

Fixes #
