### PR TITLE
fix(systemd-tmpfiles): do not install /etc/passwd & /etc/group

### DIFF
--- a/modules.d/01systemd-tmpfiles/module-setup.sh
+++ b/modules.d/01systemd-tmpfiles/module-setup.sh
@@ -45,8 +45,6 @@ install() {
     # Install the hosts local user configurations if enabled.
     if [[ $hostonly ]]; then
         inst_multiple -H -o \
-            /etc/group \
-            /etc/passwd \
             "$tmpfilesconfdir/*.conf" \
             "$systemdsystemconfdir"/systemd-tmpfiles-clean.service \
             "$systemdsystemconfdir/systemd-tmpfiles-clean.service.d/*.conf" \


### PR DESCRIPTION
Original commit - https://github.com/dracut-ng/dracut-ng/commit/2b61be32b890e70b1fce45d984327c27302da9bc

Do not install full unmodified /etc/passwd and /etc/group form the host. This code is misleading as it is always a no-op since /etc/passwd would already exists and this line would be ignored.

## Changes

## Checklist
- [ ] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it

Fixes #
