### PR TITLE
fix(systemd-cryptsetup): only filter out modules for strict hostonly

### DIFF
--- a/modules.d/71systemd-cryptsetup/module-setup.sh
+++ b/modules.d/71systemd-cryptsetup/module-setup.sh
@@ -23,7 +23,7 @@ check() {
 depends() {
     local deps
     deps="crypt systemd-ask-password"
-    if [[ $hostonly && -f "${dracutsysrootdir-}"/etc/crypttab ]]; then
+    if [[ ${hostonly-} && $hostonly_mode == "strict" && -f "${dracutsysrootdir-}"/etc/crypttab ]]; then
         if grep -q -e "fido2-device=" -e "fido2-cid=" "${dracutsysrootdir-}"/etc/crypttab; then
             deps+=" fido2"
         fi
@@ -33,7 +33,7 @@ depends() {
         if grep -q "tpm2-device=" "${dracutsysrootdir-}"/etc/crypttab; then
             deps+=" tpm2-tss"
         fi
-    elif [[ ! $hostonly ]]; then
+    else
         for module in fido2 pkcs11 tpm2-tss; do
             module_check $module > /dev/null 2>&1
             if [[ $? == 255 ]] && ! [[ " $omit_dracutmodules " == *\ $module\ * ]]; then


### PR DESCRIPTION
## Changes

Exclude (filter out) dracut modules only when hostonly_mode is set to strict (needs opt in even in hostonly).

In sloppy mode all installable optional dependencies will be installed.

Helps with the discussion for https://github.com/dracut-ng/dracut-ng/issues/748

## Checklist
- [ ] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it

Fixes #
