### PR TITLE
ci: add root=LABEL=dracut to the common kernel cmdline for tests

### DIFF
--- a/test/TEST-10-BASIC/test.sh
+++ b/test/TEST-10-BASIC/test.sh
@@ -12,7 +12,7 @@ test_run() {
 
     "$testdir"/run-qemu -nic none \
         "${disk_args[@]}" \
-        -append "$TEST_KERNEL_CMDLINE root=LABEL=dracut" \
+        -append "$TEST_KERNEL_CMDLINE" \
         -initrd "$TESTDIR"/initramfs.testing || return 1
 
     test_marker_check || return 1

--- a/test/TEST-11-USR-MOUNT/test.sh
+++ b/test/TEST-11-USR-MOUNT/test.sh
@@ -29,7 +29,7 @@ client_run() {
     test_marker_reset
     "$testdir"/run-qemu \
         "${disk_args[@]}" \
-        -append "$TEST_KERNEL_CMDLINE root=LABEL=dracut $client_opts" \
+        -append "$TEST_KERNEL_CMDLINE $client_opts" \
         -initrd "$TESTDIR"/initramfs.testing || return 1
 
     if ! test_marker_check; then

--- a/test/TEST-20-STORAGE/create-root.sh
+++ b/test/TEST-20-STORAGE/create-root.sh
@@ -10,7 +10,7 @@ if [ "$TEST_FSTYPE" = "zfs" ]; then
     zpool create dracut mirror /dev/disk/by-id/scsi-0QEMU_QEMU_HARDDISK_disk[12]
     zfs create dracut/root
 elif [ "$TEST_FSTYPE" = "btrfs" ]; then
-    mkfs.btrfs -q -draid1 -mraid1 -L root /dev/disk/by-id/scsi-0QEMU_QEMU_HARDDISK_disk[12]
+    mkfs.btrfs -q -draid1 -mraid1 -L dracut /dev/disk/by-id/scsi-0QEMU_QEMU_HARDDISK_disk[12]
     udevadm settle
     btrfs device scan
 else
@@ -51,7 +51,7 @@ else
 
     lvm vgchange --ignoremonitoring -ay
 
-    eval "mkfs.${TEST_FSTYPE} -q -L root /dev/dracut/root"
+    eval "mkfs.${TEST_FSTYPE} -q -L dracut /dev/dracut/root"
 fi
 
 udevadm settle

--- a/test/TEST-20-STORAGE/test.sh
+++ b/test/TEST-20-STORAGE/test.sh
@@ -9,15 +9,9 @@ test_check() {
     (command -v zfs || (command -v lvm && command -v "mkfs.$TEST_FSTYPE")) &> /dev/null
 }
 
-if [ "$TEST_FSTYPE" = "zfs" ]; then
-    TEST_KERNEL_CMDLINE+=" root=ZFS=dracut/root "
-elif [ "$TEST_FSTYPE" = "btrfs" ]; then
-    TEST_KERNEL_CMDLINE+=" root=LABEL=root "
-else
-    TEST_KERNEL_CMDLINE+=" root=LABEL=root "
-
+if [ "$TEST_FSTYPE" != "zfs" ] && [ "$TEST_FSTYPE" != "btrfs" ]; then
     # test fips mode
-    [ -f /usr/share/crypto-policies/default-fips-config ] && TEST_KERNEL_CMDLINE+=" fips=1 rd.fips.skipkernel boot=LABEL=root "
+    [ -f /usr/share/crypto-policies/default-fips-config ] && TEST_KERNEL_CMDLINE+=" fips=1 rd.fips.skipkernel boot=LABEL=dracut "
 
     export USE_LVM=1
     command -v mdadm > /dev/null && export HAVE_RAID=1
@@ -44,6 +38,10 @@ client_run() {
     if ! grep -qF 'degraded' "$test_name"; then
         # only add disk2 if RAID is NOT degraded
         qemu_add_drive disk_index disk_args "$TESTDIR/${disk}-2.img" disk2
+    fi
+
+    if [ "$TEST_FSTYPE" = "zfs" ]; then
+        TEST_KERNEL_CMDLINE+=" root=ZFS=dracut/root "
     fi
 
     test_marker_reset

--- a/test/TEST-41-FULL-SYSTEMD/test.sh
+++ b/test/TEST-41-FULL-SYSTEMD/test.sh
@@ -33,7 +33,7 @@ client_run() {
     "$testdir"/run-qemu \
         "${disk_args[@]}" \
         -smbios type=11,value=io.systemd.credential:key=test \
-        -append "$TEST_KERNEL_CMDLINE root=LABEL=dracut mount.usr=LABEL=dracutusr mount.usrflags=subvol=usr $client_opts $DEBUGOUT" \
+        -append "$TEST_KERNEL_CMDLINE mount.usr=LABEL=dracutusr mount.usrflags=subvol=usr $client_opts $DEBUGOUT" \
         -initrd "$TESTDIR"/initramfs.testing || return 1
 
     if ! test_marker_check; then

--- a/test/TEST-42-SYSTEMD-INITRD/test.sh
+++ b/test/TEST-42-SYSTEMD-INITRD/test.sh
@@ -23,7 +23,7 @@ client_run() {
     test_marker_reset
     "$testdir"/run-qemu \
         "${disk_args[@]}" \
-        -append "$TEST_KERNEL_CMDLINE root=LABEL=dracut $client_opts" \
+        -append "$TEST_KERNEL_CMDLINE $client_opts" \
         -initrd "$TESTDIR"/initramfs.testing || return 1
 
     if ! test_marker_check; then

--- a/test/TEST-43-KERNEL-INSTALL/test.sh
+++ b/test/TEST-43-KERNEL-INSTALL/test.sh
@@ -31,7 +31,7 @@ test_run() {
 
     "$testdir"/run-qemu \
         "${disk_args[@]}" \
-        -append "$TEST_KERNEL_CMDLINE root=LABEL=dracut" \
+        -append "$TEST_KERNEL_CMDLINE" \
         -initrd "$BOOT_ROOT/$TOKEN/$KVERSION"/initrd || return 1
 
     test_marker_check || return 1
@@ -41,7 +41,7 @@ test_run() {
     # rescue (non-hostonly) boot
     "$testdir"/run-qemu \
         "${disk_args[@]}" \
-        -append "$TEST_KERNEL_CMDLINE root=LABEL=dracut" \
+        -append "$TEST_KERNEL_CMDLINE" \
         -initrd "$BOOT_ROOT/$TOKEN"/0-rescue/initrd || return 1
 
     test_marker_check || return 1

--- a/test/test-functions
+++ b/test/test-functions
@@ -22,7 +22,7 @@ PKGLIBDIR=${PKGLIBDIR-$basedir}
 [[ -f /etc/machine-id ]] && read -r TOKEN < /etc/machine-id
 [ -z "$TOKEN" ] && . /etc/os-release && TOKEN="$ID"
 
-TEST_KERNEL_CMDLINE+=" panic=1 oops=panic softlockup_panic=1 systemd.crash_reboot $DEBUGFAIL "
+TEST_KERNEL_CMDLINE+=" root=LABEL=dracut panic=1 oops=panic softlockup_panic=1 systemd.crash_reboot $DEBUGFAIL "
 
 if [[ $V != "1" && $V != "2" ]]; then
     TEST_KERNEL_CMDLINE+="quiet "


### PR DESCRIPTION
## Changes

Individual tests can (and do) override the default root.

## Checklist
- [ ] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it

Fixes #
