### PR TITLE
ci(fedora): change the default FSTYPE to btrfs for Fedora

### DIFF
--- a/test/container/Dockerfile-fedora
+++ b/test/container/Dockerfile-fedora
@@ -21,6 +21,9 @@ FROM ${REGISTRY}/${DISTRIBUTION}
 # export ARG
 ARG DISTRIBUTION
 
+# prefer running tests with btrfs
+ENV TEST_FSTYPE=btrfs
+
 RUN \
 if [[ "${DISTRIBUTION}" =~ "centos:" ]]; then \
     dnf config-manager --set-enabled crb; \


### PR DESCRIPTION

## Checklist
- [ ] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it

Fixes #
