### PR TITLE
fix(systemd-sysusers): always silence stdout

### DIFF
--- a/modules.d/60systemd-sysusers/module-setup.sh
+++ b/modules.d/60systemd-sysusers/module-setup.sh
@@ -15,5 +15,5 @@ check() {
 install() {
     inst_sysusers basic.conf
 
-    systemd-sysusers --root="$initdir"
+    systemd-sysusers --root="$initdir" > /dev/null
 }


### PR DESCRIPTION
## Changes

systemd-sysusers does not have quiet option, so always silence stdout (but not stderr).

Fixes: https://github.com/dracut-ng/dracut-ng/issues/1195

## Checklist
- [ ] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it

Fixes #
