### PR TITLE
fix(rngd): do not check for +x perms

### DIFF
--- a/modules.d/06rngd/module-setup.sh
+++ b/modules.d/06rngd/module-setup.sh
@@ -21,7 +21,7 @@
 check() {
     # if there's no rngd binary, no go.
     require_binaries rngd || return 1
-    require_binaries "${systemdsystemunitdir}/rngd.service" || return 1
+    [[ -e "${systemdsystemunitdir}/rngd.service" ]] || return 1
 
     return 0
 }


### PR DESCRIPTION
require_binaries checks for an executable binary, but systemd service files are usually not executable nor binary.

resolves an issue discovered on gentoo where the rngd module would refuse to be included due to a missing file that does in fact exist

This pull request changes...

## Changes

## Checklist
- [x] I have tested it locally
- [x] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it

Fixes #
