### PR TITLE
fix(Fedora): fix for rawhide

### DIFF
--- a/test/container/Dockerfile-fedora
+++ b/test/container/Dockerfile-fedora
@@ -32,7 +32,7 @@ if [[ "${DISTRIBUTION}" =~ "centos:" ]]; then \
     dnf config-manager --set-enabled crb; \
     dnf -y install epel-release; \
 else \
-    dnf -y install --setopt=install_weak_deps=False \
+    dnf -y install --allowerasing --setopt=install_weak_deps=False \
     btrfs-progs \
     dhcp-client \
     dhcp-server \


### PR DESCRIPTION
## Changes

Fixes he following error:

```
package dhcp-client-12:4.4.3-16.P1.fc42.aarch64 from rawhide requires systemd, but none of the providers can be installed
```

## Checklist
- [ ] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it

Fixes #
