### PR TITLE
fix(systemd-sysusers): silence "Creating " on stderr

### DIFF
--- a/modules.d/60systemd-sysusers/module-setup.sh
+++ b/modules.d/60systemd-sysusers/module-setup.sh
@@ -15,5 +15,9 @@ check() {
 install() {
     inst_sysusers basic.conf
 
-    systemd-sysusers --root="$initdir" > /dev/null
+    # redirect stdout temporarily to FD 3 to use filter stderr
+    {
+        set -o pipefail
+        systemd-sysusers --root="$initdir" 2>&1 >&3 | grep -v "^Creating " >&2
+    } 3>&1
 }


### PR DESCRIPTION
## Changes

dracut prints 20 lines when creating users and groups even with `--quiet` option. Sample output:

```
Creating group 'nobody' with GID 65534.
Creating group 'audio' with GID 997.
Creating group 'disk' with GID 995.
Creating group 'input' with GID 994.
Creating group 'kmem' with GID 993.
Creating group 'kvm' with GID 992.
Creating group 'lp' with GID 991.
Creating group 'optical' with GID 990.
Creating group 'render' with GID 989.
Creating group 'sgx' with GID 988.
Creating group 'storage' with GID 987.
Creating group 'tty' with GID 5.
Creating group 'uucp' with GID 986.
Creating group 'video' with GID 985.
Creating group 'users' with GID 984.
Creating group 'systemd-journal' with GID 983.
Creating user 'root' (Super User) with UID 0 and GID 0.
Creating user 'nobody' (Kernel Overflow User) with UID 65534 and GID 65534.
Creating group 'nobody' with GID 65534.
Creating group 'audio' with GID 997.
```

Filter "Creating " messages from stderr, but keep the other messages on stderr and all messages on stdout untouched.

## Checklist
- [x] I have tested it locally
- [x] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it

Fixes: https://github.com/dracut-ng/dracut-ng/issues/1195
Fixes: f3dacc013d90 ("feat(systemd-sysusers): run systemd-sysusers as part of the build process")
