### PR TITLE
test(FULL-SYSTEMD): skip encrypted root if qemu -smbios is not supported

### DIFF
--- a/test/TEST-41-FULL-SYSTEMD/test.sh
+++ b/test/TEST-41-FULL-SYSTEMD/test.sh
@@ -52,11 +52,16 @@ test_run() {
     # shellcheck source=$TESTDIR/luks.uuid
     . "$TESTDIR"/luks.uuid
 
-    # luks
-    client_run "encrypted root with rd.luks.uuid" "type=11,value=io.systemd.credential:key=test" \
-        "rw root=LABEL=dracut_crypt rd.luks.uuid=$ID_FS_UUID rd.luks.key=/run/credentials/@system/key" || return 1
-    client_run "encrypted root with rd.luks.name" "type=11,value=io.systemd.credential:key=test" \
-        "rw root=/dev/mapper/crypt rd.luks.name=$ID_FS_UUID=crypt rd.luks.key=/run/credentials/@system/key" || return 1
+    if "$testdir"/run-qemu --supports -smbios; then
+        # luks
+        client_run "encrypted root with rd.luks.uuid" "type=11,value=io.systemd.credential:key=test" \
+            "rw root=LABEL=dracut_crypt rd.luks.uuid=$ID_FS_UUID rd.luks.key=/run/credentials/@system/key" || return 1
+        client_run "encrypted root with rd.luks.name" "type=11,value=io.systemd.credential:key=test" \
+            "rw root=/dev/mapper/crypt rd.luks.name=$ID_FS_UUID=crypt rd.luks.key=/run/credentials/@system/key" || return 1
+    else
+        echo "CLIENT TEST: encrypted root with rd.luks.uuid [SKIPPED]"
+        echo "CLIENT TEST: encrypted root with rd.luks.name [SKIPPED]"
+    fi
     return 0
 }
 


### PR DESCRIPTION
## Changes

The qemu option `-smbios` is not supported on most architectures. Therefore `TEIT-41-FULL-SYSTEMD` will fail.

## Checklist
- [x] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it

Fixes #1213
