### PR TITLE
fix(35network-manager): install nftables kernel modules needed

### DIFF
--- a/modules.d/35network-manager/module-setup.sh
+++ b/modules.d/35network-manager/module-setup.sh
@@ -15,6 +15,11 @@ depends() {
 }
 
 # called by dracut
+installkernel() {
+    instmods nf_tables nfnetlink nft_fwd_netdev
+}
+
+# called by dracut
 install() {
     local _nm_version
 


### PR DESCRIPTION
NetworkManager requires nf_tables, nfnetlink and nft_fwd_netdev kernel modules to operate balance-slb bonding mode.

Fixes a6264d1726d9 ("fix(35network-manager): install nft binary during module installation")

This pull request changes...

## Changes

## Checklist
- [X] I have tested it locally
- [X] I have reviewed and updated any documentation if relevant
- [X] I am providing new code and test(s) for it

Fixes #
