### PR TITLE
btrfs: also install btrfstune

### DIFF
--- a/modules.d/90btrfs/module-setup.sh
+++ b/modules.d/90btrfs/module-setup.sh
@@ -55,6 +55,6 @@ install() {
         inst_hook initqueue/timeout 10 "$moddir/btrfs_timeout.sh"
     fi
 
-    inst_multiple -o btrfsck btrfs-zero-log
+    inst_multiple -o btrfsck btrfs-zero-log btrfstune
     inst "$(command -v btrfs)" /sbin/btrfs
 }


### PR DESCRIPTION
btrfs-progs also includes the program btrfstune; can we please include this in dracut?

This controls a few things that require the filesystem to be unmounted, so having it in dracut would be useful for anything that affects the root partition. My use case was that I needed the block group tree to be enabled for my root partition, but as btrfstune wasn't there I couldn't use the rescue console for this.

Thanks