### PR TITLE
ci(opensuse): install systemd-portable

### DIFF
--- a/test/container/Dockerfile-opensuse
+++ b/test/container/Dockerfile-opensuse
@@ -45,6 +45,7 @@ RUN zypper --non-interactive install --no-recommends \
     swtpm \
     systemd-boot \
     systemd-experimental \
+    systemd-portable \
     tgt \
     tpm2.0-tools \
     /usr/bin/qemu-system-$(uname -m) \


### PR DESCRIPTION
systemd-portable is installed on all other systemd enabled containers except opensuse. systemd-portable is an established tool, there is no need to handle teh case in the CI when it is not available.

## Checklist
- [ ] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it

Fixes #
