### PR TITLE
fix(release): tagging and release generation is no longer automated

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,11 +25,3 @@ jobs:
 
       - name: Build
         run: bash ${GITHUB_WORKSPACE}/tools/release.sh ${{ inputs.tag }}
-
-      - name: Release
-        if: ${{ env.new_version }}
-        uses: softprops/action-gh-release@v2.2.1
-        with:
-          tag_name: ${{ env.new_version }}
-          name: dracut-${{ env.new_version }}
-          body_path: ${{ github.workspace }}/release.md

--- a/tools/release.sh
+++ b/tools/release.sh
@@ -58,7 +58,7 @@ if [ -z "$(git config --get user.name)" ]; then
 fi
 
 if [ -z "$(git config --get user.email)" ]; then
-    git config user.email "<dracutng@gombos.dev>"
+    git config user.email "<dracutng@localhost.localdomain>"
 fi
 
 # Check in AUTHORS and NEWS.md
@@ -69,17 +69,4 @@ if ! git push -u origin release; then
     exit $?
 fi
 
-# Tag the release, validate the tag and push
-KEYS=$(gpg --list-secret-keys --keyid-format=long 2> /dev/null)
-
-if [ -z "$KEYS" ]; then
-    echo "Could not find gpg or gpg secrets, not signing the git tag."
-    git tag "$NEW_VERSION" -m "$NEW_VERSION"
-else
-    git tag -s "$NEW_VERSION" -m "$NEW_VERSION"
-    git tag -v "$NEW_VERSION"
-fi
-
-# export new version to Github Action
-# release will not be generated if pushing the tag failed
-git push --tags && echo "new_version=${NEW_VERSION,,}" >> "${GITHUB_ENV}"
+# tagging and release genaration is no longer automated


### PR DESCRIPTION
Create release commit on relese branch automatically, but leave the rest of the release creation process up to the project admins to allow manual review and intervention.

We do not have a valid email address for the release automation, so let's make it obvious that it is just a placeholder email address.

@bdrung @Conan-Kudo 
