### PR TITLE
fix(test-root): dracut-getarg is no longer used for test-root

### DIFF
--- a/test/modules.d/80test-root/module-setup.sh
+++ b/test/modules.d/80test-root/module-setup.sh
@@ -23,13 +23,6 @@ install() {
     done
     inst_multiple -o "${_terminfodir}/l/linux"
 
-    inst_binary "${dracutbasedir}/dracut-util" "/usr/bin/dracut-util"
-    ln -s dracut-util "${initdir}/usr/bin/dracut-getarg"
-    ln -s dracut-util "${initdir}/usr/bin/dracut-getargs"
-
-    inst_script "${dracutbasedir}/modules.d/99base/dracut-lib.sh" "/lib/dracut-lib.sh"
-    inst_script "${dracutbasedir}/modules.d/99base/dracut-dev-lib.sh" "/lib/dracut-dev-lib.sh"
-
     inst_script "$moddir/test-init.sh" "/sbin/init"
 
     inst_multiple -o plymouth


### PR DESCRIPTION


## Checklist
- [ ] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it

Fixes #
