### PR TITLE
test(FULL-SYSTEMD): support both dbus-broker and dbus-daemon

### DIFF
--- a/test/TEST-41-FULL-SYSTEMD/test.sh
+++ b/test/TEST-41-FULL-SYSTEMD/test.sh
@@ -63,18 +63,17 @@ test_setup() {
     trap "$(shopt -p globstar)" RETURN
     shopt -q -s globstar
 
-    local dracut_modules="resume systemd-udevd systemd-journald systemd-tmpfiles systemd-cryptsetup systemd-emergency systemd-ac-power systemd-coredump systemd-creds systemd-integritysetup systemd-ldconfig systemd-pstore systemd-repart systemd-sysext systemd-veritysetup"
+    local dracut_modules="resume systemd-udevd systemd-journald systemd-tmpfiles systemd-cryptsetup systemd-emergency systemd-ac-power systemd-coredump systemd-creds systemd-integritysetup systemd-ldconfig systemd-pstore systemd-repart systemd-sysext systemd-veritysetup systemd-hostnamed systemd-portabled systemd-timedated"
 
+    # TODO - this workaround should not be needed and should be removed
     if [ -f /usr/bin/dbus-broker ]; then
-        dracut_modules="$dracut_modules dbus-broker systemd-hostnamed systemd-portabled systemd-timedated"
+        dracut_modules="$dracut_modules dbus-broker"
+    else
+        dracut_modules="$dracut_modules dbus-daemon"
     fi
 
     if [ -f /usr/lib/systemd/systemd-networkd ]; then
-        if [ -f /usr/bin/dbus-broker ]; then
-            dracut_modules="$dracut_modules systemd-network-management"
-        else
-            dracut_modules="$dracut_modules systemd-networkd"
-        fi
+        dracut_modules="$dracut_modules systemd-network-management"
     fi
 
     if [ -f /usr/lib/systemd/systemd-battery-check ]; then


### PR DESCRIPTION
## Changes

All CI containers should be able to test the following dracut modules, so no check is needed
 - systemd-hostnamed
 - systemd-portabled
 - systemd-timedated
 - systemd-network-management

## Checklist
- [ ] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it

Fixes #
