### PR TITLE
feat(crypt): remove empty /etc/crypttab

### DIFF
--- a/modules.d/90crypt/module-setup.sh
+++ b/modules.d/90crypt/module-setup.sh
@@ -136,7 +136,13 @@ install() {
                 done
             fi
         done < "$dracutsysrootdir"/etc/crypttab > "$initdir"/etc/crypttab
-        mark_hostonly /etc/crypttab
+
+        # Remove empty /etc/crypttab to allow creating it later
+        if [ -s "$initdir"/etc/crypttab ]; then
+            mark_hostonly /etc/crypttab
+        else
+            rm -rf "$initdir"/etc/crypttab
+        fi
     fi
 
     inst_simple "$moddir/crypt-lib.sh" "/lib/dracut-crypt-lib.sh"


### PR DESCRIPTION
crypt module should not install an empty /etc/crypttab in hostonly mode.

Some distributions ship with an /etc/crypttab without entries (just with comments). In those distributions installing /etc/crypttab as part of --install command line option in hostonly mode would not work as expected.

## Checklist
- [X] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it

Fixes: https://github.com/dracut-ng/dracut-ng/issues/1057
