### PR TITLE
feat(systemd-integritysetup): add remote-integritysetup.target

### DIFF
--- a/modules.d/01systemd-integritysetup/module-setup.sh
+++ b/modules.d/01systemd-integritysetup/module-setup.sh
@@ -26,6 +26,7 @@ depends() {
 
 }
 
+# Install kernel module(s).
 installkernel() {
     instmods dm-integrity
 }
@@ -36,9 +37,11 @@ install() {
     inst_multiple -o \
         "$systemdutildir"/systemd-integritysetup \
         "$systemdutildir"/system-generators/systemd-integritysetup-generator \
+        "$systemdsystemunitdir"/remote-integritysetup.target \
         "$systemdsystemunitdir"/integritysetup-pre.target \
         "$systemdsystemunitdir"/integritysetup.target \
-        "$systemdsystemunitdir"/sysinit.target.wants/integritysetup.target
+        "$systemdsystemunitdir"/sysinit.target.wants/integritysetup.target \
+        "$systemdsystemunitdir"/initrd-root-device.target.wants/remote-integritysetup.target
 
     # Install the hosts local user configurations if enabled.
     if [[ $hostonly ]]; then
@@ -48,8 +51,11 @@ install() {
             "$systemdsystemconfdir/integritysetup.target.wants/*.target" \
             "$systemdsystemconfdir"/integritysetup-pre.target \
             "$systemdsystemconfdir/integritysetup-pre.target.wants/*.target" \
+            "$systemdsystemconfdir"/remote-integritysetup.target \
+            "$systemdsystemconfdir/remote-integritysetup.target.wants/*.target" \
             "$systemdsystemconfdir"/sysinit.target.wants/integritysetup.target \
-            "$systemdsystemconfdir/sysinit.target.wants/integritysetup.target.wants/*.target"
+            "$systemdsystemconfdir/sysinit.target.wants/integritysetup.target.wants/*.target" \
+            "$systemdsystemconfdir"/initrd-root-device.target.wants/remote-integritysetup.target
     fi
 
     # Install required libraries.


### PR DESCRIPTION
Required since https://github.com/systemd/systemd/commit/810708f4b820543b8585a36e84ccca4bc5b18fee

## Checklist
- [ ] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it
