### PR TITLE
test: ignore shellcheck for disk_index

### DIFF
--- a/test/TEST-10-BASIC/test.sh
+++ b/test/TEST-10-BASIC/test.sh
@@ -4,6 +4,7 @@ TEST_DESCRIPTION="root filesystem on ext4 filesystem"
 
 test_run() {
     declare -a disk_args=()
+    # shellcheck disable=SC2034  # disk_index used in qemu_add_drive
     declare -i disk_index=0
     qemu_add_drive disk_index disk_args "$TESTDIR"/marker.img marker
     qemu_add_drive disk_index disk_args "$TESTDIR"/root.img root

--- a/test/TEST-11-USR-MOUNT/test.sh
+++ b/test/TEST-11-USR-MOUNT/test.sh
@@ -65,6 +65,7 @@ test_setup() {
 
     # Create the blank file to use as a root filesystem
     declare -a disk_args=()
+    # shellcheck disable=SC2034  # disk_index used in qemu_add_drive
     declare -i disk_index=0
     qemu_add_drive disk_index disk_args "$TESTDIR"/marker.img marker 1
     qemu_add_drive disk_index disk_args "$TESTDIR"/root.btrfs root 1

--- a/test/TEST-12-UEFI/test.sh
+++ b/test/TEST-12-UEFI/test.sh
@@ -24,6 +24,7 @@ client_run() {
     echo "CLIENT TEST START: $test_name"
 
     declare -a disk_args=()
+    # shellcheck disable=SC2034  # disk_index used in qemu_add_drive
     declare -i disk_index=1
     qemu_add_drive disk_index disk_args "$TESTDIR"/marker.img marker
     qemu_add_drive disk_index disk_args "$TESTDIR"/squashfs.img root

--- a/test/TEST-23-IMSM/test.sh
+++ b/test/TEST-23-IMSM/test.sh
@@ -73,6 +73,7 @@ test_setup() {
 
     # Create the blank files to use as a root filesystem
     declare -a disk_args=()
+    # shellcheck disable=SC2034  # disk_index used in qemu_add_drive
     declare -i disk_index=0
     qemu_add_drive disk_index disk_args "$TESTDIR"/marker.img marker 1
     qemu_add_drive disk_index disk_args "$TESTDIR"/disk-1.img disk1 420

--- a/test/TEST-26-ENC-RAID-LVM/test.sh
+++ b/test/TEST-26-ENC-RAID-LVM/test.sh
@@ -72,6 +72,7 @@ test_setup() {
 
     # Create the blank files to use as a root filesystem
     declare -a disk_args=()
+    # shellcheck disable=SC2034  # disk_index used in qemu_add_drive
     declare -i disk_index=0
     qemu_add_drive disk_index disk_args "$TESTDIR"/marker.img marker 1
     qemu_add_drive disk_index disk_args "$TESTDIR"/disk-1.img disk1 1

--- a/test/TEST-30-DMSQUASH/test.sh
+++ b/test/TEST-30-DMSQUASH/test.sh
@@ -93,6 +93,7 @@ test_setup() {
 
     # Create the blank file to use as a root filesystem
     declare -a disk_args=()
+    # shellcheck disable=SC2034  # disk_index used in qemu_add_drive
     declare -i disk_index=0
     qemu_add_drive disk_index disk_args "$TESTDIR"/root.img root 1
 

--- a/test/TEST-40-SYSTEMD/test.sh
+++ b/test/TEST-40-SYSTEMD/test.sh
@@ -42,6 +42,7 @@ test_setup() {
         -f "$TESTDIR"/initramfs.makeroot "$KVERSION" || return 1
 
     declare -a disk_args=()
+    # shellcheck disable=SC2034  # disk_index used in qemu_add_drive
     declare -i disk_index=0
     qemu_add_drive disk_index disk_args "$TESTDIR"/marker.img marker 1
     qemu_add_drive disk_index disk_args "$TESTDIR"/root.img root 1

--- a/test/TEST-42-SYSTEMD-INITRD/test.sh
+++ b/test/TEST-42-SYSTEMD-INITRD/test.sh
@@ -57,6 +57,7 @@ test_setup() {
         -f "$TESTDIR"/initramfs.makeroot "$KVERSION" || return 1
 
     declare -a disk_args=()
+    # shellcheck disable=SC2034  # disk_index used in qemu_add_drive
     declare -i disk_index=0
     qemu_add_drive disk_index disk_args "$TESTDIR"/marker.img marker 1
     qemu_add_drive disk_index disk_args "$TESTDIR"/root.img root 1

--- a/test/TEST-43-KERNEL-INSTALL/test.sh
+++ b/test/TEST-43-KERNEL-INSTALL/test.sh
@@ -21,6 +21,7 @@ test_check() {
 
 test_run() {
     declare -a disk_args=()
+    # shellcheck disable=SC2034  # disk_index used in qemu_add_drive
     declare -i disk_index=0
     qemu_add_drive disk_index disk_args "$TESTDIR"/marker.img marker
     qemu_add_drive disk_index disk_args "$TESTDIR"/root.img root

--- a/test/TEST-62-BONDBRIDGEVLAN/test.sh
+++ b/test/TEST-62-BONDBRIDGEVLAN/test.sh
@@ -351,6 +351,7 @@ test_setup() {
         -f "$TESTDIR"/initramfs.makeroot "$KVERSION" || return 1
 
     declare -a disk_args=()
+    # shellcheck disable=SC2034  # disk_index used in qemu_add_drive
     declare -i disk_index=0
     qemu_add_drive disk_index disk_args "$TESTDIR"/marker.img marker 1
     qemu_add_drive disk_index disk_args "$TESTDIR"/server.ext4 root 1

--- a/test/TEST-71-ISCSI-MULTI/test.sh
+++ b/test/TEST-71-ISCSI-MULTI/test.sh
@@ -207,6 +207,7 @@ test_setup() {
     rm -rf -- "$TESTDIR"/overlay
 
     declare -a disk_args=()
+    # shellcheck disable=SC2034  # disk_index used in qemu_add_drive
     declare -i disk_index=0
     qemu_add_drive disk_index disk_args "$TESTDIR"/marker.img marker 1
     qemu_add_drive disk_index disk_args "$TESTDIR"/server.img root 1

--- a/test/TEST-72-NBD/test.sh
+++ b/test/TEST-72-NBD/test.sh
@@ -299,6 +299,7 @@ EOF
         -f "$TESTDIR"/initramfs.makeroot "$KVERSION" || return 1
 
     declare -a disk_args=()
+    # shellcheck disable=SC2034  # disk_index used in qemu_add_drive
     declare -i disk_index=0
     qemu_add_drive disk_index disk_args "$TESTDIR"/marker.img marker 1
     qemu_add_drive disk_index disk_args "$TESTDIR"/server.img root 1


### PR DESCRIPTION
## Changes

shellcheck complains about `disk_index` for appearing to be unused, but this variable is used in `qemu_add_drive`. So ignore those shellcheck complaints.

## Checklist
- [x] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it
