### PR TITLE
dracut-init: strip out unused/unlikely AMDGPU firmware

### DIFF
--- a/dracut-init.sh
+++ b/dracut-init.sh
@@ -985,6 +985,70 @@ for_each_module_dir() {
 dracut_kernel_post() {
     local dstdir="${dstdir:-"$initdir"}"
 
+    if [ -d "${dstdir}"/lib/firmware/amdgpu/ ]; then
+        # AMDGPU firmware stripping: Remove unlikely or impossible firmware on
+        # a platform-specific basis to save space - this is the largest set of
+        # firmware in the linux-firmware.git tree.
+        #
+        # To update the list of prefixes below:
+        #
+        #   1. Look for (grep) MODULE_FIRMWARE in /drivers/gpu/drm/amd (please
+        #      note that AMD does not always use the file name to the firmware
+        #      as parameter to this macro.
+        #   2. Reference "Misc AMDGPU driver information"[^1], Wikipedia, and
+        #      TechPowerUp to determine which class certain set(s) of firmware
+        #      belong out of the list below.
+        #   3. Refer to manufacturers and/or OEM contacts for state of support
+        #      (some should be obvious - there is no non-x86 APUs - yet?).
+        #
+        # [^1]: https://docs.kernel.org/gpu/amdgpu/driver-misc.html
+
+        # APU-specific firmware.
+        _apu_prefix=" \
+            cyan_skillfish2 kabini kaveri mullins picasso raven renoir vangogh"
+        # AMD Instinct firmware.
+        _mi_prefix="aldebaran arcturus"
+        # Mobile firmware.
+        _mobile_prefix="hainan stoney topaz"
+        # Some firmware (non-x86/ARM platforms with no x86-64 GOP support/
+        # emulation) are unlikely to support post-GCN 4.0 cards. Firmware found on
+        # MIPS-based Loongson 3 boards with x86 GOP emulation support are known to
+        # crash with these cards installed.
+        _post_gcn4_prefix=" \
+            beige_goby dcn dimgrey_cavefish gc green_sardine navi navy_flounder \
+            psp sdma_4 sdma_5 sdma_6 sdma_7 sienna_cichlid vega vpe yellow_carp"
+
+        # To avoid the directory being removed if for some reason a prefix variable
+        # was not defined.
+        cd "${dstdir}"/lib/firmware/amdgpu/ \
+            || dfatal "AMDGPU firmware directory exists but is inaccessible!"
+
+        # Using `rm -f' below as some distribution may not ship all firmware.
+
+        # Non-x86 APU is not a thing (yet).
+        if [[ ${DRACUT_ARCH:-$(uname -m)} != x86_64 ]]; then
+            ddebug "Removing AMDGPU firmware unused by non-x86-64 systems ..."
+            for _amdgpu_prefix in ${_apu_prefix}; do
+                rm -f "${_amdgpu_prefix}"*
+            done
+        fi
+
+        if [[ ${DRACUT_ARCH:-$(uname -m)} == arm64 ]]; then
+            ddebug "Removing AMDGPU firmware unused by AArch64 systems ..."
+            for _amdgpu_prefix in ${_mobile_prefix}; do
+                rm -f "${_amdgpu_prefix}"*
+            done
+        elif [[ ${DRACUT_ARCH:-$(uname -m)} == mips64 ]]; then
+            # No post-GCN 4.0 support - crashes firmware.
+            # Mobile AMD GPUs likely.
+            ddebug "Removing AMDGPU firmware unused by MIPS64 (Loongson 3) systems ..."
+            for _amdgpu_prefix in \
+                ${_mi_prefix} ${_post_gcn4_prefix}; do
+                rm -f "${_amdgpu_prefix}"*
+            done
+        fi
+    fi
+
     for _f in modules.builtin modules.builtin.alias modules.builtin.modinfo modules.order; do
         [[ -e $srcmods/$_f ]] && inst_simple "$srcmods/$_f" "/lib/modules/$kernel/$_f"
     done


### PR DESCRIPTION
This pull request changes...

## Changes

Introduce logic to remove unlikely or impossible firmware on a platform- specific basis to save space - this is the largest set of firmware in the linux-firmware.git tree.

To update the list of prefixes:

1. Look for (grep) MODULE_FIRMWARE in /drivers/gpu/drm/amd (please note that AMD does not always use the file name to the firmware as parameter to this macro.
2. Reference "Misc AMDGPU driver information"[^1], Wikipedia, and TechPowerUp to determine which class certain set(s) of firmware belong out of the list below.
3. Refer to manufacturers and/or OEM contacts for state of support (some should be obvious - there is no non-x86 APUs - yet?).

[^1]: https://docs.kernel.org/gpu/amdgpu/driver-misc.html

## Checklist
- [x] I have tested it locally
- [x] I have reviewed and updated any documentation if relevant
- [x] I am providing new code and test(s) for it