### PR TITLE
ci: restore regression for console messages

### DIFF
--- a/test/TEST-10-BASIC/test.sh
+++ b/test/TEST-10-BASIC/test.sh
@@ -12,6 +12,7 @@ test_run() {
 
     "$testdir"/run-qemu \
         "${disk_args[@]}" \
+        -append "$TEST_KERNEL_CMDLINE root=LABEL=dracut" \
         -initrd "$TESTDIR"/initramfs.testing || return 1
 
     test_marker_check || return 1
@@ -28,7 +29,6 @@ test_setup() {
 
     test_dracut \
         --omit systemd \
-        --kernel-cmdline "$TEST_KERNEL_CMDLINE root=LABEL=dracut" \
         "$TESTDIR"/initramfs.testing
 }
 

--- a/test/TEST-12-UEFI/test.sh
+++ b/test/TEST-12-UEFI/test.sh
@@ -64,12 +64,12 @@ test_setup() {
         ukify build \
             --linux="$VMLINUZ" \
             --initrd="$TESTDIR"/initramfs.testing \
-            --cmdline='root=/dev/disk/by-id/scsi-0QEMU_QEMU_HARDDISK_root' \
+            --cmdline="$TEST_KERNEL_CMDLINE root=/dev/disk/by-id/scsi-0QEMU_QEMU_HARDDISK_root" \
             --output="$TESTDIR"/ESP/EFI/BOOT/BOOTX64.efi
     else
         echo "Using dracut to create UKI"
         test_dracut \
-            --kernel-cmdline 'root=/dev/disk/by-id/scsi-0QEMU_QEMU_HARDDISK_root' \
+            --kernel-cmdline "$TEST_KERNEL_CMDLINE root=/dev/disk/by-id/scsi-0QEMU_QEMU_HARDDISK_root" \
             --drivers 'squashfs' \
             --uefi \
             "$TESTDIR"/ESP/EFI/BOOT/BOOTX64.efi

--- a/test/TEST-30-DMSQUASH/test.sh
+++ b/test/TEST-30-DMSQUASH/test.sh
@@ -30,7 +30,7 @@ client_run() {
     test_marker_reset
     "$testdir"/run-qemu \
         "${disk_args[@]}" \
-        -append "$client_opts" \
+        -append "$TEST_KERNEL_CMDLINE rd.live.overlay.overlayfs=1 root=live:/dev/disk/by-label/dracut $client_opts" \
         -initrd "$TESTDIR"/initramfs.testing
 
     if ! test_marker_check; then
@@ -129,7 +129,6 @@ EOF
     test_dracut \
         --no-hostonly \
         --modules "dmsquash-live-autooverlay" \
-        --kernel-cmdline "$TEST_KERNEL_CMDLINE rd.live.overlay.overlayfs=1 root=live:/dev/disk/by-label/dracut" \
         "$TESTDIR"/initramfs.testing
 }
 

--- a/test/test-functions
+++ b/test/test-functions
@@ -18,7 +18,7 @@ if [[ -z $basedir ]]; then basedir="$(realpath ../..)"; fi
 DRACUT=${DRACUT-dracut}
 PKGLIBDIR=${PKGLIBDIR-$basedir}
 
-TEST_KERNEL_CMDLINE+=" rd.retry=10 rd.timeout=30 rd.info rd.shell=0 panic=1 oops=panic softlockup_panic=1 systemd.crash_reboot console=ttyS0,115200n81 $DEBUGFAIL "
+TEST_KERNEL_CMDLINE+=" rd.retry=10 rd.timeout=30 rd.info rd.shell=0 panic=1 oops=panic softlockup_panic=1 systemd.crash_reboot console=ttyS0 $DEBUGFAIL "
 if [[ $V != "1" && $V != "2" ]]; then
     TEST_KERNEL_CMDLINE+="quiet "
 fi


### PR DESCRIPTION
## Changes

BASIC, UEFI, DMSQUASH tests did not had some of the kernel command line options properly set


## Checklist
- [ ] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it

Fixes #
