### PR TITLE
test: graceful poweroff for systemd based tests

### DIFF
--- a/test/modules.d/80test-root/test-init.sh
+++ b/test/modules.d/80test-root/test-init.sh
@@ -29,4 +29,11 @@ fi
 
 echo "made it to the rootfs!"
 echo "Powering down."
-poweroff -f
+
+if [ -f /usr/lib/systemctl ]; then
+    # graceful poweroff
+    systemctl poweroff
+else
+    # force immediate poweroff
+    poweroff -f
+fi


### PR DESCRIPTION
This PR makes the test case more life-like and prepares for testing dracut-shutdown.

## Checklist
- [ ] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it

Fixes #
