### PR TITLE
fix(systemd-sysuser): add support for Gentoo

### DIFF
--- a/dracut-init.sh
+++ b/dracut-init.sh
@@ -636,10 +636,10 @@ inst_libdir_file() {
 
 # install sysusers files
 inst_sysusers() {
-    inst_multiple -o "$sysusers/$*"
+    inst_multiple -o "$sysusers/$*" "$sysusers/acct-*-$*"
 
     if [[ $hostonly ]]; then
-        inst_multiple -H -o "$sysusersconfdir/$*"
+        inst_multiple -H -o "$sysusersconfdir/$*" "$sysusers/acct-*-$*"
     fi
 }
 


### PR DESCRIPTION
## Changes

systemd-sysuser dracut module uses inst_sysusers function to install configuration files. These configuration files are named differently in Gentoo, which impacts upstream Gentoo CI as well.

Partially fixes https://github.com/dracut-ng/dracut-ng/issues/274

Based on Gentoo downstream patch https://github.com/gentoo/gentoo/blob/master/sys-kernel/dracut/files/dracut-103-acct-user-group-gentoo.patch by Nowa Ammerlaan <nowa@gentoo.org>

This PR is required to restore green CI.

CC @Nowa-Ammerlaan 

## Checklist
- [X] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it

Fixes #274
