### PR TITLE
ci: move more logic to test dracut config

### DIFF
--- a/test/dracut.conf.d/test/test.conf
+++ b/test/dracut.conf.d/test/test.conf
@@ -4,3 +4,6 @@ do_strip="no"
 do_hardlink="no"
 early_microcode="no"
 hostonly_cmdline="no"
+
+# systemd on arm64 on GitHub CI needs the 60 sec timeout
+kernel_cmdline=" rd.retry=10 rd.timeout=60 rd.info rd.shell=0 "

--- a/test/test-functions
+++ b/test/test-functions
@@ -18,8 +18,7 @@ if [[ -z $basedir ]]; then basedir="$(realpath ../..)"; fi
 DRACUT=${DRACUT-dracut}
 PKGLIBDIR=${PKGLIBDIR-$basedir}
 
-# systemd on arm64 on GitHub CI needs the 60 sec timeout
-TEST_KERNEL_CMDLINE+=" rd.retry=10 rd.timeout=60 rd.info rd.shell=0 panic=1 oops=panic softlockup_panic=1 systemd.crash_reboot $DEBUGFAIL "
+TEST_KERNEL_CMDLINE+=" panic=1 oops=panic softlockup_panic=1 systemd.crash_reboot $DEBUGFAIL "
 
 if [[ $V != "1" && $V != "2" ]]; then
     TEST_KERNEL_CMDLINE+="quiet "


### PR DESCRIPTION
## Changes

test dracut config is available for all test runs, including kernel-install runs.

## Checklist
- [ ] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it

Fixes #
