### PR TITLE
ci(alpine): dhclient is no longer packaged in alpine

### DIFF
--- a/test/container/Dockerfile-alpine
+++ b/test/container/Dockerfile-alpine
@@ -26,10 +26,10 @@ ARG DISTRIBUTION
 # Packages to pass the BASIC test
 RUN apk add --no-cache \
     asciidoc \
-    dracut \
     dracut-tests \
     file \
     gcc \
+    iputils \
     kmod \
     kmod-dev \
     linux-virt \
@@ -45,7 +45,6 @@ if [ "$DISTRIBUTION" = "alpine:edge" ] ; then \
     cpio \
     cryptsetup \
     device-mapper \
-    dhclient \
     dmraid \
     elogind \
     gpg \


### PR DESCRIPTION
Resolves the following error:

```
dhclient (no such package):
```

## Checklist
- [ ] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it

Fixes #
