### PR TITLE
ci(opensuse): install dracut-sshd

### DIFF
--- a/test/container/Dockerfile-opensuse
+++ b/test/container/Dockerfile-opensuse
@@ -4,7 +4,7 @@
 # - network-legacy
 # - mkosi-initrd
 # - hmaccalc (fido)
-# - rdma out of tree dracut module
+# - sshd, rdma out of tree dracut module
 # - dbus-broker
 # - network: network-legacy, network-manager
 
@@ -19,6 +19,7 @@ RUN zypper --non-interactive install --no-recommends \
     cryptsetup \
     dhcp-client \
     dhcp-server \
+    dracut-sshd \
     distribution-gpg-keys \
     e2fsprogs \
     erofs-utils \


### PR DESCRIPTION
Make sure that sshd dracut module does not interfere with upstream dracut modules.

## Checklist
- [ ] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it

Fixes #
