### PR TITLE
feat(livenet): get live image size from TFTP servers

### DIFF
--- a/modules.d/90livenet/livenetroot.sh
+++ b/modules.d/90livenet/livenetroot.sh
@@ -16,20 +16,31 @@ liveurl="${netroot#livenet:}"
 info "fetching $liveurl"
 
 if getargbool 0 'rd.writable.fsimg'; then
-    imgheader=$(curl -sIL "$liveurl")
-
-    # shellcheck disable=SC2181
-    ret=$?
-    if [ $ret != 0 ]; then
-        warn "failed to get live image header: error $ret"
-    else
-        imgheaderlen=$(echo "$imgheader" | sed -n 's/[cC]ontent-[lL]ength: *\([[:digit:]]*\).*/\1/p')
+    if str_starts "$liveurl" "tftp"; then
+        # we need to pass -v to get tftp tsize value in stderr
+        imgheader=$(curl -vsIL "$liveurl" 2>&1)
+        # curl returns a non-zero exit status in this case
+        ret=$?
+        imgheaderlen=$(echo "$imgheader" | sed -n 's/\* got option=(tsize) value=(*\([[:digit:]]*\).*/\1/p')
         if [ -z "$imgheaderlen" ]; then
-            warn "failed to get 'Content-Length' header from live image"
-        else
-            imgsize=$((imgheaderlen / (1024 * 1024)))
-            check_live_ram $imgsize
+            warn "failed to get 'tsize' header from TFTP live image: error $ret"
         fi
+    else
+        imgheader=$(curl -sIL "$liveurl")
+        ret=$?
+        if [ $ret != 0 ]; then
+            warn "failed to get live image header: error $ret"
+        else
+            imgheaderlen=$(echo "$imgheader" | sed -n 's/[cC]ontent-[lL]ength: *\([[:digit:]]*\).*/\1/p')
+            if [ -z "$imgheaderlen" ]; then
+                warn "failed to get 'Content-Length' header from live image"
+            fi
+        fi
+    fi
+
+    if [ -n "$imgheaderlen" ]; then
+        imgsize=$((imgheaderlen / (1024 * 1024)))
+        check_live_ram $imgsize
     fi
 fi
 


### PR DESCRIPTION
While the current code handles HTTP and FTP headers, parsing `Content-Length`, TFTP servers need a special handling. E.g.:

```
$ curl -sIL tftp://127.0.0.1/leap-15.3/Leap-15.3_appliance.x86_64-1.15.3.iso
$ echo $?
8
```

Being more verbose (`-v`), we can see:

```
$ curl -vsIL tftp://127.0.0.1/leap-15.3/Leap-15.3_appliance.x86_64-1.15.3.iso
*   Trying 127.0.0.1:69...
* Connected to 127.0.0.1 (127.0.0.1) port 69
* set timeouts for state 0; Total  300000, retry 6 maxtry 50
* got option=(tsize) value=(285802496)
* tsize parsed from OACK (285802496)
* got option=(timeout) value=(6)
* got option=(blksize) value=(512)
* blksize parsed from OACK (512) requested (512)
* Connected for receive
* set timeouts for state 1; Total  0, retry 72 maxtry 50
* Closing connection
$ echo $?
8
```

So, in this case, we can ignore the non-zero exit from curl and parse the `tsize` value received.

## Checklist
- [X] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it