### PR TITLE
fix(base): replace possible existing dracut-util symlinks

### DIFF
--- a/modules.d/99base/module-setup.sh
+++ b/modules.d/99base/module-setup.sh
@@ -15,9 +15,8 @@ install() {
     inst_multiple -o findmnt less kmod
 
     inst_binary "${dracutbasedir}/dracut-util" "/usr/bin/dracut-util"
-
-    ln -s dracut-util "${initdir}/usr/bin/dracut-getarg"
-    ln -s dracut-util "${initdir}/usr/bin/dracut-getargs"
+    ln -sf dracut-util "${initdir}/usr/bin/dracut-getarg"
+    ln -sf dracut-util "${initdir}/usr/bin/dracut-getargs"
 
     # add common users in /etc/passwd, it will be used by nfs/ssh currently
     # use password for hostonly images to facilitate secure sulogin in emergency console

--- a/test/TEST-60-NFS/test.sh
+++ b/test/TEST-60-NFS/test.sh
@@ -319,8 +319,8 @@ test_setup() {
         inst_simple "${PKGLIBDIR}/modules.d/45net-lib/net-lib.sh" "/lib/net-lib.sh"
         inst_simple "${PKGLIBDIR}/modules.d/95nfs/nfs-lib.sh" "/lib/nfs-lib.sh"
         inst_binary "${PKGLIBDIR}/dracut-util" "/usr/bin/dracut-util"
-        ln -s dracut-util "${initdir}/usr/bin/dracut-getarg"
-        ln -s dracut-util "${initdir}/usr/bin/dracut-getargs"
+        ln -sf dracut-util "${initdir}/usr/bin/dracut-getarg"
+        ln -sf dracut-util "${initdir}/usr/bin/dracut-getargs"
 
         inst ./client-init.sh /sbin/init
         inst_simple /etc/os-release

--- a/test/modules.d/80test-root/module-setup.sh
+++ b/test/modules.d/80test-root/module-setup.sh
@@ -24,8 +24,8 @@ install() {
     inst_multiple -o "${_terminfodir}/l/linux"
 
     inst_binary "${dracutbasedir}/dracut-util" "/usr/bin/dracut-util"
-    ln -s dracut-util "${initdir}/usr/bin/dracut-getarg"
-    ln -s dracut-util "${initdir}/usr/bin/dracut-getargs"
+    ln -sf dracut-util "${initdir}/usr/bin/dracut-getarg"
+    ln -sf dracut-util "${initdir}/usr/bin/dracut-getargs"
 
     inst_script "${dracutbasedir}/modules.d/99base/dracut-lib.sh" "/lib/dracut-lib.sh"
     inst_script "${dracutbasedir}/modules.d/99base/dracut-dev-lib.sh" "/lib/dracut-dev-lib.sh"


### PR DESCRIPTION
## Changes

TEST-70-ISCSI has following error message in the logs:

```
ln: failed to create symbolic link '[...]/dracut.l765OC/initramfs/usr/bin/dracut-getarg': File exists
ln: failed to create symbolic link '[...]/dracut.l765OC/initramfs/usr/bin/dracut-getargs': File exists
```

This is caused by including both the `test-root` and `base` dracut module. Both modules copy `dracut-util` and want to create the `dracut-getarg` and `dracut-getargs` symlinks.

In this case just override the existing symlinks.

## Checklist
- [ ] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it