### PR TITLE
ci(opensuse): make mkosi-initrd installation more complete

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -121,7 +121,7 @@ jobs:
                     - "42"
         container:
             image: ghcr.io/dracut-ng/${{ matrix.container }}
-            options: '--device=/dev/kvm'
+            options: '--device=/dev/kvm --privileged'
         steps:
             - name: "Checkout Repository"
               uses: actions/checkout@v4

--- a/test/container/Dockerfile-opensuse
+++ b/test/container/Dockerfile-opensuse
@@ -49,7 +49,13 @@ RUN zypper --non-interactive install --no-recommends \
     tpm2.0-tools \
     /usr/bin/qemu-system-$(uname -m) \
     util-linux-systemd \
-    && zypper --non-interactive dist-upgrade --no-recommends && zypper --non-interactive clean
+    && zypper --non-interactive dist-upgrade --no-recommends
 
+# install mkosi from source
 RUN \
-  cd / && git clone https://github.com/systemd/mkosi && ln -s /mkosi/bin/mkosi /usr/bin/mkosi && ln -s /mkosi/bin/mkosi-initrd /usr/bin/mkosi-initrd
+  cd / \
+  && git clone https://github.com/systemd/mkosi \
+  && ln -s /mkosi/bin/mkosi /usr/bin/mkosi \
+  && ln -s /mkosi/bin/mkosi-initrd /usr/bin/mkosi-initrd \
+  && zypper --non-interactive remove busybox-diffutils busybox-less \
+  && /usr/bin/mkosi dependencies | xargs zypper --non-interactive install


### PR DESCRIPTION
Add '--privileged' flag for running systemd tests to make sure mkosi-initrd runs well.

## Checklist
- [ ] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it

Fixes #
