### PR TITLE
perf(base): remove the chmod dependency from base 

### DIFF
--- a/modules.d/00systemd/module-setup.sh
+++ b/modules.d/00systemd/module-setup.sh
@@ -84,6 +84,7 @@ install() {
         "$systemdsystemunitdir"/-.slice \
         systemctl \
         echo swapoff \
+        chmod \
         mount umount reboot poweroff \
         systemd-run systemd-escape \
         systemd-cgls

--- a/modules.d/35network-legacy/ifup.sh
+++ b/modules.d/35network-legacy/ifup.sh
@@ -47,7 +47,6 @@ do_dhcp_parallel() {
         echo 'dhcp=dhclient' >> /run/NetworkManager/conf.d/10-dracut-dhclient.conf
     fi
 
-    chmod +x /sbin/dhcp-multi.sh
     /sbin/dhcp-multi.sh "$netif" "$DO_VLAN" "$@" &
     return 0
 }

--- a/modules.d/95ssh-client/module-setup.sh
+++ b/modules.d/95ssh-client/module-setup.sh
@@ -65,7 +65,7 @@ inst_sshenv() {
 install() {
     local _nsslibs
 
-    inst_multiple ssh scp
+    inst_multiple ssh scp chmod
     inst_sshenv
 
     _nsslibs=$(

--- a/modules.d/99base/module-setup.sh
+++ b/modules.d/99base/module-setup.sh
@@ -9,7 +9,6 @@ depends() {
 # called by dracut
 install() {
     inst_multiple \
-        chmod \
         cp \
         dmesg \
         flock \


### PR DESCRIPTION
## Changes

1. chore(network-legacy): no need to call chmod on ifup.sh
This is a small optimization, with the goal of avoiding calling chmod for a file that is already guaranteed to be an executable.

2. perf(base): move the chmod dependency from base to systemd
base dracut module no longer requires chmod.

## Checklist
- [ ] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it

Fixes #
