### PR TITLE
ci: switch to native ARM GitHub runners

### DIFF
--- a/.github/workflows/container-extra.yml
+++ b/.github/workflows/container-extra.yml
@@ -71,7 +71,7 @@ jobs:
     arm64:
         if: github.repository == 'dracut-ng/dracut-ng' || vars.CONTAINER == 'enabled'
         name: ${{ matrix.config.tag }} on ${{ matrix.config.platform }}
-        runs-on: ubuntu-latest
+        runs-on: ubuntu-24.04-arm
         concurrency:
             group: arm64-${{ github.workflow }}-${{ github.ref }}-${{ matrix.config.dockerfile }}
             cancel-in-progress: true
@@ -82,10 +82,6 @@ jobs:
                     - {dockerfile: 'Dockerfile-debian', tag: 'debian-arm64:latest', platform: 'linux/arm64'}
                     - {dockerfile: 'Dockerfile-fedora', tag: 'fedora-arm64:latest', platform: 'linux/arm64'}
         steps:
-            - name: Set up QEMU
-              uses: docker/setup-qemu-action@v3
-              with:
-                  platforms: ${{ matrix.config.platform }}
             - name: Check out the repo
               uses: actions/checkout@v4
             - name: Set up Docker Buildx

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -154,7 +154,7 @@ jobs:
     arm64:
         needs: basic
         name: ${{ matrix.test }} on ${{ matrix.container }} on arm64
-        runs-on: ubuntu-latest
+        runs-on: ubuntu-24.04-arm
         timeout-minutes: 20
         concurrency:
             group: arm64-${{ github.workflow }}-${{ github.ref }}-${{ matrix.container }}-${{ matrix.test }}
@@ -167,15 +167,14 @@ jobs:
                     - fedora-arm64
                 test:
                     - "80"
+        container:
+            image: ghcr.io/dracut-ng/${{ matrix.container }}
+            options: '--privileged'
         steps:
-            - name: Set up QEMU
-              uses: docker/setup-qemu-action@v3
-              with:
-                  platforms: 'linux/arm64'
             - name: "Checkout Repository"
               uses: actions/checkout@v4
             - name: "${{ matrix.container }} TEST-${{ matrix.test }}"
-              run: docker run --platform linux/arm64 '--device=/dev/kvm' -v $PWD:/w ghcr.io/dracut-ng/${{ matrix.container }} /w/test/test-github.sh "TEST-${{ matrix.test }}" ${{ matrix.test }}
+              run: ./test/test-github.sh "TEST-${{ matrix.test }}" ${{ matrix.test }}
     network:
         needs: basic
         # all nfs based on default networking


### PR DESCRIPTION
## Changes

See https://github.blog/changelog/2025-01-16-linux-arm64-hosted-runners-now-available-for-free-in-public-repositories-public-preview/

Fedora arm container building time reduced from 40 min to 3 min with this PR.

## Checklist
- [ ] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it

Fixes #
