### PR TITLE
ci(debian): install console-data to test i18n module

### DIFF
--- a/test/container/Dockerfile-debian
+++ b/test/container/Dockerfile-debian
@@ -44,7 +44,7 @@ RUN \
     btrfs-progs \
     ca-certificates \
     cargo \
-    console-setup \
+    console-data \
     cpio \
     cryptsetup \
     docbook \
@@ -60,6 +60,7 @@ RUN \
     isc-dhcp-client \
     isc-dhcp-server \
     jq \
+    kbd \
     kmod \
     libkmod-dev \
     linux-image-generic \


### PR DESCRIPTION
console-data is required for loadkeys to work properly.

If console-data is not installed, the following command fails

```
loadkeys  --default
loadkeys: Unable to find file: defkeymap.map
```

## Checklist
- [ ] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it

Fixes #
