### PR TITLE
fix(crypt): crypt-lib.sh optionally depends on stty

### DIFF
--- a/modules.d/90crypt/module-setup.sh
+++ b/modules.d/90crypt/module-setup.sh
@@ -145,6 +145,7 @@ install() {
         fi
     fi
 
+    inst_multiple -o stty
     inst_simple "$moddir/crypt-lib.sh" "/lib/dracut-crypt-lib.sh"
     inst_script "$moddir/crypt-run-generator.sh" "/sbin/crypt-run-generator"
 

--- a/modules.d/91crypt-gpg/module-setup.sh
+++ b/modules.d/91crypt-gpg/module-setup.sh
@@ -3,7 +3,7 @@
 # GPG support is optional
 # called by dracut
 check() {
-    require_binaries gpg tr stty || return 1
+    require_binaries gpg tr || return 1
 
     if sc_requested; then
         if ! sc_supported; then
@@ -23,7 +23,7 @@ depends() {
 
 # called by dracut
 install() {
-    inst_multiple gpg tr stty
+    inst_multiple gpg tr
     inst "$moddir/crypt-gpg-lib.sh" "/lib/dracut-crypt-gpg-lib.sh"
 
     if sc_requested; then


### PR DESCRIPTION
Follow-up to 1af3531.

## Checklist
- [ ] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it

Fixes #
