### PR TITLE
test: use persistent names for network devices

### DIFF
--- a/test/TEST-61-MULTINIC/client-persistent-lan0.link
+++ b/test/TEST-61-MULTINIC/client-persistent-lan0.link
@@ -1,0 +1,5 @@
+[Match]
+MACAddress=52:54:00:12:34:00
+
+[Link]
+Name=lan0

--- a/test/TEST-61-MULTINIC/client-persistent-lan1.link
+++ b/test/TEST-61-MULTINIC/client-persistent-lan1.link
@@ -1,0 +1,5 @@
+[Match]
+MACAddress=52:54:00:12:34:01
+
+[Link]
+Name=lan1

--- a/test/TEST-61-MULTINIC/client-persistent-lan2.link
+++ b/test/TEST-61-MULTINIC/client-persistent-lan2.link
@@ -1,0 +1,5 @@
+[Match]
+MACAddress=52:54:00:12:34:02
+
+[Link]
+Name=lan2

--- a/test/TEST-61-MULTINIC/client-persistent-lan254.link
+++ b/test/TEST-61-MULTINIC/client-persistent-lan254.link
@@ -1,0 +1,5 @@
+[Match]
+MACAddress=52:54:00:12:34:fe
+
+[Link]
+Name=lan254

--- a/test/TEST-61-MULTINIC/client-persistent-lan255.link
+++ b/test/TEST-61-MULTINIC/client-persistent-lan255.link
@@ -1,0 +1,5 @@
+[Match]
+MACAddress=52:54:00:12:34:ff
+
+[Link]
+Name=lan255

--- a/test/TEST-61-MULTINIC/client-persistent-lan98.link
+++ b/test/TEST-61-MULTINIC/client-persistent-lan98.link
@@ -1,0 +1,5 @@
+[Match]
+MACAddress=52:54:00:12:34:98
+
+[Link]
+Name=lan98

--- a/test/TEST-61-MULTINIC/client-persistent-lan99.link
+++ b/test/TEST-61-MULTINIC/client-persistent-lan99.link
@@ -1,0 +1,5 @@
+[Match]
+MACAddress=52:54:00:12:34:99
+
+[Link]
+Name=lan99

--- a/test/TEST-61-MULTINIC/client.link
+++ b/test/TEST-61-MULTINIC/client.link
@@ -1,6 +1,0 @@
-[Match]
-OriginalName=*
-
-[Link]
-NamePolicy=keep kernel database onboard slot path
-MACAddressPolicy=keep

--- a/test/TEST-70-ISCSI/client-persistent-lan0.link
+++ b/test/TEST-70-ISCSI/client-persistent-lan0.link
@@ -1,0 +1,5 @@
+[Match]
+MACAddress=52:54:00:12:34:00
+
+[Link]
+Name=lan0

--- a/test/TEST-70-ISCSI/client-persistent-lan1.link
+++ b/test/TEST-70-ISCSI/client-persistent-lan1.link
@@ -1,0 +1,5 @@
+[Match]
+MACAddress=52:54:00:12:34:01
+
+[Link]
+Name=lan1

--- a/test/TEST-70-ISCSI/client.link
+++ b/test/TEST-70-ISCSI/client.link
@@ -1,6 +1,0 @@
-[Match]
-OriginalName=*
-
-[Link]
-NamePolicy=keep kernel database onboard slot path
-MACAddressPolicy=keep

