### PR TITLE
ci: consolidate output filename for test runs

### DIFF
--- a/test/TEST-10-BASIC/test.sh
+++ b/test/TEST-10-BASIC/test.sh
@@ -27,8 +27,7 @@ test_setup() {
     dd if=/dev/zero of="$TESTDIR"/root.img bs=200MiB count=1 status=none && sync
     mkfs.ext4 -q -L dracut -d "$TESTDIR"/dracut.*/initramfs/ "$TESTDIR"/root.img && sync
 
-    test_dracut \
-        "$TESTDIR"/initramfs.testing
+    test_dracut
 }
 
 # shellcheck disable=SC1090

--- a/test/TEST-11-USR-MOUNT/test.sh
+++ b/test/TEST-11-USR-MOUNT/test.sh
@@ -82,8 +82,7 @@ test_setup() {
     fi
 
     test_dracut \
-        -d "btrfs" \
-        "$TESTDIR"/initramfs.testing
+        -d "btrfs"
 }
 
 # shellcheck disable=SC1090

--- a/test/TEST-12-UEFI/test.sh
+++ b/test/TEST-12-UEFI/test.sh
@@ -58,8 +58,7 @@ test_setup() {
     if command -v ukify &> /dev/null; then
         echo "Using ukify to create UKI"
         test_dracut --no-uefi \
-            --drivers 'squashfs' \
-            "$TESTDIR"/initramfs.testing
+            --drivers 'squashfs'
 
         ukify build \
             --linux="$VMLINUZ" \

--- a/test/TEST-20-STORAGE/test.sh
+++ b/test/TEST-20-STORAGE/test.sh
@@ -167,8 +167,7 @@ test_setup() {
         $(if command -v cryptsetup > /dev/null; then echo "-a crypt"; fi) \
         $(if [ "$TEST_FSTYPE" = "zfs" ]; then echo "-a zfs"; else echo "--add-drivers ${TEST_FSTYPE}"; fi) \
         -i "/tmp/crypttab" "/etc/crypttab" \
-        -i "/tmp/key" "/etc/key" \
-        "$TESTDIR"/initramfs.testing
+        -i "/tmp/key" "/etc/key"
 }
 
 # shellcheck disable=SC1090

--- a/test/TEST-23-IMSM/test.sh
+++ b/test/TEST-23-IMSM/test.sh
@@ -94,8 +94,7 @@ test_setup() {
     echo "$MD_UUID" > "$TESTDIR"/mduuid
 
     test_dracut \
-        -a "lvm mdraid" \
-        "$TESTDIR"/initramfs.testing
+        -a "lvm mdraid"
 }
 
 # shellcheck disable=SC1090

--- a/test/TEST-26-ENC-RAID-LVM/test.sh
+++ b/test/TEST-26-ENC-RAID-LVM/test.sh
@@ -100,8 +100,7 @@ test_setup() {
     test_dracut \
         -a "crypt lvm mdraid" \
         -i "/tmp/crypttab" "/etc/crypttab" \
-        -i "/tmp/key" "/etc/key" \
-        "$TESTDIR"/initramfs.testing
+        -i "/tmp/key" "/etc/key"
 }
 
 # shellcheck disable=SC1090

--- a/test/TEST-30-DMSQUASH/test.sh
+++ b/test/TEST-30-DMSQUASH/test.sh
@@ -128,8 +128,7 @@ EOF
 
     test_dracut \
         --no-hostonly \
-        --modules "dmsquash-live-autooverlay" \
-        "$TESTDIR"/initramfs.testing
+        --modules "dmsquash-live-autooverlay"
 }
 
 # shellcheck disable=SC1090

--- a/test/TEST-40-SYSTEMD/test.sh
+++ b/test/TEST-40-SYSTEMD/test.sh
@@ -62,8 +62,7 @@ test_setup() {
     test_dracut \
         --omit-drivers 'a b c d e f g h i j k l m n o p q r s t u v w x y z' \
         -i ./systemd-analyze.sh /lib/dracut/hooks/pre-pivot/00-systemd-analyze.sh \
-        -i "/bin/true" "/usr/bin/man" \
-        "$TESTDIR"/initramfs.testing
+        -i "/bin/true" "/usr/bin/man"
 }
 
 # shellcheck disable=SC1090

