### PR TITLE
test(KERNEL-INSTALL): enable dracut test config

### DIFF
--- a/test/TEST-43-KERNEL-INSTALL/test.sh
+++ b/test/TEST-43-KERNEL-INSTALL/test.sh
@@ -44,8 +44,8 @@ test_setup() {
     mkdir -p "$BOOT_ROOT/$machine_id/$KVERSION" /run/kernel/
     echo 'initrd_generator=dracut' >> /run/kernel/install.conf
 
-    mkdir -p /usr/lib/dracut/dracut.conf.d
-    echo 'add_dracutmodules+=" test "' >> /usr/lib/dracut/dracut.conf.d/extra.conf
+    # enable test dracut config
+    cp /usr/lib/dracut/test/dracut.conf.d/test/test.conf /usr/lib/dracut/dracut.conf.d/
 
     kernel-install add-all
     mv "$BOOT_ROOT/$machine_id/$KVERSION"/initrd "$TESTDIR"/initramfs.testing


### PR DESCRIPTION
## Changes

Enable the dracut test config not just the test dracut module.

## Checklist
- [ ] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it

Fixes #
