### PR TITLE
ci: enable BASIC arm test for Void CI container

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -166,6 +166,7 @@ jobs:
                     - fedora
                     - opensuse
                     - ubuntu
+                    - void
                 test:
                     - "10"
         container:


### PR DESCRIPTION
Enable BASIC arm test for Void CI container.

## Checklist
- [ ] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it

Fixes #
