### PR TITLE
ci(fedora): switch Fedora to dbus-broker

### DIFF
--- a/test/container/Dockerfile-alpine
+++ b/test/container/Dockerfile-alpine
@@ -6,7 +6,7 @@
 # - elogind (instead of logind)
 # - busybox default shell (no dash installed)
 # - gzip compression
-# - clang
+# - dbus-daemon
 
 # Not installed
 # - cargo (to increase coverage)

--- a/test/container/Dockerfile-arch
+++ b/test/container/Dockerfile-arch
@@ -4,6 +4,7 @@
 # - sbsigntools
 # - qrencode (systemd-bsod)
 # - rdma out of tree dracut module
+# - both dbus-daemon and dbus-broker
 
 # Not installed
 # - busybox (no need, tested elsewhere)

--- a/test/container/Dockerfile-debian
+++ b/test/container/Dockerfile-debian
@@ -4,6 +4,7 @@
 # - mawk (instead of gawk)
 # - zstd compression
 # - verbose logging for tests
+# - dbus-daemon
 
 # Not installed
 # - dmraid (no longer maintained, https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=1056944)

--- a/test/container/Dockerfile-fedora
+++ b/test/container/Dockerfile-fedora
@@ -13,6 +13,7 @@
 # - nss-softokn, kdumpbase out of tree dracut modules
 # - fips
 # - ignition
+# - dbus-broker
 
 ARG DISTRIBUTION=fedora
 ARG REGISTRY=registry.fedoraproject.org
@@ -50,7 +51,6 @@ RUN dnf -y install --setopt=install_weak_deps=False \
     cifs-utils \
     cryptsetup \
     crypto-policies-scripts \
-    dbus-daemon \
     device-mapper-multipath \
     dracut-live \
     e2fsprogs \

--- a/test/container/Dockerfile-gentoo
+++ b/test/container/Dockerfile-gentoo
@@ -2,6 +2,7 @@
 # - glibc/systemd or musl/openrc
 # - systemd-networkd
 # - bash
+# - dbus-daemon
 
 # Not installed
 # - NetworkManager (to increase coverage)

--- a/test/container/Dockerfile-opensuse
+++ b/test/container/Dockerfile-opensuse
@@ -3,6 +3,7 @@
 # - mkosi-initrd
 # - hmaccalc (fido)
 # - rdma out of tree dracut module
+# - dbus-broker
 
 FROM registry.opensuse.org/opensuse/tumbleweed:latest
 
@@ -13,7 +14,6 @@ RUN zypper --non-interactive install --no-recommends \
     btrfsprogs \
     cargo \
     cryptsetup \
-    dbus-broker \
     dhcp-client \
     dhcp-server \
     distribution-gpg-keys \

--- a/test/container/Dockerfile-void
+++ b/test/container/Dockerfile-void
@@ -7,6 +7,7 @@
 # - zfs and zfs out of tree dracut module
 # - gzip compression
 # - clang
+# - dbus-daemon
 
 FROM ghcr.io/void-linux/void-glibc-full
 


### PR DESCRIPTION
## Changes

switch Fedora to dbus-broker and document the status of dbus-daemon and dbus-broker for each CI container.

In general if the distribution supports a dbus metapackage, try to honor the distribution default choice.


## Checklist
- [ ] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it

Fixes #
