### PR TITLE
ci: demote dmraid testing

### DIFF
--- a/test/container/Dockerfile-alpine
+++ b/test/container/Dockerfile-alpine
@@ -1,5 +1,5 @@
 # Test coverage provided by this container:
-# - hostonly
+# - default hostonly
 # - musl (instead of glibc)
 # - openrc (instead of systemd)
 # - eudev (instead of systemd-udev)
@@ -14,7 +14,8 @@
 # - ntfs-3g (not enabled with linux-virt)
 # - erofs-utils (not enabled with linux-virt)
 # - multipath-tools (does not work well)
-# - ovmf (systemd-boot-efistub is not available)
+# - ovmf (systemd-boot-efistub, UEFI, UKI is not available)
+# - kernel-install is not available
 # - networkmanager (does not work with dracut)
 
 ARG DISTRIBUTION=alpine
@@ -45,7 +46,6 @@ if [ "$DISTRIBUTION" = "alpine:edge" ] ; then \
     cpio \
     cryptsetup \
     device-mapper \
-    dmraid \
     elogind \
     gpg \
     iputils \

--- a/test/container/Dockerfile-arch
+++ b/test/container/Dockerfile-arch
@@ -5,6 +5,7 @@
 # - qrencode (systemd-bsod)
 # - rdma out of tree dracut module
 # - both dbus-daemon and dbus-broker
+# - dmraid (not activly maintained)
 
 # Not installed
 # - busybox (no need, tested elsewhere)

--- a/test/container/Dockerfile-debian
+++ b/test/container/Dockerfile-debian
@@ -7,7 +7,6 @@
 # - dbus-daemon
 
 # Not installed
-# - dmraid (no longer maintained, https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=1056944)
 # - iscsiuio, open-iscsi (not yet working with dracut, https://bugs.launchpad.net/ubuntu/+source/open-iscsi/+bug/2072484)
 # - busybox-static
 

--- a/test/container/Dockerfile-fedora
+++ b/test/container/Dockerfile-fedora
@@ -1,6 +1,6 @@
 # Test coverage provided by this container:
 # - arm64
-# - hostonly
+# - default hostonly
 # - xfs
 # - memstrack
 # - ndctl (for nvdimm)
@@ -35,7 +35,6 @@ else \
     btrfs-progs \
     dhcp-client \
     dhcp-server \
-    dmraid \
     nbd \
     qemu \
     scsi-target-utils \

--- a/test/container/Dockerfile-gentoo
+++ b/test/container/Dockerfile-gentoo
@@ -10,6 +10,7 @@
 # - dash (to increase coverage)
 # - rng-tools (to increase coverage)
 # - ntfs3g (to keep container small)
+# - xorriso (to keep container small, no .iso generation)
 
 ARG OPTION=systemd
 
@@ -80,7 +81,6 @@ if [ "$OPTION" = "systemd" ] ; then \
     sys-devel/flex \
     sys-fs/btrfs-progs \
     sys-fs/cryptsetup \
-    sys-fs/dmraid \
     sys-fs/mdadm \
     sys-fs/multipath-tools \
     sys-fs/squashfs-tools \

--- a/test/container/Dockerfile-opensuse
+++ b/test/container/Dockerfile-opensuse
@@ -1,5 +1,6 @@
 # Test coverage provided by this container:
 # - arm64
+# - default hostonly
 # - network-legacy
 # - mkosi-initrd
 # - hmaccalc (fido)
@@ -18,7 +19,6 @@ RUN zypper --non-interactive install --no-recommends \
     dhcp-client \
     dhcp-server \
     distribution-gpg-keys \
-    dmraid \
     e2fsprogs \
     erofs-utils \
     gcc \

--- a/test/container/Dockerfile-void
+++ b/test/container/Dockerfile-void
@@ -4,11 +4,14 @@
 # - runit (instead of systemd)
 # - eudev (instead of systemd-udev)
 # - elogind (instead of logind)
-# - uki (without systemd)
+# - UEFI boot, UKI (without systemd)
 # - zfs and zfs out of tree dracut module
 # - gzip compression
 # - clang
 # - dbus-daemon
+
+# Not installed
+# - kernel-install is not available
 
 FROM ghcr.io/void-linux/void-glibc-full
 
@@ -27,7 +30,6 @@ RUN xbps-install -Syu xbps && xbps-install -yu \
     cryptsetup \
     dhclient \
     dhcp \
-    dmraid \
     e2fsprogs \
     edk2-ovmf \
     elfutils \


### PR DESCRIPTION
## Changes

dmraid is no longer activly maitaned and has been already removed form the following distributions
 - CentOS
 - Debian
 - Ubuntu

Dracut will continue to support dmraid, but lets minimize the CI burdon and only test dmraid on Arch container going forward.

One of the other motivation of this change is to align Fedora configuration a bit more with CentOS configuration for ease of maintenance.

## Checklist
- [ ] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it

Fixes #
