### PR TITLE
ci: test xfs on Fedora and btrfs on Arch

### DIFF
--- a/test/container/Dockerfile-arch
+++ b/test/container/Dockerfile-arch
@@ -1,5 +1,5 @@
 # Test coverage provided by this container:
-# - xfs, ntfs-3g
+# - ntfs-3g
 # - mkinitcpio
 # - sbsigntools
 # - qrencode (systemd-bsod)
@@ -13,8 +13,8 @@
 
 FROM docker.io/archlinux
 
-# prefer running tests with xfs
-ENV TEST_FSTYPE=xfs
+# prefer running tests with btrfs
+ENV TEST_FSTYPE=btrfs
 
 RUN pacman --noconfirm -Syu \
     asciidoc \
@@ -56,5 +56,4 @@ RUN pacman --noconfirm -Syu \
     systemd-ukify \
     tgt \
     tpm2-tools \
-    xfsprogs \
     && yes | pacman -Scc

--- a/test/container/Dockerfile-fedora
+++ b/test/container/Dockerfile-fedora
@@ -1,6 +1,7 @@
 # Test coverage provided by this container:
 # - arm64
 # - hostonly
+# - xfs
 # - memstrack
 # - ndctl (for nvdimm)
 # - fcoe-utils (Fibre Channel over Ethernet)
@@ -21,8 +22,8 @@ FROM ${REGISTRY}/${DISTRIBUTION}
 # export ARG
 ARG DISTRIBUTION
 
-# prefer running tests with btrfs
-ENV TEST_FSTYPE=btrfs
+# prefer running tests with xfs
+ENV TEST_FSTYPE=xfs
 
 RUN \
 if [[ "${DISTRIBUTION}" =~ "centos:" ]]; then \
@@ -87,6 +88,7 @@ RUN dnf -y install --setopt=install_weak_deps=False \
     systemd-resolved \
     systemd-ukify \
     tpm2-tools \
+    xfsprogs \
     && dnf -y update && dnf clean all
 
 # CentOS Stream ships only qemu-kvm, but it disables the KVM accel when it's not available


### PR DESCRIPTION
btrfs is not readily available on CentOS.

Fixes: https://github.com/dracut-ng/dracut-ng/issues/1079


