### PR TITLE
ci: remove workaround from test cases

### DIFF
--- a/test/TEST-30-DMSQUASH/test.sh
+++ b/test/TEST-30-DMSQUASH/test.sh
@@ -88,9 +88,6 @@ test_setup() {
     # test to make sure /proc /sys and /dev is not needed inside the generated initrd
     rm -rf "$TESTDIR"/rootfs/proc "$TESTDIR"/rootfs/sys "$TESTDIR"/rootfs/dev
 
-    # speed up test run
-    rm -rf "$TESTDIR"/rootfs/usr/lib/firmware
-
     mkdir -p "$TESTDIR"/live/LiveOS
     mksquashfs "$TESTDIR"/rootfs/ "$TESTDIR"/live/LiveOS/rootfs.img -quiet
 

--- a/test/TEST-43-KERNEL-INSTALL/test.sh
+++ b/test/TEST-43-KERNEL-INSTALL/test.sh
@@ -55,13 +55,6 @@ test_setup() {
     dd if=/dev/zero of="$TESTDIR"/root.img bs=200MiB count=1 status=none && sync
     mkfs.ext4 -q -L dracut -d "$TESTDIR"/dracut.*/initramfs/ "$TESTDIR"/root.img && sync
 
-    # workaround for openSUSE on arm64
-    [ -e /usr/lib/modules/"$KVERSION"/Image ] && ln -sf /usr/lib/modules/"$KVERSION"/Image /usr/lib/modules/"$KVERSION"/vmlinuz
-
-    # workaround needed for Debian/Ubuntu based distros
-    ! [ -e /usr/lib/modules/"$KVERSION"/vmlinuz ] && ln -sf /boot/vmlinuz /usr/lib/modules/"$KVERSION"/vmlinuz
-    ! [ -e /usr/lib/modules/"$KVERSION"/vmlinuz ] && ln -sf /boot/vmlinuz-"$KVERSION" /usr/lib/modules/"$KVERSION"/vmlinuz
-
     mkdir -p /run/kernel
     echo 'initrd_generator=dracut' >> /run/kernel/install.conf
 


### PR DESCRIPTION
## Changes

Now that workarounds are executed during test container generation from containerfile, workarounds are no longer needed in test cases.

## Checklist
- [ ] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it

Fixes #
