### PR TITLE
test: use "set -eu" in all tests

### DIFF
--- a/test/TEST-10-BASIC/test.sh
+++ b/test/TEST-10-BASIC/test.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+set -eu
 # shellcheck disable=SC2034
 TEST_DESCRIPTION="root filesystem on ext4 filesystem"
 
@@ -14,16 +15,16 @@ test_run() {
     "$testdir"/run-qemu -nic none \
         "${disk_args[@]}" \
         -append "$TEST_KERNEL_CMDLINE" \
-        -initrd "$TESTDIR"/initramfs.testing || return 1
+        -initrd "$TESTDIR"/initramfs.testing
 
-    test_marker_check || return 1
+    test_marker_check
 }
 
 test_setup() {
     # create root filesystem
     "$DRACUT" -N --keep --tmpdir "$TESTDIR" \
         --add-confdir test-root \
-        -f "$TESTDIR"/initramfs.root "$KVERSION" || return 1
+        -f "$TESTDIR"/initramfs.root "$KVERSION"
 
     dd if=/dev/zero of="$TESTDIR"/root.img bs=200MiB count=1 status=none && sync
     mkfs.ext4 -q -L dracut -d "$TESTDIR"/dracut.*/initramfs/ "$TESTDIR"/root.img && sync

--- a/test/TEST-10-BASIC/test.sh
+++ b/test/TEST-10-BASIC/test.sh
@@ -4,6 +4,7 @@ TEST_DESCRIPTION="root filesystem on ext4 filesystem"
 
 test_run() {
     declare -a disk_args=()
+    # shellcheck disable=SC2034  # disk_index used in qemu_add_drive
     declare -i disk_index=0
     qemu_add_drive disk_index disk_args "$TESTDIR"/marker.img marker
     qemu_add_drive disk_index disk_args "$TESTDIR"/root.img root

--- a/test/TEST-11-USR-MOUNT/test.sh
+++ b/test/TEST-11-USR-MOUNT/test.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+set -eu
 
 # shellcheck disable=SC2034
 TEST_DESCRIPTION="root filesystem on a btrfs filesystem with /usr subvolume"
@@ -30,7 +31,7 @@ client_run() {
     "$testdir"/run-qemu \
         "${disk_args[@]}" \
         -append "$TEST_KERNEL_CMDLINE $client_opts" \
-        -initrd "$TESTDIR"/initramfs.testing || return 1
+        -initrd "$TESTDIR"/initramfs.testing
 
     if ! test_marker_check; then
         echo "CLIENT TEST END: $test_name [FAILED]"
@@ -40,9 +41,9 @@ client_run() {
 }
 
 test_run() {
-    client_run "no option specified" || return 1
-    client_run "readonly root" "ro" || return 1
-    client_run "writeable root" "rw" || return 1
+    client_run "no option specified"
+    client_run "readonly root" "ro"
+    client_run "writeable root" "rw"
 }
 
 test_setup() {
@@ -50,7 +51,7 @@ test_setup() {
     "$DRACUT" -N --keep --tmpdir "$TESTDIR" \
         --add-confdir test-root \
         -i ./fstab /etc/fstab \
-        -f "$TESTDIR"/initramfs.root "$KVERSION" || return 1
+        -f "$TESTDIR"/initramfs.root "$KVERSION"
     mkdir -p "$TESTDIR"/overlay/source && mv "$TESTDIR"/dracut.*/initramfs/* "$TESTDIR"/overlay/source && rm -rf "$TESTDIR"/dracut.*
 
     # second, install the files needed to make the root filesystem
@@ -61,7 +62,7 @@ test_setup() {
         --add-confdir test-makeroot \
         -I "mkfs.btrfs" \
         -i ./create-root.sh /lib/dracut/hooks/initqueue/01-create-root.sh \
-        -f "$TESTDIR"/initramfs.makeroot "$KVERSION" || return 1
+        -f "$TESTDIR"/initramfs.makeroot "$KVERSION"
 
     # Create the blank file to use as a root filesystem
     declare -a disk_args=()
@@ -75,7 +76,7 @@ test_setup() {
     "$testdir"/run-qemu \
         "${disk_args[@]}" \
         -append "root=/dev/dracut/root quiet console=ttyS0,115200n81" \
-        -initrd "$TESTDIR"/initramfs.makeroot || return 1
+        -initrd "$TESTDIR"/initramfs.makeroot
 
     if ! test_marker_check dracut-root-block-created; then
         echo "Could not create root filesystem"

--- a/test/TEST-11-USR-MOUNT/test.sh
+++ b/test/TEST-11-USR-MOUNT/test.sh
@@ -65,6 +65,7 @@ test_setup() {
 
     # Create the blank file to use as a root filesystem
     declare -a disk_args=()
+    # shellcheck disable=SC2034  # disk_index used in qemu_add_drive
     declare -i disk_index=0
     qemu_add_drive disk_index disk_args "$TESTDIR"/marker.img marker 1
     qemu_add_drive disk_index disk_args "$TESTDIR"/root.btrfs root 1

--- a/test/TEST-12-UEFI/test.sh
+++ b/test/TEST-12-UEFI/test.sh
@@ -24,6 +24,7 @@ client_run() {
     echo "CLIENT TEST START: $test_name"
 
     declare -a disk_args=()
+    # shellcheck disable=SC2034  # disk_index used in qemu_add_drive
     declare -i disk_index=1
     qemu_add_drive disk_index disk_args "$TESTDIR"/marker.img marker
     qemu_add_drive disk_index disk_args "$TESTDIR"/squashfs.img root

--- a/test/TEST-12-UEFI/test.sh
+++ b/test/TEST-12-UEFI/test.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+set -eu
 
 # shellcheck disable=SC2034
 TEST_DESCRIPTION="UEFI boot (ukify, kernel-install)"
@@ -34,18 +35,18 @@ client_run() {
         -drive file=fat:rw:"$TESTDIR"/ESP,format=vvfat,label=EFI \
         -global driver=cfi.pflash01,property=secure,value=on \
         -drive if=pflash,format=raw,unit=0,file="$(ovmf_code)",readonly=on
-    test_marker_check || return 1
+    test_marker_check
 }
 
 test_run() {
-    client_run "UEFI with UKI and squashfs root" || return 1
+    client_run "UEFI with UKI and squashfs root"
 }
 
 test_setup() {
     # Create what will eventually be our root filesystem
     "$DRACUT" -N --keep --tmpdir "$TESTDIR" \
         --add-confdir test-root \
-        "$TESTDIR"/tmp-initramfs.root "$KVERSION" || return 1
+        "$TESTDIR"/tmp-initramfs.root "$KVERSION"
 
     mksquashfs "$TESTDIR"/dracut.*/initramfs/ "$TESTDIR"/squashfs.img -quiet -no-progress
 

--- a/test/TEST-23-IMSM/test.sh
+++ b/test/TEST-23-IMSM/test.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+set -eu
 # shellcheck disable=SC2034
 TEST_DESCRIPTION="root filesystem on LVM PV on a isw dmraid"
 
@@ -23,7 +24,7 @@ client_run() {
     "$testdir"/run-qemu \
         "${disk_args[@]}" \
         -append "$TEST_KERNEL_CMDLINE $* root=LABEL=root" \
-        -initrd "$TESTDIR"/initramfs.testing || return 1
+        -initrd "$TESTDIR"/initramfs.testing
 
     if ! test_marker_check; then
         echo "CLIENT TEST END: $* [FAIL]"
@@ -41,14 +42,14 @@ test_run() {
         return 1
     fi
 
-    client_run rd.auto rd.md.imsm=0 || return 1
-    client_run rd.md.uuid="$MD_UUID" rd.dm=0 || return 1
+    client_run rd.auto rd.md.imsm=0
+    client_run rd.md.uuid="$MD_UUID" rd.dm=0
     # This test succeeds, because the mirror parts are found without
     # assembling the mirror itself, which is what we want
     client_run rd.md.uuid="$MD_UUID" rd.md=0 rd.md.imsm failme && return 1
     client_run rd.md.uuid="$MD_UUID" rd.md=0 failme && return 1
     # the following test hangs on newer md
-    client_run rd.md.uuid="$MD_UUID" rd.dm=0 rd.md.imsm rd.md.conf=0 || return 1
+    client_run rd.md.uuid="$MD_UUID" rd.dm=0 rd.md.imsm rd.md.conf=0
     return 0
 }
 
@@ -56,7 +57,7 @@ test_setup() {
     # Create what will eventually be our root filesystem onto an overlay
     "$DRACUT" -N --keep --tmpdir "$TESTDIR" \
         --add-confdir test-root \
-        -f "$TESTDIR"/initramfs.root "$KVERSION" || return 1
+        -f "$TESTDIR"/initramfs.root "$KVERSION"
     mkdir -p "$TESTDIR"/overlay/source && mv "$TESTDIR"/dracut.*/initramfs/* "$TESTDIR"/overlay/source && rm -rf "$TESTDIR"/dracut.*
 
     # second, install the files needed to make the root filesystem
@@ -69,7 +70,7 @@ test_setup() {
         -d "piix ide-gd_mod ata_piix ext4 sd_mod dm-multipath dm-crypt dm-round-robin faulty linear multipath raid0 raid10 raid1 raid456" \
         -I "grep sfdisk realpath" \
         -i ./create-root.sh /lib/dracut/hooks/initqueue/01-create-root.sh \
-        -f "$TESTDIR"/initramfs.makeroot "$KVERSION" || return 1
+        -f "$TESTDIR"/initramfs.makeroot "$KVERSION"
 
     # Create the blank files to use as a root filesystem
     declare -a disk_args=()
@@ -83,8 +84,8 @@ test_setup() {
     "$testdir"/run-qemu \
         "${disk_args[@]}" \
         -append "root=/dev/dracut/root quiet console=ttyS0,115200n81" \
-        -initrd "$TESTDIR"/initramfs.makeroot || return 1
-    test_marker_check dracut-root-block-created || return 1
+        -initrd "$TESTDIR"/initramfs.makeroot
+    test_marker_check dracut-root-block-created
     eval "$(grep -F --binary-files=text -m 1 MD_UUID "$TESTDIR"/marker.img)"
 
     if [[ -z $MD_UUID ]]; then

--- a/test/TEST-23-IMSM/test.sh
+++ b/test/TEST-23-IMSM/test.sh
@@ -73,6 +73,7 @@ test_setup() {
 
     # Create the blank files to use as a root filesystem
     declare -a disk_args=()
+    # shellcheck disable=SC2034  # disk_index used in qemu_add_drive
     declare -i disk_index=0
     qemu_add_drive disk_index disk_args "$TESTDIR"/marker.img marker 1
     qemu_add_drive disk_index disk_args "$TESTDIR"/disk-1.img disk1 420

--- a/test/TEST-26-ENC-RAID-LVM/test.sh
+++ b/test/TEST-26-ENC-RAID-LVM/test.sh
@@ -72,6 +72,7 @@ test_setup() {
 
     # Create the blank files to use as a root filesystem
     declare -a disk_args=()
+    # shellcheck disable=SC2034  # disk_index used in qemu_add_drive
     declare -i disk_index=0
     qemu_add_drive disk_index disk_args "$TESTDIR"/marker.img marker 1
     qemu_add_drive disk_index disk_args "$TESTDIR"/disk-1.img disk1 1

--- a/test/TEST-26-ENC-RAID-LVM/test.sh
+++ b/test/TEST-26-ENC-RAID-LVM/test.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+set -eu
 # shellcheck disable=SC2034
 TEST_DESCRIPTION="root filesystem on LVM on encrypted partitions of a RAID"
 
@@ -35,7 +36,7 @@ test_run() {
         "${disk_args[@]}" \
         -append "$TEST_KERNEL_CMDLINE root=/dev/dracut/root ro rd.auto rootwait $LUKSARGS" \
         -initrd "$TESTDIR"/initramfs.testing
-    test_marker_check || return 1
+    test_marker_check
     echo "CLIENT TEST END: [OK]"
 
     test_marker_reset
@@ -45,7 +46,7 @@ test_run() {
         "${disk_args[@]}" \
         -append "$TEST_KERNEL_CMDLINE root=/dev/dracut/root rd.auto" \
         -initrd "$TESTDIR"/initramfs.testing
-    test_marker_check || return 1
+    test_marker_check
     echo "CLIENT TEST END: [OK]"
 
     return 0
@@ -55,7 +56,7 @@ test_setup() {
     # Create what will eventually be our root filesystem onto an overlay
     "$DRACUT" -N --keep --tmpdir "$TESTDIR" \
         --add-confdir test-root \
-        -f "$TESTDIR"/initramfs.root "$KVERSION" || return 1
+        -f "$TESTDIR"/initramfs.root "$KVERSION"
     mkdir -p "$TESTDIR"/overlay/source && mv "$TESTDIR"/dracut.*/initramfs/* "$TESTDIR"/overlay/source && rm -rf "$TESTDIR"/dracut.*
 
     # second, install the files needed to make the root filesystem
@@ -68,7 +69,7 @@ test_setup() {
         -a "bash crypt lvm mdraid" \
         -I "grep cryptsetup" \
         -i ./create-root.sh /lib/dracut/hooks/initqueue/01-create-root.sh \
-        -f "$TESTDIR"/initramfs.makeroot "$KVERSION" || return 1
+        -f "$TESTDIR"/initramfs.makeroot "$KVERSION"
 
     # Create the blank files to use as a root filesystem
     declare -a disk_args=()
@@ -81,8 +82,8 @@ test_setup() {
     "$testdir"/run-qemu \
         "${disk_args[@]}" \
         -append "root=/dev/fakeroot quiet console=ttyS0,115200n81" \
-        -initrd "$TESTDIR"/initramfs.makeroot || return 1
-    test_marker_check dracut-root-block-created || return 1
+        -initrd "$TESTDIR"/initramfs.makeroot
+    test_marker_check dracut-root-block-created
     cryptoUUIDS=$(grep -F --binary-files=text -m 3 ID_FS_UUID "$TESTDIR"/marker.img)
     for uuid in $cryptoUUIDS; do
         eval "$uuid"

--- a/test/TEST-30-DMSQUASH/test.sh
+++ b/test/TEST-30-DMSQUASH/test.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+set -eu
 
 # shellcheck disable=SC2034
 TEST_DESCRIPTION="live root on a squash filesystem"
@@ -41,29 +42,29 @@ client_run() {
 }
 
 test_run() {
-    client_run "overlayfs" "" || return 1
+    client_run "overlayfs" ""
 
-    client_run "live" "rd.live.image" || return 1
-    client_run "livedir" "rd.live.image rd.live.dir=LiveOS" || return 1
+    client_run "live" "rd.live.image"
+    client_run "livedir" "rd.live.image rd.live.dir=LiveOS"
 
     # Run the erofs test only if mkfs.erofs is available
     if command -v mkfs.erofs &> /dev/null; then
-        client_run "erofs" "root=live:/dev/disk/by-id/scsi-0QEMU_QEMU_HARDDISK_root_erofs" || return 1
+        client_run "erofs" "root=live:/dev/disk/by-id/scsi-0QEMU_QEMU_HARDDISK_root_erofs"
     fi
 
     # Run the iso test only if xorriso is available
     if command -v xorriso &> /dev/null; then
-        client_run "iso" "iso-scan/filename=linux.iso root=live:/dev/disk/by-label/ISO" || return 1
+        client_run "iso" "iso-scan/filename=linux.iso root=live:/dev/disk/by-label/ISO"
     fi
 
     test_marker_reset
     rootPartitions=$(sfdisk -d "$TESTDIR"/root.img | grep -c 'root\.img[0-9]')
-    [ "$rootPartitions" -eq 1 ] || return 1
+    [ "$rootPartitions" -eq 1 ]
 
-    client_run "autooverlay" "init=/sbin/init-persist rd.live.image rd.live.overlay=LABEL=persist rd.live.dir=LiveOS" || return 1
+    client_run "autooverlay" "init=/sbin/init-persist rd.live.image rd.live.overlay=LABEL=persist rd.live.dir=LiveOS"
 
     rootPartitions=$(sfdisk -d "$TESTDIR"/root.img | grep -c 'root\.img[0-9]')
-    [ "$rootPartitions" -eq 2 ] || return 1
+    [ "$rootPartitions" -eq 2 ]
 
     (
         # Ensure that this test works when run with the `V=1` parameter, which runs the script with `set -o pipefail`.
@@ -72,7 +73,7 @@ test_run() {
         # Verify that the string "dracut-autooverlay-success" occurs in the second partition in the image file.
         dd if="$TESTDIR"/root.img bs=1MiB status=none \
             | grep -U --binary-files=binary -F -m 1 -q dracut-autooverlay-success
-    ) || return 1
+    )
 
     return 0
 }
@@ -82,7 +83,7 @@ test_setup() {
     "$DRACUT" -N --keep --tmpdir "$TESTDIR" \
         --add-confdir test-root \
         -i ./test-init.sh /sbin/init-persist \
-        -f "$TESTDIR"/initramfs.root "$KVERSION" || return 1
+        -f "$TESTDIR"/initramfs.root "$KVERSION"
     mkdir -p "$TESTDIR"/rootfs && mv "$TESTDIR"/dracut.*/initramfs/* "$TESTDIR"/rootfs && rm -rf "$TESTDIR"/dracut.*
 
     # test to make sure /proc /sys and /dev is not needed inside the generated initrd

--- a/test/TEST-30-DMSQUASH/test.sh
+++ b/test/TEST-30-DMSQUASH/test.sh
@@ -93,6 +93,7 @@ test_setup() {
 
     # Create the blank file to use as a root filesystem
     declare -a disk_args=()
+    # shellcheck disable=SC2034  # disk_index used in qemu_add_drive
     declare -i disk_index=0
     qemu_add_drive disk_index disk_args "$TESTDIR"/root.img root 1
 

--- a/test/TEST-40-SYSTEMD/test.sh
+++ b/test/TEST-40-SYSTEMD/test.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+set -eu
 # shellcheck disable=SC2034
 TEST_DESCRIPTION="root filesystem on a ext4 filesystem"
 
@@ -18,16 +19,16 @@ test_run() {
     "$testdir"/run-qemu \
         "${disk_args[@]}" \
         -append "$TEST_KERNEL_CMDLINE \"root=LABEL=  rdinit=/bin/sh\" systemd.log_target=console init=/sbin/init" \
-        -initrd "$TESTDIR"/initramfs.testing || return 1
+        -initrd "$TESTDIR"/initramfs.testing
 
-    test_marker_check || return 1
+    test_marker_check
 }
 
 test_setup() {
     # Create what will eventually be our root filesystem onto an overlay
     "$DRACUT" -N --keep --tmpdir "$TESTDIR" \
         --add-confdir test-root \
-        -f "$TESTDIR"/initramfs.root "$KVERSION" || return 1
+        -f "$TESTDIR"/initramfs.root "$KVERSION"
     mkdir -p "$TESTDIR"/overlay/source && mv "$TESTDIR"/dracut.*/initramfs/* "$TESTDIR"/overlay/source && rm -rf "$TESTDIR"/dracut.*
 
     # second, install the files needed to make the root filesystem
@@ -39,7 +40,7 @@ test_setup() {
         -i ./create-root.sh /lib/dracut/hooks/initqueue/01-create-root.sh \
         --nomdadmconf \
         --no-hostonly-cmdline -N \
-        -f "$TESTDIR"/initramfs.makeroot "$KVERSION" || return 1
+        -f "$TESTDIR"/initramfs.makeroot "$KVERSION"
 
     declare -a disk_args=()
     # shellcheck disable=SC2034  # disk_index used in qemu_add_drive
@@ -51,8 +52,8 @@ test_setup() {
     "$testdir"/run-qemu \
         "${disk_args[@]}" \
         -append "root=/dev/fakeroot quiet console=ttyS0,115200n81" \
-        -initrd "$TESTDIR"/initramfs.makeroot || return 1
-    test_marker_check dracut-root-block-created || return 1
+        -initrd "$TESTDIR"/initramfs.makeroot
+    test_marker_check dracut-root-block-created
     rm -- "$TESTDIR"/marker.img
 
     # systemd-analyze.sh calls man indirectly

--- a/test/TEST-40-SYSTEMD/test.sh
+++ b/test/TEST-40-SYSTEMD/test.sh
@@ -42,6 +42,7 @@ test_setup() {
         -f "$TESTDIR"/initramfs.makeroot "$KVERSION" || return 1
 
     declare -a disk_args=()
+    # shellcheck disable=SC2034  # disk_index used in qemu_add_drive
     declare -i disk_index=0
     qemu_add_drive disk_index disk_args "$TESTDIR"/marker.img marker 1
     qemu_add_drive disk_index disk_args "$TESTDIR"/root.img root 1

--- a/test/TEST-41-FULL-SYSTEMD/test.sh
+++ b/test/TEST-41-FULL-SYSTEMD/test.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+set -eu
 
 # shellcheck disable=SC2034
 TEST_DESCRIPTION="Full systemd serialization/deserialization test with /usr mount"
@@ -34,7 +35,7 @@ client_run() {
         "${disk_args[@]}" \
         -smbios type=11,value=io.systemd.credential:key=test \
         -append "$TEST_KERNEL_CMDLINE mount.usr=LABEL=dracutusr mount.usrflags=subvol=usr $client_opts $DEBUGOUT" \
-        -initrd "$TESTDIR"/initramfs.testing || return 1
+        -initrd "$TESTDIR"/initramfs.testing
 
     if ! test_marker_check; then
         echo "CLIENT TEST END: $test_name [FAILED]"
@@ -45,16 +46,16 @@ client_run() {
 
 test_run() {
     # mask services that require rw
-    client_run "readonly root" "ro systemd.mask=systemd-sysusers systemd.mask=systemd-timesyncd systemd.mask=systemd-resolved" || return 1
+    client_run "readonly root" "ro systemd.mask=systemd-sysusers systemd.mask=systemd-timesyncd systemd.mask=systemd-resolved"
 
-    client_run "writeable root" "rw" || return 1
+    client_run "writeable root" "rw"
 
     # shellcheck source=$TESTDIR/luks.uuid
     . "$TESTDIR"/luks.uuid
 
     # luks
-    client_run "encrypted root with rd.luks.uuid" "rw root=LABEL=dracut_crypt rd.luks.uuid=$ID_FS_UUID rd.luks.key=/run/credentials/@system/key" || return 1
-    client_run "encrypted root with rd.luks.name" "rw root=/dev/mapper/crypt rd.luks.name=$ID_FS_UUID=crypt rd.luks.key=/run/credentials/@system/key" || return 1
+    client_run "encrypted root with rd.luks.uuid" "rw root=LABEL=dracut_crypt rd.luks.uuid=$ID_FS_UUID rd.luks.key=/run/credentials/@system/key"
+    client_run "encrypted root with rd.luks.name" "rw root=/dev/mapper/crypt rd.luks.name=$ID_FS_UUID=crypt rd.luks.key=/run/credentials/@system/key"
     return 0
 }
 
@@ -90,7 +91,7 @@ test_setup() {
     "$DRACUT" -N --keep --tmpdir "$TESTDIR" \
         --add-confdir test-root \
         -a "$dracut_modules" \
-        -f "$TESTDIR"/initramfs.root "$KVERSION" || return 1
+        -f "$TESTDIR"/initramfs.root "$KVERSION"
 
     mkdir -p "$TESTDIR"/overlay/source && cp -a "$TESTDIR"/dracut.*/initramfs/* "$TESTDIR"/overlay/source && rm -rf "$TESTDIR"/dracut.*
 
@@ -103,7 +104,7 @@ test_setup() {
         -a "btrfs crypt" \
         -I "mkfs.btrfs cryptsetup" \
         -i ./create-root.sh /lib/dracut/hooks/initqueue/01-create-root.sh \
-        -f "$TESTDIR"/initramfs.makeroot "$KVERSION" || return 1
+        -f "$TESTDIR"/initramfs.makeroot "$KVERSION"
 
     # Create the blank file to use as a root filesystem
     declare -a disk_args=()
@@ -118,8 +119,8 @@ test_setup() {
     "$testdir"/run-qemu \
         "${disk_args[@]}" \
         -append "root=/dev/fakeroot quiet console=ttyS0,115200n81" \
-        -initrd "$TESTDIR"/initramfs.makeroot || return 1
-    test_marker_check dracut-root-block-created || return 1
+        -initrd "$TESTDIR"/initramfs.makeroot
+    test_marker_check dracut-root-block-created
 
     grep -F -a -m 1 ID_FS_UUID "$TESTDIR"/marker.img > "$TESTDIR"/luks.uuid
 

--- a/test/TEST-42-SYSTEMD-INITRD/test.sh
+++ b/test/TEST-42-SYSTEMD-INITRD/test.sh
@@ -57,6 +57,7 @@ test_setup() {
         -f "$TESTDIR"/initramfs.makeroot "$KVERSION" || return 1
 
     declare -a disk_args=()
+    # shellcheck disable=SC2034  # disk_index used in qemu_add_drive
     declare -i disk_index=0
     qemu_add_drive disk_index disk_args "$TESTDIR"/marker.img marker 1
     qemu_add_drive disk_index disk_args "$TESTDIR"/root.img root 1

--- a/test/TEST-42-SYSTEMD-INITRD/test.sh
+++ b/test/TEST-42-SYSTEMD-INITRD/test.sh
@@ -1,4 +1,6 @@
 #!/usr/bin/env bash
+set -eu
+
 # shellcheck disable=SC2034
 TEST_DESCRIPTION="root filesystem on a ext4 filesystem with systemd but without dracut-systemd"
 
@@ -24,7 +26,7 @@ client_run() {
     "$testdir"/run-qemu \
         "${disk_args[@]}" \
         -append "$TEST_KERNEL_CMDLINE $client_opts" \
-        -initrd "$TESTDIR"/initramfs.testing || return 1
+        -initrd "$TESTDIR"/initramfs.testing
 
     if ! test_marker_check; then
         echo "CLIENT TEST END: $test_name [FAILED]"
@@ -34,15 +36,15 @@ client_run() {
 }
 
 test_run() {
-    client_run "readonly root" "ro" || return 1
-    client_run "writeable root" "rw" || return 1
+    client_run "readonly root" "ro"
+    client_run "writeable root" "rw"
 }
 
 test_setup() {
     # Create what will eventually be our root filesystem onto an overlay
     "$DRACUT" -N --keep --tmpdir "$TESTDIR" \
         --add-confdir test-root \
-        -f "$TESTDIR"/initramfs.root "$KVERSION" || return 1
+        -f "$TESTDIR"/initramfs.root "$KVERSION"
     mkdir -p "$TESTDIR"/overlay/source && mv "$TESTDIR"/dracut.*/initramfs/* "$TESTDIR"/overlay/source && rm -rf "$TESTDIR"/dracut.*
 
     # second, install the files needed to make the root filesystem
@@ -54,7 +56,7 @@ test_setup() {
         -i ./create-root.sh /lib/dracut/hooks/initqueue/01-create-root.sh \
         --nomdadmconf \
         --no-hostonly-cmdline -N \
-        -f "$TESTDIR"/initramfs.makeroot "$KVERSION" || return 1
+        -f "$TESTDIR"/initramfs.makeroot "$KVERSION"
 
     declare -a disk_args=()
     # shellcheck disable=SC2034  # disk_index used in qemu_add_drive
@@ -66,8 +68,8 @@ test_setup() {
     "$testdir"/run-qemu \
         "${disk_args[@]}" \
         -append "root=/dev/fakeroot quiet console=ttyS0,115200n81" \
-        -initrd "$TESTDIR"/initramfs.makeroot || return 1
-    test_marker_check dracut-root-block-created || return 1
+        -initrd "$TESTDIR"/initramfs.makeroot
+    test_marker_check dracut-root-block-created
     rm -- "$TESTDIR"/marker.img
 
     # initrd for test infra and required kernel modules
@@ -86,7 +88,7 @@ test_setup() {
 
     # verify that dracut systemd services are not included
     (
-        cd "$TESTDIR"/initrd/dracut.*/initramfs/usr/lib/systemd/system/ || return 1
+        cd "$TESTDIR"/initrd/dracut.*/initramfs/usr/lib/systemd/system/
         for f in dracut*.service; do
             [ -e "$f" ] && echo "unexpected dracut service found: $f" && return 1
         done

--- a/test/TEST-43-KERNEL-INSTALL/test.sh
+++ b/test/TEST-43-KERNEL-INSTALL/test.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+set -eu
 # shellcheck disable=SC2034
 TEST_DESCRIPTION="kernel-install with root filesystem on ext4 filesystem"
 
@@ -31,9 +32,9 @@ test_run() {
     "$testdir"/run-qemu \
         "${disk_args[@]}" \
         -append "$TEST_KERNEL_CMDLINE" \
-        -initrd "$BOOT_ROOT/$TOKEN/$KVERSION"/initrd || return 1
+        -initrd "$BOOT_ROOT/$TOKEN/$KVERSION"/initrd
 
-    test_marker_check || return 1
+    test_marker_check
 
     test_marker_reset
 
@@ -41,9 +42,9 @@ test_run() {
     "$testdir"/run-qemu \
         "${disk_args[@]}" \
         -append "$TEST_KERNEL_CMDLINE" \
-        -initrd "$BOOT_ROOT/$TOKEN"/0-rescue/initrd || return 1
+        -initrd "$BOOT_ROOT/$TOKEN"/0-rescue/initrd
 
-    test_marker_check || return 1
+    test_marker_check
 }
 
 test_setup() {
@@ -51,7 +52,7 @@ test_setup() {
     # shellcheck disable=SC2153
     "$DRACUT" -N --keep --tmpdir "$TESTDIR" \
         --add-confdir test-root \
-        -f "$TESTDIR"/initramfs.root "$KVERSION" || return 1
+        -f "$TESTDIR"/initramfs.root "$KVERSION"
 
     dd if=/dev/zero of="$TESTDIR"/root.img bs=200MiB count=1 status=none && sync
     mkfs.ext4 -q -L dracut -d "$TESTDIR"/dracut.*/initramfs/ "$TESTDIR"/root.img && sync

--- a/test/TEST-43-KERNEL-INSTALL/test.sh
+++ b/test/TEST-43-KERNEL-INSTALL/test.sh
@@ -21,6 +21,7 @@ test_check() {
 
 test_run() {
     declare -a disk_args=()
+    # shellcheck disable=SC2034  # disk_index used in qemu_add_drive
     declare -i disk_index=0
     qemu_add_drive disk_index disk_args "$TESTDIR"/marker.img marker
     qemu_add_drive disk_index disk_args "$TESTDIR"/root.img root

--- a/test/TEST-60-NFS/test.sh
+++ b/test/TEST-60-NFS/test.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+set -eu
 
 # shellcheck disable=SC2034
 TEST_DESCRIPTION="root filesystem on NFS with $USE_NETWORK"
@@ -32,11 +33,11 @@ run_server() {
         -serial "${SERIAL:-"file:$TESTDIR/server.log"}" \
         -append "panic=1 oops=panic softlockup_panic=1 root=LABEL=dracut rootfstype=ext4 rw console=ttyS0,115200n81 $SERVER_DEBUG" \
         -initrd "$TESTDIR"/initramfs.server \
-        -pidfile "$TESTDIR"/server.pid -daemonize || return 1
-    chmod 644 "$TESTDIR"/server.pid || return 1
+        -pidfile "$TESTDIR"/server.pid -daemonize
+    chmod 644 "$TESTDIR"/server.pid
 
     if ! [[ $SERIAL ]]; then
-        wait_for_server_startup || return 1
+        wait_for_server_startup
     else
         echo Sleeping 10 seconds to give the server a head start
         sleep 10
@@ -127,47 +128,47 @@ test_nfsv3() {
     # NFSv4: last octet starts at 0x80 and works up
 
     client_test "NFSv3 root=dhcp DHCP path only" 52:54:00:12:34:00 \
-        "root=dhcp" 192.168.50.1 -wsize=4096 || return 1
+        "root=dhcp" 192.168.50.1 -wsize=4096
 
     client_test "NFSv3 Legacy root=/dev/nfs nfsroot=IP:path" 52:54:00:12:34:01 \
-        "root=/dev/nfs nfsroot=192.168.50.1:/nfs/client" 192.168.50.1 -wsize=4096 || return 1
+        "root=/dev/nfs nfsroot=192.168.50.1:/nfs/client" 192.168.50.1 -wsize=4096
 
     client_test "NFSv3 Legacy root=/dev/nfs DHCP path only" 52:54:00:12:34:00 \
-        "root=/dev/nfs" 192.168.50.1 -wsize=4096 || return 1
+        "root=/dev/nfs" 192.168.50.1 -wsize=4096
 
     client_test "NFSv3 Legacy root=/dev/nfs DHCP IP:path" 52:54:00:12:34:01 \
-        "root=/dev/nfs" 192.168.50.2 -wsize=4096 || return 1
+        "root=/dev/nfs" 192.168.50.2 -wsize=4096
 
     client_test "NFSv3 root=dhcp DHCP IP:path" 52:54:00:12:34:01 \
-        "root=dhcp" 192.168.50.2 -wsize=4096 || return 1
+        "root=dhcp" 192.168.50.2 -wsize=4096
 
     client_test "NFSv3 root=dhcp DHCP proto:IP:path" 52:54:00:12:34:02 \
-        "root=dhcp" 192.168.50.3 -wsize=4096 || return 1
+        "root=dhcp" 192.168.50.3 -wsize=4096
 
     client_test "NFSv3 root=dhcp DHCP proto:IP:path:options" 52:54:00:12:34:03 \
-        "root=dhcp" 192.168.50.3 wsize=4096 || return 1
+        "root=dhcp" 192.168.50.3 wsize=4096
 
     client_test "NFSv3 root=nfs:..." 52:54:00:12:34:04 \
-        "root=nfs:192.168.50.1:/nfs/client" 192.168.50.1 -wsize=4096 || return 1
+        "root=nfs:192.168.50.1:/nfs/client" 192.168.50.1 -wsize=4096
 
     client_test "NFSv3 Bridge root=nfs:..." 52:54:00:12:34:04 \
-        "root=nfs:192.168.50.1:/nfs/client bridge net.ifnames=0" 192.168.50.1 -wsize=4096 || return 1
+        "root=nfs:192.168.50.1:/nfs/client bridge net.ifnames=0" 192.168.50.1 -wsize=4096
 
     client_test "NFSv3 Legacy root=IP:path" 52:54:00:12:34:04 \
-        "root=192.168.50.1:/nfs/client" 192.168.50.1 -wsize=4096 || return 1
+        "root=192.168.50.1:/nfs/client" 192.168.50.1 -wsize=4096
 
     client_test "NFSv3 root=dhcp DHCP path,options" 52:54:00:12:34:05 \
-        "root=dhcp" 192.168.50.1 wsize=4096 || return 1
+        "root=dhcp" 192.168.50.1 wsize=4096
 
     client_test "NFSv3 root=dhcp DHCP IP:path,options" 52:54:00:12:34:06 \
-        "root=dhcp" 192.168.50.2 wsize=4096 || return 1
+        "root=dhcp" 192.168.50.2 wsize=4096
 
     client_test "NFSv3 root=dhcp DHCP proto:IP:path,options" 52:54:00:12:34:07 \
-        "root=dhcp" 192.168.50.3 wsize=4096 || return 1
+        "root=dhcp" 192.168.50.3 wsize=4096
 
     # TODO FIXME
     #    client_test "NFSv3 Bridge Customized root=dhcp DHCP path,options" 52:54:00:12:34:05 \
-    #        "root=dhcp bridge=foobr0:enp0s1" 192.168.50.1 wsize=4096 || return 1
+    #        "root=dhcp bridge=foobr0:enp0s1" 192.168.50.1 wsize=4096
 
     return 0
 }
@@ -178,22 +179,22 @@ test_nfsv4() {
     # switch_root
 
     client_test "NFSv4 root=dhcp DHCP proto:IP:path" 52:54:00:12:34:82 \
-        "root=dhcp" 192.168.50.3 -wsize=4096 || return 1
+        "root=dhcp" 192.168.50.3 -wsize=4096
 
     client_test "NFSv4 root=dhcp DHCP proto:IP:path:options" 52:54:00:12:34:83 \
-        "root=dhcp" 192.168.50.3 wsize=4096 || return 1
+        "root=dhcp" 192.168.50.3 wsize=4096
 
     client_test "NFSv4 root=nfs4:..." 52:54:00:12:34:84 \
-        "root=nfs4:192.168.50.1:/client" 192.168.50.1 -wsize=4096 || return 1
+        "root=nfs4:192.168.50.1:/client" 192.168.50.1 -wsize=4096
 
     client_test "NFSv4 root=dhcp DHCP proto:IP:path,options" 52:54:00:12:34:87 \
-        "root=dhcp" 192.168.50.3 wsize=4096 || return 1
+        "root=dhcp" 192.168.50.3 wsize=4096
 
     client_test "NFSv4 Overlayfs root=nfs4:..." 52:54:00:12:34:84 \
-        "root=nfs4:192.168.50.1:/client rd.live.overlay.overlayfs=1 " 192.168.50.1 -wsize=4096 || return 1
+        "root=nfs4:192.168.50.1:/client rd.live.overlay.overlayfs=1 " 192.168.50.1 -wsize=4096
 
     client_test "NFSv4 Live Overlayfs root=nfs4:..." 52:54:00:12:34:84 \
-        "root=nfs4:192.168.50.1:/client rd.live.image rd.live.overlay.overlayfs=1" 192.168.50.1 -wsize=4096 || return 1
+        "root=nfs4:192.168.50.1:/client rd.live.image rd.live.overlay.overlayfs=1" 192.168.50.1 -wsize=4096
 
     return 0
 }
@@ -362,7 +363,7 @@ test_setup() {
         -d "piix ide-gd_mod ata_piix ext4 sd_mod" \
         --nomdadmconf \
         --no-hostonly-cmdline -N \
-        -f "$TESTDIR"/initramfs.makeroot "$KVERSION" || return 1
+        -f "$TESTDIR"/initramfs.makeroot "$KVERSION"
     rm -rf -- "$TESTDIR"/server
 
     declare -a disk_args=()
@@ -375,8 +376,8 @@ test_setup() {
     "$testdir"/run-qemu \
         "${disk_args[@]}" \
         -append "root=/dev/dracut/root rw rootfstype=ext4 quiet console=ttyS0,115200n81" \
-        -initrd "$TESTDIR"/initramfs.makeroot || return 1
-    test_marker_check dracut-root-block-created || return 1
+        -initrd "$TESTDIR"/initramfs.makeroot
+    test_marker_check dracut-root-block-created
 
     # Make an overlay with needed tools for the test harness
     (
@@ -411,7 +412,7 @@ test_setup() {
         -a "network-legacy ${SERVER_DEBUG:+debug}" \
         -d "af_packet piix ide-gd_mod ata_piix ext4 sd_mod i6300esb virtio_net" \
         --no-hostonly-cmdline -N \
-        -f "$TESTDIR"/initramfs.server "$KVERSION" || return 1
+        -f "$TESTDIR"/initramfs.server "$KVERSION"
 }
 
 test_cleanup() {

--- a/test/TEST-61-MULTINIC/test.sh
+++ b/test/TEST-61-MULTINIC/test.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+set -eu
 
 # shellcheck disable=SC2034
 TEST_DESCRIPTION="root filesystem on NFS with multiple nics with $USE_NETWORK"
@@ -37,12 +38,12 @@ run_server() {
         -serial "${SERIAL:-"file:$TESTDIR/server.log"}" \
         -append "panic=1 oops=panic softlockup_panic=1 systemd.crash_reboot root=LABEL=dracut rootfstype=ext4 rw console=ttyS0,115200n81 $SERVER_DEBUG" \
         -initrd "$TESTDIR"/initramfs.server \
-        -pidfile "$TESTDIR"/server.pid -daemonize || return 1
+        -pidfile "$TESTDIR"/server.pid -daemonize
 
-    chmod 644 -- "$TESTDIR"/server.pid || return 1
+    chmod 644 -- "$TESTDIR"/server.pid
 
     if ! [[ $SERIAL ]]; then
-        wait_for_server_startup || return 1
+        wait_for_server_startup
     else
         echo Sleeping 10 seconds to give the server a head start
         sleep 10
@@ -78,7 +79,7 @@ client_test() {
         -device virtio-net-pci,netdev=n1,mac=52:54:00:12:34:98 \
         -device virtio-net-pci,netdev=n2,mac=52:54:00:12:34:99 \
         -append "$TEST_KERNEL_CMDLINE $cmdline ro init=/sbin/init systemd.log_target=console" \
-        -initrd "$TESTDIR"/initramfs.testing || return 1
+        -initrd "$TESTDIR"/initramfs.testing
 
     {
         read -r OK
@@ -130,47 +131,47 @@ test_client() {
     client_test "MULTINIC root=nfs BOOTIF=" \
         00 01 02 \
         "root=nfs:192.168.50.1:/nfs/client BOOTIF=52-54-00-12-34-00" \
-        "enp0s1" || return 1
+        "enp0s1"
 
     client_test "MULTINIC root=nfs BOOTIF= ip=enp0s3:dhcp" \
         00 01 02 \
         "root=nfs:192.168.50.1:/nfs/client BOOTIF=52-54-00-12-34-00 ip=enp0s2:dhcp" \
-        "enp0s1 enp0s2" || return 1
+        "enp0s1 enp0s2"
 
     # PXE Style BOOTIF= with dhcp root-path
     client_test "MULTINIC root=dhcp BOOTIF=" \
         00 01 02 \
         "root=dhcp BOOTIF=52-54-00-12-34-02" \
-        "enp0s3" || return 1
+        "enp0s3"
 
     # Multinic case, where only one nic works
     client_test "MULTINIC root=nfs ip=dhcp" \
         FF 00 FE \
         "root=nfs:192.168.50.1:/nfs/client ip=dhcp" \
-        "enp0s2" || return 1
+        "enp0s2"
 
     # Require two interfaces
     client_test "MULTINIC root=nfs ip=enp0s2:dhcp ip=enp0s3:dhcp bootdev=enp0s2" \
         00 01 02 \
         "root=nfs:192.168.50.1:/nfs/client ip=enp0s2:dhcp ip=enp0s3:dhcp bootdev=enp0s2" \
-        "enp0s2 enp0s3" || return 1
+        "enp0s2 enp0s3"
 
     # Require three interfaces with dhcp root-path
     client_test "MULTINIC root=dhcp ip=enp0s1:dhcp ip=enp0s2:dhcp ip=enp0s3:dhcp bootdev=enp0s3" \
         00 01 02 \
         "root=dhcp ip=enp0s1:dhcp ip=enp0s2:dhcp ip=enp0s3:dhcp bootdev=enp0s3" \
-        "enp0s1 enp0s2 enp0s3" || return 1
+        "enp0s1 enp0s2 enp0s3"
 
     client_test "MULTINIC bonding" \
         00 01 02 \
         "root=nfs:192.168.50.1:/nfs/client ip=bond0:dhcp  bond=bond0:enp0s1,enp0s2,enp0s3:mode=balance-rr" \
-        "bond0" || return 1
+        "bond0"
 
     # bridge, where only one interface is actually connected
     client_test "MULTINIC bridging" \
         00 01 02 \
         "root=nfs:192.168.50.1:/nfs/client ip=bridge0:dhcp::52:54:00:12:34:00 bridge=bridge0:enp0s1,enp0s5,enp0s6" \
-        "bridge0" || return 1
+        "bridge0"
     return 0
 }
 
@@ -302,7 +303,7 @@ test_setup() {
         -d "piix ide-gd_mod ata_piix ext4 sd_mod" \
         --nomdadmconf \
         --no-hostonly-cmdline -N \
-        -f "$TESTDIR"/initramfs.makeroot "$KVERSION" || return 1
+        -f "$TESTDIR"/initramfs.makeroot "$KVERSION"
     rm -rf -- "$TESTDIR"/overlay
 
     declare -a disk_args=()
@@ -315,8 +316,8 @@ test_setup() {
     "$testdir"/run-qemu \
         "${disk_args[@]}" \
         -append "root=/dev/dracut/root rw rootfstype=ext4 quiet console=ttyS0,115200n81" \
-        -initrd "$TESTDIR"/initramfs.makeroot || return 1
-    test_marker_check dracut-root-block-created || return 1
+        -initrd "$TESTDIR"/initramfs.makeroot
+    test_marker_check dracut-root-block-created
 
     # Make an overlay with needed tools for the test harness
     (
@@ -352,7 +353,7 @@ test_setup() {
         -m "bash rootfs-block kernel-modules watchdog qemu network-legacy ${SERVER_DEBUG:+debug}" \
         -d "af_packet piix ide-gd_mod ata_piix ext4 sd_mod nfsv2 nfsv3 nfsv4 nfs_acl nfs_layout_nfsv41_files nfsd i6300esb virtio_net" \
         --no-hostonly-cmdline -N \
-        -f "$TESTDIR"/initramfs.server "$KVERSION" || return 1
+        -f "$TESTDIR"/initramfs.server "$KVERSION"
 
 }
 

--- a/test/TEST-62-BONDBRIDGEVLAN/test.sh
+++ b/test/TEST-62-BONDBRIDGEVLAN/test.sh
@@ -351,6 +351,7 @@ test_setup() {
         -f "$TESTDIR"/initramfs.makeroot "$KVERSION" || return 1
 
     declare -a disk_args=()
+    # shellcheck disable=SC2034  # disk_index used in qemu_add_drive
     declare -i disk_index=0
     qemu_add_drive disk_index disk_args "$TESTDIR"/marker.img marker 1
     qemu_add_drive disk_index disk_args "$TESTDIR"/server.ext4 root 1

--- a/test/TEST-62-BONDBRIDGEVLAN/test.sh
+++ b/test/TEST-62-BONDBRIDGEVLAN/test.sh
@@ -1,6 +1,7 @@
 #!/usr/bin/env bash
 # -*- mode: shell-script; indent-tabs-mode: nil; sh-basic-offset: 4; -*-
 # ex: ts=8 sw=4 sts=4 et filetype=sh
+set -eu
 
 # shellcheck disable=SC2034
 TEST_DESCRIPTION="root filesystem on NFS with bridging/bonding/vlan with $USE_NETWORK"
@@ -60,11 +61,11 @@ run_server() {
         -serial "${SERIAL:-"file:$TESTDIR/server.log"}" \
         -append "panic=1 oops=panic softlockup_panic=1 root=LABEL=dracut rootfstype=ext4 rw console=ttyS0,115200n81" \
         -initrd "$TESTDIR"/initramfs.server \
-        -pidfile "$TESTDIR"/server.pid -daemonize || return 1
-    chmod 644 -- "$TESTDIR"/server.pid || return 1
+        -pidfile "$TESTDIR"/server.pid -daemonize
+    chmod 644 -- "$TESTDIR"/server.pid
 
     if ! [[ $SERIAL ]]; then
-        wait_for_server_startup || return 1
+        wait_for_server_startup
     else
         echo Sleeping 10 seconds to give the server a head start
         sleep 10
@@ -101,7 +102,7 @@ client_test() {
         ifname=net5:52:54:00:12:34:05
         $cmdline rd.net.timeout.dhcp=30
         rw init=/sbin/init" \
-        -initrd "$TESTDIR"/initramfs.testing || return 1
+        -initrd "$TESTDIR"/initramfs.testing
 
     {
         read -r OK _
@@ -114,7 +115,7 @@ client_test() {
             [[ $line == END ]] && break
             CONF+="$line "
         done
-    } < "$TESTDIR"/client.img || return 1
+    } < "$TESTDIR"/client.img
 
     if [[ $check != "$CONF" ]]; then
         echo "Expected: '$check'"
@@ -168,8 +169,7 @@ rd.neednet=1
 root=nfs:192.168.50.1:/nfs/client
 bootdev=net1
 " \
-        "net1 net2.0004 net2.3 vlan0001 vlan2 PING1=0 PING2=0 PING3=0 PING4=0 PING5=0 ${NETCONF}EOF " \
-        || return 1
+        "net1 net2.0004 net2.3 vlan0001 vlan2 PING1=0 PING2=0 PING3=0 PING4=0 PING5=0 ${NETCONF}EOF "
 
     ### TEST 2: bond
     if [ "$USE_NETWORK" = network-legacy ]; then
@@ -187,8 +187,7 @@ rd.neednet=1
 root=nfs:192.168.51.1:/nfs/client
 bootdev=bond0
 " \
-        "bond0 PING1=0 NET3=0 NET4=0 ${NETCONF}EOF " \
-        || return 1
+        "bond0 PING1=0 NET3=0 NET4=0 ${NETCONF}EOF "
 
     ### TEST 3: bridge
     if [ "$USE_NETWORK" = network-legacy ]; then
@@ -206,8 +205,7 @@ rd.neednet=1
 root=nfs:192.168.50.1:/nfs/client
 bootdev=br0
 " \
-        "br0 PING1=0 NET1=0 NET5=0 ${NETCONF}EOF " \
-        || return 1
+        "br0 PING1=0 NET1=0 NET5=0 ${NETCONF}EOF "
 
     kill_server
     return 0
@@ -348,7 +346,7 @@ test_setup() {
         -d "piix ide-gd_mod ata_piix ext4 sd_mod" \
         --nomdadmconf \
         --no-hostonly-cmdline -N \
-        -f "$TESTDIR"/initramfs.makeroot "$KVERSION" || return 1
+        -f "$TESTDIR"/initramfs.makeroot "$KVERSION"
 
     declare -a disk_args=()
     # shellcheck disable=SC2034  # disk_index used in qemu_add_drive
@@ -360,8 +358,8 @@ test_setup() {
     "$testdir"/run-qemu \
         "${disk_args[@]}" \
         -append "root=/dev/dracut/root rw rootfstype=ext4 quiet console=ttyS0,115200n81" \
-        -initrd "$TESTDIR"/initramfs.makeroot || return 1
-    test_marker_check dracut-root-block-created || return 1
+        -initrd "$TESTDIR"/initramfs.makeroot
+    test_marker_check dracut-root-block-created
     rm -- "$TESTDIR"/marker.img
     rm -fr "$TESTDIR"/overlay
 
@@ -396,7 +394,7 @@ test_setup() {
         -m "rootfs-block kernel-modules watchdog qemu network network-legacy ${SERVER_DEBUG:+debug}" \
         -d "ipvlan macvlan af_packet piix ide-gd_mod ata_piix ext4 sd_mod nfsv2 nfsv3 nfsv4 nfs_acl nfs_layout_nfsv41_files nfsd virtio-net i6300esb" \
         --no-hostonly-cmdline -N \
-        -f "$TESTDIR"/initramfs.server "$KVERSION" || return 1
+        -f "$TESTDIR"/initramfs.server "$KVERSION"
 }
 
 kill_server() {

--- a/test/TEST-70-ISCSI/test.sh
+++ b/test/TEST-70-ISCSI/test.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+set -eu
 
 # shellcheck disable=SC2034
 TEST_DESCRIPTION="root filesystem over iSCSI with $USE_NETWORK"
@@ -26,11 +27,11 @@ run_server() {
         -net socket,listen=127.0.0.1:12330 \
         -append "panic=1 oops=panic softlockup_panic=1 quiet root=/dev/disk/by-id/scsi-0QEMU_QEMU_HARDDISK_serverroot rw console=ttyS0,115200n81 $SERVER_DEBUG" \
         -initrd "$TESTDIR"/initramfs.server \
-        -pidfile "$TESTDIR"/server.pid -daemonize || return 1
-    chmod 644 "$TESTDIR"/server.pid || return 1
+        -pidfile "$TESTDIR"/server.pid -daemonize
+    chmod 644 "$TESTDIR"/server.pid
 
     if ! [[ $SERIAL ]]; then
-        wait_for_server_startup || return 1
+        wait_for_server_startup
     else
         echo Sleeping 10 seconds to give the server a head start
         sleep 10
@@ -73,29 +74,25 @@ do_test_run() {
 
     run_client "root=dhcp" "" \
         "root=/dev/root netroot=dhcp ip=enp0s1:dhcp" \
-        "rd.iscsi.initiator=$initiator" \
-        || return 1
+        "rd.iscsi.initiator=$initiator"
 
     run_client "netroot=iscsi target0" "" \
         "root=LABEL=singleroot netroot=iscsi:192.168.50.1::::iqn.2009-06.dracut:target0" \
         "ip=192.168.50.101::192.168.50.1:255.255.255.0:iscsi-1:enp0s1:off" \
-        "rd.iscsi.initiator=$initiator" \
-        || return 1
+        "rd.iscsi.initiator=$initiator"
 
     run_client "netroot=iscsi target1 target2" "" \
         "root=LABEL=sysroot" \
         "ip=dhcp" \
         "netroot=iscsi:192.168.51.1::::iqn.2009-06.dracut:target1" \
         "netroot=iscsi:192.168.50.1::::iqn.2009-06.dracut:target2" \
-        "rd.iscsi.initiator=$initiator" \
-        || return 1
+        "rd.iscsi.initiator=$initiator"
 
     if "$testdir"/run-qemu --supports -acpitable; then
         run_client "root=ibft" "ibft.table" \
             "root=LABEL=singleroot" \
             "rd.iscsi.ibft=1" \
-            "rd.iscsi.firmware=1" \
-            || return 1
+            "rd.iscsi.firmware=1"
     else
         echo "CLIENT TEST: root=ibft [SKIPPED]"
     fi
@@ -138,7 +135,7 @@ test_setup() {
     "$DRACUT" -N --keep --tmpdir "$TESTDIR" \
         --add-confdir test-root \
         -I "ip grep setsid" \
-        -f "$TESTDIR"/initramfs.root "$KVERSION" || return 1
+        -f "$TESTDIR"/initramfs.root "$KVERSION"
     mkdir -p "$TESTDIR"/overlay/source && mv "$TESTDIR"/dracut.*/initramfs/* "$TESTDIR"/overlay/source && rm -rf "$TESTDIR"/dracut.*
 
     mkdir -p -- "$TESTDIR"/overlay/source/var/lib/nfs/rpc_pipefs
@@ -153,7 +150,7 @@ test_setup() {
         -I "setsid blockdev" \
         -i ./create-client-root.sh /lib/dracut/hooks/initqueue/01-create-client-root.sh \
         --no-hostonly-cmdline -N \
-        -f "$TESTDIR"/initramfs.makeroot "$KVERSION" || return 1
+        -f "$TESTDIR"/initramfs.makeroot "$KVERSION"
     rm -rf -- "$TESTDIR"/overlay
 
     declare -a disk_args=()
@@ -167,8 +164,8 @@ test_setup() {
     "$testdir"/run-qemu \
         "${disk_args[@]}" \
         -append "root=/dev/fakeroot rw quiet console=ttyS0,115200n81" \
-        -initrd "$TESTDIR"/initramfs.makeroot || return 1
-    test_marker_check dracut-root-block-created || return 1
+        -initrd "$TESTDIR"/initramfs.makeroot
+    test_marker_check dracut-root-block-created
     rm -- "$TESTDIR"/marker.img
 
     # Create what will eventually be the server root filesystem onto an overlay
@@ -179,7 +176,7 @@ test_setup() {
         -I "modprobe chmod ip setsid pidof tgtd tgtadm /etc/passwd" \
         --install-optional "/etc/netconfig dhcpd /etc/group /etc/nsswitch.conf /etc/rpc /etc/protocols /etc/services /usr/etc/nsswitch.conf /usr/etc/rpc /usr/etc/protocols /usr/etc/services" \
         -i "./dhcpd.conf" "/etc/dhcpd.conf" \
-        -f "$TESTDIR"/initramfs.root "$KVERSION" || return 1
+        -f "$TESTDIR"/initramfs.root "$KVERSION"
     mkdir -p "$TESTDIR"/overlay/source && mv "$TESTDIR"/dracut.*/initramfs/* "$TESTDIR"/overlay/source && rm -rf "$TESTDIR"/dracut.*
 
     mkdir -p "$TESTDIR"/overlay/source/var/lib/dhcpd
@@ -192,7 +189,7 @@ test_setup() {
     "$DRACUT" -N -i "$TESTDIR"/overlay / \
         --add-confdir test-makeroot \
         -i ./create-server-root.sh /lib/dracut/hooks/initqueue/01-create-server-root.sh \
-        -f "$TESTDIR"/initramfs.makeroot "$KVERSION" || return 1
+        -f "$TESTDIR"/initramfs.makeroot "$KVERSION"
     rm -rf -- "$TESTDIR"/overlay
 
     declare -a disk_args=()
@@ -205,8 +202,8 @@ test_setup() {
     "$testdir"/run-qemu \
         "${disk_args[@]}" \
         -append "root=/dev/dracut/root rw quiet console=ttyS0,115200n81" \
-        -initrd "$TESTDIR"/initramfs.makeroot || return 1
-    test_marker_check dracut-root-block-created || return 1
+        -initrd "$TESTDIR"/initramfs.makeroot
+    test_marker_check dracut-root-block-created
     rm -- "$TESTDIR"/marker.img
 
     # Make server's dracut image
@@ -216,7 +213,7 @@ test_setup() {
         -i "./server.link" "/etc/systemd/network/01-server.link" \
         -i ./wait-if-server.sh /lib/dracut/hooks/pre-mount/99-wait-if-server.sh \
         --no-hostonly-cmdline -N \
-        -f "$TESTDIR"/initramfs.server "$KVERSION" || return 1
+        -f "$TESTDIR"/initramfs.server "$KVERSION"
 
     # Make client's dracut image
     test_dracut \

--- a/test/TEST-71-ISCSI-MULTI/test.sh
+++ b/test/TEST-71-ISCSI-MULTI/test.sh
@@ -207,6 +207,7 @@ test_setup() {
     rm -rf -- "$TESTDIR"/overlay
 
     declare -a disk_args=()
+    # shellcheck disable=SC2034  # disk_index used in qemu_add_drive
     declare -i disk_index=0
     qemu_add_drive disk_index disk_args "$TESTDIR"/marker.img marker 1
     qemu_add_drive disk_index disk_args "$TESTDIR"/server.img root 1

--- a/test/TEST-72-NBD/test.sh
+++ b/test/TEST-72-NBD/test.sh
@@ -299,6 +299,7 @@ EOF
         -f "$TESTDIR"/initramfs.makeroot "$KVERSION" || return 1
 
     declare -a disk_args=()
+    # shellcheck disable=SC2034  # disk_index used in qemu_add_drive
     declare -i disk_index=0
     qemu_add_drive disk_index disk_args "$TESTDIR"/marker.img marker 1
     qemu_add_drive disk_index disk_args "$TESTDIR"/server.img root 1

--- a/test/TEST-72-NBD/test.sh
+++ b/test/TEST-72-NBD/test.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+set -eu
 
 # shellcheck disable=SC2034
 TEST_DESCRIPTION="root filesystem on NBD with $USE_NETWORK"
@@ -45,11 +46,11 @@ run_server() {
         -net socket,listen=127.0.0.1:12340 \
         -append "panic=1 oops=panic softlockup_panic=1 rd.luks=0 systemd.crash_reboot quiet root=/dev/disk/by-id/scsi-0QEMU_QEMU_HARDDISK_serverroot rootfstype=ext4 rw console=ttyS0,115200n81 $SERVER_DEBUG" \
         -initrd "$TESTDIR"/initramfs.server \
-        -pidfile "$TESTDIR"/server.pid -daemonize || return 1
-    chmod 644 "$TESTDIR"/server.pid || return 1
+        -pidfile "$TESTDIR"/server.pid -daemonize
+    chmod 644 "$TESTDIR"/server.pid
 
     if ! [[ $SERIAL ]]; then
-        wait_for_server_startup || return 1
+        wait_for_server_startup
     else
         echo Sleeping 10 seconds to give the server a head start
         sleep 10
@@ -127,39 +128,39 @@ client_run() {
     # The default is ext4,errors=continue so use that to determine
     # if our options were parsed and used
     client_test "NBD root=nbd:IP:port" 52:54:00:12:34:00 \
-        "root=nbd:192.168.50.1:raw rd.luks=0" || return 1
+        "root=nbd:192.168.50.1:raw rd.luks=0"
 
     client_test "NBD root=nbd:IP:port::fsopts" 52:54:00:12:34:00 \
         "root=nbd:192.168.50.1:raw::errors=panic rd.luks=0" \
-        ext4 errors=panic || return 1
+        ext4 errors=panic
 
     client_test "NBD root=nbd:IP:port:fstype" 52:54:00:12:34:00 \
-        "root=nbd:192.168.50.1:raw:ext4 rd.luks=0" ext4 || return 1
+        "root=nbd:192.168.50.1:raw:ext4 rd.luks=0" ext4
 
     client_test "NBD root=nbd:IP:port:fstype:fsopts" 52:54:00:12:34:00 \
         "root=nbd:192.168.50.1:raw:ext4:errors=panic rd.luks=0" \
-        ext4 errors=panic || return 1
+        ext4 errors=panic
 
     # DHCP root-path parsing
 
     client_test "NBD root=/dev/root netroot=dhcp DHCP root-path nbd:srv:port" 52:54:00:12:34:01 \
-        "root=/dev/root netroot=dhcp ip=dhcp rd.luks=0" || return 1
+        "root=/dev/root netroot=dhcp ip=dhcp rd.luks=0"
 
     # BROKEN
     #client_test "NBD root=/dev/root netroot=dhcp DHCP root-path nbd:srv:port:fstype" \
-    #    52:54:00:12:34:02 "root=/dev/root netroot=dhcp ip=dhcp rd.luks=0" ext2 || return 1
+    #    52:54:00:12:34:02 "root=/dev/root netroot=dhcp ip=dhcp rd.luks=0" ext2
 
     client_test "NBD root=/dev/root netroot=dhcp DHCP root-path nbd:srv:port::fsopts" \
-        52:54:00:12:34:03 "root=/dev/root netroot=dhcp ip=dhcp rd.luks=0" ext4 errors=panic || return 1
+        52:54:00:12:34:03 "root=/dev/root netroot=dhcp ip=dhcp rd.luks=0" ext4 errors=panic
 
     # BROKEN
     #client_test "NBD root=/dev/root netroot=dhcp DHCP root-path nbd:srv:port:fstype:fsopts" \
-    #    52:54:00:12:34:04 "root=/dev/root netroot=dhcp ip=dhcp rd.luks=0" ext2 errors=panic || return 1
+    #    52:54:00:12:34:04 "root=/dev/root netroot=dhcp ip=dhcp rd.luks=0" ext2 errors=panic
 
     # netroot handling
 
     client_test "NBD netroot=nbd:IP:port" 52:54:00:12:34:00 \
-        "root=LABEL=dracut netroot=nbd:192.168.50.1:raw ip=dhcp rd.luks=0" || return 1
+        "root=LABEL=dracut netroot=nbd:192.168.50.1:raw ip=dhcp rd.luks=0"
 
     # Encrypted root handling via LVM/LUKS over NBD
 
@@ -168,14 +169,14 @@ client_run() {
 
     client_test "NBD root=LABEL=dracut netroot=nbd:IP:port" \
         52:54:00:12:34:00 \
-        "root=LABEL=dracut rd.luks.uuid=$ID_FS_UUID rd.lv.vg=dracut ip=dhcp netroot=nbd:192.168.50.1:encrypted" || return 1
+        "root=LABEL=dracut rd.luks.uuid=$ID_FS_UUID rd.lv.vg=dracut ip=dhcp netroot=nbd:192.168.50.1:encrypted"
 
     # XXX This should be ext4,errors=panic but that doesn't currently
     # XXX work when you have a real root= line in addition to netroot=
     # XXX How we should work here needs clarification
     #    client_test "NBD root=LABEL=dracut netroot=dhcp (w/ fstype and opts)" \
     #                52:54:00:12:34:05 \
-    #                "root=LABEL=dracut rd.luks.uuid=$ID_FS_UUID rd.lv.vg=dracut netroot=dhcp" || return 1
+    #                "root=LABEL=dracut rd.luks.uuid=$ID_FS_UUID rd.lv.vg=dracut netroot=dhcp"
 
     if [[ -s server.pid ]]; then
         kill -TERM "$(cat "$TESTDIR"/server.pid)"
@@ -191,7 +192,7 @@ make_encrypted_root() {
         --add-confdir test-root \
         -I "ip grep" \
         --no-hostonly --no-hostonly-cmdline --nohardlink \
-        -f "$TESTDIR"/initramfs.root "$KVERSION" || return 1
+        -f "$TESTDIR"/initramfs.root "$KVERSION"
     mkdir -p "$TESTDIR"/overlay/source && mv "$TESTDIR"/dracut.*/initramfs/* "$TESTDIR"/overlay/source && rm -rf "$TESTDIR"/dracut.*
     cp ./client-init.sh "$TESTDIR"/overlay/source/sbin/init
 
@@ -205,7 +206,7 @@ make_encrypted_root() {
         -I "cryptsetup" \
         -i ./create-encrypted-root.sh /lib/dracut/hooks/initqueue/01-create-encrypted-root.sh \
         --no-hostonly-cmdline -N \
-        -f "$TESTDIR"/initramfs.makeroot "$KVERSION" || return 1
+        -f "$TESTDIR"/initramfs.makeroot "$KVERSION"
     rm -rf -- "$TESTDIR"/overlay
 
     declare -a disk_args=()
@@ -217,8 +218,8 @@ make_encrypted_root() {
     "$testdir"/run-qemu \
         "${disk_args[@]}" \
         -append "root=/dev/fakeroot rw quiet console=ttyS0,115200n81" \
-        -initrd "$TESTDIR"/initramfs.makeroot || return 1
-    test_marker_check dracut-root-block-created || return 1
+        -initrd "$TESTDIR"/initramfs.makeroot
+    test_marker_check dracut-root-block-created
     grep -F -a -m 1 ID_FS_UUID "$TESTDIR"/marker.img > "$TESTDIR"/luks.uuid
 }
 
@@ -228,7 +229,7 @@ make_client_root() {
         --add-confdir test-root \
         -I "ip" \
         --no-hostonly --no-hostonly-cmdline --nohardlink \
-        -f "$TESTDIR"/initramfs.root "$KVERSION" || return 1
+        -f "$TESTDIR"/initramfs.root "$KVERSION"
     mkdir -p "$TESTDIR"/overlay/source && mv "$TESTDIR"/dracut.*/initramfs/* "$TESTDIR"/overlay/source && rm -rf "$TESTDIR"/dracut.*
     cp ./client-init.sh "$TESTDIR"/overlay/source/sbin/init
 
@@ -241,7 +242,7 @@ make_client_root() {
         -i ./create-client-root.sh /lib/dracut/hooks/initqueue/01-create-client-root.sh \
         --nomdadmconf \
         --no-hostonly-cmdline -N \
-        -f "$TESTDIR"/initramfs.makeroot "$KVERSION" || return 1
+        -f "$TESTDIR"/initramfs.makeroot "$KVERSION"
 
     declare -a disk_args=()
     declare -i disk_index=0
@@ -252,8 +253,8 @@ make_client_root() {
     "$testdir"/run-qemu \
         "${disk_args[@]}" \
         -append "root=/dev/dracut/root rw quiet console=ttyS0,115200n81" \
-        -initrd "$TESTDIR"/initramfs.makeroot || return 1
-    test_marker_check dracut-root-block-created || return 1
+        -initrd "$TESTDIR"/initramfs.makeroot
+    test_marker_check dracut-root-block-created
     rm -fr "$TESTDIR"/overlay
 }
 
@@ -280,7 +281,7 @@ EOF
         -i /tmp/config /etc/nbd-server/config \
         -i "./dhcpd.conf" "/etc/dhcpd.conf" \
         --no-hostonly --no-hostonly-cmdline --nohardlink \
-        -f "$TESTDIR"/initramfs.root "$KVERSION" || return 1
+        -f "$TESTDIR"/initramfs.root "$KVERSION"
     mkdir -p "$TESTDIR"/overlay/source && mv "$TESTDIR"/dracut.*/initramfs/* "$TESTDIR"/overlay/source && rm -rf "$TESTDIR"/dracut.*
 
     mkdir -p -- "$TESTDIR"/overlay/source/var/lib/dhcpd "$TESTDIR"/overlay/source/etc/nbd-server
@@ -296,7 +297,7 @@ EOF
         -i ./create-server-root.sh /lib/dracut/hooks/initqueue/01-create-server-root.sh \
         --nomdadmconf \
         --no-hostonly-cmdline -N \
-        -f "$TESTDIR"/initramfs.makeroot "$KVERSION" || return 1
+        -f "$TESTDIR"/initramfs.makeroot "$KVERSION"
 
     declare -a disk_args=()
     # shellcheck disable=SC2034  # disk_index used in qemu_add_drive
@@ -308,15 +309,15 @@ EOF
     "$testdir"/run-qemu \
         "${disk_args[@]}" \
         -append "root=/dev/dracut/root rw rootfstype=ext4 quiet console=ttyS0,115200n81" \
-        -initrd "$TESTDIR"/initramfs.makeroot || return 1
-    test_marker_check dracut-root-block-created || return 1
+        -initrd "$TESTDIR"/initramfs.makeroot
+    test_marker_check dracut-root-block-created
     rm -fr "$TESTDIR"/overlay
 }
 
 test_setup() {
-    make_encrypted_root || return 1
-    make_client_root || return 1
-    make_server_root || return 1
+    make_encrypted_root
+    make_client_root
+    make_server_root
 
     rm -fr "$TESTDIR"/overlay
     # Make the test image
@@ -339,7 +340,7 @@ test_setup() {
         -d "af_packet piix ide-gd_mod ata_piix ext4 sd_mod drbg virtio_net" \
         -i "./server.link" "/etc/systemd/network/01-server.link" \
         -i "./wait-if-server.sh" "/lib/dracut/hooks/pre-mount/99-wait-if-server.sh" \
-        -f "$TESTDIR"/initramfs.server "$KVERSION" || return 1
+        -f "$TESTDIR"/initramfs.server "$KVERSION"
 }
 
 kill_server() {

--- a/test/TEST-80-GETARG/test.sh
+++ b/test/TEST-80-GETARG/test.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+set -eu
 
 # This file is part of dracut.
 # SPDX-License-Identifier: GPL-2.0-or-later

--- a/test/TEST-81-SKIPCPIO/test.sh
+++ b/test/TEST-81-SKIPCPIO/test.sh
@@ -1,6 +1,7 @@
 #!/usr/bin/env bash
 # This file is part of dracut.
 # SPDX-License-Identifier: GPL-2.0-or-later
+set -eu
 
 # shellcheck disable=SC2034
 TEST_DESCRIPTION="test skipcpio"
@@ -65,8 +66,7 @@ test_run() {
 }
 
 test_setup() {
-    CPIO_TESTDIR=$(mktemp --directory -p "$TESTDIR" cpio-test.XXXXXXXXXX) \
-        || return 1
+    CPIO_TESTDIR=$(mktemp --directory -p "$TESTDIR" cpio-test.XXXXXXXXXX)
     export CPIO_TESTDIR
     return 0
 }

--- a/test/TEST-82-DRACUT-CPIO/test.sh
+++ b/test/TEST-82-DRACUT-CPIO/test.sh
@@ -1,6 +1,7 @@
 #!/usr/bin/env bash
 # This file is part of dracut.
 # SPDX-License-Identifier: GPL-2.0-or-later
+set -eu
 
 # shellcheck disable=SC2034
 TEST_DESCRIPTION="kernel cpio extraction tests for dracut-cpio"
@@ -38,14 +39,14 @@ EOF
         -daemonize -pidfile "$tdir/vm.pid" \
         -serial "file:$tdir/console.out" \
         -append "panic=1 oops=panic softlockup_panic=1 console=ttyS0 rd.shell=1" \
-        -initrd "$tdir/initramfs" || return 1
+        -initrd "$tdir/initramfs"
 
     timeout=120
     while [[ -f $tdir/vm.pid ]] \
         && ps -p "$(head -n1 "$tdir/vm.pid")" > /dev/null; do
         echo "$timeout - awaiting VM shutdown"
         sleep 1
-        [[ $((timeout--)) -le 0 ]] && return 1
+        [[ $((timeout--)) -gt 0 ]]
     done
 
     cat "$tdir/console.out"
@@ -58,15 +59,14 @@ test_run() {
 
     # dracut-cpio is typically used with compression and strip disabled, to
     # increase the chance of (reflink) extent sharing.
-    test_dracut_cpio "simple" "--no-compress" "--nostrip" || return 1
+    test_dracut_cpio "simple" "--no-compress" "--nostrip"
     # dracut-cpio should still work fine with compression and stripping enabled
-    test_dracut_cpio "compress" "--gzip" "--nostrip" || return 1
-    test_dracut_cpio "strip" "--gzip" "--strip" || return 1
+    test_dracut_cpio "compress" "--gzip" "--nostrip"
+    test_dracut_cpio "strip" "--gzip" "--strip"
 }
 
 test_setup() {
-    CPIO_TESTDIR=$(mktemp --directory -p "$TESTDIR" cpio-test.XXXXXXXXXX) \
-        || return 1
+    CPIO_TESTDIR=$(mktemp --directory -p "$TESTDIR" cpio-test.XXXXXXXXXX)
     export CPIO_TESTDIR
     return 0
 }

--- a/test/test-functions
+++ b/test/test-functions
@@ -4,25 +4,25 @@ export PATH
 
 # shellcheck disable=SC1090
 [[ -e .testdir${TEST_RUN_ID:+-$TEST_RUN_ID} ]] && . .testdir${TEST_RUN_ID:+-$TEST_RUN_ID}
-if [[ -z $TESTDIR ]] || [[ ! -d $TESTDIR ]]; then
+if [[ -z ${TESTDIR-} ]] || [[ ! -d $TESTDIR ]]; then
     TESTDIR=$(mktemp -d -p "/var/tmp" -t dracut-test.XXXXXX)
 fi
 echo "TESTDIR=\"$TESTDIR\"" > .testdir${TEST_RUN_ID:+-$TEST_RUN_ID}
 export TESTDIR
 export BOOT_ROOT="$TESTDIR"
 
-[ -z "$USE_NETWORK" ] && USE_NETWORK="network"
-[ -z "$TEST_FSTYPE" ] && TEST_FSTYPE="ext4"
+[ -z "${USE_NETWORK-}" ] && USE_NETWORK="network"
+[ -z "${TEST_FSTYPE-}" ] && TEST_FSTYPE="ext4"
 
-if [[ -z $basedir ]]; then basedir="$(realpath ../..)"; fi
+if [[ -z ${basedir-} ]]; then basedir="$(realpath ../..)"; fi
 
 DRACUT=${DRACUT-dracut}
 PKGLIBDIR=${PKGLIBDIR-$basedir}
 
 [[ -f /etc/machine-id ]] && read -r TOKEN < /etc/machine-id
-[ -z "$TOKEN" ] && . /etc/os-release && TOKEN="$ID"
+[ -z "${TOKEN-}" ] && . /etc/os-release && TOKEN="$ID"
 
-TEST_KERNEL_CMDLINE+=" root=LABEL=dracut panic=1 oops=panic softlockup_panic=1 systemd.crash_reboot $DEBUGFAIL "
+TEST_KERNEL_CMDLINE+=" root=LABEL=dracut panic=1 oops=panic softlockup_panic=1 systemd.crash_reboot ${DEBUGFAIL-} "
 
 if [[ $V != "1" && $V != "2" ]]; then
     TEST_KERNEL_CMDLINE+="quiet "
@@ -107,10 +107,10 @@ determine_kernel_version() {
     # we are running inside a container already
 
     # shellcheck disable=SC2012
-    [[ $KVERSION ]] || KVERSION="$(cd /lib/modules && ls -1 | tail -1)"
+    [[ ${KVERSION-} ]] || KVERSION="$(cd /lib/modules && ls -1 | tail -1)"
     # shellcheck disable=SC2012
-    [[ $KVERSION ]] || KVERSION="$(cd /usr/lib/modules && ls -1 | tail -1)"
-    [[ $KVERSION ]] || KVERSION="$(uname -r)"
+    [[ ${KVERSION-} ]] || KVERSION="$(cd /usr/lib/modules && ls -1 | tail -1)"
+    [[ ${KVERSION-} ]] || KVERSION="$(uname -r)"
 }
 
 set_vmlinux_env() {
@@ -206,7 +206,7 @@ qemu_add_drive() {
     local file=$3
     local name=${4:-$index}
     local size=${5:-0}
-    local bootindex=$6
+    local bootindex=${6-}
 
     if [ "${size}" -ne 0 ]; then
         if [[ ${name} =~ "marker" ]]; then


### PR DESCRIPTION
## Changes

To make all tests more robust, use `set -eu` in all tests. Then the `|| return 1` constructs can be removed.

## Checklist
- [ ] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it

Fixes #
