### PR TITLE
ci(opensuses): limit the number of warnings with small fixes

### DIFF
--- a/test/container/Dockerfile-opensuse
+++ b/test/container/Dockerfile-opensuse
@@ -23,24 +23,23 @@ RUN zypper --non-interactive install --no-recommends \
     gcc \
     git \
     hmaccalc \
-    iproute \
+    iproute2 \
     iputils \
     iscsiuio \
     kbd \
-    kernel \
+    kernel-vanilla \
     libkmod-devel \
     lvm2 \
     make \
     mdadm \
     nbd \
     NetworkManager \
-    nfs-utils \
+    nfs-kernel-server \
     open-iscsi \
     parted \
     pciutils \
-    procps \
     python3-pefile \
-    qemu-kvm \
+    qemu \
     squashfs \
     swtpm \
     systemd-boot \
@@ -48,7 +47,6 @@ RUN zypper --non-interactive install --no-recommends \
     systemd-portable \
     tgt \
     tpm2.0-tools \
-    /usr/bin/qemu-system-$(uname -m) \
     util-linux-systemd \
     && zypper --non-interactive dist-upgrade --no-recommends
 


### PR DESCRIPTION
## Changes

procps is already installed.
iproute maps to iproute2.
kernel maps to kernel-vanilla
nfs-utils maps to nfs-kernel-server                                                                                                                                                                                                   
qemu-kvm maps to qemu   

## Checklist
- [ ] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it

Fixes #
