### PR TITLE
fix(mdraid): do not call mdadm with full path

### DIFF
--- a/modules.d/90mdraid/module-setup.sh
+++ b/modules.d/90mdraid/module-setup.sh
@@ -46,7 +46,7 @@ cmdline() {
         [[ ${host_fs_types[$dev]} != *_raid_member ]] && continue
 
         UUID=$(
-            /sbin/mdadm --examine --export "$dev" \
+            mdadm --examine --export "$dev" \
                 | while read -r line || [[ "$line" ]]; do
                     [[ ${line#MD_UUID=} == "$line" ]] && continue
                     printf "%s" "${line#MD_UUID=} "


### PR DESCRIPTION
We use `command -v` to find mdadm binary on the system anyway, so it makes no sense to call it using the full path.

Bug: https://bugs.gentoo.org/951284

## Checklist
- [x] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it