--- a/test/TEST-70-ISCSI/test.sh
+++ b/test/TEST-70-ISCSI/test.sh
@@ -72,13 +72,13 @@ do_test_run() {
     initiator=$(iscsi-iname)
 
     run_client "root=dhcp" "" \
-        "root=/dev/root netroot=dhcp ip=enp0s1:dhcp" \
+        "root=/dev/root netroot=dhcp ip=lan0:dhcp" \
         "rd.iscsi.initiator=$initiator" \
         || return 1
 
     run_client "netroot=iscsi target0" "" \
         "root=LABEL=singleroot netroot=iscsi:192.168.50.1::::iqn.2009-06.dracut:target0" \
-        "ip=192.168.50.101::192.168.50.1:255.255.255.0:iscsi-1:enp0s1:off" \
+        "ip=192.168.50.101::192.168.50.1:255.255.255.0:iscsi-1:lan0:off" \
         "rd.iscsi.initiator=$initiator" \
         || return 1
 
@@ -222,7 +222,8 @@ test_setup() {
     test_dracut \
         --no-hostonly --no-hostonly-cmdline \
         --add "$USE_NETWORK" \
-        --include "./client.link" "/etc/systemd/network/01-client.link" \
+        --include "./client-persistent-lan0.link" "/etc/systemd/network/01-persistent-lan0.link" \
+        --include "./client-persistent-lan1.link" "/etc/systemd/network/01-persistent-lan1.link" \
         --kernel-cmdline "rw rd.auto"
 }
 

--- a/test/TEST-71-ISCSI-MULTI/client-persistent-lan0.link
+++ b/test/TEST-71-ISCSI-MULTI/client-persistent-lan0.link
@@ -1,0 +1,5 @@
+[Match]
+MACAddress=52:54:00:12:34:00
+
+[Link]
+Name=lan0

--- a/test/TEST-71-ISCSI-MULTI/client-persistent-lan1.link
+++ b/test/TEST-71-ISCSI-MULTI/client-persistent-lan1.link
@@ -1,0 +1,5 @@
+[Match]
+MACAddress=52:54:00:12:34:01
+
+[Link]
+Name=lan1

--- a/test/TEST-71-ISCSI-MULTI/client.link
+++ b/test/TEST-71-ISCSI-MULTI/client.link
@@ -1,6 +1,0 @@
-[Match]
-OriginalName=*
-
-[Link]
-NamePolicy=keep kernel database onboard slot path
-MACAddressPolicy=keep

--- a/test/TEST-71-ISCSI-MULTI/test.sh
+++ b/test/TEST-71-ISCSI-MULTI/test.sh
@@ -67,8 +67,8 @@ do_test_run() {
     initiator=$(iscsi-iname)
     run_client "netroot=iscsi target1 target2" \
         "root=LABEL=sysroot" \
-        "ip=192.168.50.101:::255.255.255.0::enp0s1:off" \
-        "ip=192.168.51.101:::255.255.255.0::enp0s2:off" \
+        "ip=192.168.50.101:::255.255.255.0::lan0:off" \
+        "ip=192.168.51.101:::255.255.255.0::lan1:off" \
         "netroot=iscsi:192.168.51.1::::iqn.2009-06.dracut:target1" \
         "netroot=iscsi:192.168.50.1::::iqn.2009-06.dracut:target2" \
         "rd.iscsi.initiator=$initiator" \
@@ -76,8 +76,8 @@ do_test_run() {
 
     run_client "netroot=iscsi target1 target2 rd.iscsi.waitnet=0" \
         "root=LABEL=sysroot" \
-        "ip=192.168.50.101:::255.255.255.0::enp0s1:off" \
-        "ip=192.168.51.101:::255.255.255.0::enp0s2:off" \
+        "ip=192.168.50.101:::255.255.255.0::lan0:off" \
+        "ip=192.168.51.101:::255.255.255.0::lan1:off" \
         "netroot=iscsi:192.168.51.1::::iqn.2009-06.dracut:target1" \
         "netroot=iscsi:192.168.50.1::::iqn.2009-06.dracut:target2" \
         "rd.iscsi.firmware" \
@@ -87,8 +87,8 @@ do_test_run() {
 
     run_client "netroot=iscsi target1 target2 rd.iscsi.waitnet=0 rd.iscsi.testroute=0" \
         "root=LABEL=sysroot" \
-        "ip=192.168.50.101:::255.255.255.0::enp0s1:off" \
-        "ip=192.168.51.101:::255.255.255.0::enp0s2:off" \
+        "ip=192.168.50.101:::255.255.255.0::lan0:off" \
+        "ip=192.168.51.101:::255.255.255.0::lan1:off" \
         "netroot=iscsi:192.168.51.1::::iqn.2009-06.dracut:target1" \
         "netroot=iscsi:192.168.50.1::::iqn.2009-06.dracut:target2" \
         "rd.iscsi.firmware" \
@@ -98,8 +98,8 @@ do_test_run() {
 
     run_client "netroot=iscsi target1 target2 rd.iscsi.waitnet=0 rd.iscsi.testroute=0 default GW" \
         "root=LABEL=sysroot" \
-        "ip=192.168.50.101::192.168.50.1:255.255.255.0::enp0s1:off" \
-        "ip=192.168.51.101::192.168.51.1:255.255.255.0::enp0s2:off" \
+        "ip=192.168.50.101::192.168.50.1:255.255.255.0::lan0:off" \
+        "ip=192.168.51.101::192.168.51.1:255.255.255.0::lan1:off" \
         "netroot=iscsi:192.168.51.1::::iqn.2009-06.dracut:target1" \
         "netroot=iscsi:192.168.50.1::::iqn.2009-06.dracut:target2" \
         "rd.iscsi.firmware" \
@@ -223,7 +223,8 @@ test_setup() {
     test_dracut \
         --no-hostonly --no-hostonly-cmdline \
         --add "$USE_NETWORK" \
-        -i "./client.link" "/etc/systemd/network/01-client.link"
+        -i ./client-persistent-lan0.link /etc/systemd/network/01-persistent-lan0.link \
+        -i ./client-persistent-lan1.link /etc/systemd/network/01-persistent-lan1.link
 
     # Make server's dracut image
     "$DRACUT" -i "$TESTDIR"/overlay / \


### PR DESCRIPTION
## Changes

TEST-70-ISCSI fails on Ubuntu s390x because the network device is named `enc0` instead of `enp0s1`:

```
CLIENT TEST START: NBD root=nbd:IP:port
[...]
[   36.084991] virtio_net virtio2 enc0: renamed from eth0
```

## Checklist
- [ ] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it
