### PR TITLE
ci(fedora): always use update-crypto-policies to enable fips

### DIFF
--- a/test/container/Dockerfile-fedora
+++ b/test/container/Dockerfile-fedora
@@ -96,7 +96,5 @@ RUN \
 if [[ "${DISTRIBUTION}" =~ "centos:" ]]; then \
     [[ -e /usr/bin/qemu-kvm ]] || ln -sf /usr/libexec/qemu-kvm /usr/bin/qemu-kvm ;\
     [[ -e /usr/bin/qemu-system-$(uname -m) ]] || ln -sv /usr/libexec/qemu-kvm /usr/bin/qemu-system-$(uname -m) ;\
-    update-crypto-policies --no-reload --set FIPS ;\
-else \
-    fips-mode-setup --enable ;\
-fi
+fi ;\
+update-crypto-policies --no-reload --set FIPS


### PR DESCRIPTION
## Changes

Fix the following error message on Fedora Rawhide .

```
fips-mode-setup: command not found
```

## Checklist
- [ ] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it


CC @LaszloGombos @Conan-Kudo 