--- a/test/TEST-41-FULL-SYSTEMD/test.sh
+++ b/test/TEST-41-FULL-SYSTEMD/test.sh
@@ -126,8 +126,7 @@ test_setup() {
     # force add all available dracut modules that are dependent on systemd
     test_dracut \
         -a "dracut-systemd $dracut_modules" \
-        --add-drivers "btrfs" \
-        "$TESTDIR"/initramfs.testing
+        --add-drivers "btrfs"
 
     if command -v mkosi-initrd &> /dev/null; then
         mkosi-initrd --kernel-version "$KVERSION" -t directory -o mkosi -O "$TESTDIR"

--- a/test/TEST-60-NFS/test.sh
+++ b/test/TEST-60-NFS/test.sh
@@ -395,8 +395,7 @@ test_setup() {
     # Make client's dracut image
     test_dracut \
         --no-hostonly --no-hostonly-cmdline \
-        -a "dmsquash-live ${USE_NETWORK}" \
-        "$TESTDIR"/initramfs.testing
+        -a "dmsquash-live ${USE_NETWORK}"
 
     (
         # shellcheck disable=SC2031

--- a/test/TEST-61-MULTINIC/test.sh
+++ b/test/TEST-61-MULTINIC/test.sh
@@ -336,8 +336,7 @@ test_setup() {
     # Make client's dracut image
     test_dracut \
         --no-hostonly --no-hostonly-cmdline \
-        -a "${USE_NETWORK}" \
-        "$TESTDIR"/initramfs.testing
+        -a "${USE_NETWORK}"
 
     (
         # shellcheck disable=SC2031

--- a/test/TEST-62-BONDBRIDGEVLAN/test.sh
+++ b/test/TEST-62-BONDBRIDGEVLAN/test.sh
@@ -378,8 +378,7 @@ test_setup() {
     # Make client's dracut image
     test_dracut \
         --no-hostonly --no-hostonly-cmdline \
-        -a "${USE_NETWORK} ifcfg ${DEBUGFAIL:+debug}" \
-        "$TESTDIR"/initramfs.testing
+        -a "${USE_NETWORK} ifcfg ${DEBUGFAIL:+debug}"
 
     (
         # shellcheck disable=SC2031

--- a/test/TEST-70-ISCSI/test.sh
+++ b/test/TEST-70-ISCSI/test.sh
@@ -218,8 +218,7 @@ test_setup() {
         --no-hostonly --no-hostonly-cmdline \
         --add "$USE_NETWORK" \
         --include "./client.link" "/etc/systemd/network/01-client.link" \
-        --kernel-cmdline "rw rd.auto" \
-        "$TESTDIR"/initramfs.testing
+        --kernel-cmdline "rw rd.auto"
 }
 
 test_cleanup() {

--- a/test/TEST-71-ISCSI-MULTI/test.sh
+++ b/test/TEST-71-ISCSI-MULTI/test.sh
@@ -223,8 +223,7 @@ test_setup() {
     test_dracut \
         --no-hostonly --no-hostonly-cmdline \
         --add "$USE_NETWORK" \
-        -i "./client.link" "/etc/systemd/network/01-client.link" \
-        "$TESTDIR"/initramfs.testing
+        -i "./client.link" "/etc/systemd/network/01-client.link"
 
     # Make server's dracut image
     "$DRACUT" -i "$TESTDIR"/overlay / \

--- a/test/TEST-72-NBD/test.sh
+++ b/test/TEST-72-NBD/test.sh
@@ -331,8 +331,7 @@ test_setup() {
         -a "${USE_NETWORK}" \
         -i "./client.link" "/etc/systemd/network/01-client.link" \
         -i "/tmp/crypttab" "/etc/crypttab" \
-        -i "/tmp/key" "/etc/key" \
-        "$TESTDIR"/initramfs.testing
+        -i "/tmp/key" "/etc/key"
 
     "$DRACUT" -N -i "$TESTDIR"/overlay / \
         -a "test network-legacy ${SERVER_DEBUG:+debug}" \

--- a/test/test-functions
+++ b/test/test-functions
@@ -62,7 +62,7 @@ test_dracut() {
 
     "$DRACUT" \
         "${TEST_DRACUT_ARGS_ARRAY[@]}" \
-        "$@" || return 1
+        "$@" "$TESTDIR"/initramfs.testing || return 1
 }
 
 # Wait for the server QEMU has been started up.


### PR DESCRIPTION
## Changes

Move initramfs.testing output file name from individual tests into test-functions.

## Checklist
- [ ] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it

Fixes #
