### PR TITLE
ci(fedora): use Debian, Arch, Gentoo to test systemd-networkd

### DIFF
--- a/test/container/Dockerfile-alpine
+++ b/test/container/Dockerfile-alpine
@@ -7,6 +7,7 @@
 # - busybox default shell (no dash installed)
 # - gzip compression
 # - dbus-daemon
+# - network: none
 
 # Not installed
 # - cargo (to increase coverage)
@@ -30,7 +31,6 @@ RUN apk add --no-cache \
     dracut-tests \
     file \
     gcc \
-    iputils \
     kmod \
     kmod-dev \
     linux-virt \
@@ -48,7 +48,6 @@ if [ "$DISTRIBUTION" = "alpine:edge" ] ; then \
     device-mapper \
     elogind \
     gpg \
-    iputils \
     jq \
     kbd \
     keyutils \

--- a/test/container/Dockerfile-arch
+++ b/test/container/Dockerfile-arch
@@ -6,6 +6,7 @@
 # - rdma out of tree dracut module
 # - both dbus-daemon and dbus-broker
 # - dmraid (not activly maintained)
+# - network: network-legacy, network-manager, systemd-networkd
 
 # Not installed
 # - busybox (no need, tested elsewhere)

--- a/test/container/Dockerfile-debian
+++ b/test/container/Dockerfile-debian
@@ -5,6 +5,7 @@
 # - zstd compression
 # - verbose logging for tests
 # - dbus-daemon
+# - network: network-legacy, network-manager, systemd-networkd
 
 # Not installed
 # - iscsiuio, open-iscsi (not yet working with dracut, https://bugs.launchpad.net/ubuntu/+source/open-iscsi/+bug/2072484)

--- a/test/container/Dockerfile-fedora
+++ b/test/container/Dockerfile-fedora
@@ -14,6 +14,7 @@
 # - fips
 # - ignition
 # - dbus-broker
+# - network: network-legacy, network-manager
 
 ARG DISTRIBUTION=fedora
 ARG REGISTRY=registry.fedoraproject.org
@@ -38,7 +39,6 @@ else \
     nbd \
     qemu \
     scsi-target-utils \
-    systemd-networkd \
 ; fi
 
 RUN dnf -y install --setopt=install_weak_deps=False \

--- a/test/container/Dockerfile-gentoo
+++ b/test/container/Dockerfile-gentoo
@@ -3,6 +3,7 @@
 # - systemd-networkd
 # - bash
 # - dbus-daemon
+# - network: network-legacy, systemd-networkd
 
 # Not installed
 # - NetworkManager (to increase coverage)

--- a/test/container/Dockerfile-opensuse
+++ b/test/container/Dockerfile-opensuse
@@ -6,6 +6,7 @@
 # - hmaccalc (fido)
 # - rdma out of tree dracut module
 # - dbus-broker
+# - network: network-legacy, network-manager
 
 FROM registry.opensuse.org/opensuse/tumbleweed:latest
 

--- a/test/container/Dockerfile-void
+++ b/test/container/Dockerfile-void
@@ -9,6 +9,7 @@
 # - gzip compression
 # - clang
 # - dbus-daemon
+# - network: network-legacy, network-manager
 
 # Not installed
 # - kernel-install is not available


### PR DESCRIPTION
## Changes

This is in an effort to simplify the CI and minimize the difference between CentOS and Fedora testing.

While Fedora supports systemd-networkd, CentOS does not and Debian, Arch and Gentoo already provides enought test coverage for the Dracut CI.

## Checklist
- [ ] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it

Fixes #
