### PR TITLE
fix(systemd-tmpfiles): copy systemd-stub.conf into the initrd

### DIFF
--- a/modules.d/01systemd-tmpfiles/module-setup.sh
+++ b/modules.d/01systemd-tmpfiles/module-setup.sh
@@ -27,6 +27,7 @@ install() {
         "$tmpfilesdir/static-nodes-permissions.conf" \
         "$tmpfilesdir/systemd-tmp.conf" \
         "$tmpfilesdir/systemd.conf" \
+        "$tmpfilesdir/20-systemd-stub.conf" \
         "$tmpfilesdir/var.conf" \
         "$systemdsystemunitdir"/systemd-tmpfiles-clean.service \
         "$systemdsystemunitdir/systemd-tmpfiles-clean.service.d/*.conf" \


### PR DESCRIPTION
Some of the tmpfiles to be managed during initrd phase are now described in a separate tmpfiles.d snippet, see
https://github.com/systemd/systemd/commit/408ab988dbf6723871afd3503d11bd0deb50f846

Fixes: https://github.com/dracut-ng/dracut-ng/issues/1046
