### PR TITLE
test(UEFI): unskip test for Arch

### DIFF
--- a/test/test-functions
+++ b/test/test-functions
@@ -80,6 +80,7 @@ ovmf_code() {
         "/usr/share/OVMF/OVMF_CODE.fd" \
         "/usr/share/OVMF/OVMF_CODE_4M.fd" \
         "/usr/share/edk2/x64/OVMF_CODE.fd" \
+        "/usr/share/edk2/x64/OVMF_CODE.4m.fd" \
         "/usr/share/edk2-ovmf/OVMF_CODE.fd" \
         "/usr/share/qemu/ovmf-x86_64-4m.bin"; do
         [[ -s $path ]] && echo -n "$path" && return


### PR DESCRIPTION
## Changes

On Arch the path for OVMF is /usr/share/edk2/x64/OVMF_CODE.4m.fd .

## Checklist
- [ ] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it

Fixes #
