### PR TITLE
chore(mdraid): remove mdmon-pre-udev hook

### DIFF
--- a/modules.d/90mdraid/mdmon-pre-udev.sh
+++ b/modules.d/90mdraid/mdmon-pre-udev.sh
@@ -1,4 +1,0 @@
-#!/bin/sh
-# save state dir for mdmon/mdadm for the real root
-[ -d /run/mdadm ] || mkdir -m 0755 -p /run/mdadm
-# backward compat link

--- a/modules.d/90mdraid/module-setup.sh
+++ b/modules.d/90mdraid/module-setup.sh
@@ -107,7 +107,6 @@ install() {
         fi
     fi
 
-    inst_hook pre-udev 30 "$moddir/mdmon-pre-udev.sh"
     inst_hook pre-trigger 30 "$moddir/parse-md.sh"
     inst_hook pre-mount 10 "$moddir/mdraid-waitclean.sh"
     inst_hook cleanup 99 "$moddir/mdraid-needshutdown.sh"


### PR DESCRIPTION
## Changes

Follow-up to 19f3a80 .

`mdadm` creates `/run`, so `mdmon-pre-udev` hook is not necessary anymore.

## Checklist
- [ ] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it

