### PR TITLE
Feat(crypt-gpg): handle multiple gpg pubkeys

### DIFF
--- a/modules.d/91crypt-gpg/README
+++ b/modules.d/91crypt-gpg/README
@@ -43,6 +43,19 @@ $ su -c 'cp /safe/place/keyfile_sc.gpg /boot/${KEYFILE}'
 $ gpg --armor --export-options export-minimal --export ${RECIPIENT} > /safe/place/crypt-public-key.gpg
 $ su -c 'cp /safe/place/crypt-public-key.gpg /etc/dracut.conf.d/crypt-public-key.gpg'
 
+
+# Multiple recipients for decryption with multiple keys
+# you can encrypt a keyfile with multiple recipients:
+$ cat /safe/place/keyfile.bak.gpg | gpg -d | gpg --encrypt --recipient ${RECIPIENT1} --recipient ${RECIPIENT2} --recipient ${RECIPIENT3} --cipher-algo aes256 --armor -c > /safe/place/keyfile_sc.gpg
+# the public keys can each be export with
+$ gpg --armor --export-options export-minimal --export ${RECIPIENT1} > /safe/place/crypt-public-key1.gpg
+$ su -c 'cp /safe/place/crypt-public-key1.gpg /etc/dracut.conf.d/crypt-public-key1.gpg'
+$ gpg --armor --export-options export-minimal --export ${RECIPIENT2} > /safe/place/crypt-public-key2.gpg
+$ su -c 'cp /safe/place/crypt-public-key2.gpg /etc/dracut.conf.d/crypt-public-key2.gpg'
+$ gpg --armor --export-options export-minimal --export ${RECIPIENT3} > /safe/place/crypt-public-key3.gpg
+$ su -c 'cp /safe/place/crypt-public-key3.gpg /etc/dracut.conf.d/crypt-public-key3.gpg'
+# this way any of the 3 recipients can decrypt the keyfile
+
 # Rebuild your initramfs as usual
 # When booting with any of the requirements not met, crypt-gpg will default to password-based keyfile unlocking.
 # If all requirements are met and smartcard support is not disabled by setting the kernel option "rd.luks.smartcard=0"

--- a/modules.d/91crypt-gpg/crypt-gpg-lib.sh
+++ b/modules.d/91crypt-gpg/crypt-gpg-lib.sh
@@ -36,11 +36,13 @@ gpg_decrypt() {
     gpgMinorVersion="$(gpg --version | sed -n 1p | sed -n -r -e 's|.* [0-9]*\.([0-9]*).*|\1|p')"
 
     if [ "${gpgMajorVersion}" -ge 2 ] && [ "${gpgMinorVersion}" -ge 1 ] \
-        && [ -f /root/crypt-public-key.gpg ] && getargbool 1 rd.luks.smartcard; then
+        && ls /root/crypt-public-key*.gpg > /dev/null 2>&1 && getargbool 1 rd.luks.smartcard; then
         useSmartcard="1"
         echo "allow-loopback-pinentry" >> "$gpghome/gpg-agent.conf"
         GNUPGHOME="$gpghome" gpg-agent --quiet --daemon
-        GNUPGHOME="$gpghome" gpg --quiet --no-tty --import < /root/crypt-public-key.gpg
+        for file in /root/crypt-public-key*.gpg; do
+            GNUPGHOME="$gpghome" gpg --quiet --no-tty --import < "$file"
+        done
         GNUPGHOME="$gpghome" gpg-connect-agent 1> /dev/null learn /bye
         local smartcardSerialNumber
         smartcardSerialNumber="$(GNUPGHOME=$gpghome gpg --no-tty --card-status \


### PR DESCRIPTION
This pull request changes crypt-gpg, allows it to import multiple pubkeys that match `crypt-public-key*.gpg` instead of importing only `crypt-public-key.gpg`. This way a keyfile can be decrypted by multiple recipients thus allowing for backups or for multiple users.

## Changes
At install, all keys matching `crypt-public-key*.gpg` are found with `find` and copied.

At boot, these are listed with `ls` by glob matching and later imported

## Checklist
- [x] I have tested it locally
- [x] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it

Fixes #1246 
