### PR TITLE
ci: remove busybox from Fedora and Arch

### DIFF
--- a/doc_site/modules/ROOT/pages/developer/compatability.adoc
+++ b/doc_site/modules/ROOT/pages/developer/compatability.adoc
@@ -40,6 +40,6 @@ Dependencies for the generated initramfs:
 |linux-kernel (debian 12) | 6.1
 |bash (debian 12)         | 5.2
 |eudev (alpine/void)      | 3.2.14
-|busybox (alpine)         | 1.36
+|busybox (alpine)         | 1.37
 |qemu (debian 12)         | 7.2
 |===

--- a/test/container/Dockerfile-arch
+++ b/test/container/Dockerfile-arch
@@ -21,7 +21,6 @@ RUN pacman --noconfirm -Syu \
     asciidoc \
     bluez \
     btrfs-progs \
-    busybox \
     cargo \
     cpio \
     dhclient \

--- a/test/container/Dockerfile-fedora
+++ b/test/container/Dockerfile-fedora
@@ -33,7 +33,6 @@ if [[ "${DISTRIBUTION}" =~ "centos:" ]]; then \
 else \
     dnf -y install --setopt=install_weak_deps=False \
     btrfs-progs \
-    busybox \
     dhcp-client \
     dhcp-server \
     dmraid \


### PR DESCRIPTION
## Changes

busybox compatibility is tested with the Alpine container.

Update documentation on the busybox version used on the CI.

## Checklist
- [ ] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it

Fixes #
