### PR TITLE
test: log error when constructing sysroot

### DIFF
--- a/test/dracut.conf.d/test-makeroot/test-makeroot.conf
+++ b/test/dracut.conf.d/test-makeroot/test-makeroot.conf
@@ -5,4 +5,4 @@ do_strip="no"
 do_hardlink="no"
 early_microcode="no"
 hostonly_cmdline="no"
-stdloglvl=1
+stdloglvl=2

--- a/test/dracut.conf.d/test-root/test-root.conf
+++ b/test/dracut.conf.d/test-root/test-root.conf
@@ -5,4 +5,4 @@ do_strip="no"
 do_hardlink="no"
 early_microcode="no"
 hostonly_cmdline="no"
-stdloglvl=1
+stdloglvl=2


### PR DESCRIPTION
Log dracut errors for all dracut invocations. Otherwise tests can fail without any log output.

Fixes: 8631284afbfa ("ci: do not log how sysroot is constructed")