### PR TITLE
test: add container for Azure Linux

### DIFF
--- a/.github/workflows/container-extra.yml
+++ b/.github/workflows/container-extra.yml
@@ -46,6 +46,7 @@ jobs:
                     - {dockerfile: 'Dockerfile-gentoo', tag: 'gentoo:amd64-openrc', option: 'amd64-openrc'}
                     - {dockerfile: 'Dockerfile-fedora', tag: 'fedora:rawhide', registry: 'registry.fedoraproject.org'}
                     - {dockerfile: 'Dockerfile-fedora', tag: 'centos:stream10-development', registry: 'quay.io/centos'}
+                    - {dockerfile: 'Dockerfile-azurelinux', tag: 'azurelinux:3.0', registry: 'mcr.microsoft.com'}
                 exclude:
                    - config: {tag: 'alpine:edge'}
                      architecture: {platform: 'linux/arm64'}
@@ -77,3 +78,4 @@ jobs:
                       DISTRIBUTION=${{ matrix.config.tag }}
                       REGISTRY=${{ matrix.config.registry }}
                       OPTION=${{ matrix.config.option }}
+                      PLATFORM=${{ matrix.config.platform }}

--- a/.github/workflows/integration-extra.yml
+++ b/.github/workflows/integration-extra.yml
@@ -28,6 +28,7 @@ jobs:
                     - alpine:latest
                     - alpine:edge
                     - arch:latest
+                    - azurelinux:3.0
                     - debian:latest
                     - debian:sid
                     - fedora:latest

--- a/.github/workflows/manualtest.yml
+++ b/.github/workflows/manualtest.yml
@@ -15,6 +15,7 @@ on:  # yamllint disable-line rule:truthy
                     - "all"
                     - "alpine:latest"
                     - "alpine:edge"
+                    - "azurelinux:3.0"
                     - "centos:stream10-development"
                     - "fedora:latest"
                     - "fedora:rawhide"

--- a/test/container/Dockerfile-azurelinux
+++ b/test/container/Dockerfile-azurelinux
@@ -1,0 +1,55 @@
+FROM mcr.microsoft.com/azurelinux/base/core:3.0
+
+ARG PLATFORM=linux/amd64
+
+RUN \
+if [[ "${PLATFORM}" =~ "amd64" ]]; then \
+    tdnf -y install --setopt=install_weak_deps=False \
+        systemd-boot \
+        systemd-ukify \
+; fi
+
+RUN tdnf -y install --setopt=install_weak_deps=False \
+    asciidoc \
+    bash-completion \
+    bluez \
+    btrfs-progs \
+    cargo \
+    chrony \
+    cifs-utils \
+    cryptsetup \
+    device-mapper-multipath \
+    dhcpcd \
+    e2fsprogs \
+    fuse3 \
+    gcc \
+    iproute \
+    iputils \
+    iscsi-initiator-utils \
+    jq \
+    kbd \
+    kexec-tools \
+    kernel \
+    kmod-devel \
+    libkcapi-hmaccalc \
+    libselinux-utils \
+    lvm2 \
+    make \
+    mdadm \
+    nbd \
+    ndctl \
+    nfs-utils \
+    nvme-cli \
+    parted \
+    pcsc-lite \
+    qemu \
+    qemu-kvm \
+    rng-tools \
+    rsyslog \
+    squashfs-tools \
+    swtpm \
+    systemd-resolved \
+    tpm2-tools \
+    xfsprogs \
+    xorriso \
+    && tdnf clean all


### PR DESCRIPTION
Add Dockerfile for Azure Linux.

The Azure Linux Dockerfile is mostly based off the Fedora version without the unavailable packages.

`TEST-43-KERNEL-INSTALL` is failing with the following message, but I have not figured out why

```
Failed to chase path /usr/lib/modules/6.6.78.1-3.azl3/vmlinuz for kernel image file specified via command line, ignoring: No such file or directory
```

## Changes

## Checklist
- [x] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it

Fixes #
