### PR TITLE
test(test-root): include terminfo dracut module

### DIFF
--- a/test/modules.d/80test-root/module-setup.sh
+++ b/test/modules.d/80test-root/module-setup.sh
@@ -6,10 +6,14 @@ check() {
 }
 
 depends() {
+    local deps
+    deps="terminfo"
+
     if [[ $V == "2" ]]; then
-        echo debug
+        deps+=" debug"
     fi
 
+    echo "$deps"
     return 0
 }
 
@@ -17,11 +21,6 @@ install() {
     inst_simple /etc/os-release
 
     inst_multiple mkdir ln dd stty mount poweroff umount setsid sync cat grep
-
-    for _terminfodir in /lib/terminfo /etc/terminfo /usr/share/terminfo; do
-        [ -f "${_terminfodir}/l/linux" ] && break
-    done
-    inst_multiple -o "${_terminfodir}/l/linux"
 
     inst_script "$moddir/test-init.sh" "/sbin/init"
 


### PR DESCRIPTION
Include an existing dracut module instead of attempting to reimplement it.

## Checklist
- [ ] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it

Fixes #
