### PR TITLE
ci(opensuse): switch to packaged version for mkosi-initrd

### DIFF
--- a/test/container/Dockerfile-opensuse
+++ b/test/container/Dockerfile-opensuse
@@ -35,6 +35,7 @@ RUN zypper --non-interactive install --no-recommends \
     lvm2 \
     make \
     mdadm \
+    mkosi-initrd \
     nbd \
     NetworkManager \
     nfs-utils \
@@ -56,5 +57,4 @@ RUN zypper --non-interactive install --no-recommends \
 
 # force non-hostonly mode, but keep all the other config
 RUN \
-  echo 'hostonly="no"' > /usr/lib/dracut/dracut.conf.d/02-dist.conf \
-  && cd / && git clone https://github.com/systemd/mkosi && ln -s /mkosi/bin/mkosi /usr/bin/mkosi && ln -s /mkosi/bin/mkosi-initrd /usr/bin/mkosi-initrd
+  echo 'hostonly="no"' > /usr/lib/dracut/dracut.conf.d/02-dist.conf


### PR DESCRIPTION
The packaged version is a better reference and possible better integrated than the upstream version.


## Checklist
- [ ] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it

Fixes #
