### PR TITLE
test(FULL-SYSTEMD): remove the check for dbus-broker

### DIFF
--- a/modules.d/09dbus/module-setup.sh
+++ b/modules.d/09dbus/module-setup.sh
@@ -10,19 +10,22 @@ check() {
 
 # Module dependency requirements.
 depends() {
-    local _module
-    # Add a dbus meta dependency based on the module in use.
-    for _module in dbus-daemon dbus-broker; do
-        if dracut_module_included "$_module"; then
-            echo "$_module"
+    for module in dbus-broker dbus-daemon; do
+        if dracut_module_included "$module"; then
+            echo "$module"
             return 0
         fi
     done
 
-    if check_module "dbus-broker"; then
-        echo "dbus-broker"
-        return 0
-    fi
+    for module in dbus-broker dbus-daemon; do
+        # install the first viable module, unless there omitted
+        module_check $module > /dev/null 2>&1
+        if [[ $? == 255 ]] && ! [[ " $omit_dracutmodules " == *\ $module\ * ]] && check_module "$module"; then
+            echo "$module"
+            return 0
+        fi
+    done
+
     echo "dbus-daemon"
     return 0
 }

--- a/test/TEST-41-FULL-SYSTEMD/test.sh
+++ b/test/TEST-41-FULL-SYSTEMD/test.sh
@@ -63,11 +63,7 @@ test_setup() {
     trap "$(shopt -p globstar)" RETURN
     shopt -q -s globstar
 
-    local dracut_modules="resume systemd-udevd systemd-journald systemd-tmpfiles systemd-cryptsetup systemd-emergency systemd-ac-power systemd-coredump systemd-creds systemd-integritysetup systemd-ldconfig systemd-pstore systemd-repart systemd-sysext systemd-veritysetup"
-
-    if [ -f /usr/bin/dbus-broker ]; then
-        dracut_modules="$dracut_modules dbus-broker systemd-hostnamed systemd-portabled systemd-timedated"
-    fi
+    local dracut_modules="resume systemd-udevd systemd-journald systemd-tmpfiles systemd-cryptsetup systemd-emergency systemd-ac-power systemd-coredump systemd-creds systemd-integritysetup systemd-ldconfig systemd-pstore systemd-repart systemd-sysext systemd-veritysetup systemd-hostnamed systemd-portabled systemd-timedated"
 
     if [ -f /usr/lib/systemd/systemd-networkd ]; then
         if [ -f /usr/bin/dbus-broker ]; then


### PR DESCRIPTION
## Changes

All CI containers should be able to test the following dracut modules, so no check is needed
 - systemd-hostnamed
 - systemd-portabled
 - systemd-timedated


## Checklist
- [ ] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it

Fixes #
