### PR TITLE
ci: adapt the test.sh script to the new container labeling

### DIFF
--- a/doc_site/modules/ROOT/pages/developer/hacking.adoc
+++ b/doc_site/modules/ROOT/pages/developer/hacking.adoc
@@ -105,6 +105,9 @@ with `[CONTAINER]` being one of the
 https://github.com/orgs/dracut-ng/packages[github `dracut-ng` containers].
 Default container is `fedora`.
 
+If the container supports arm64, and the test.sh script is run on an arm64
+enviroment, the test would also run using an arm64 container.
+
 Run only specific test::
 e.g. only runs the 10, 20 tests inside the default container.
 +

--- a/test/test.sh
+++ b/test/test.sh
@@ -10,6 +10,29 @@ export CONTAINER="${CONTAINER:=fedora}"
 export TESTS="${TESTS:=$2}"
 export TEST_RUN_ID="${TEST_RUN_ID:=id}"
 
+# if registry is not specified, add our registry
+if [[ $CONTAINER != *"/"* ]]; then
+    CONTAINER="ghcr.io/dracut-ng/$CONTAINER"
+fi
+
+# if label is not specified, add latest label
+if [[ $CONTAINER != *":"* ]]; then
+    CONTAINER="$CONTAINER:latest"
+fi
+
+# add architecture tag, see commit d8ff139
+ARCH="${ARCH-$(uname -m)}"
+case "$ARCH" in
+    aarch64 | arm64)
+        CONTAINER="$CONTAINER-arm"
+        ;;
+    amd64 | i?86 | x86_64)
+        CONTAINER="$CONTAINER-amd"
+        ;;
+esac
+
+echo "Running in a container from $CONTAINER"
+
 if command -v podman &> /dev/null; then
     PODMAN=podman
 else
@@ -28,5 +51,5 @@ TARGETS='clean all install check' "$PODMAN" run --rm -it \
     --device=/dev/kvm --privileged \
     -e V -e TESTS -e TEST_RUN_ID -e TARGETS -e MAKEFLAGS \
     -v "$PWD"/:/z \
-    "ghcr.io/dracut-ng/$CONTAINER" \
+    "$CONTAINER" \
     /z/test/test-github.sh


### PR DESCRIPTION
## Changes

Add architecture tag, see commit d8ff139 .

Document that the script now supports arm64.


## Checklist
- [ ] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it

Fixes #
