### PR TITLE
test(FULL-SYSTEMD): test more systemd dracut modules

### DIFF
--- a/test/TEST-41-FULL-SYSTEMD/test.sh
+++ b/test/TEST-41-FULL-SYSTEMD/test.sh
@@ -67,6 +67,10 @@ test_setup() {
         dracut_modules="$dracut_modules dbus-broker systemd-hostnamed systemd-portabled systemd-timedated"
     fi
 
+    if [ -f /usr/lib/systemd/systemd-networkd ]; then
+        dracut_modules="$dracut_modules systemd-networkd"
+    fi
+
     if [ -f /usr/lib/systemd/systemd-battery-check ]; then
         dracut_modules="$dracut_modules systemd-battery-check"
     fi


### PR DESCRIPTION
Goal is to gradually test more systemd modules and without destabilizing the CI.

- when dbus-broker is available, add dbus dependent modules
- when systemd-networkd is available, install it

## Checklist
- [ ] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it

Fixes #
