### PR TITLE
fix(base): deduplicate root entries in shadow

### DIFF
--- a/modules.d/99base/module-setup.sh
+++ b/modules.d/99base/module-setup.sh
@@ -50,6 +50,7 @@ install() {
     grep '^root:' "$initdir/etc/passwd" > /dev/null 2>&1 || echo "root:$pwshadow:0:0::/root:/bin/sh" >> "$initdir/etc/passwd"
     grep '^nobody:' "$dracutsysrootdir"/etc/passwd >> "$initdir/etc/passwd"
 
+    [[ $hostonly ]] && sed -i '/^root:/d' "$initdir/etc/shadow"
     [[ $hostonly ]] && grep '^root:' "$dracutsysrootdir"/etc/shadow >> "$initdir/etc/shadow"
 
     # install our scripts and hooks


### PR DESCRIPTION
Having two entries for root in /etc/shadow causes SSH to reject login, even through public key authentication.

Fixes: #1199
Fixes: gsauthof/dracut-sshd#91
