### PR TITLE
test(BASIC): simplify and further strip down basic test

### DIFF
--- a/test/TEST-20-STORAGE/test.sh
+++ b/test/TEST-20-STORAGE/test.sh
@@ -15,6 +15,10 @@ elif [ "$TEST_FSTYPE" = "btrfs" ]; then
     TEST_KERNEL_CMDLINE+=" root=LABEL=root "
 else
     TEST_KERNEL_CMDLINE+=" root=LABEL=root "
+
+    # test fips mode
+    [ -f /usr/share/crypto-policies/default-fips-config ] && TEST_KERNEL_CMDLINE+=" fips=1 rd.fips.skipkernel boot=LABEL=root "
+
     export USE_LVM=1
     command -v mdadm > /dev/null && export HAVE_RAID=1
     command -v cryptsetup > /dev/null && export HAVE_CRYPT=1


### PR DESCRIPTION
Move fips testing into the more complex STORAGE test.

Build the kernel command line option into the BASIC initrd.

## Checklist
- [ ] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it

Fixes #
