### PR TITLE
feat: add inst_service for installing service files

### DIFF
--- a/modules.d/95iscsi/module-setup.sh
+++ b/modules.d/95iscsi/module-setup.sh
@@ -210,7 +210,7 @@ install() {
     if ! dracut_module_included "systemd"; then
         inst "$moddir/mount-lun.sh" "/bin/mount-lun.sh"
     else
-        inst_multiple -o \
+        inst_service -o \
             "$systemdsystemunitdir"/iscsi.service \
             "$systemdsystemunitdir"/iscsi-init.service \
             "$systemdsystemunitdir"/iscsid.service \
@@ -219,9 +219,6 @@ install() {
             "$systemdsystemunitdir"/iscsiuio.socket \
             "$systemdsystemunitdir"/sockets.target.wants/iscsid.socket \
             "$systemdsystemunitdir"/sockets.target.wants/iscsiuio.socket
-        if grep -q '^ExecStartPre=/usr/lib/open-iscsi/startup-checks.sh$' "$systemdsystemunitdir/iscsid.service"; then
-            inst_simple /usr/lib/open-iscsi/startup-checks.sh
-        fi
 
         for i in \
             iscsid.socket \


### PR DESCRIPTION
## Changes

Systemd service file can define commands in `ExecStart`, `ExecStartPre`, `ExecStartPost`, `ExecStop`, etc.

Add an `inst_service` helper function to install service files together with all the referenced executables. This allows dropping the workaround from commit 7fe7fa943748 for iSCSI on Debian/Ubuntu.

Needed before merging:
* check if the initrd content is still the same
* add some test cases. Useful real world examples:
```
/usr/lib/systemd/system/apt-daily.service:ExecStartPre=-/usr/lib/apt/apt-helper wait-online
/usr/lib/systemd/system/initrd-parse-etc.service:ExecStart=@/usr/lib/systemd/system-generators/systemd-fstab-generator systemd-sysroot-fstab-check
/usr/lib/systemd/system/man-db.service:ExecStart=+/usr/bin/install -d -o man -g man -m 0755 /var/cache/man
/usr/lib/systemd/system/systemd-networkd.service:ExecStart=!!/usr/lib/systemd/systemd-networkd
```

## Checklist
- [ ] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it

Fixes #
