### PR TITLE
ci(opensuse): install mkosi for reference

### DIFF
--- a/test/container/Dockerfile-arch
+++ b/test/container/Dockerfile-arch
@@ -1,6 +1,6 @@
 # Test coverage provided by this container:
 # - xfs, ntfs-3g
-# - mkinitcpio, mkosi
+# - mkinitcpio
 # - sbsigntools
 # - qrencode (systemd-bsod)
 # - rdma out of tree dracut module
@@ -32,12 +32,10 @@ RUN pacman --noconfirm -Syu \
     gcc \
     jq \
     linux \
-    linux-firmware \
     lvm2 \
     make \
     mdadm \
     mkinitcpio \
-    mkosi \
     multipath-tools \
     nbd \
     networkmanager \

--- a/test/container/Dockerfile-opensuse
+++ b/test/container/Dockerfile-opensuse
@@ -1,5 +1,6 @@
 # Test coverage provided by this container:
 # - network-legacy
+# - mkosi-initrd
 # - hmaccalc (fido)
 # - rdma out of tree dracut module
 
@@ -18,10 +19,12 @@ RUN dnf -y install --setopt=install_weak_deps=False \
     dbus-broker \
     dhcp-client \
     dhcp-server \
+    distribution-gpg-keys \
     dmraid \
     e2fsprogs \
     erofs-utils \
     gcc \
+    git \
     hmaccalc \
     iproute \
     iputils \
@@ -53,4 +56,5 @@ RUN dnf -y install --setopt=install_weak_deps=False \
 
 # force non-hostonly mode, but keep all the other config
 RUN \
-  echo 'hostonly="no"' > /usr/lib/dracut/dracut.conf.d/02-dist.conf
+  echo 'hostonly="no"' > /usr/lib/dracut/dracut.conf.d/02-dist.conf \
+  && cd / && git clone https://github.com/systemd/mkosi && ln -s /mkosi/bin/mkosi /usr/bin/mkosi && ln -s /mkosi/bin/mkosi-initrd /usr/bin/mkosi-initrd


### PR DESCRIPTION
mkosi is well supported in openSUSE (https://en.opensuse.org/Mkosi-initrd) and I was not able to make it work in the Arch container, so lets move mkosi
reference testing from Arch to openSUSE.

## Checklist
- [ ] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it
