### PR TITLE
fix(dracut): protect existing output file against build errors

### DIFF
--- a/dracut.sh
+++ b/dracut.sh
@@ -2373,6 +2373,12 @@ if dracut_module_included "squash-lib"; then
     compress="cat"
 fi
 
+# protect existing output file against build errors
+if [[ -e $outfile ]]; then
+    outfile_final="$outfile"
+    outfile="${outfile}.tmp"
+fi
+
 dinfo "*** Creating image file '$outfile' ***"
 
 if [[ $uefi == yes ]]; then
@@ -2675,6 +2681,18 @@ else
     else
         rm -f -- "$outfile"
         dfatal "Creation of $outfile failed"
+        exit 1
+    fi
+fi
+
+if [[ $outfile_final ]]; then
+    dinfo "*** Moving image file '$outfile' to '$outfile_final' ***"
+    if mv -f "$outfile" "$outfile_final"; then
+        dinfo "*** Moving image file '$outfile' to '$outfile_final' done ***"
+        outfile="$outfile_final"
+    else
+        rm -f -- "$outfile_final"
+        dfatal "Move of $outfile_final failed"
         exit 1
     fi
 fi


### PR DESCRIPTION
If dracut fails to build the initrd image or EFI binary for any reason (e.g., if `cp` fails because there is no space left on the device), it removes the existing output file before exiting, which may result in an unbootable system. Instead of copying the initrd image directly to the output, copy it alongside it to the same output directory, and if the copy succeeds, replace it.

## Checklist
- [ ] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it