### PR TITLE
ci: install xorriso into CI containers

### DIFF
--- a/test/container/Dockerfile-alpine
+++ b/test/container/Dockerfile-alpine
@@ -63,4 +63,5 @@ if [ "$DISTRIBUTION" = "alpine:edge" ] ; then \
     squashfs-tools \
     util-linux-misc \
     util-linux-login \
+    xorriso \
 ; fi

--- a/test/container/Dockerfile-arch
+++ b/test/container/Dockerfile-arch
@@ -56,4 +56,5 @@ RUN pacman --noconfirm -Syu \
     systemd-ukify \
     tgt \
     tpm2-tools \
+    xorriso \
     && yes | pacman -Scc

--- a/test/container/Dockerfile-debian
+++ b/test/container/Dockerfile-debian
@@ -94,6 +94,7 @@ RUN \
     tgt \
     thin-provisioning-tools \
     tpm2-tools \
+    xorriso \
     zstd \
     && apt-get clean \
     && chmod a+r /boot/vmlinu*

--- a/test/container/Dockerfile-fedora
+++ b/test/container/Dockerfile-fedora
@@ -89,6 +89,7 @@ RUN dnf -y install --setopt=install_weak_deps=False \
     systemd-ukify \
     tpm2-tools \
     xfsprogs \
+    xorriso \
     && dnf -y update && dnf clean all
 
 # CentOS Stream ships only qemu-kvm, but it disables the KVM accel when it's not available

--- a/test/container/Dockerfile-opensuse
+++ b/test/container/Dockerfile-opensuse
@@ -49,6 +49,7 @@ RUN zypper --non-interactive install --no-recommends \
     tgt \
     tpm2.0-tools \
     util-linux-systemd \
+    xorriso \
     && zypper --non-interactive dist-upgrade --no-recommends
 
 # install mkosi from source

--- a/test/container/Dockerfile-void
+++ b/test/container/Dockerfile-void
@@ -55,5 +55,6 @@ RUN xbps-install -Syu xbps && xbps-install -yu \
     systemd-boot-efistub \
     ncurses-base \
     ukify \
+    xorriso \
     zfs \
     && rm -rf /var/cache/xbps


### PR DESCRIPTION
## Changes

Preparation to test iso-scan dracut feature which requires an iso file that xorriso would generate.

## Checklist
- [ ] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it

Fixes #
