### PR TITLE
feat(50-dracut.install): support for Gentoo(openrc),Debian installkernel

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -225,6 +225,8 @@ endif
 	mkdir -p $(DESTDIR)${prefix}/lib/kernel/install.d
 	install -m 0755 install.d/50-dracut.install $(DESTDIR)${prefix}/lib/kernel/install.d/50-dracut.install
 	install -m 0755 install.d/51-dracut-rescue.install $(DESTDIR)${prefix}/lib/kernel/install.d/51-dracut-rescue.install
+	mkdir -p $(DESTDIR)${prefix}/lib/kernel/preinst.d
+	install -m 0755 preinst.d/50-dracut.install $(DESTDIR)${prefix}/lib/kernel/preinst.d/50-dracut.install
 	mkdir -p $(DESTDIR)${bashcompletiondir}
 	install -m 0644 shell-completion/bash/dracut $(DESTDIR)${bashcompletiondir}/dracut
 	install -m 0644 shell-completion/bash/lsinitrd $(DESTDIR)${bashcompletiondir}/lsinitrd

--- a/preinst.d/50-dracut.install
+++ b/preinst.d/50-dracut.install
@@ -1,0 +1,89 @@
+#!/bin/bash
+
+ver=${1}
+img=${2}
+basedir=$(dirname "${img}")
+initrd="${INSTALLKERNEL_STAGING_AREA:-${basedir}}/initrd"
+uki="${INSTALLKERNEL_STAGING_AREA:-${basedir}}/uki.efi"
+tmp="${INSTALLKERNEL_STAGING_AREA:-${basedir}}/dracut-tmp"
+
+if [[ -n "${INSTALLKERNEL_INITRD_GENERATOR}" &&
+    ${INSTALLKERNEL_INITRD_GENERATOR} != dracut ]]
+then
+    # We are not selected as the initrd generator
+    echo "initrd_generator=${INSTALLKERNEL_INITRD_GENERATOR}, skipping dracut"
+    exit 0
+fi
+
+# do nothing if somehow dracut is not installed
+if ! [[ -x $(command -v dracut) ]]; then
+    echo "dracut is not installed, not generating an initramfs"
+    exit 0
+fi
+
+if ! [[ ${EUID} -eq 0 ]]; then
+    echo "Please run this script as root"
+    exit 1
+fi
+
+initramfs_gen_args=(
+    --add-confdir hostonly
+    # if uefi=yes is used, dracut needs to locate the kernel image
+    --kernel-image "${img}"
+)
+
+[[ ${INSTALLKERNEL_VERBOSE} == 1 ]] && initramfs_gen_args+=( --verbose )
+
+if [[ ${INSTALLKERNEL_UKI_GENERATOR} == dracut ]]; then
+    echo "Using dracut as the initramfs and UKI generator..."
+    initramfs_gen_args+=( --uefi )
+    out="${uki}"
+    if [[ -f ${basedir}/uki.efi ]]; then
+        echo "There is an UKI image at the same place as the kernel, skipping generating a new one"
+        cp --reflink=auto "${basedir}/uki.efi" "${uki}" \
+            && chown root:root "${uki}" \
+            && chmod 0600 "${uki}" \
+            && exit 0
+    fi
+elif [[ ${INSTALLKERNEL_INITRD_GENERATOR} == dracut ]]; then
+    echo "Using dracut as the initramfs generator..."
+    initramfs_gen_args+=( --no-uefi )
+    out="${initrd}"
+    if [[ -f ${basedir}/initrd ]]; then
+        echo "There is an initramfs image at the same place as the kernel, skipping generating a new one"
+        cp --reflink=auto "${basedir}/initrd" "${initrd}" \
+            && chown root:root "${initrd}" \
+            && chmod 0600 "${initrd}" \
+            && exit 0
+    fi
+else
+    echo "No install.conf preference set, falling back to dracut.conf..."
+    out="${tmp}"
+fi
+
+cleanup() {
+	rm -rf "${out}"
+}
+trap cleanup EXIT
+
+initramfs_gen_args+=(
+    # positional arguments
+    "${out}" "${ver}"
+)
+
+dracut "${initramfs_gen_args[@]}" || exit 1
+
+# Fallback path for if we don't know if we generated an initramfs or an
+# UKI. If dracut is used in uefi=yes mode, initrd will actually be a
+# combined kernel+initramfs UEFI executable. We can easily recognize it
+# by PE magic (vs cpio for a regular initramfs).
+if [[ -s ${tmp} ]]; then
+    read -rn 2 magic <"${tmp}" || exit 1
+    if [[ ${magic} == MZ ]]; then
+        echo "Combined UEFI kernel+initramfs executable found"
+        mv "${tmp}" "${uki}" || exit 1
+    else
+        echo "Plain initramfs image found"
+        mv "${tmp}" "${initrd}" || exit 1
+    fi
+fi

--- a/test/container/Dockerfile-gentoo
+++ b/test/container/Dockerfile-gentoo
@@ -28,12 +28,10 @@ RUN \
     echo "MAKEOPTS=\"-j$(nproc) -l$(nproc)\"" >> /etc/portage/make.conf ;\
     echo "EMERGE_DEFAULT_OPTS=\"-j$(nproc) -l$(nproc)\"" >> /etc/portage/make.conf ;\
     echo "FEATURES=\"getbinpkg binpkg-ignore-signature parallel-fetch parallel-install pkgdir-index-trusted\"" >> /etc/portage/make.conf ;\
-    # systemd-boot, no need to install intramfs with kernel \
-    echo "USE=\"boot kernel-install pkcs7 pkcs11 tpm -initramfs\"" >> /etc/portage/make.conf ;\
-    # Use debian's installkernel \
-    echo 'sys-kernel/installkernel -systemd' >> /etc/portage/package.use/kernel ;\
-    # Enable ukify, qrcode and cryptsetup (includes unit generator for crypttab) \
-    echo 'sys-apps/systemd ukify qrcode cryptsetup' >> /etc/portage/package.use/systemd ;\
+    # disable initramfs sanity checks for kernel to avoid pulling in dracut package \
+    echo "USE=\"pkcs7 pkcs11 tpm -initramfs\"" >> /etc/portage/make.conf ;\
+    # Enable systemd-boot, ukify, qrcode and cryptsetup (includes unit generator for crypttab) \
+    echo 'sys-apps/systemd boot kernel-install ukify qrcode cryptsetup' >> /etc/portage/package.use/systemd ;\
     # Support thin volumes and build all of LVM2 including daemons and tools like lvchange \
     echo 'sys-fs/lvm2 thin lvm' >> /etc/portage/package.use/lvm2 ;\
     # force hostonly mode as this is the config recommended by https://wiki.gentoo.org/wiki/Dracut \


### PR DESCRIPTION
This is a slightly modified version of Gentoo's dracut `installkernel` hook for openrc systems (i.e. systems without systemd's `kernel-install`).

Gentoo's installkernel for openrc is based on the installkernel implementation found in Debian's debianutils package. Though Gentoo has modified this installkernel script, this hook retains compatibility both with Gentoo's modified version and with the original Debian version.

See-also: https://github.com/dracut-ng/dracut-ng/issues/1224

## Checklist
- [x] I have tested it locally
- [x] I have reviewed and updated any documentation if relevant
- [x] I am providing new code and test(s) for it

Fixes #
