### PR TITLE
test: define default network/fstype in the respective tests

### DIFF
--- a/test/TEST-60-NFS/test.sh
+++ b/test/TEST-60-NFS/test.sh
@@ -1,6 +1,8 @@
 #!/usr/bin/env bash
 set -e
 
+[ -z "${USE_NETWORK-}" ] && USE_NETWORK="network"
+
 # shellcheck disable=SC2034
 TEST_DESCRIPTION="root filesystem on NFS with $USE_NETWORK"
 

--- a/test/TEST-61-MULTINIC/test.sh
+++ b/test/TEST-61-MULTINIC/test.sh
@@ -1,6 +1,8 @@
 #!/usr/bin/env bash
 set -e
 
+[ -z "${USE_NETWORK-}" ] && USE_NETWORK="network"
+
 # shellcheck disable=SC2034
 TEST_DESCRIPTION="root filesystem on NFS with multiple nics with $USE_NETWORK"
 

--- a/test/TEST-62-BONDBRIDGEVLAN/test.sh
+++ b/test/TEST-62-BONDBRIDGEVLAN/test.sh
@@ -3,6 +3,8 @@
 # ex: ts=8 sw=4 sts=4 et filetype=sh
 set -e
 
+[ -z "${USE_NETWORK-}" ] && USE_NETWORK="network"
+
 # shellcheck disable=SC2034
 TEST_DESCRIPTION="root filesystem on NFS with bridging/bonding/vlan with $USE_NETWORK"
 

--- a/test/TEST-70-ISCSI/test.sh
+++ b/test/TEST-70-ISCSI/test.sh
@@ -1,6 +1,8 @@
 #!/usr/bin/env bash
 set -e
 
+[ -z "${USE_NETWORK-}" ] && USE_NETWORK="network"
+
 # shellcheck disable=SC2034
 TEST_DESCRIPTION="root filesystem over iSCSI with $USE_NETWORK"
 

--- a/test/TEST-71-ISCSI-MULTI/test.sh
+++ b/test/TEST-71-ISCSI-MULTI/test.sh
@@ -1,6 +1,8 @@
 #!/usr/bin/env bash
 set -e
 
+[ -z "${USE_NETWORK-}" ] && USE_NETWORK="network"
+
 # shellcheck disable=SC2034
 TEST_DESCRIPTION="root filesystem over multiple iSCSI with $USE_NETWORK"
 

--- a/test/TEST-72-NBD/test.sh
+++ b/test/TEST-72-NBD/test.sh
@@ -1,6 +1,8 @@
 #!/usr/bin/env bash
 set -e
 
+[ -z "${USE_NETWORK-}" ] && USE_NETWORK="network"
+
 # shellcheck disable=SC2034
 TEST_DESCRIPTION="root filesystem on NBD with $USE_NETWORK"
 

--- a/test/test-functions
+++ b/test/test-functions
@@ -11,7 +11,6 @@ echo "TESTDIR=\"$TESTDIR\"" > .testdir${TEST_RUN_ID:+-$TEST_RUN_ID}
 export TESTDIR
 export BOOT_ROOT="$TESTDIR"
 
-[ -z "$USE_NETWORK" ] && USE_NETWORK="network"
 [ -z "$TEST_FSTYPE" ] && TEST_FSTYPE="ext4"
 
 if [[ -z $basedir ]]; then basedir="$(realpath ../..)"; fi

--- a/test/test-functions
+++ b/test/test-functions
@@ -11,8 +11,6 @@ echo "TESTDIR=\"$TESTDIR\"" > .testdir${TEST_RUN_ID:+-$TEST_RUN_ID}
 export TESTDIR
 export BOOT_ROOT="$TESTDIR"
 
-[ -z "$TEST_FSTYPE" ] && TEST_FSTYPE="ext4"
-
 if [[ -z $basedir ]]; then basedir="$(realpath ../..)"; fi
 
 DRACUT=${DRACUT-dracut}


### PR DESCRIPTION
## Changes

The variable `TEST_FSTYPE` will be needed to construct `TEST_DESCRIPTION`.

So define `TEST_FSTYPE` in the respective tests before defining `TEST_DESCRIPTION`.

## Checklist
- [x] I have tested it locally
- [x] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it