### PR TITLE
fix(systemd-sysusers): systemd.conf no longer exists

### DIFF
--- a/modules.d/01systemd-sysusers/module-setup.sh
+++ b/modules.d/01systemd-sysusers/module-setup.sh
@@ -16,7 +16,6 @@ install() {
     inst_simple "$moddir/sysusers-dracut.conf" "$systemdsystemunitdir/systemd-sysusers.service.d/sysusers-dracut.conf"
 
     inst_sysusers basic.conf
-    inst_sysusers systemd.conf
 
     inst_multiple -o \
         "$systemdsystemunitdir"/systemd-sysusers.service \


### PR DESCRIPTION
systemd.conf has been removed in systemd v250.

See https://github.com/systemd/systemd/commit/564761f

## Checklist
- [ ] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it

Fixes #
