### PR TITLE
fix(dracut-systemd): suppress gpt-auto-root devices if not needed

### DIFF
--- a/modules.d/98dracut-systemd/rootfs-generator.sh
+++ b/modules.d/98dracut-systemd/rootfs-generator.sh
@@ -50,6 +50,12 @@ generator_mount_rootfs() {
         [ -d "$GENERATOR_DIR"/initrd-root-fs.target.requires ] || mkdir -p "$GENERATOR_DIR"/initrd-root-fs.target.requires
         ln -s ../sysroot.mount "$GENERATOR_DIR"/initrd-root-fs.target.requires/sysroot.mount
     fi
+    if ! [ -L "$GENERATOR_DIR"/dev-gpt\\x2dauto\\x2droot.device ]; then
+        ln -s /dev/null "$GENERATOR_DIR"/dev-gpt\\x2dauto\\x2droot.device
+    fi
+    if ! [ -L "$GENERATOR_DIR"/dev-gpt\\x2dauto\\x2droot\\x2dluks.device ]; then
+        ln -s /dev/null "$GENERATOR_DIR"/dev-gpt\\x2dauto\\x2droot\\x2dluks.device
+    fi
 }
 
 generator_fsck_after_pre_mount() {


### PR DESCRIPTION
The `systemd-gpt-auto-generator` comes into play if there is no `root=` on kernel command line defined. However dracut-generated image may embed `root=` inside the image (`/etc/cmdline`, `/etc/cmdline.d`). Then dracut's `rootfs-generator` attempts to boot using "embedded" `root=`. As a result both generators fall into conflict and cause a broken boot.

## Changes

The patch suppresses gpt-auto-root devices if `root=` is known but is not found on kernel command line.

## Checklist
- [x] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it

Fixes #1062
