### PR TITLE
fix(multipath): skip default multipath.conf with mpathconf

### DIFF
--- a/modules.d/90multipath/module-setup.sh
+++ b/modules.d/90multipath/module-setup.sh
@@ -122,7 +122,7 @@ install() {
         fi
     }
 
-    [[ $hostonly ]] || {
+    [[ $hostonly ]] || mpathconf_installed || {
         for_each_host_dev_and_slaves is_mpath \
             || [[ -f /etc/multipath.conf ]] || {
             cat > "${initdir}"/etc/multipath.conf << EOF


### PR DESCRIPTION
Commit 1e802f15f creates a default multipath.conf file with "find_multipaths strict" when run in non-hostonly mode if there are no multipath devices and no multipath.conf. Unfortunately for systems that want to use mpathconf to create a multipath.conf file (e.g. Fedora and Centos) either through multipathd-configure.service or multipathd.sh, this default file keeps that from occurring. To make sure mpathconf is called to create the config file, do not install a default config file if mpathconf is installed.

Fixes: ("fix(multipath): include module with find_multipaths strict")

This pull request changes...

## Changes

## Checklist
- [x] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it

Fixes #509
CC: @pvalena @LaszloGombos @mwilck @jlebon 