### PR TITLE
ci: remove leftover '-j' argument from mkfs.ext4

### DIFF
--- a/test/TEST-70-ISCSI/create-client-root.sh
+++ b/test/TEST-70-ISCSI/create-client-root.sh
@@ -3,7 +3,7 @@
 trap 'poweroff -f' EXIT
 set -ex
 
-mkfs.ext4 -q -j -L singleroot -F /dev/disk/by-id/scsi-0QEMU_QEMU_HARDDISK_singleroot
+mkfs.ext4 -q -L singleroot -F /dev/disk/by-id/scsi-0QEMU_QEMU_HARDDISK_singleroot
 mkdir -p /sysroot
 mount -t ext4 /dev/disk/by-id/scsi-0QEMU_QEMU_HARDDISK_singleroot /sysroot
 cp -a -t /sysroot /source/*
@@ -14,7 +14,7 @@ lvm pvcreate -ff -y /dev/md0
 lvm vgcreate dracut /dev/md0
 lvm lvcreate --yes -l 100%FREE -n root dracut
 lvm vgchange -ay
-mkfs.ext4 -q -j -L sysroot /dev/dracut/root
+mkfs.ext4 -q -L sysroot /dev/dracut/root
 mount -t ext4 /dev/dracut/root /sysroot
 cp -a -t /sysroot /source/*
 umount /sysroot

--- a/test/TEST-71-ISCSI-MULTI/create-client-root.sh
+++ b/test/TEST-71-ISCSI-MULTI/create-client-root.sh
@@ -3,7 +3,7 @@
 trap 'poweroff -f' EXIT
 set -ex
 
-mkfs.ext4 -q -j -L singleroot -F /dev/disk/by-id/scsi-0QEMU_QEMU_HARDDISK_singleroot
+mkfs.ext4 -q -L singleroot -F /dev/disk/by-id/scsi-0QEMU_QEMU_HARDDISK_singleroot
 mkdir -p /sysroot
 mount -t ext4 /dev/disk/by-id/scsi-0QEMU_QEMU_HARDDISK_singleroot /sysroot
 cp -a -t /sysroot /source/*
@@ -14,7 +14,7 @@ lvm pvcreate -ff -y /dev/md0
 lvm vgcreate dracut /dev/md0
 lvm lvcreate --yes -l 100%FREE -n root dracut
 lvm vgchange -ay
-mkfs.ext4 -q -j -L sysroot /dev/dracut/root
+mkfs.ext4 -q -L sysroot /dev/dracut/root
 mount -t ext4 /dev/dracut/root /sysroot
 cp -a -t /sysroot /source/*
 umount /sysroot

--- a/test/TEST-72-NBD/create-encrypted-root.sh
+++ b/test/TEST-72-NBD/create-encrypted-root.sh
@@ -12,7 +12,7 @@ lvm vgcreate dracut /dev/mapper/dracut_crypt_test
 lvm lvcreate --yes -l 100%FREE -n root dracut
 lvm vgchange -ay
 udevadm settle
-mkfs.ext4 -q -L dracut -j /dev/dracut/root
+mkfs.ext4 -q -L dracut /dev/dracut/root
 mkdir -p /sysroot
 mount -t ext4 /dev/dracut/root /sysroot
 cp -a -t /sysroot /source/*


### PR DESCRIPTION
As the projects transitioned over to ext4, passing `-j` is no longer desired.

## Checklist
- [ ] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it

Fixes #
