### PR TITLE
feat(dracut.install): force hostonly for kernel-install plugin

### DIFF
--- a/install.d/50-dracut.install
+++ b/install.d/50-dracut.install
@@ -71,6 +71,7 @@ done
 
 # shellcheck disable=SC2046
 dracut -f \
+    --add-confdir hostonly \
     ${noimageifnotneeded:+--noimageifnotneeded} \
     $([[ $KERNEL_INSTALL_VERBOSE == 1 ]] && echo --verbose) \
     $([[ -n $KERNEL_IMAGE ]] && echo --kernel-image "$KERNEL_IMAGE") \


### PR DESCRIPTION
Distributions that have adapted and integrated dracut and adopted the dracut kernel install plugin should default to hostonly mode initrd.

This PR also makes the two plugins (50-dracut.install  51-dracut-rescue.install) a bit more aligned and symmetric as 51-dracut-rescue.install) is already forcing non-hostonly/generic.

Follow-up to 9fc9128a08e6262393e6b7ae5ade040795ab6668 and https://github.com/dracut-ng/dracut-ng/pull/990 .

CC @Nowa-Ammerlaan

## Checklist
- [ ] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it

Fixes #
