### PR TITLE
test(ENC-RAID-LVM): simplify raid configuration

### DIFF
--- a/test/TEST-26-ENC-RAID-LVM/create-root.sh
+++ b/test/TEST-26-ENC-RAID-LVM/create-root.sh
@@ -5,11 +5,9 @@ set -ex
 printf test > keyfile
 cryptsetup -q luksFormat /dev/disk/by-id/scsi-0QEMU_QEMU_HARDDISK_disk1 /keyfile
 cryptsetup -q luksFormat /dev/disk/by-id/scsi-0QEMU_QEMU_HARDDISK_disk2 /keyfile
-cryptsetup -q luksFormat /dev/disk/by-id/scsi-0QEMU_QEMU_HARDDISK_disk3 /keyfile
 cryptsetup luksOpen /dev/disk/by-id/scsi-0QEMU_QEMU_HARDDISK_disk1 dracut_disk1 < /keyfile
 cryptsetup luksOpen /dev/disk/by-id/scsi-0QEMU_QEMU_HARDDISK_disk2 dracut_disk2 < /keyfile
-cryptsetup luksOpen /dev/disk/by-id/scsi-0QEMU_QEMU_HARDDISK_disk3 dracut_disk3 < /keyfile
-mdadm --create /dev/md0 --run --auto=yes --level=5 --raid-devices=3 /dev/mapper/dracut_disk1 /dev/mapper/dracut_disk2 /dev/mapper/dracut_disk3
+mdadm --create /dev/md0 --run --auto=yes --level=1 --metadata=0.90 --raid-devices=2 /dev/mapper/dracut_disk1 /dev/mapper/dracut_disk2
 # wait for the array to finish initializing, otherwise this sometimes fails
 # randomly.
 mdadm -W /dev/md0
@@ -28,7 +26,6 @@ mdadm -W /dev/md0 || :
 mdadm --stop /dev/md0
 cryptsetup luksClose /dev/mapper/dracut_disk1
 cryptsetup luksClose /dev/mapper/dracut_disk2
-cryptsetup luksClose /dev/mapper/dracut_disk3
 
 {
     echo "dracut-root-block-created"

--- a/test/TEST-26-ENC-RAID-LVM/test.sh
+++ b/test/TEST-26-ENC-RAID-LVM/test.sh
@@ -29,7 +29,6 @@ test_run() {
     qemu_add_drive disk_index disk_args "$TESTDIR"/marker.img marker
     qemu_add_drive disk_index disk_args "$TESTDIR"/disk-1.img disk1
     qemu_add_drive disk_index disk_args "$TESTDIR"/disk-2.img disk2
-    qemu_add_drive disk_index disk_args "$TESTDIR"/disk-3.img disk3
 
     test_marker_reset
     "$testdir"/run-qemu \
@@ -77,7 +76,6 @@ test_setup() {
     qemu_add_drive disk_index disk_args "$TESTDIR"/marker.img marker 1
     qemu_add_drive disk_index disk_args "$TESTDIR"/disk-1.img disk1 1
     qemu_add_drive disk_index disk_args "$TESTDIR"/disk-2.img disk2 1
-    qemu_add_drive disk_index disk_args "$TESTDIR"/disk-3.img disk3 1
 
     "$testdir"/run-qemu \
         "${disk_args[@]}" \


### PR DESCRIPTION
Use two (instead of three) drives for the raid to speculativly improve the stability of this tests.
It has been randomly failing on the CI.


## Checklist
- [ ] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it

Fixes #
