### PR TITLE
test(DMSQUASH): reorganize test steps into test runs

### DIFF
--- a/test/TEST-30-DMSQUASH/test.sh
+++ b/test/TEST-30-DMSQUASH/test.sh
@@ -13,64 +13,53 @@ test_check() {
     fi
 }
 
-test_run() {
+client_run() {
+    local test_name="$1"
+    shift
+    local client_opts="$*"
+
+    echo "CLIENT TEST START: $test_name"
+
     declare -a disk_args=()
     declare -i disk_index=0
     qemu_add_drive disk_index disk_args "$TESTDIR"/marker.img marker
     qemu_add_drive disk_index disk_args "$TESTDIR"/root.img root
+    qemu_add_drive disk_index disk_args "$TESTDIR"/root_erofs.img root_erofs
 
     test_marker_reset
     "$testdir"/run-qemu \
         "${disk_args[@]}" \
+        -append "$client_opts" \
         -initrd "$TESTDIR"/initramfs.testing
 
-    test_marker_check || return 1
+    if ! test_marker_check; then
+        echo "CLIENT TEST END: $test_name [FAILED]"
+        return 1
+    fi
+    echo "CLIENT TEST END: $test_name [OK]"
+}
+
+test_run() {
+    client_run "overlayfs" "" || return 1
 
     # The remaining subtests are not yet passing on arm, bail out
     if [[ ${DRACUT_ARCH:-$(uname -m)} == arm* || ${DRACUT_ARCH:-$(uname -m)} == aarch64 ]]; then
         return 0
     fi
 
-    # erofs drive
-    qemu_add_drive disk_index disk_args "$TESTDIR"/root_erofs.img root_erofs
+    client_run "live" "rd.live.image" || return 1
+    client_run "livedir" "rd.live.image rd.live.dir=testdir" || return 1
 
     # Run the erofs test only if mkfs.erofs is available
-    if command -v mkfs.erofs; then
-        test_marker_reset
-        "$testdir"/run-qemu \
-            "${disk_args[@]}" \
-            -append "root=live:/dev/disk/by-id/scsi-0QEMU_QEMU_HARDDISK_root_erofs" \
-            -initrd "$TESTDIR"/initramfs.testing
-
-        test_marker_check || return 1
+    if command -v mkfs.erofs &> /dev/null; then
+        client_run "erofs" "root=live:/dev/disk/by-id/scsi-0QEMU_QEMU_HARDDISK_root_erofs" || return 1
     fi
-
-    test_marker_reset
-    "$testdir"/run-qemu \
-        "${disk_args[@]}" \
-        -append "rd.live.image" \
-        -initrd "$TESTDIR"/initramfs.testing
-
-    test_marker_check || return 1
-
-    test_marker_reset
-    "$testdir"/run-qemu \
-        "${disk_args[@]}" \
-        -boot order=d \
-        -append "rd.live.image rd.live.dir=testdir" \
-        -initrd "$TESTDIR"/initramfs.testing
-
-    test_marker_check || return 1
 
     test_marker_reset
     rootPartitions=$(sfdisk -d "$TESTDIR"/root.img | grep -c 'root\.img[0-9]')
     [ "$rootPartitions" -eq 1 ] || return 1
 
-    "$testdir"/run-qemu \
-        "${disk_args[@]}" \
-        -boot order=d \
-        -append "init=/sbin/init-persist rd.live.image rd.live.overlay=LABEL=persist rd.live.dir=testdir" \
-        -initrd "$TESTDIR"/initramfs.testing
+    client_run "autooverlay" "init=/sbin/init-persist rd.live.image rd.live.overlay=LABEL=persist rd.live.dir=testdir" || return 1
 
     rootPartitions=$(sfdisk -d "$TESTDIR"/root.img | grep -c 'root\.img[0-9]')
     [ "$rootPartitions" -eq 2 ] || return 1
@@ -83,6 +72,8 @@ test_run() {
         dd if="$TESTDIR"/root.img bs=1MiB status=none \
             | grep -U --binary-files=binary -F -m 1 -q dracut-autooverlay-success
     ) || return 1
+
+    return 0
 }
 
 test_setup() {
@@ -120,7 +111,7 @@ EOF
     qemu_add_drive disk_index disk_args "$TESTDIR"/root_erofs.img root_erofs 1
 
     # Write the erofs compressed filesystem to the partition
-    if command -v mkfs.erofs; then
+    if command -v mkfs.erofs &> /dev/null; then
         mkfs.erofs "$TESTDIR"/root_erofs.img "$TESTDIR"/rootfs/
     fi
 


### PR DESCRIPTION
Make DMSQUASH test same structure as some other tests to make it easier to debug and reason about.

## Checklist
- [ ] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it

Fixes #
