### PR TITLE
ci: reenable some tests for arm64

### DIFF
--- a/.github/workflows/integration-extra-arm64.yml
+++ b/.github/workflows/integration-extra-arm64.yml
@@ -30,7 +30,11 @@ jobs:
                     - ubuntu
                     - void
                 test:
+                    - "10"
+                    - "30"
                     - "43"
+                    - "80"
+                    - "81"
         container:
             image: ghcr.io/dracut-ng/${{ matrix.container }}:latest-arm
             options: '--privileged'


### PR DESCRIPTION
## Changes

These tests were accidentally disabled by 987be72 .

## Checklist
- [ ] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it

Fixes #
