### PR TITLE
test(KERNEL-INSTALL): enable test for Arch, Gentoo, openSUSE as well

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -140,7 +140,10 @@ jobs:
             fail-fast: false
             matrix:
                 container:
+                    - arch
                     - fedora
+                    - gentoo
+                    - opensuse
                 test:
                     - "43"
         container:

--- a/test/TEST-43-KERNEL-INSTALL/test.sh
+++ b/test/TEST-43-KERNEL-INSTALL/test.sh
@@ -30,6 +30,7 @@ test_run() {
 
 test_setup() {
     # create root filesystem
+    # shellcheck disable=SC2153
     "$DRACUT" -N --keep --tmpdir "$TESTDIR" \
         --add-confdir test-root \
         -f "$TESTDIR"/initramfs.root "$KVERSION" || return 1
@@ -37,18 +38,19 @@ test_setup() {
     dd if=/dev/zero of="$TESTDIR"/root.img bs=200MiB count=1 status=none && sync
     mkfs.ext4 -q -L dracut -d "$TESTDIR"/dracut.*/initramfs/ "$TESTDIR"/root.img && sync
 
-    echo "Using kernell-install to invoke dracut"
-
-    read -r machine_id < /etc/machine-id
     export BOOT_ROOT="$TESTDIR"
-    mkdir -p "$BOOT_ROOT/$machine_id/$KVERSION" /run/kernel/
+    [[ -f /etc/machine-id ]] && read -r TOKEN < /etc/machine-id
+    [[ -z $TOKEN ]] && . /etc/os-release && TOKEN="$ID"
+    mkdir -p "$BOOT_ROOT/$TOKEN/$KVERSION" /run/kernel/
     echo 'initrd_generator=dracut' >> /run/kernel/install.conf
 
     # enable test dracut config
     cp /usr/lib/dracut/test/dracut.conf.d/test/test.conf /usr/lib/dracut/dracut.conf.d/
 
+    # using kernell-install to invoke dracut
     kernel-install add-all
-    mv "$BOOT_ROOT/$machine_id/$KVERSION"/initrd "$TESTDIR"/initramfs.testing
+
+    mv "$BOOT_ROOT/$TOKEN/$KVERSION"/initrd "$TESTDIR"/initramfs.testing
 }
 
 # shellcheck disable=SC1090


### PR DESCRIPTION
## Changes

Fix initrd location when /etc/machine-id does not exists.

The test does not yet work on Debian/Ubuntu.

## Checklist
- [ ] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it

Fixes #
