### PR TITLE
fix(systemd-ask-password): do not half-install systemd-ask-password-wall

### DIFF
--- a/modules.d/01systemd-ask-password/module-setup.sh
+++ b/modules.d/01systemd-ask-password/module-setup.sh
@@ -43,7 +43,6 @@ install() {
     inst_multiple -o \
         "$systemdsystemunitdir"/systemd-ask-password-console.path \
         "$systemdsystemunitdir"/systemd-ask-password-console.service \
-        "$systemdsystemunitdir"/multi-user.target.wants/systemd-ask-password-wall.path \
         "$systemdsystemunitdir"/sysinit.target.wants/systemd-ask-password-console.path \
         systemd-ask-password \
         systemd-tty-ask-password-agent


### PR DESCRIPTION
## Changes

Do not install the path unit when the service unit is not installed for systemd-ask-password-wall.

Fixes the following warning on the CI:

```
[FAILED] Failed to start Forward Password Requests to Wall Directory Watch. 
See 'systemctl status systemd-ask-password-wall.path' for details. 
...
systemd[1]: systemd-ask-password-wall.path: Refusing to start, unit systemd-ask-password-wall.service to trigger not loaded. 
systemd[1]: Failed to start Forward Password Requests to Wall Directory Watch.
```

## Checklist
- [X] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it

Fixes #
