### PR TITLE
ci: only set console for amd64

### DIFF
--- a/test/test-functions
+++ b/test/test-functions
@@ -18,7 +18,8 @@ if [[ -z $basedir ]]; then basedir="$(realpath ../..)"; fi
 DRACUT=${DRACUT-dracut}
 PKGLIBDIR=${PKGLIBDIR-$basedir}
 
-TEST_KERNEL_CMDLINE+=" rd.retry=10 rd.timeout=30 rd.info rd.shell=0 panic=1 oops=panic softlockup_panic=1 systemd.crash_reboot console=ttyS0 $DEBUGFAIL "
+TEST_KERNEL_CMDLINE+=" rd.retry=10 rd.timeout=30 rd.info rd.shell=0 panic=1 oops=panic softlockup_panic=1 systemd.crash_reboot $DEBUGFAIL "
+
 if [[ $V != "1" && $V != "2" ]]; then
     TEST_KERNEL_CMDLINE+="quiet "
 fi
@@ -26,6 +27,14 @@ fi
 if [[ $V == "2" ]]; then
     TEST_KERNEL_CMDLINE+="rd.debug "
 fi
+
+ARCH="${ARCH-$(uname -m)}"
+
+case "$ARCH" in
+    amd64 | i?86 | x86_64)
+        TEST_KERNEL_CMDLINE+="console=ttyS0 "
+        ;;
+esac
 
 test_dracut() {
     # directory for test configurations and for the generated initrd (extracted)


### PR DESCRIPTION
Follow-up to 25795c7.                                                                                                                                                                                                                 
                                                                                                                                                                                                                                      
This PR restores green CI for arm64. 

## Checklist
- [ ] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it

Fixes #
