### PR TITLE
ci(centos): install btrfs-progs

### DIFF
--- a/test/container/Dockerfile-fedora
+++ b/test/container/Dockerfile-fedora
@@ -28,9 +28,9 @@ ENV TEST_FSTYPE=xfs
 RUN \
 if [[ "${DISTRIBUTION}" =~ "centos:" ]]; then \
     dnf config-manager --set-enabled crb; \
+    dnf -y install epel-release; \
 else \
     dnf -y install --setopt=install_weak_deps=False \
-    btrfs-progs \
     busybox \
     dhcp-client \
     dhcp-server \
@@ -45,6 +45,7 @@ RUN dnf -y install --setopt=install_weak_deps=False \
     asciidoc \
     bash-completion \
     bluez \
+    btrfs-progs \
     cargo \
     cifs-utils \
     cryptsetup \


### PR DESCRIPTION
See https://communityblog.fedoraproject.org/epel-10-is-now-available/ .

`btrfs-progs` enables running FULL-SYSTEMD test on CentOS.

## Checklist
- [ ] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it

Fixes #
