### PR TITLE
test(ISCSI): skip root=ibft if qemu -acpitable is not supported

### DIFF
--- a/test/TEST-70-ISCSI/test.sh
+++ b/test/TEST-70-ISCSI/test.sh
@@ -90,11 +90,15 @@ do_test_run() {
         "rd.iscsi.initiator=$initiator" \
         || return 1
 
-    run_client "root=ibft" "ibft.table" \
-        "root=LABEL=singleroot" \
-        "rd.iscsi.ibft=1" \
-        "rd.iscsi.firmware=1" \
-        || return 1
+    if "$testdir"/run-qemu --supports -acpitable; then
+        run_client "root=ibft" "ibft.table" \
+            "root=LABEL=singleroot" \
+            "rd.iscsi.ibft=1" \
+            "rd.iscsi.firmware=1" \
+            || return 1
+    else
+        echo "CLIENT TEST: root=ibft [SKIPPED]"
+    fi
 
     echo "All tests passed [OK]"
     return 0

--- a/test/run-qemu
+++ b/test/run-qemu
@@ -1,6 +1,7 @@
 #!/usr/bin/env bash
 # Check which virtualization technology to use
 # We prefer kvm, kqemu, userspace in that order.
+set -eu
 
 export PATH=/usr/sbin:/usr/bin:/sbin:/bin
 ARCH="${ARCH-$(uname -m)}"

--- a/test/run-qemu
+++ b/test/run-qemu
@@ -21,6 +21,12 @@ QEMU_CPU="${QEMU_CPU:-max}"
     exit 1
 }
 
+if test "${1-}" = "--supports"; then
+    option="$2"
+    "$BIN" -help | grep -q "^$option"
+    exit 0
+fi
+
 case "$ARCH" in
     aarch64 | arm64)
         ARGS+=(-M "virt,gic-version=max")


### PR DESCRIPTION
## Changes

Several architectures do not support the qemu option `-acpitable`. Skip the `root=ibft` in this case.

## Checklist
- [ ] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it

Fixes #
