### PR TITLE
ci: run arm64 tests on more CI containers

### DIFF
--- a/.github/workflows/container-extra.yml
+++ b/.github/workflows/container-extra.yml
@@ -60,44 +60,10 @@ jobs:
               uses: docker/build-push-action@v6
               with:
                   file: test/container/${{ matrix.config.dockerfile }}
-                  tags: ghcr.io/${{env.repository_owner}}/${{ matrix.config.tag }}
+                  tags: ghcr.io/${{env.repository_owner}}/${{ matrix.config.tag }}-amd
                   push: ${{ github.event_name == 'push' ||  github.event_name == 'schedule' }}
                   platforms: ${{ matrix.config.platform }}
                   build-args: |
                       DISTRIBUTION=${{ matrix.config.tag }}
                       REGISTRY=${{ matrix.config.registry }}
                       OPTION=${{ matrix.config.option }}
-
-    arm64:
-        if: github.repository == 'dracut-ng/dracut-ng' || vars.CONTAINER == 'enabled'
-        name: ${{ matrix.config.tag }} on ${{ matrix.config.platform }}
-        runs-on: ubuntu-24.04-arm
-        concurrency:
-            group: arm64-${{ github.workflow }}-${{ github.ref }}-${{ matrix.config.dockerfile }}
-            cancel-in-progress: true
-        strategy:
-            fail-fast: false
-            matrix:
-                config:
-                    - {dockerfile: 'Dockerfile-debian', tag: 'debian-arm64:latest', platform: 'linux/arm64'}
-                    - {dockerfile: 'Dockerfile-fedora', tag: 'fedora-arm64:latest', platform: 'linux/arm64'}
-        steps:
-            - name: Check out the repo
-              uses: actions/checkout@v4
-            - name: Set up Docker Buildx
-              uses: docker/setup-buildx-action@v3
-            - name: Login to GitHub Container Registry
-              uses: docker/login-action@v3
-              with:
-                  registry: ghcr.io
-                  username: ${{ github.repository_owner }}
-                  password: ${{ secrets.GITHUB_TOKEN }}
-            - name: Set up env
-              run: echo "repository_owner=${GITHUB_REPOSITORY_OWNER,,}" >>${GITHUB_ENV}
-            - name: Build and Push Container
-              uses: docker/build-push-action@v6
-              with:
-                  file: test/container/${{ matrix.config.dockerfile }}
-                  tags: ghcr.io/${{env.repository_owner}}/${{ matrix.config.tag }}
-                  push: ${{ github.event_name == 'push' ||  github.event_name == 'schedule' }}
-                  platforms: ${{ matrix.config.platform }}

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -163,8 +163,12 @@ jobs:
             fail-fast: false
             matrix:
                 container:
+                    - alpine
                     - debian
                     - fedora
+                    - opensuse
+                    - ubuntu
+                    - void
                 test:
                     - "80"
         container:


### PR DESCRIPTION
## Changes

In addition to Debian and Fedora, run arm64 tests on Alpine, openSUSE, Ubuntu and Void as well.

debian-arm64 and fedora-arm64 tags are no longer needed.

## Checklist
- [ ] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it

Fixes #
