### PR TITLE
test(DMSQUASH): increase partition size

### DIFF
--- a/test/TEST-30-DMSQUASH/create-root.sh
+++ b/test/TEST-30-DMSQUASH/create-root.sh
@@ -5,7 +5,7 @@ set -e
 
 # create a single partition using 50% of the capacity of the image file created by test_setup() in test.sh
 sfdisk /dev/disk/by-id/scsi-0QEMU_QEMU_HARDDISK_root << EOF
-2048,452688
+2048,652688
 EOF
 
 udevadm settle


### PR DESCRIPTION
initrd on void is larger due to non-hostonly configuration. Increase partition size to accommodate the larger initrd.

## Checklist
- [ ] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it

Fixes #
