### PR TITLE
test(BASIC): remove workaround for systemd on arm64

### DIFF
--- a/test/TEST-10-BASIC/test.sh
+++ b/test/TEST-10-BASIC/test.sh
@@ -10,7 +10,7 @@ test_run() {
 
     test_marker_reset
 
-    "$testdir"/run-qemu \
+    "$testdir"/run-qemu -nic none \
         "${disk_args[@]}" \
         -append "$TEST_KERNEL_CMDLINE root=LABEL=dracut" \
         -initrd "$TESTDIR"/initramfs.testing || return 1
@@ -28,7 +28,6 @@ test_setup() {
     mkfs.ext4 -q -L dracut -d "$TESTDIR"/dracut.*/initramfs/ "$TESTDIR"/root.img && sync
 
     test_dracut \
-        --omit systemd \
         "$TESTDIR"/initramfs.testing
 }
 

--- a/test/test-functions
+++ b/test/test-functions
@@ -18,7 +18,8 @@ if [[ -z $basedir ]]; then basedir="$(realpath ../..)"; fi
 DRACUT=${DRACUT-dracut}
 PKGLIBDIR=${PKGLIBDIR-$basedir}
 
-TEST_KERNEL_CMDLINE+=" rd.retry=10 rd.timeout=30 rd.info rd.shell=0 panic=1 oops=panic softlockup_panic=1 systemd.crash_reboot $DEBUGFAIL "
+# systemd on arm64 on GitHub CI needs the 60 sec timeout
+TEST_KERNEL_CMDLINE+=" rd.retry=10 rd.timeout=60 rd.info rd.shell=0 panic=1 oops=panic softlockup_panic=1 systemd.crash_reboot $DEBUGFAIL "
 
 if [[ $V != "1" && $V != "2" ]]; then
     TEST_KERNEL_CMDLINE+="quiet "


### PR DESCRIPTION
## Changes

Removed omitting systemd modules from the BASIC test. Increase the rd.timeout=60 to give enough time for systemd on arm64.

Disable networking for this test (inside the qemu VM) to increase test covergae and make this test even more basic.

## Checklist
- [ ] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it

Fixes #
