### PR TITLE
ci: move distro specific workarounds to the containerfiles

### DIFF
--- a/test/container/Dockerfile-debian
+++ b/test/container/Dockerfile-debian
@@ -102,5 +102,5 @@ RUN \
 # workaround for kernel-install
 RUN \
     KVERSION="$(cd /lib/modules && ls -1 | tail -1)" \
-    ; ! [ -e /usr/lib/modules/"$KVERSION"/vmlinuz ] && ln -sf /boot/vmlinuz /usr/lib/modules/"$KVERSION"/vmlinuz  \
-    ; ! [ -e /usr/lib/modules/"$KVERSION"/vmlinuz ] && ln -sf /boot/vmlinuz-"$KVERSION" /usr/lib/modules/"$KVERSION"/vmlinuz
+    ; if ! [ -e /usr/lib/modules/"$KVERSION"/vmlinuz ]; then ln -sf /boot/vmlinuz /usr/lib/modules/"$KVERSION"/vmlinuz; fi  \
+    ; if ! [ -e /usr/lib/modules/"$KVERSION"/vmlinuz ]; then ln -sf /boot/vmlinuz-"$KVERSION" /usr/lib/modules/"$KVERSION"/vmlinuz; fi


### PR DESCRIPTION
## Changes

Follow-up to cfe8b21.

Debian and Uunbtu container worked well, but ubuntu:rolling and ubuntu:devel did not.

I tested this PR on ubuntu:rolling.

## Checklist
- [ ] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it

Fixes #
