### PR TITLE
ci(ubuntu:devel): adopt uutils utilities by default

### DIFF
--- a/test/container/Dockerfile-debian
+++ b/test/container/Dockerfile-debian
@@ -99,3 +99,9 @@ RUN \
     KVERSION="$(cd /lib/modules && ls -1 | tail -1)" \
     ; if ! [ -e /usr/lib/modules/"$KVERSION"/vmlinuz ]; then ln -sf /boot/vmlinuz /usr/lib/modules/"$KVERSION"/vmlinuz; fi  \
     ; if ! [ -e /usr/lib/modules/"$KVERSION"/vmlinuz ]; then ln -sf /boot/vmlinuz-"$KVERSION" /usr/lib/modules/"$KVERSION"/vmlinuz; fi
+
+# adopt uutils utilities by default for ubuntu:devel
+RUN if [ "$DISTRIBUTION" = "ubuntu:devel" ] ; then \
+    cargo install --git https://github.com/jnsgruk/oxidizr \
+    && /root/.cargo/bin/oxidizr enable --experiments coreutils --yes \
+    ; fi


### PR DESCRIPTION
## Changes

The goal of this change is to enable interoperability testing between uutils for dracut projects.

First step towards https://github.com/dracut-ng/dracut-ng/issues/1253

## Checklist
- [ ] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it

CC @LaszloGombos @bdrung 