### PR TITLE
ci: teach the CI where to find the openSUSE arm64 kernel

### DIFF
--- a/.github/workflows/container.yml
+++ b/.github/workflows/container.yml
@@ -47,10 +47,6 @@ jobs:
                      architecture: {platform: 'linux/arm64'}
                    - config: {tag: 'arch:latest'}
                      architecture: {platform: 'linux/arm64'}
-                   - config: {tag: 'opensuse:latest'}
-                     architecture: {platform: 'linux/arm64'}
-                   - config: {tag: 'void:latest'}
-                     architecture: {platform: 'linux/arm64'}
         runs-on: ${{ matrix.architecture.runner }}
         steps:
             - name: Check out the repo

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -164,6 +164,7 @@ jobs:
                 container:
                     - debian
                     - fedora
+                    - opensuse
                     - ubuntu
                 test:
                     - "10"

--- a/test/test-functions
+++ b/test/test-functions
@@ -117,6 +117,8 @@ set_vmlinux_env() {
             VMLINUZ="/boot/vmlinux-${KVERSION}"
         elif [ -f "/boot/kernel-${KVERSION}" ]; then
             VMLINUZ="/boot/kernel-${KVERSION}"
+        elif [ -f "/boot/Image-${KVERSION}" ]; then
+            VMLINUZ="/boot/Image-${KVERSION}"
         fi
     fi
 


### PR DESCRIPTION
On openSUSE kernel seems to be called /boot/Image-6.12.9-1-vanilla.

## Checklist
- [ ] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it

Fixes #
