### PR TITLE
ci(Fedora): make sure portablectl is installed

### DIFF
--- a/test/container/Dockerfile-fedora
+++ b/test/container/Dockerfile-fedora
@@ -84,6 +84,7 @@ RUN dnf -y install --setopt=install_weak_deps=False \
     squashfs-tools \
     swtpm \
     systemd-boot-unsigned \
+    systemd-container \
     systemd-resolved \
     systemd-ukify \
     tpm2-tools \


### PR DESCRIPTION
Add systemd-container to make sure portablectl is installed.

See https://src.fedoraproject.org/rpms/systemd/c/49ec9f3286e6c18e48f3ee3a08da950d0113f853?branch=rawhide portablectl and importctl are moved to systemd-container (rhbz#2345551)

This change is required to restore green CI.

It seems the Fedora container is not actively maintained by the Fedora team and it seems this adds a bit of a burden on non-Fedora contributors. 

CC @pvalena @keszybz @lnykryn  

## Changes

## Checklist
- [ ] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it

Fixes #
