### PR TITLE
ci: release Dracut quarterly

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,8 +3,8 @@ name: Release
 
 on:  # yamllint disable-line rule:truthy
   schedule:
-    ## Schedule the job to run on Apr-1, Aug-1, Dec-1
-    - cron: '0 0 1 APR,AUG,DEC *'
+    ## Schedule the job quarterly to run on Feb-1, May-1, Aug-1, and Nov-1
+    - cron: '0 0 1 FEB,MAY,AUG,NOV *'
   workflow_dispatch:
     inputs:
       tag:


### PR DESCRIPTION
## Changes

Release Dracut quarterly to synchronize the Dracut release with the Ubuntu release. Ubuntu XX.04 has its feature freeze mid to end of February. Ubuntu XX.10 has its feature freeze mid to end of August. So release Dracut on the beginning of February and August to have some time left to get it landed in the distribution.

To get into sync, we should do a release on Dec-1. Then do the follow-up release on Feb-1.

## Checklist
- [ ] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it
