### PR TITLE
fix(test): running tests on bare metal fail with syntax error

### DIFF
--- a/test/test-functions
+++ b/test/test-functions
@@ -249,7 +249,7 @@ while (($# > 0)); do
         --all)
             set_test_envonment_variables
             if ! test_check 2 &> test${TEST_RUN_ID:+-$TEST_RUN_ID}.log; then
-                if [ "$V" -ge 1 ]; then
+                if [[ $V == "1" || $V == "2" ]]; then
                     cat test${TEST_RUN_ID:+-$TEST_RUN_ID}.log
                 fi
                 echo -e "TEST: $TEST_DESCRIPTION " "$COLOR_WARNING" "[SKIPPED]" "$COLOR_NORMAL"


### PR DESCRIPTION
```
$ sudo make TESTS="62" check
make[1]: Entering directory '/mnt/work/dracut-ng/test/TEST-62-BONDBRIDGEVLAN'
/mnt/work/dracut-ng/test/test-functions: line 252: [: : integer expression expected
```

## Checklist
- [X] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it

Fixes add225f6b4198c7eaa20e5504b0711ee37bd7f13
