### PR TITLE
ci: switch integration tests from ubuntu:latest to ubuntu:rolling

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -30,18 +30,18 @@ jobs:
             fail-fast: false
             matrix:
                 container:
-                    - alpine
-                    - arch
-                    - debian
-                    - fedora
-                    - gentoo
-                    - opensuse
-                    - ubuntu
-                    - void
+                    - alpine:latest
+                    - arch:latest
+                    - debian:latest
+                    - fedora:latest
+                    - gentoo:latest
+                    - opensuse:latest
+                    - ubuntu:rolling
+                    - void:latest
                 test:
                     - "10"
         container:
-            image: ghcr.io/dracut-ng/${{ matrix.container }}:latest-amd
+            image: ghcr.io/dracut-ng/${{ matrix.container }}-amd
             options: '--device=/dev/kvm'
         steps:
             - name: "Checkout Repository"
@@ -74,12 +74,12 @@ jobs:
             fail-fast: false
             matrix:
                 container:
-                    - arch
-                    - fedora
-                    - gentoo
-                    - opensuse
-                    - ubuntu
-                    - void
+                    - arch:latest
+                    - fedora:latest
+                    - gentoo:latest
+                    - opensuse:latest
+                    - ubuntu:rolling
+                    - void:latest
                 test:
                     - "11"
                     - "12"
@@ -90,7 +90,7 @@ jobs:
                     - "80"
                     - "81"
         container:
-            image: ghcr.io/dracut-ng/${{ matrix.container }}:latest-amd
+            image: ghcr.io/dracut-ng/${{ matrix.container }}-amd
             options: '--device=/dev/kvm'
         steps:
             - name: "Checkout Repository"
@@ -110,18 +110,18 @@ jobs:
             fail-fast: false
             matrix:
                 container:
-                    - arch
-                    - fedora
-                    - gentoo
-                    - opensuse
-                    - ubuntu
+                    - arch:latest
+                    - fedora:latest
+                    - gentoo:latest
+                    - opensuse:latest
+                    - ubuntu:rolling
                 test:
                     - "40"
                     - "41"
                     - "42"
                     - "43"
         container:
-            image: ghcr.io/dracut-ng/${{ matrix.container }}:latest-amd
+            image: ghcr.io/dracut-ng/${{ matrix.container }}-amd
             options: '--device=/dev/kvm --privileged'
         steps:
             - name: "Checkout Repository"
@@ -141,11 +141,11 @@ jobs:
             fail-fast: false
             matrix:
                 container:
-                    - opensuse
+                    - opensuse:latest
                 test:
                     - "82"
         container:
-            image: ghcr.io/dracut-ng/${{ matrix.container }}:latest-amd
+            image: ghcr.io/dracut-ng/${{ matrix.container }}-amd
             options: '--device=/dev/kvm'
         steps:
             - name: "Checkout Repository"
@@ -165,12 +165,12 @@ jobs:
             fail-fast: false
             matrix:
                 container:
-                    - arch
-                    - debian
-                    - fedora
-                    - gentoo
-                    - opensuse
-                    - ubuntu
+                    - arch:latest
+                    - debian:latest
+                    - fedora:latest
+                    - gentoo:latest
+                    - opensuse:latest
+                    - ubuntu:rolling
                 test:
                     - "60"
                     - "61"
@@ -178,13 +178,13 @@ jobs:
                 include:
                     - network: ""
                     # on debian run tests with systemd-networkd
-                    - container: "debian"
+                    - container: "debian:latest"
                       network: "systemd-networkd"
                     # on openSUSE run tests with network-legacy
-                    - container: "opensuse"
+                    - container: "opensuse:latest"
                       network: "network-legacy"
         container:
-            image: ghcr.io/dracut-ng/${{ matrix.container }}:latest-amd
+            image: ghcr.io/dracut-ng/${{ matrix.container }}-amd
             options: '--device=/dev/kvm'
         steps:
             - name: "Checkout Repository"
@@ -203,15 +203,15 @@ jobs:
             fail-fast: false
             matrix:
                 container:
-                    - opensuse
+                    - opensuse:latest
                 test:
                     - "70"
                 include:
                     # on openSUSE run tests with network-legacy
-                    - container: "opensuse"
+                    - container: "opensuse:latest"
                       network: "network-legacy"
         container:
-            image: ghcr.io/dracut-ng/${{ matrix.container }}:latest-amd
+            image: ghcr.io/dracut-ng/${{ matrix.container }}-amd
             options: '--device=/dev/kvm'
         steps:
             - name: "Checkout Repository"


### PR DESCRIPTION
## Changes

ubuntu:latest points to Ubuntu 24.04.

ubuntu:rolling currently points ot 24.10 and soon will point to 25.04.

This change has no impact on the "Daily Integration tests", which anyways expect to test and pass both with ubuntu:latest and ubuntu:rolling.

For Fedora fedora:latest points to the bi-yearly releases, and the corresponding label for Ubuntu is ubuntu:rolling.

## Checklist
- [ ] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it

Fixes #
