### PR TITLE
fix(systemd-pcrphase): include systemd-pcrphase in hostonly mode

### DIFF
--- a/modules.d/01systemd-pcrphase/module-setup.sh
+++ b/modules.d/01systemd-pcrphase/module-setup.sh
@@ -11,10 +11,6 @@ check() {
         return 1
     fi
 
-    if [[ $hostonly ]]; then
-        return 255
-    fi
-
     return 0
 }
 


### PR DESCRIPTION
Commit https://github.com/jozzsi/dracut-ng/commit/a2193b7 enables to include systemd-pcrphase in hostonly mode without undesired side-effects.

## Checklist
- [ ] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it

CC @trungams @dalto8 @Nowa-Ammerlaan  @ossimoi @BSerpent86 

Fixes #1048
Related #329