### PR TITLE
test(FULL-SYSTEMD): skip systemd-network-management if missing

### DIFF
--- a/test/TEST-41-FULL-SYSTEMD/test.sh
+++ b/test/TEST-41-FULL-SYSTEMD/test.sh
@@ -72,7 +72,7 @@ test_setup() {
         dracut_modules="$dracut_modules dbus-daemon"
     fi
 
-    if [ -f /usr/lib/systemd/systemd-networkd ]; then
+    if [ -f /usr/lib/systemd/systemd-networkd ] && [ -e "${PKGLIBDIR}/modules.d/00systemd-network-management/module-setup.sh" ]; then
         dracut_modules="$dracut_modules systemd-network-management"
     fi
 


### PR DESCRIPTION
The Debian/Ubuntu package runs the FULL-SYSTEMD test without dracut-network installed. Therefore the test fails due to the missing `systemd-network-management` module:

```
TEST: Full systemd serialization/deserialization test with /usr mount
dracut[E]: Module 'systemd-network-management' cannot be found.
```

Fixes: 75f3a191b675 ("test(FULL-SYSTEMD): when systemd-networkd is available, install it")