### PR TITLE
fix(img-lib): trim required binaries

### DIFF
--- a/modules.d/99img-lib/module-setup.sh
+++ b/modules.d/99img-lib/module-setup.sh
@@ -3,14 +3,14 @@
 
 # called by dracut
 check() {
-    require_binaries tar gzip dd echo tr || return 1
+    require_binaries dd echo tr || return 1
     return 255
 }
 
 # called by dracut
 install() {
-    inst_multiple tar gzip dd echo tr rmdir
+    inst_multiple dd echo tr
     # TODO: make this conditional on a cmdline flag / config option
-    inst_multiple -o cpio xz bzip2 zstd
+    inst_multiple -o cpio xz bzip2 zstd tar gzip rmdir
     inst_simple "$moddir/img-lib.sh" "/lib/img-lib.sh"
 }


### PR DESCRIPTION
## Changes

Make all compression methods optional to allow including only the binaries that are needed to uncompress.

## Checklist
- [ ] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it

Fixes #
