### PR TITLE
test: use "set -e" in all tests

### DIFF
--- a/modules.d/99base/dracut-lib.sh
+++ b/modules.d/99base/dracut-lib.sh
@@ -340,7 +340,7 @@ splitsep() {
 }
 
 setdebug() {
-    [ -f /usr/lib/initrd-release ] || return
+    [ -f /usr/lib/initrd-release ] || return 0
     if [ -z "$RD_DEBUG" ]; then
         if [ -e /proc/cmdline ]; then
             RD_DEBUG=no

--- a/test/TEST-10-BASIC/test.sh
+++ b/test/TEST-10-BASIC/test.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+set -e
 # shellcheck disable=SC2034
 TEST_DESCRIPTION="root filesystem on ext4 filesystem"
 
@@ -14,16 +15,16 @@ test_run() {
     "$testdir"/run-qemu -nic none \
         "${disk_args[@]}" \
         -append "$TEST_KERNEL_CMDLINE" \
-        -initrd "$TESTDIR"/initramfs.testing || return 1
+        -initrd "$TESTDIR"/initramfs.testing
 
-    test_marker_check || return 1
+    test_marker_check
 }
 
 test_setup() {
     # create root filesystem
     "$DRACUT" -N --keep --tmpdir "$TESTDIR" \
         --add-confdir test-root \
-        -f "$TESTDIR"/initramfs.root "$KVERSION" || return 1
+        -f "$TESTDIR"/initramfs.root "$KVERSION"
 
     dd if=/dev/zero of="$TESTDIR"/root.img bs=200MiB count=1 status=none && sync
     mkfs.ext4 -q -L dracut -d "$TESTDIR"/dracut.*/initramfs/ "$TESTDIR"/root.img && sync

--- a/test/TEST-11-USR-MOUNT/test.sh
+++ b/test/TEST-11-USR-MOUNT/test.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+set -e
 
 # shellcheck disable=SC2034
 TEST_DESCRIPTION="root filesystem on a btrfs filesystem with /usr subvolume"
@@ -30,7 +31,7 @@ client_run() {
     "$testdir"/run-qemu \
         "${disk_args[@]}" \
         -append "$TEST_KERNEL_CMDLINE $client_opts" \
-        -initrd "$TESTDIR"/initramfs.testing || return 1
+        -initrd "$TESTDIR"/initramfs.testing
 
     if ! test_marker_check; then
         echo "CLIENT TEST END: $test_name [FAILED]"
@@ -40,9 +41,9 @@ client_run() {
 }
 
 test_run() {
-    client_run "no option specified" || return 1
-    client_run "readonly root" "ro" || return 1
-    client_run "writeable root" "rw" || return 1
+    client_run "no option specified"
+    client_run "readonly root" "ro"
+    client_run "writeable root" "rw"
 }
 
 test_setup() {
@@ -50,7 +51,7 @@ test_setup() {
     "$DRACUT" -N --keep --tmpdir "$TESTDIR" \
         --add-confdir test-root \
         -i ./fstab /etc/fstab \
-        -f "$TESTDIR"/initramfs.root "$KVERSION" || return 1
+        -f "$TESTDIR"/initramfs.root "$KVERSION"
     mkdir -p "$TESTDIR"/overlay/source && mv "$TESTDIR"/dracut.*/initramfs/* "$TESTDIR"/overlay/source && rm -rf "$TESTDIR"/dracut.*
 
     # second, install the files needed to make the root filesystem
@@ -61,7 +62,7 @@ test_setup() {
         --add-confdir test-makeroot \
         -I "mkfs.btrfs" \
         -i ./create-root.sh /lib/dracut/hooks/initqueue/01-create-root.sh \
-        -f "$TESTDIR"/initramfs.makeroot "$KVERSION" || return 1
+        -f "$TESTDIR"/initramfs.makeroot "$KVERSION"
 
     # Create the blank file to use as a root filesystem
     declare -a disk_args=()
@@ -75,7 +76,7 @@ test_setup() {
     "$testdir"/run-qemu \
         "${disk_args[@]}" \
         -append "root=/dev/dracut/root quiet console=ttyS0,115200n81" \
-        -initrd "$TESTDIR"/initramfs.makeroot || return 1
+        -initrd "$TESTDIR"/initramfs.makeroot
 
     if ! test_marker_check dracut-root-block-created; then
         echo "Could not create root filesystem"

--- a/test/TEST-12-UEFI/test.sh
+++ b/test/TEST-12-UEFI/test.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+set -e
 
 # shellcheck disable=SC2034
 TEST_DESCRIPTION="UEFI boot (ukify, kernel-install)"
@@ -34,18 +35,18 @@ client_run() {
         -drive file=fat:rw:"$TESTDIR"/ESP,format=vvfat,label=EFI \
         -global driver=cfi.pflash01,property=secure,value=on \
         -drive if=pflash,format=raw,unit=0,file="$(ovmf_code)",readonly=on
-    test_marker_check || return 1
+    test_marker_check
 }
 
 test_run() {
-    client_run "UEFI with UKI and squashfs root" || return 1
+    client_run "UEFI with UKI and squashfs root"
 }
 
 test_setup() {
     # Create what will eventually be our root filesystem
     "$DRACUT" -N --keep --tmpdir "$TESTDIR" \
         --add-confdir test-root \
-        "$TESTDIR"/tmp-initramfs.root "$KVERSION" || return 1
+        "$TESTDIR"/tmp-initramfs.root "$KVERSION"
 
     mksquashfs "$TESTDIR"/dracut.*/initramfs/ "$TESTDIR"/squashfs.img -quiet -no-progress
 

--- a/test/TEST-20-STORAGE/test.sh
+++ b/test/TEST-20-STORAGE/test.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+set -e
 
 [ -z "$TEST_FSTYPE" ] && TEST_FSTYPE="ext4"
 
@@ -48,37 +49,37 @@ client_run() {
     "$testdir"/run-qemu \
         "${disk_args[@]}" \
         -append "$TEST_KERNEL_CMDLINE ro $client_opts " \
-        -initrd "$TESTDIR"/initramfs.testing || return 1
-    test_marker_check || return 1
+        -initrd "$TESTDIR"/initramfs.testing
+    test_marker_check
 
     echo "CLIENT TEST END: $test_name [OK]"
 }
 
 test_run() {
     # ignore crypttab with rd.luks.crypttab=0 and RAID with rd.md=0
-    client_run "$TEST_FSTYPE" "disk" "rd.auto=1 rd.luks.crypttab=0 rd.md=0" || return 1
+    client_run "$TEST_FSTYPE" "disk" "rd.auto=1 rd.luks.crypttab=0 rd.md=0"
 
     # LVM-THIN
     if [ -n "$USE_LVM" ]; then
-        client_run "$TEST_FSTYPE" "disk-thin" "rd.auto=1 rd.luks.crypttab=0 rd.md=0" || return 1
+        client_run "$TEST_FSTYPE" "disk-thin" "rd.auto=1 rd.luks.crypttab=0 rd.md=0"
     fi
 
     # ignore crypttab with rd.luks.crypttab=0
     if [ -n "$HAVE_RAID" ]; then
-        client_run "raid" "raid" "rd.auto=1 rd.luks.crypttab=0" || return 1
-        client_run "degraded raid" "raid" "rd.auto=1 rd.luks.crypttab=0" || return 1
+        client_run "raid" "raid" "rd.auto=1 rd.luks.crypttab=0"
+        client_run "degraded raid" "raid" "rd.auto=1 rd.luks.crypttab=0"
     fi
 
     # for encrypted test run - use raid-crypt.img drives instead of raid.img drives
     if [ -n "$HAVE_CRYPT" ] && [ -n "$HAVE_RAID" ]; then
-        client_run "raid crypt" "raid-crypt" "rd.auto=1 " || return 1
-        client_run "degraded raid crypt" "raid-crypt" "rd.auto=1 " || return 1
+        client_run "raid crypt" "raid-crypt" "rd.auto=1 "
+        client_run "degraded raid crypt" "raid-crypt" "rd.auto=1 "
 
         read -r LUKS_UUID < "$TESTDIR"/luksuuid
         read -r MD_UUID < "$TESTDIR"/mduuid
-        client_run "degraded raid crypt" "raid-crypt" "rd.luks.uuid=$LUKS_UUID rd.md.uuid=$MD_UUID rd.md.conf=0 rd.lvm.vg=dracut" || return 1
-        client_run "degraded raid crypt" "raid-crypt" "rd.luks.uuid=$LUKS_UUID rd.md.uuid=$MD_UUID rd.lvm.vg=dracut" || return 1
-        client_run "degraded raid crypt" "raid-crypt" "rd.luks.uuid=$LUKS_UUID rd.md.uuid=$MD_UUID rd.lvm.lv=dracut/root" || return 1
+        client_run "degraded raid crypt" "raid-crypt" "rd.luks.uuid=$LUKS_UUID rd.md.uuid=$MD_UUID rd.md.conf=0 rd.lvm.vg=dracut"
+        client_run "degraded raid crypt" "raid-crypt" "rd.luks.uuid=$LUKS_UUID rd.md.uuid=$MD_UUID rd.lvm.vg=dracut"
+        client_run "degraded raid crypt" "raid-crypt" "rd.luks.uuid=$LUKS_UUID rd.md.uuid=$MD_UUID rd.lvm.lv=dracut/root"
     fi
 }
 
@@ -102,8 +103,8 @@ test_makeroot() {
     "$testdir"/run-qemu \
         "${disk_args[@]}" \
         -append "root=/dev/fakeroot quiet console=ttyS0,115200n81 $client_opts " \
-        -initrd "$TESTDIR"/initramfs.makeroot || return 1
-    test_marker_check dracut-root-block-created || return 1
+        -initrd "$TESTDIR"/initramfs.makeroot
+    test_marker_check dracut-root-block-created
 
     echo "MAKEROOT END: $test_name [OK]"
 }
@@ -112,7 +113,7 @@ test_setup() {
     # Create what will eventually be our root filesystem onto an overlay
     "$DRACUT" -N --keep --tmpdir "$TESTDIR" \
         --add-confdir test-root \
-        -f "$TESTDIR"/initramfs.root "$KVERSION" || return 1
+        -f "$TESTDIR"/initramfs.root "$KVERSION"
     mkdir -p "$TESTDIR"/overlay/source && mv "$TESTDIR"/dracut.*/initramfs/* "$TESTDIR"/overlay/source && rm -rf "$TESTDIR"/dracut.*
 
     # pass enviroment variables to make the root filesystem
@@ -132,23 +133,23 @@ test_setup() {
         $(if command -v cryptsetup > /dev/null; then echo "-a crypt -I cryptsetup"; fi) \
         $(if [ "$TEST_FSTYPE" = "zfs" ]; then echo "-a zfs"; else echo "-I mkfs.${TEST_FSTYPE} --add-drivers ${TEST_FSTYPE}"; fi) \
         -i ./create-root.sh /lib/dracut/hooks/initqueue/01-create-root.sh \
-        -f "$TESTDIR"/initramfs.makeroot "$KVERSION" || return 1
+        -f "$TESTDIR"/initramfs.makeroot "$KVERSION"
 
     # LVM
-    test_makeroot "$TEST_FSTYPE" "disk" "rd.md=0 rd.luks=0" || return 1
+    test_makeroot "$TEST_FSTYPE" "disk" "rd.md=0 rd.luks=0"
 
     # LVM-THIN
     if [ -n "$USE_LVM" ]; then
-        test_makeroot "$TEST_FSTYPE" "disk-thin" "rd.md=0 rd.luks=0 test.thin" || return 1
+        test_makeroot "$TEST_FSTYPE" "disk-thin" "rd.md=0 rd.luks=0 test.thin"
     fi
 
     if [ -n "$HAVE_RAID" ]; then
-        test_makeroot "raid" "raid" "rd.luks=0" || return 1
+        test_makeroot "raid" "raid" "rd.luks=0"
     fi
 
     # for encrypted test run - use raid-crypt.img drives instead of raid.img drives
     if [ -n "$HAVE_CRYPT" ] && [ -n "$HAVE_RAID" ]; then
-        test_makeroot "raid-crypt" "raid-crypt" " " || return 1
+        test_makeroot "raid-crypt" "raid-crypt" " "
 
         eval "$(grep -F --binary-files=text -m 1 MD_UUID "$TESTDIR"/marker.img)"
         echo "$MD_UUID" > "$TESTDIR"/mduuid

--- a/test/TEST-40-SYSTEMD/test.sh
+++ b/test/TEST-40-SYSTEMD/test.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+set -e
 # shellcheck disable=SC2034
 TEST_DESCRIPTION="root filesystem on a ext4 filesystem"
 
@@ -18,16 +19,16 @@ test_run() {
     "$testdir"/run-qemu \
         "${disk_args[@]}" \
         -append "$TEST_KERNEL_CMDLINE \"root=LABEL=  rdinit=/bin/sh\" systemd.log_target=console init=/sbin/init" \
-        -initrd "$TESTDIR"/initramfs.testing || return 1
+        -initrd "$TESTDIR"/initramfs.testing
 
-    test_marker_check || return 1
+    test_marker_check
 }
 
 test_setup() {
     # Create what will eventually be our root filesystem onto an overlay
     "$DRACUT" -N --keep --tmpdir "$TESTDIR" \
         --add-confdir test-root \
-        -f "$TESTDIR"/initramfs.root "$KVERSION" || return 1
+        -f "$TESTDIR"/initramfs.root "$KVERSION"
     mkdir -p "$TESTDIR"/overlay/source && mv "$TESTDIR"/dracut.*/initramfs/* "$TESTDIR"/overlay/source && rm -rf "$TESTDIR"/dracut.*
 
     # second, install the files needed to make the root filesystem
@@ -39,7 +40,7 @@ test_setup() {
         -i ./create-root.sh /lib/dracut/hooks/initqueue/01-create-root.sh \
         --nomdadmconf \
         --no-hostonly-cmdline -N \
-        -f "$TESTDIR"/initramfs.makeroot "$KVERSION" || return 1
+        -f "$TESTDIR"/initramfs.makeroot "$KVERSION"
 
     declare -a disk_args=()
     # shellcheck disable=SC2034  # disk_index used in qemu_add_drive
@@ -51,8 +52,8 @@ test_setup() {
     "$testdir"/run-qemu \
         "${disk_args[@]}" \
         -append "root=/dev/fakeroot quiet console=ttyS0,115200n81" \
-        -initrd "$TESTDIR"/initramfs.makeroot || return 1
-    test_marker_check dracut-root-block-created || return 1
+        -initrd "$TESTDIR"/initramfs.makeroot
+    test_marker_check dracut-root-block-created
     rm -- "$TESTDIR"/marker.img
 
     # systemd-analyze.sh calls man indirectly

--- a/test/TEST-41-FULL-SYSTEMD/test.sh
+++ b/test/TEST-41-FULL-SYSTEMD/test.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+set -e
 
 # shellcheck disable=SC2034
 TEST_DESCRIPTION="Full systemd serialization/deserialization test with /usr mount"
@@ -34,7 +35,7 @@ client_run() {
     "$testdir"/run-qemu \
         "${disk_args[@]}" ${smbios:+-smbios "${smbios}"} \
         -append "$TEST_KERNEL_CMDLINE mount.usr=LABEL=dracutusr mount.usrflags=subvol=usr $client_opts $DEBUGOUT" \
-        -initrd "$TESTDIR"/initramfs.testing || return 1
+        -initrd "$TESTDIR"/initramfs.testing
 
     if ! test_marker_check; then
         echo "CLIENT TEST END: $test_name [FAILED]"
@@ -45,9 +46,9 @@ client_run() {
 
 test_run() {
     # mask services that require rw
-    client_run "readonly root" "" "ro systemd.mask=systemd-sysusers systemd.mask=systemd-timesyncd systemd.mask=systemd-resolved" || return 1
+    client_run "readonly root" "" "ro systemd.mask=systemd-sysusers systemd.mask=systemd-timesyncd systemd.mask=systemd-resolved"
 
-    client_run "writeable root" "" "rw" || return 1
+    client_run "writeable root" "" "rw"
 
     # shellcheck source=$TESTDIR/luks.uuid
     . "$TESTDIR"/luks.uuid
@@ -55,9 +56,9 @@ test_run() {
     if "$testdir"/run-qemu --supports -smbios; then
         # luks
         client_run "encrypted root with rd.luks.uuid" "type=11,value=io.systemd.credential:key=test" \
-            "rw root=LABEL=dracut_crypt rd.luks.uuid=$ID_FS_UUID rd.luks.key=/run/credentials/@system/key" || return 1
+            "rw root=LABEL=dracut_crypt rd.luks.uuid=$ID_FS_UUID rd.luks.key=/run/credentials/@system/key"
         client_run "encrypted root with rd.luks.name" "type=11,value=io.systemd.credential:key=test" \
-            "rw root=/dev/mapper/crypt rd.luks.name=$ID_FS_UUID=crypt rd.luks.key=/run/credentials/@system/key" || return 1
+            "rw root=/dev/mapper/crypt rd.luks.name=$ID_FS_UUID=crypt rd.luks.key=/run/credentials/@system/key"
     else
         echo "CLIENT TEST: encrypted root with rd.luks.uuid [SKIPPED]"
         echo "CLIENT TEST: encrypted root with rd.luks.name [SKIPPED]"
@@ -97,7 +98,7 @@ test_setup() {
     "$DRACUT" -N --keep --tmpdir "$TESTDIR" \
         --add-confdir test-root \
         -a "$dracut_modules" \
-        -f "$TESTDIR"/initramfs.root "$KVERSION" || return 1
+        -f "$TESTDIR"/initramfs.root "$KVERSION"
 
     mkdir -p "$TESTDIR"/overlay/source && cp -a "$TESTDIR"/dracut.*/initramfs/* "$TESTDIR"/overlay/source && rm -rf "$TESTDIR"/dracut.*
 
@@ -110,7 +111,7 @@ test_setup() {
         -a "btrfs crypt" \
         -I "mkfs.btrfs cryptsetup" \
         -i ./create-root.sh /lib/dracut/hooks/initqueue/01-create-root.sh \
-        -f "$TESTDIR"/initramfs.makeroot "$KVERSION" || return 1
+        -f "$TESTDIR"/initramfs.makeroot "$KVERSION"
 
     # Create the blank file to use as a root filesystem
     declare -a disk_args=()
@@ -125,8 +126,8 @@ test_setup() {
     "$testdir"/run-qemu \
         "${disk_args[@]}" \
         -append "root=/dev/fakeroot quiet console=ttyS0,115200n81" \
-        -initrd "$TESTDIR"/initramfs.makeroot || return 1
-    test_marker_check dracut-root-block-created || return 1
+        -initrd "$TESTDIR"/initramfs.makeroot
+    test_marker_check dracut-root-block-created
 
     grep -F -a -m 1 ID_FS_UUID "$TESTDIR"/marker.img > "$TESTDIR"/luks.uuid
 

--- a/test/TEST-43-KERNEL-INSTALL/test.sh
+++ b/test/TEST-43-KERNEL-INSTALL/test.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+set -e
 # shellcheck disable=SC2034
 TEST_DESCRIPTION="kernel-install with root filesystem on ext4 filesystem"
 
@@ -31,9 +32,9 @@ test_run() {
     "$testdir"/run-qemu \
         "${disk_args[@]}" \
         -append "$TEST_KERNEL_CMDLINE" \
-        -initrd "$BOOT_ROOT/$TOKEN/$KVERSION"/initrd || return 1
+        -initrd "$BOOT_ROOT/$TOKEN/$KVERSION"/initrd
 
-    test_marker_check || return 1
+    test_marker_check
 
     test_marker_reset
 
@@ -41,9 +42,9 @@ test_run() {
     "$testdir"/run-qemu \
         "${disk_args[@]}" \
         -append "$TEST_KERNEL_CMDLINE" \
-        -initrd "$BOOT_ROOT/$TOKEN"/0-rescue/initrd || return 1
+        -initrd "$BOOT_ROOT/$TOKEN"/0-rescue/initrd
 
-    test_marker_check || return 1
+    test_marker_check
 }
 
 test_setup() {
@@ -51,7 +52,7 @@ test_setup() {
     # shellcheck disable=SC2153
     "$DRACUT" -N --keep --tmpdir "$TESTDIR" \
         --add-confdir test-root \
-        -f "$TESTDIR"/initramfs.root "$KVERSION" || return 1
+        -f "$TESTDIR"/initramfs.root "$KVERSION"
 
     dd if=/dev/zero of="$TESTDIR"/root.img bs=200MiB count=1 status=none && sync
     mkfs.ext4 -q -L dracut -d "$TESTDIR"/dracut.*/initramfs/ "$TESTDIR"/root.img && sync

--- a/test/TEST-60-NFS/test.sh
+++ b/test/TEST-60-NFS/test.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+set -e
 
 # shellcheck disable=SC2034
 TEST_DESCRIPTION="root filesystem on NFS with $USE_NETWORK"
@@ -32,11 +33,11 @@ run_server() {
         -serial "${SERIAL:-"file:$TESTDIR/server.log"}" \
         -append "panic=1 oops=panic softlockup_panic=1 root=LABEL=dracut rootfstype=ext4 rw console=ttyS0,115200n81 $SERVER_DEBUG" \
         -initrd "$TESTDIR"/initramfs.server \
-        -pidfile "$TESTDIR"/server.pid -daemonize || return 1
-    chmod 644 "$TESTDIR"/server.pid || return 1
+        -pidfile "$TESTDIR"/server.pid -daemonize
+    chmod 644 "$TESTDIR"/server.pid
 
     if ! [[ $SERIAL ]]; then
-        wait_for_server_startup || return 1
+        wait_for_server_startup
     else
         echo Sleeping 10 seconds to give the server a head start
         sleep 10
@@ -127,47 +128,47 @@ test_nfsv3() {
     # NFSv4: last octet starts at 0x80 and works up
 
     client_test "NFSv3 root=dhcp DHCP path only" 52:54:00:12:34:00 \
-        "root=dhcp" 192.168.50.1 -wsize=4096 || return 1
+        "root=dhcp" 192.168.50.1 -wsize=4096
 
     client_test "NFSv3 Legacy root=/dev/nfs nfsroot=IP:path" 52:54:00:12:34:01 \
-        "root=/dev/nfs nfsroot=192.168.50.1:/nfs/client" 192.168.50.1 -wsize=4096 || return 1
+        "root=/dev/nfs nfsroot=192.168.50.1:/nfs/client" 192.168.50.1 -wsize=4096
 
     client_test "NFSv3 Legacy root=/dev/nfs DHCP path only" 52:54:00:12:34:00 \
-        "root=/dev/nfs" 192.168.50.1 -wsize=4096 || return 1
+        "root=/dev/nfs" 192.168.50.1 -wsize=4096
 
     client_test "NFSv3 Legacy root=/dev/nfs DHCP IP:path" 52:54:00:12:34:01 \
-        "root=/dev/nfs" 192.168.50.2 -wsize=4096 || return 1
+        "root=/dev/nfs" 192.168.50.2 -wsize=4096
 
     client_test "NFSv3 root=dhcp DHCP IP:path" 52:54:00:12:34:01 \
-        "root=dhcp" 192.168.50.2 -wsize=4096 || return 1
+        "root=dhcp" 192.168.50.2 -wsize=4096
 
     client_test "NFSv3 root=dhcp DHCP proto:IP:path" 52:54:00:12:34:02 \
-        "root=dhcp" 192.168.50.3 -wsize=4096 || return 1
+        "root=dhcp" 192.168.50.3 -wsize=4096
 
     client_test "NFSv3 root=dhcp DHCP proto:IP:path:options" 52:54:00:12:34:03 \
-        "root=dhcp" 192.168.50.3 wsize=4096 || return 1
+        "root=dhcp" 192.168.50.3 wsize=4096
 
     client_test "NFSv3 root=nfs:..." 52:54:00:12:34:04 \
-        "root=nfs:192.168.50.1:/nfs/client" 192.168.50.1 -wsize=4096 || return 1
+        "root=nfs:192.168.50.1:/nfs/client" 192.168.50.1 -wsize=4096
 
     client_test "NFSv3 Bridge root=nfs:..." 52:54:00:12:34:04 \
-        "root=nfs:192.168.50.1:/nfs/client bridge net.ifnames=0" 192.168.50.1 -wsize=4096 || return 1
+        "root=nfs:192.168.50.1:/nfs/client bridge net.ifnames=0" 192.168.50.1 -wsize=4096
 
     client_test "NFSv3 Legacy root=IP:path" 52:54:00:12:34:04 \
-        "root=192.168.50.1:/nfs/client" 192.168.50.1 -wsize=4096 || return 1
+        "root=192.168.50.1:/nfs/client" 192.168.50.1 -wsize=4096
 
     client_test "NFSv3 root=dhcp DHCP path,options" 52:54:00:12:34:05 \
-        "root=dhcp" 192.168.50.1 wsize=4096 || return 1
+        "root=dhcp" 192.168.50.1 wsize=4096
 
     client_test "NFSv3 root=dhcp DHCP IP:path,options" 52:54:00:12:34:06 \
-        "root=dhcp" 192.168.50.2 wsize=4096 || return 1
+        "root=dhcp" 192.168.50.2 wsize=4096
 
     client_test "NFSv3 root=dhcp DHCP proto:IP:path,options" 52:54:00:12:34:07 \
-        "root=dhcp" 192.168.50.3 wsize=4096 || return 1
+        "root=dhcp" 192.168.50.3 wsize=4096
 
     # TODO FIXME
     #    client_test "NFSv3 Bridge Customized root=dhcp DHCP path,options" 52:54:00:12:34:05 \
-    #        "root=dhcp bridge=foobr0:enp0s1" 192.168.50.1 wsize=4096 || return 1
+    #        "root=dhcp bridge=foobr0:enp0s1" 192.168.50.1 wsize=4096
 
     return 0
 }
@@ -178,22 +179,22 @@ test_nfsv4() {
     # switch_root
 
     client_test "NFSv4 root=dhcp DHCP proto:IP:path" 52:54:00:12:34:82 \
-        "root=dhcp" 192.168.50.3 -wsize=4096 || return 1
+        "root=dhcp" 192.168.50.3 -wsize=4096
 
     client_test "NFSv4 root=dhcp DHCP proto:IP:path:options" 52:54:00:12:34:83 \
-        "root=dhcp" 192.168.50.3 wsize=4096 || return 1
+        "root=dhcp" 192.168.50.3 wsize=4096
 
     client_test "NFSv4 root=nfs4:..." 52:54:00:12:34:84 \
-        "root=nfs4:192.168.50.1:/client" 192.168.50.1 -wsize=4096 || return 1
+        "root=nfs4:192.168.50.1:/client" 192.168.50.1 -wsize=4096
 
     client_test "NFSv4 root=dhcp DHCP proto:IP:path,options" 52:54:00:12:34:87 \
-        "root=dhcp" 192.168.50.3 wsize=4096 || return 1
+        "root=dhcp" 192.168.50.3 wsize=4096
 
     client_test "NFSv4 Overlayfs root=nfs4:..." 52:54:00:12:34:84 \
-        "root=nfs4:192.168.50.1:/client rd.live.overlay.overlayfs=1 " 192.168.50.1 -wsize=4096 || return 1
+        "root=nfs4:192.168.50.1:/client rd.live.overlay.overlayfs=1 " 192.168.50.1 -wsize=4096
 
     client_test "NFSv4 Live Overlayfs root=nfs4:..." 52:54:00:12:34:84 \
-        "root=nfs4:192.168.50.1:/client rd.live.image rd.live.overlay.overlayfs=1" 192.168.50.1 -wsize=4096 || return 1
+        "root=nfs4:192.168.50.1:/client rd.live.image rd.live.overlay.overlayfs=1" 192.168.50.1 -wsize=4096
 
     return 0
 }
@@ -362,7 +363,7 @@ test_setup() {
         -d "piix ide-gd_mod ata_piix ext4 sd_mod" \
         --nomdadmconf \
         --no-hostonly-cmdline -N \
-        -f "$TESTDIR"/initramfs.makeroot "$KVERSION" || return 1
+        -f "$TESTDIR"/initramfs.makeroot "$KVERSION"
     rm -rf -- "$TESTDIR"/server
 
     declare -a disk_args=()
@@ -375,8 +376,8 @@ test_setup() {
     "$testdir"/run-qemu \
         "${disk_args[@]}" \
         -append "root=/dev/dracut/root rw rootfstype=ext4 quiet console=ttyS0,115200n81" \
-        -initrd "$TESTDIR"/initramfs.makeroot || return 1
-    test_marker_check dracut-root-block-created || return 1
+        -initrd "$TESTDIR"/initramfs.makeroot
+    test_marker_check dracut-root-block-created
 
     # Make an overlay with needed tools for the test harness
     (
@@ -411,7 +412,7 @@ test_setup() {
         -a "network-legacy ${SERVER_DEBUG:+debug}" \
         -d "af_packet piix ide-gd_mod ata_piix ext4 sd_mod i6300esb virtio_net" \
         --no-hostonly-cmdline -N \
-        -f "$TESTDIR"/initramfs.server "$KVERSION" || return 1
+        -f "$TESTDIR"/initramfs.server "$KVERSION"
 }
 
 test_cleanup() {

--- a/test/TEST-70-ISCSI/test.sh
+++ b/test/TEST-70-ISCSI/test.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+set -e
 
 # shellcheck disable=SC2034
 TEST_DESCRIPTION="root filesystem over iSCSI with $USE_NETWORK"
@@ -26,11 +27,11 @@ run_server() {
         -net socket,listen=127.0.0.1:12330 \
         -append "panic=1 oops=panic softlockup_panic=1 quiet root=/dev/disk/by-id/scsi-0QEMU_QEMU_HARDDISK_serverroot rw console=ttyS0,115200n81 $SERVER_DEBUG" \
         -initrd "$TESTDIR"/initramfs.server \
-        -pidfile "$TESTDIR"/server.pid -daemonize || return 1
-    chmod 644 "$TESTDIR"/server.pid || return 1
+        -pidfile "$TESTDIR"/server.pid -daemonize
+    chmod 644 "$TESTDIR"/server.pid
 
     if ! [[ $SERIAL ]]; then
-        wait_for_server_startup || return 1
+        wait_for_server_startup
     else
         echo Sleeping 10 seconds to give the server a head start
         sleep 10
@@ -73,29 +74,25 @@ do_test_run() {
 
     run_client "root=dhcp" "" \
         "root=/dev/root netroot=dhcp ip=lan0:dhcp" \
-        "rd.iscsi.initiator=$initiator" \
-        || return 1
+        "rd.iscsi.initiator=$initiator"
 
     run_client "netroot=iscsi target0" "" \
         "root=LABEL=singleroot netroot=iscsi:192.168.50.1::::iqn.2009-06.dracut:target0" \
         "ip=192.168.50.101::192.168.50.1:255.255.255.0:iscsi-1:lan0:off" \
-        "rd.iscsi.initiator=$initiator" \
-        || return 1
+        "rd.iscsi.initiator=$initiator"
 
     run_client "netroot=iscsi target1 target2" "" \
         "root=LABEL=sysroot" \
         "ip=dhcp" \
         "netroot=iscsi:192.168.51.1::::iqn.2009-06.dracut:target1" \
         "netroot=iscsi:192.168.50.1::::iqn.2009-06.dracut:target2" \
-        "rd.iscsi.initiator=$initiator" \
-        || return 1
+        "rd.iscsi.initiator=$initiator"
 
     if "$testdir"/run-qemu --supports -acpitable; then
         run_client "root=ibft" "ibft.table" \
             "root=LABEL=singleroot" \
             "rd.iscsi.ibft=1" \
-            "rd.iscsi.firmware=1" \
-            || return 1
+            "rd.iscsi.firmware=1"
     else
         echo "CLIENT TEST: root=ibft [SKIPPED]"
     fi
@@ -138,7 +135,7 @@ test_setup() {
     "$DRACUT" -N --keep --tmpdir "$TESTDIR" \
         --add-confdir test-root \
         -I "ip grep setsid" \
-        -f "$TESTDIR"/initramfs.root "$KVERSION" || return 1
+        -f "$TESTDIR"/initramfs.root "$KVERSION"
     mkdir -p "$TESTDIR"/overlay/source && mv "$TESTDIR"/dracut.*/initramfs/* "$TESTDIR"/overlay/source && rm -rf "$TESTDIR"/dracut.*
 
     mkdir -p -- "$TESTDIR"/overlay/source/var/lib/nfs/rpc_pipefs
@@ -153,7 +150,7 @@ test_setup() {
         -I "setsid blockdev" \
         -i ./create-client-root.sh /lib/dracut/hooks/initqueue/01-create-client-root.sh \
         --no-hostonly-cmdline -N \
-        -f "$TESTDIR"/initramfs.makeroot "$KVERSION" || return 1
+        -f "$TESTDIR"/initramfs.makeroot "$KVERSION"
     rm -rf -- "$TESTDIR"/overlay
 
     declare -a disk_args=()
@@ -167,8 +164,8 @@ test_setup() {
     "$testdir"/run-qemu \
         "${disk_args[@]}" \
         -append "root=/dev/fakeroot rw quiet console=ttyS0,115200n81" \
-        -initrd "$TESTDIR"/initramfs.makeroot || return 1
-    test_marker_check dracut-root-block-created || return 1
+        -initrd "$TESTDIR"/initramfs.makeroot
+    test_marker_check dracut-root-block-created
     rm -- "$TESTDIR"/marker.img
 
     # Create what will eventually be the server root filesystem onto an overlay
@@ -179,7 +176,7 @@ test_setup() {
         -I "modprobe chmod ip setsid pidof tgtd tgtadm /etc/passwd" \
         --install-optional "/etc/netconfig dhcpd /etc/group /etc/nsswitch.conf /etc/rpc /etc/protocols /etc/services /usr/etc/nsswitch.conf /usr/etc/rpc /usr/etc/protocols /usr/etc/services" \
         -i "./dhcpd.conf" "/etc/dhcpd.conf" \
-        -f "$TESTDIR"/initramfs.root "$KVERSION" || return 1
+        -f "$TESTDIR"/initramfs.root "$KVERSION"
     mkdir -p "$TESTDIR"/overlay/source && mv "$TESTDIR"/dracut.*/initramfs/* "$TESTDIR"/overlay/source && rm -rf "$TESTDIR"/dracut.*
 
     mkdir -p "$TESTDIR"/overlay/source/var/lib/dhcpd
@@ -192,7 +189,7 @@ test_setup() {
     "$DRACUT" -N -i "$TESTDIR"/overlay / \
         --add-confdir test-makeroot \
         -i ./create-server-root.sh /lib/dracut/hooks/initqueue/01-create-server-root.sh \
-        -f "$TESTDIR"/initramfs.makeroot "$KVERSION" || return 1
+        -f "$TESTDIR"/initramfs.makeroot "$KVERSION"
     rm -rf -- "$TESTDIR"/overlay
 
     declare -a disk_args=()
@@ -205,8 +202,8 @@ test_setup() {
     "$testdir"/run-qemu \
         "${disk_args[@]}" \
         -append "root=/dev/dracut/root rw quiet console=ttyS0,115200n81" \
-        -initrd "$TESTDIR"/initramfs.makeroot || return 1
-    test_marker_check dracut-root-block-created || return 1
+        -initrd "$TESTDIR"/initramfs.makeroot
+    test_marker_check dracut-root-block-created
     rm -- "$TESTDIR"/marker.img
 
     # Make server's dracut image
@@ -216,7 +213,7 @@ test_setup() {
         -i "./server.link" "/etc/systemd/network/01-server.link" \
         -i ./wait-if-server.sh /lib/dracut/hooks/pre-mount/99-wait-if-server.sh \
         --no-hostonly-cmdline -N \
-        -f "$TESTDIR"/initramfs.server "$KVERSION" || return 1
+        -f "$TESTDIR"/initramfs.server "$KVERSION"
 
     # Make client's dracut image
     test_dracut \

--- a/test/TEST-71-ISCSI-MULTI/test.sh
+++ b/test/TEST-71-ISCSI-MULTI/test.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+set -e
 
 # shellcheck disable=SC2034
 TEST_DESCRIPTION="root filesystem over multiple iSCSI with $USE_NETWORK"
@@ -26,11 +27,11 @@ run_server() {
         -net socket,listen=127.0.0.1:12331 \
         -append "panic=1 oops=panic softlockup_panic=1 systemd.crash_reboot root=/dev/disk/by-id/scsi-0QEMU_QEMU_HARDDISK_serverroot rootfstype=ext4 rw console=ttyS0,115200n81 $SERVER_DEBUG" \
         -initrd "$TESTDIR"/initramfs.server \
-        -pidfile "$TESTDIR"/server.pid -daemonize || return 1
-    chmod 644 "$TESTDIR"/server.pid || return 1
+        -pidfile "$TESTDIR"/server.pid -daemonize
+    chmod 644 "$TESTDIR"/server.pid
 
     if ! [[ $SERIAL ]]; then
-        wait_for_server_startup || return 1
+        wait_for_server_startup
     else
         echo Sleeping 10 seconds to give the server a head start
         sleep 10
@@ -71,8 +72,7 @@ do_test_run() {
         "ip=192.168.51.101:::255.255.255.0::lan1:off" \
         "netroot=iscsi:192.168.51.1::::iqn.2009-06.dracut:target1" \
         "netroot=iscsi:192.168.50.1::::iqn.2009-06.dracut:target2" \
-        "rd.iscsi.initiator=$initiator" \
-        || return 1
+        "rd.iscsi.initiator=$initiator"
 
     run_client "netroot=iscsi target1 target2 rd.iscsi.waitnet=0" \
         "root=LABEL=sysroot" \
@@ -82,8 +82,7 @@ do_test_run() {
         "netroot=iscsi:192.168.50.1::::iqn.2009-06.dracut:target2" \
         "rd.iscsi.firmware" \
         "rd.iscsi.initiator=$initiator" \
-        "rd.iscsi.waitnet=0" \
-        || return 1
+        "rd.iscsi.waitnet=0"
 
     run_client "netroot=iscsi target1 target2 rd.iscsi.waitnet=0 rd.iscsi.testroute=0" \
         "root=LABEL=sysroot" \
@@ -93,8 +92,7 @@ do_test_run() {
         "netroot=iscsi:192.168.50.1::::iqn.2009-06.dracut:target2" \
         "rd.iscsi.firmware" \
         "rd.iscsi.initiator=$initiator" \
-        "rd.iscsi.waitnet=0 rd.iscsi.testroute=0" \
-        || return 1
+        "rd.iscsi.waitnet=0 rd.iscsi.testroute=0"
 
     run_client "netroot=iscsi target1 target2 rd.iscsi.waitnet=0 rd.iscsi.testroute=0 default GW" \
         "root=LABEL=sysroot" \
@@ -104,8 +102,7 @@ do_test_run() {
         "netroot=iscsi:192.168.50.1::::iqn.2009-06.dracut:target2" \
         "rd.iscsi.firmware" \
         "rd.iscsi.initiator=$initiator" \
-        "rd.iscsi.waitnet=0 rd.iscsi.testroute=0" \
-        || return 1
+        "rd.iscsi.waitnet=0 rd.iscsi.testroute=0"
 
     echo "All tests passed [OK]"
     return 0
@@ -148,7 +145,7 @@ test_setup() {
         --add-confdir test-root \
         -I "ip grep setsid" \
         --no-hostonly --no-hostonly-cmdline --nohardlink \
-        -f "$TESTDIR"/initramfs.root "$KVERSION" || return 1
+        -f "$TESTDIR"/initramfs.root "$KVERSION"
     mkdir -p "$TESTDIR"/overlay/source && mv "$TESTDIR"/dracut.*/initramfs/* "$TESTDIR"/overlay/source && rm -rf "$TESTDIR"/dracut.*
     mkdir -p -- "$TESTDIR"/overlay/source/var/lib/nfs/rpc_pipefs
     cp ./client-init.sh "$TESTDIR"/overlay/source/sbin/init
@@ -163,7 +160,7 @@ test_setup() {
         -I "setsid blockdev" \
         -i ./create-client-root.sh /lib/dracut/hooks/initqueue/01-create-client-root.sh \
         --no-hostonly-cmdline -N \
-        -f "$TESTDIR"/initramfs.makeroot "$KVERSION" || return 1
+        -f "$TESTDIR"/initramfs.makeroot "$KVERSION"
     rm -rf -- "$TESTDIR"/overlay
 
     declare -a disk_args=()
@@ -177,8 +174,8 @@ test_setup() {
     "$testdir"/run-qemu \
         "${disk_args[@]}" \
         -append "root=/dev/fakeroot rw rootfstype=ext4 quiet console=ttyS0,115200n81" \
-        -initrd "$TESTDIR"/initramfs.makeroot || return 1
-    test_marker_check dracut-root-block-created || return 1
+        -initrd "$TESTDIR"/initramfs.makeroot
+    test_marker_check dracut-root-block-created
     rm -- "$TESTDIR"/marker.img
 
     rm -rf -- "$TESTDIR"/overlay
@@ -190,7 +187,7 @@ test_setup() {
         --install-optional "/etc/netconfig dhcpd /etc/group /etc/nsswitch.conf /etc/rpc /etc/protocols /etc/services /usr/etc/nsswitch.conf /usr/etc/rpc /usr/etc/protocols /usr/etc/services" \
         -i /tmp/config /etc/nbd-server/config \
         -i "./dhcpd.conf" "/etc/dhcpd.conf" \
-        -f "$TESTDIR"/initramfs.root "$KVERSION" || return 1
+        -f "$TESTDIR"/initramfs.root "$KVERSION"
     mkdir -p "$TESTDIR"/overlay/source && mv "$TESTDIR"/dracut.*/initramfs/* "$TESTDIR"/overlay/source && rm -rf "$TESTDIR"/dracut.*
 
     mkdir -p -- "$TESTDIR"/overlay/source/var/lib/dhcpd "$TESTDIR"/overlay/source/etc/iscsi
@@ -203,7 +200,7 @@ test_setup() {
     "$DRACUT" -N -i "$TESTDIR"/overlay / \
         --add-confdir test-makeroot \
         -i ./create-server-root.sh /lib/dracut/hooks/initqueue/01-create-server-root.sh \
-        -f "$TESTDIR"/initramfs.makeroot "$KVERSION" || return 1
+        -f "$TESTDIR"/initramfs.makeroot "$KVERSION"
     rm -rf -- "$TESTDIR"/overlay
 
     declare -a disk_args=()
@@ -216,8 +213,8 @@ test_setup() {
     "$testdir"/run-qemu \
         "${disk_args[@]}" \
         -append "root=/dev/dracut/root rw rootfstype=ext4 quiet console=ttyS0,115200n81" \
-        -initrd "$TESTDIR"/initramfs.makeroot || return 1
-    test_marker_check dracut-root-block-created || return 1
+        -initrd "$TESTDIR"/initramfs.makeroot
+    test_marker_check dracut-root-block-created
     rm -- "$TESTDIR"/marker.img
 
     # Make client's dracut image
@@ -234,7 +231,7 @@ test_setup() {
         -i "./server.link" "/etc/systemd/network/01-server.link" \
         -i "./wait-if-server.sh" "/lib/dracut/hooks/pre-mount/99-wait-if-server.sh" \
         --no-hostonly-cmdline -N \
-        -f "$TESTDIR"/initramfs.server "$KVERSION" || return 1
+        -f "$TESTDIR"/initramfs.server "$KVERSION"
 }
 
 test_cleanup() {

--- a/test/TEST-80-GETARG/test.sh
+++ b/test/TEST-80-GETARG/test.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+set -e
 
 # This file is part of dracut.
 # SPDX-License-Identifier: GPL-2.0-or-later

--- a/test/TEST-80-GETARG/test.sh
+++ b/test/TEST-80-GETARG/test.sh
@@ -59,9 +59,7 @@ test_run() {
 
         INVALIDKEYS=("key" "4" "5" "6" "key8" "9" '"' "baz")
         for key in "${INVALIDKEYS[@]}"; do
-            val=$(./dracut-getarg "$key")
-            # shellcheck disable=SC2181
-            if (($? == 0)); then
+            if val=$(./dracut-getarg "$key"); then
                 echo "key '$key' should not be found"
                 ret=$((ret + 1))
             fi

--- a/test/TEST-81-SKIPCPIO/test.sh
+++ b/test/TEST-81-SKIPCPIO/test.sh
@@ -1,6 +1,7 @@
 #!/usr/bin/env bash
 # This file is part of dracut.
 # SPDX-License-Identifier: GPL-2.0-or-later
+set -e
 
 # shellcheck disable=SC2034
 TEST_DESCRIPTION="test skipcpio"
@@ -65,8 +66,7 @@ test_run() {
 }
 
 test_setup() {
-    CPIO_TESTDIR=$(mktemp --directory -p "$TESTDIR" cpio-test.XXXXXXXXXX) \
-        || return 1
+    CPIO_TESTDIR=$(mktemp --directory -p "$TESTDIR" cpio-test.XXXXXXXXXX)
     export CPIO_TESTDIR
     return 0
 }

--- a/test/TEST-82-DRACUT-CPIO/test.sh
+++ b/test/TEST-82-DRACUT-CPIO/test.sh
@@ -1,6 +1,7 @@
 #!/usr/bin/env bash
 # This file is part of dracut.
 # SPDX-License-Identifier: GPL-2.0-or-later
+set -e
 
 # shellcheck disable=SC2034
 TEST_DESCRIPTION="kernel cpio extraction tests for dracut-cpio"
@@ -38,14 +39,14 @@ EOF
         -daemonize -pidfile "$tdir/vm.pid" \
         -serial "file:$tdir/console.out" \
         -append "panic=1 oops=panic softlockup_panic=1 console=ttyS0 rd.shell=1" \
-        -initrd "$tdir/initramfs" || return 1
+        -initrd "$tdir/initramfs"
 
     timeout=120
     while [[ -f $tdir/vm.pid ]] \
         && ps -p "$(head -n1 "$tdir/vm.pid")" > /dev/null; do
         echo "$timeout - awaiting VM shutdown"
         sleep 1
-        [[ $((timeout--)) -le 0 ]] && return 1
+        [[ $((timeout--)) -gt 0 ]]
     done
 
     cat "$tdir/console.out"
@@ -58,15 +59,14 @@ test_run() {
 
     # dracut-cpio is typically used with compression and strip disabled, to
     # increase the chance of (reflink) extent sharing.
-    test_dracut_cpio "simple" "--no-compress" "--nostrip" || return 1
+    test_dracut_cpio "simple" "--no-compress" "--nostrip"
     # dracut-cpio should still work fine with compression and stripping enabled
-    test_dracut_cpio "compress" "--gzip" "--nostrip" || return 1
-    test_dracut_cpio "strip" "--gzip" "--strip" || return 1
+    test_dracut_cpio "compress" "--gzip" "--nostrip"
+    test_dracut_cpio "strip" "--gzip" "--strip"
 }
 
 test_setup() {
-    CPIO_TESTDIR=$(mktemp --directory -p "$TESTDIR" cpio-test.XXXXXXXXXX) \
-        || return 1
+    CPIO_TESTDIR=$(mktemp --directory -p "$TESTDIR" cpio-test.XXXXXXXXXX)
     export CPIO_TESTDIR
     return 0
 }

--- a/test/test-functions
+++ b/test/test-functions
@@ -225,7 +225,7 @@ qemu_add_drive() {
         -device "scsi-hd,bus=scsi${index}.0,drive=drive-data${index},id=data${index},${bootindex:+bootindex=$bootindex,}serial=${name}" \
         ')'
 
-    [ $(("${1}++")) -ne 0 ]
+    : $(("${1}++"))
 }
 
 test_marker_reset() {

--- a/test/test-functions
+++ b/test/test-functions
@@ -19,7 +19,9 @@ if [[ -z $basedir ]]; then basedir="$(realpath ../..)"; fi
 DRACUT=${DRACUT-dracut}
 PKGLIBDIR=${PKGLIBDIR-$basedir}
 
-[[ -f /etc/machine-id ]] && read -r TOKEN < /etc/machine-id
+if [[ -f /etc/machine-id ]]; then
+    read -r TOKEN < /etc/machine-id || true
+fi
 [ -z "$TOKEN" ] && . /etc/os-release && TOKEN="$ID"
 
 TEST_KERNEL_CMDLINE+=" root=LABEL=dracut panic=1 oops=panic softlockup_panic=1 systemd.crash_reboot $DEBUGFAIL "


### PR DESCRIPTION
## Changes

To make all tests more robust, use `set -e` in all tests. Then the `|| return 1` constructs can be removed.

## Checklist
- [ ] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it
