### PR TITLE
fix(systemd): systemd dlopens libbpf

### DIFF
--- a/modules.d/00systemd/module-setup.sh
+++ b/modules.d/00systemd/module-setup.sh
@@ -144,6 +144,7 @@ EOF
     _arch=${DRACUT_ARCH:-$(uname -m)}
     inst_libdir_file \
         {"tls/$_arch/",tls/,"$_arch/",}"libgcrypt.so*" \
+        {"tls/$_arch/",tls/,"$_arch/",}"libbpf.so*" \
         {"tls/$_arch/",tls/,"$_arch/",}"libnss_*" \
         {"tls/$_arch/",tls/,"$_arch/",}"systemd/libsystemd*.so"
 }


### PR DESCRIPTION
Following crash seen on the CI intermittently 

```
[    4.373065] systemd[1]: Failed to open libbpf, cgroup BPF features disabled: Operation not supported
systemd[1]: Failed to open libbpf, cgroup BPF features disabled: Operation not supported
[    4.404177] systemd[1]: Assertion 'close_nointr(fd) != -EBADF' failed at src/basic/fd-util.c:75, function safe_close(). Aborting.
```

Related bug found in the Fedora/RedHat bug database  - https://bugzilla.redhat.com/show_bug.cgi?id=2084955#c34

> systemd dlopens libbpf, dracut fails to add systemd's dependency on libbpf in initrd, 
> but dracut-network adds it to initrd, because it pulls in /usr/sbin/ip, which is linked against libbpf.so.0.


## Checklist
- [ ] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it

Fixes #
