### PR TITLE
test(SYSTEMD): remove subtests that do not increase test coverage

### DIFF
--- a/test/TEST-41-FULL-SYSTEMD/test.sh
+++ b/test/TEST-41-FULL-SYSTEMD/test.sh
@@ -44,13 +44,8 @@ client_run() {
 }
 
 test_run() {
-    client_run "no option specified" || return 1
     client_run "readonly root" "ro" || return 1
     client_run "writeable root" "rw" || return 1
-
-    # volatile mode
-    client_run "volatile=overlayfs root" "systemd.volatile=overlayfs" || return 1
-    client_run "volatile=state root" "systemd.volatile=state" || return 1
 
     # shellcheck source=$TESTDIR/luks.uuid
     . "$TESTDIR"/luks.uuid

--- a/test/TEST-42-SYSTEMD-INITRD/test.sh
+++ b/test/TEST-42-SYSTEMD-INITRD/test.sh
@@ -34,13 +34,8 @@ client_run() {
 }
 
 test_run() {
-    client_run "no option specified" || return 1
     client_run "readonly root" "ro" || return 1
     client_run "writeable root" "rw" || return 1
-
-    # volatile mode
-    client_run "volatile=overlayfs root" "systemd.volatile=overlayfs" || return 1
-    client_run "volatile=state root" "systemd.volatile=state" || return 1
 }
 
 test_setup() {


### PR DESCRIPTION
Testing without an option does not really increase test coverage, if we anyways test both with "ro" and "rw".

It is not actually tested if volatile mode is actually enabled. Let's remove these tests steps until there is an actual assertion for these modes.

## Checklist
- [ ] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it

Fixes #
