### PR TITLE
Parse ELF .note.dlopen entries for dependencies, replace ldd for better cross support

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -53,7 +53,7 @@ manpages = $(man1pages) $(man5pages) $(man7pages) $(man8pages)
 all: dracut.pc dracut-install src/skipcpio/skipcpio dracut-util
 
 %.o : %.c
-	$(CC) -c $(CFLAGS) $(CPPFLAGS) $(KMOD_CFLAGS) $< -o $@
+	$(CC) -c $(CFLAGS) $(CPPFLAGS) $(KMOD_CFLAGS) $(SYSTEMD_CFLAGS) $(if $(SYSTEMD_LIBS),-DHAVE_SYSTEMD) $< -o $@
 
 DRACUT_INSTALL_OBJECTS = \
         src/install/dracut-install.o \
@@ -72,7 +72,7 @@ src/install/util.o: src/install/util.c src/install/util.h src/install/macro.h sr
 src/install/strv.o: src/install/strv.c src/install/strv.h src/install/util.h src/install/macro.h src/install/log.h
 
 src/install/dracut-install: $(DRACUT_INSTALL_OBJECTS)
-	$(CC) $(LDFLAGS) -o $@ $(DRACUT_INSTALL_OBJECTS) $(LDLIBS) $(FTS_LIBS) $(KMOD_LIBS)
+	$(CC) $(LDFLAGS) -o $@ $(DRACUT_INSTALL_OBJECTS) $(LDLIBS) $(FTS_LIBS) $(KMOD_LIBS) $(SYSTEMD_LIBS)
 
 dracut-install: src/install/dracut-install
 	ln -fs $< $@

--- a/configure
+++ b/configure
@@ -191,6 +191,9 @@ bindir ?= ${bindir:-${prefix}/bin}
 KMOD_CFLAGS ?= $(${PKG_CONFIG} --cflags " libkmod >= 23 ") ${KMOD_CFLAGS_EXTRA}
 KMOD_LIBS ?= $(${PKG_CONFIG} --libs " libkmod >= 23 ")
 FTS_LIBS ?= ${FTS_LIBS}
+# For the sd-json API, which was added in systemd v257. This is optional.
+SYSTEMD_CFLAGS ?= $(${PKG_CONFIG} --cflags "libsystemd >= 257")
+SYSTEMD_LIBS ?= $(${PKG_CONFIG} --libs "libsystemd >= 257")
 EOF
 
 {

--- a/dracut-functions.sh
+++ b/dracut-functions.sh
@@ -44,6 +44,12 @@ trim() {
     printf "%s" "$var"
 }
 
+# is_elf <path>
+# Returns success if the given path is an ELF. Only checks the first 4 bytes.
+is_elf() {
+    [[ $(head --bytes=4 "$1") == $'\x7fELF' ]]
+}
+
 # find a binary.  If we were not passed the full path directly,
 # search in the usual places to find the binary.
 find_binary() {
@@ -56,13 +62,13 @@ find_binary() {
     if [[ $1 == *.so* ]]; then
         for l in $libdirs; do
             _path="${l}${_delim}${1}"
-            if { $DRACUT_LDD "${dracutsysrootdir}${_path}" &> /dev/null; }; then
+            if is_elf "${dracutsysrootdir}${_path}"; then
                 printf "%s\n" "${_path}"
                 return 0
             fi
         done
         _path="${_delim}${1}"
-        if { $DRACUT_LDD "${dracutsysrootdir}${_path}" &> /dev/null; }; then
+        if is_elf "${dracutsysrootdir}${_path}"; then
             printf "%s\n" "${_path}"
             return 0
         fi

--- a/dracut-init.sh
+++ b/dracut-init.sh
@@ -678,6 +678,15 @@ inst_opt_decompress() {
     done
 }
 
+module_functions=(
+    check
+    depends
+    cmdline
+    config
+    install
+    installkernel
+)
+
 # module_check <dracut module> [<forced>] [<module path>]
 # execute the check() function of module-setup.sh of <dracut module>
 # or the "check" script, if module-setup.sh is not found
@@ -690,7 +699,7 @@ module_check() {
     [[ -z $_moddir ]] && _moddir=$(dracut_module_path "$1")
     [ $# -ge 2 ] && _forced=$2
     [[ -f $_moddir/module-setup.sh ]] || return 1
-    unset check depends cmdline install installkernel
+    unset "${module_functions[@]}"
     check() { true; }
     # shellcheck disable=SC1090
     . "$_moddir"/module-setup.sh
@@ -700,7 +709,7 @@ module_check() {
     # shellcheck disable=SC2086
     moddir="$_moddir" check $hostonly
     _ret=$?
-    unset check depends cmdline install installkernel
+    unset "${module_functions[@]}"
     hostonly=$_hostonly
     return $_ret
 }
@@ -715,13 +724,13 @@ module_check_mount() {
     export mount_needs=1
     [[ -z $_moddir ]] && _moddir=$(dracut_module_path "$1")
     [[ -f $_moddir/module-setup.sh ]] || return 1
-    unset check depends cmdline install installkernel
+    unset "${module_functions[@]}"
     check() { false; }
     # shellcheck disable=SC1090
     . "$_moddir"/module-setup.sh
     moddir=$_moddir check 0
     _ret=$?
-    unset check depends cmdline install installkernel
+    unset "${module_functions[@]}"
     unset mount_needs
     return "$_ret"
 }
@@ -734,13 +743,13 @@ module_depends() {
     local _ret
     [[ -z $_moddir ]] && _moddir=$(dracut_module_path "$1")
     [[ -f $_moddir/module-setup.sh ]] || return 1
-    unset check depends cmdline install installkernel
+    unset "${module_functions[@]}"
     depends() { true; }
     # shellcheck disable=SC1090
     . "$_moddir"/module-setup.sh
     moddir=$_moddir depends
     _ret=$?
-    unset check depends cmdline install installkernel
+    unset "${module_functions[@]}"
     return $_ret
 }
 
@@ -752,13 +761,31 @@ module_cmdline() {
     local _ret
     [[ -z $_moddir ]] && _moddir=$(dracut_module_path "$1")
     [[ -f $_moddir/module-setup.sh ]] || return 1
-    unset check depends cmdline install installkernel
+    unset "${module_functions[@]}"
     cmdline() { true; }
     # shellcheck disable=SC1090
     . "$_moddir"/module-setup.sh
     moddir="$_moddir" cmdline
     _ret=$?
-    unset check depends cmdline install installkernel
+    unset "${module_functions[@]}"
+    return $_ret
+}
+
+# module_config <dracut module> [<module path>]
+# execute the config() function of module-setup.sh of <dracut module>
+# or the "config" script, if module-setup.sh is not found
+module_config() {
+    local _moddir=$2
+    local _ret
+    [[ -z $_moddir ]] && _moddir=$(dracut_module_path "$1")
+    [[ -f $_moddir/module-setup.sh ]] || return 1
+    unset "${module_functions[@]}"
+    config() { true; }
+    # shellcheck disable=SC1090
+    . "$_moddir"/module-setup.sh
+    moddir="$_moddir" config
+    _ret=$?
+    unset "${module_functions[@]}"
     return $_ret
 }
 
@@ -770,13 +797,13 @@ module_install() {
     local _ret
     [[ -z $_moddir ]] && _moddir=$(dracut_module_path "$1")
     [[ -f $_moddir/module-setup.sh ]] || return 1
-    unset check depends cmdline install installkernel
+    unset "${module_functions[@]}"
     install() { true; }
     # shellcheck disable=SC1090
     . "$_moddir"/module-setup.sh
     moddir="$_moddir" install
     _ret=$?
-    unset check depends cmdline install installkernel
+    unset "${module_functions[@]}"
     return $_ret
 }
 
@@ -788,13 +815,13 @@ module_installkernel() {
     local _ret
     [[ -z $_moddir ]] && _moddir=$(dracut_module_path "$1")
     [[ -f $_moddir/module-setup.sh ]] || return 1
-    unset check depends cmdline install installkernel
+    unset "${module_functions[@]}"
     installkernel() { true; }
     # shellcheck disable=SC1090
     . "$_moddir"/module-setup.sh
     moddir="$_moddir" installkernel
     _ret=$?
-    unset check depends cmdline install installkernel
+    unset "${module_functions[@]}"
     return $_ret
 }
 

--- a/dracut.sh
+++ b/dracut.sh
@@ -1561,6 +1561,17 @@ set_global_var "systemd" "modversion:systemdversion" "0"
 set_global_var "libkmod" "depmodd" "/usr/lib/depmod.d"
 set_global_var "libkmod" "depmodconfdir" "/etc/depmod.d"
 
+# Modules should check for JSON support in dracut-install before using it.
+DRACUT_INSTALL_JSON=
+$DRACUT_INSTALL --json-supported &> /dev/null && DRACUT_INSTALL_JSON=1
+
+# systemd started declaring its dlopen dependencies in v256. Checking for these
+# requires JSON support in dracut-install, provided by libsystemd v257. The
+# version in the sysroot may be different to the one used by dracut-install.
+USE_SYSTEMD_DLOPEN_DEPS=
+# shellcheck disable=SC2034 # USE_SYSTEMD_DLOPEN_DEPS is used in modules
+[[ $DRACUT_INSTALL_JSON && ${systemdversion%%.*} -ge 256 ]] && USE_SYSTEMD_DLOPEN_DEPS=1
+
 if [[ $no_kernel != yes ]] && [[ -d $srcmods ]]; then
     if ! [[ -f $srcmods/modules.dep ]]; then
         if [[ -n "$(find "$srcmods" -name '*.ko*')" ]]; then

--- a/dracut.sh
+++ b/dracut.sh
@@ -927,6 +927,9 @@ export DRACUT_LOG_LEVEL=warning
 
 [[ $dracutbasedir ]] || dracutbasedir="$dracutsysrootdir"/usr/lib/dracut
 
+# These config variables needs to be exported for dracut-install.
+export add_dlopen_features="" omit_dlopen_features=""
+
 # if we were not passed a config file, try the default one
 if [[ -z $conffile ]]; then
     if [[ $allowlocal ]]; then
@@ -2007,6 +2010,13 @@ dracut_module_included "squash-lib" && mkdir -p "$squashdir"
 
 _isize=0 #initramfs size
 modules_loaded=" "
+# Allow all modules to update the config. Do this before installing anything.
+for moddir in "$dracutbasedir/modules.d"/[0-9][0-9]*; do
+    _d_mod=${moddir##*/}
+    _d_mod=${_d_mod#[0-9][0-9]}
+    [[ $mods_to_load == *\ $_d_mod\ * ]] || continue
+    module_config "$_d_mod" "$moddir"
+done
 # source our modules.
 for moddir in "$dracutbasedir/modules.d"/[0-9][0-9]*; do
     _d_mod=${moddir##*/}

--- a/dracut.sh
+++ b/dracut.sh
@@ -1357,11 +1357,7 @@ if [[ $early_microcode == yes ]] || { [[ $acpi_override == yes ]] && [[ -d $acpi
     mkdir "$early_cpio_dir"
 fi
 
-if ${DRACUT_LDD:-ldd} "${dracutsysrootdir}/bin/sh" | grep -q musl &> /dev/null; then
-    musl=1
-fi
-
-[[ "$dracutsysrootdir" ]] || [[ "$noexec" ]] || [[ "$musl" ]] || export DRACUT_RESOLVE_LAZY="1"
+[[ "$dracutsysrootdir" ]] || [[ "$noexec" ]] || export DRACUT_RESOLVE_LAZY="1"
 
 if [[ $print_cmdline ]]; then
     stdloglvl=0

--- a/man/dracut.8.adoc
+++ b/man/dracut.8.adoc
@@ -648,13 +648,6 @@ _DRACUT_LDCONFIG_::
 Default:
     _ldconfig_
 
-_DRACUT_LDD_::
-    sets the _ldd_ program path and options. Optional.
-    Used for **--sysroot**.
-+
-Default:
-    _ldd_
-
 _PKG_CONFIG_::
     sets the _pkg-config_ program path and options. Optional.
     Most useful together with **--sysroot**.

--- a/man/dracut.conf.5.adoc
+++ b/man/dracut.conf.5.adoc
@@ -75,6 +75,19 @@ This option forces dracut to only include the specified kernel modules.
 In most cases the "--add-drivers" option is what you want to use.
 This option is not recommended to use (use at your own risk).
 
+*add_dlopen_features+=*" __<pattern>:<feature>__[__,<feature>__...] ... "::
+Specify a space-separated list of binaries matching _pattern_ against a
+comma-separated list of features to install dependencies for. For example,
+"libsystemd-shared-*.so:idn,ip4tc" will install the dependencies for systemd's
+international domain name and iptables support. _pattern_ should match the
+soname for libraries or the filename for executables.
+
+*omit_dlopen_features+=*" __<pattern>:<feature>__[__,<feature>__...] ... "::
+Specify a space-separated list of binaries matching _pattern_ against a
+comma-separated list of features to omit dependencies for. Some dracut modules
+add certain features by default. This takes precedence over add_dlopen_features
+above.
+
 *filesystems+=*" __<filesystem names>__ "::
 Specify a space-separated list of kernel filesystem modules to exclusively
 include in the generic initramfs.

--- a/modules.d/00systemd/module-setup.sh
+++ b/modules.d/00systemd/module-setup.sh
@@ -14,6 +14,11 @@ check() {
     return 255
 }
 
+# Config adjustments before installing anything.
+config() {
+    add_dlopen_features+=" libsystemd-shared-*.so:kmod "
+}
+
 installkernel() {
     hostonly='' instmods autofs4 ipv6 dmi-sysfs
     hostonly=$(optional_hostonly) instmods -s efivarfs

--- a/modules.d/00systemd/module-setup.sh
+++ b/modules.d/00systemd/module-setup.sh
@@ -144,7 +144,6 @@ EOF
     # Install library file(s)
     _arch=${DRACUT_ARCH:-$(uname -m)}
     inst_libdir_file \
-        {"tls/$_arch/",tls/,"$_arch/",}"libgcrypt.so*" \
         {"tls/$_arch/",tls/,"$_arch/",}"libbpf.so*" \
         {"tls/$_arch/",tls/,"$_arch/",}"libnss_*" \
         {"tls/$_arch/",tls/,"$_arch/",}"systemd/libsystemd*.so"

--- a/modules.d/00systemd/module-setup.sh
+++ b/modules.d/00systemd/module-setup.sh
@@ -145,6 +145,5 @@ EOF
     _arch=${DRACUT_ARCH:-$(uname -m)}
     inst_libdir_file \
         {"tls/$_arch/",tls/,"$_arch/",}"libbpf.so*" \
-        {"tls/$_arch/",tls/,"$_arch/",}"libnss_*" \
-        {"tls/$_arch/",tls/,"$_arch/",}"systemd/libsystemd*.so"
+        {"tls/$_arch/",tls/,"$_arch/",}"libnss_*"
 }

--- a/modules.d/01systemd-bsod/module-setup.sh
+++ b/modules.d/01systemd-bsod/module-setup.sh
@@ -19,6 +19,11 @@ depends() {
     return 0
 }
 
+# Config adjustments before installing anything.
+config() {
+    add_dlopen_features+=" libsystemd-shared-*.so:qrencode "
+}
+
 # Install the required file(s) for the module in the initramfs.
 install() {
     inst_multiple \

--- a/modules.d/01systemd-bsod/module-setup.sh
+++ b/modules.d/01systemd-bsod/module-setup.sh
@@ -26,5 +26,7 @@ install() {
         "$systemdsystemunitdir"/initrd.target.wants/systemd-bsod.service \
         "$systemdutildir"/systemd-bsod
 
-    inst_libdir_file "libqrencode.so*"
+    if [[ ! $USE_SYSTEMD_DLOPEN_DEPS ]]; then
+        inst_libdir_file "libqrencode.so*"
+    fi
 }

--- a/modules.d/01systemd-coredump/module-setup.sh
+++ b/modules.d/01systemd-coredump/module-setup.sh
@@ -44,10 +44,12 @@ install() {
 
     # Install library file(s)
     _arch=${DRACUT_ARCH:-$(uname -m)}
-    inst_libdir_file \
-        {"tls/$_arch/",tls/,"$_arch/",}"liblz4.so.*" \
-        {"tls/$_arch/",tls/,"$_arch/",}"liblzma.so.*" \
-        {"tls/$_arch/",tls/,"$_arch/",}"libzstd.so.*"
+    if [[ ! $USE_SYSTEMD_DLOPEN_DEPS ]]; then
+        inst_libdir_file \
+            {"tls/$_arch/",tls/,"$_arch/",}"liblz4.so.*" \
+            {"tls/$_arch/",tls/,"$_arch/",}"liblzma.so.*" \
+            {"tls/$_arch/",tls/,"$_arch/",}"libzstd.so.*"
+    fi
 
     # Install the hosts local user configurations if enabled.
     if [[ $hostonly ]]; then

--- a/modules.d/01systemd-coredump/module-setup.sh
+++ b/modules.d/01systemd-coredump/module-setup.sh
@@ -26,6 +26,11 @@ depends() {
 
 }
 
+# Config adjustments before installing anything.
+config() {
+    add_dlopen_features+=" libsystemd-shared-*.so:lz4,lzma,zstd "
+}
+
 # Install the required file(s) and directories for the module in the initramfs.
 install() {
 

--- a/modules.d/01systemd-integritysetup/module-setup.sh
+++ b/modules.d/01systemd-integritysetup/module-setup.sh
@@ -26,6 +26,11 @@ depends() {
 
 }
 
+# Config adjustments before installing anything.
+config() {
+    add_dlopen_features+=" libsystemd-shared-*.so:cryptsetup "
+}
+
 # Install kernel module(s).
 installkernel() {
     hostonly='' instmods dm-integrity

--- a/modules.d/01systemd-integritysetup/module-setup.sh
+++ b/modules.d/01systemd-integritysetup/module-setup.sh
@@ -60,6 +60,7 @@ install() {
 
     # Install required libraries.
     _arch=${DRACUT_ARCH:-$(uname -m)}
-    inst_libdir_file {"tls/$_arch/",tls/,"$_arch/",}"libcryptsetup.so.*"
-
+    if [[ ! $USE_SYSTEMD_DLOPEN_DEPS ]]; then
+        inst_libdir_file {"tls/$_arch/",tls/,"$_arch/",}"libcryptsetup.so.*"
+    fi
 }

--- a/modules.d/01systemd-journald/module-setup.sh
+++ b/modules.d/01systemd-journald/module-setup.sh
@@ -26,6 +26,11 @@ depends() {
 
 }
 
+# Config adjustments before installing anything.
+config() {
+    add_dlopen_features+=" libsystemd-shared-*.so:gcrypt,lz4,lzma,zstd "
+}
+
 # Install the required file(s) and directories for the module in the initramfs.
 install() {
 

--- a/modules.d/01systemd-journald/module-setup.sh
+++ b/modules.d/01systemd-journald/module-setup.sh
@@ -53,11 +53,13 @@ install() {
 
     # Install library file(s)
     _arch=${DRACUT_ARCH:-$(uname -m)}
-    inst_libdir_file \
-        {"tls/$_arch/",tls/,"$_arch/",}"libgcrypt.so*" \
-        {"tls/$_arch/",tls/,"$_arch/",}"liblz4.so.*" \
-        {"tls/$_arch/",tls/,"$_arch/",}"liblzma.so.*" \
-        {"tls/$_arch/",tls/,"$_arch/",}"libzstd.so.*"
+    if [[ ! $USE_SYSTEMD_DLOPEN_DEPS ]]; then
+        inst_libdir_file \
+            {"tls/$_arch/",tls/,"$_arch/",}"libgcrypt.so*" \
+            {"tls/$_arch/",tls/,"$_arch/",}"liblz4.so.*" \
+            {"tls/$_arch/",tls/,"$_arch/",}"liblzma.so.*" \
+            {"tls/$_arch/",tls/,"$_arch/",}"libzstd.so.*"
+    fi
 
     # Install the hosts local user configurations if enabled.
     if [[ $hostonly ]]; then

--- a/modules.d/01systemd-veritysetup/module-setup.sh
+++ b/modules.d/01systemd-veritysetup/module-setup.sh
@@ -26,6 +26,11 @@ depends() {
 
 }
 
+# Config adjustments before installing anything.
+config() {
+    add_dlopen_features+=" libsystemd-shared-*.so:cryptsetup "
+}
+
 # Install kernel module(s).
 installkernel() {
     hostonly='' instmods dm-verity

--- a/modules.d/01systemd-veritysetup/module-setup.sh
+++ b/modules.d/01systemd-veritysetup/module-setup.sh
@@ -60,6 +60,7 @@ install() {
 
     # Install required libraries.
     _arch=${DRACUT_ARCH:-$(uname -m)}
-    inst_libdir_file {"tls/$_arch/",tls/,"$_arch/",}"libcryptsetup.so.*"
-
+    if [[ ! $USE_SYSTEMD_DLOPEN_DEPS ]]; then
+        inst_libdir_file {"tls/$_arch/",tls/,"$_arch/",}"libcryptsetup.so.*"
+    fi
 }

--- a/modules.d/91crypt-gpg/module-setup.sh
+++ b/modules.d/91crypt-gpg/module-setup.sh
@@ -57,7 +57,7 @@ sc_supported() {
     if [[ ${gpgMajor} -gt 2 || ${gpgMajor} -eq 2 && ${gpgMinor} -ge 1 ]] \
         && require_binaries gpg-agent \
         && require_binaries gpg-connect-agent \
-        && ($DRACUT_LDD "${dracutsysrootdir}${scdaemon}" | grep libusb > /dev/null); then
+        && [[ $($DRACUT_INSTALL ${dracutsysrootdir:+-r "$dracutsysrootdir"} --dry-run -R "${scdaemon}") == *libusb* ]]; then
         return 0
     else
         return 1

--- a/test/TEST-40-SYSTEMD/test.sh
+++ b/test/TEST-40-SYSTEMD/test.sh
@@ -65,6 +65,14 @@ test_setup() {
         --omit-drivers 'a b c d e f g h i j k l m n o p q r s t u v w x y z' \
         -i ./systemd-analyze.sh /lib/dracut/hooks/pre-pivot/00-systemd-analyze.sh \
         -i "/bin/true" "/usr/bin/man"
+
+    # shellcheck disable=SC2144 # We're not installing multilib libfido2, so
+    # glob will only match once. More matches would break the test anyway.
+    if pkg-config --exists "libsystemd >= 257" && [ -e /usr/lib*/libfido2.so.1 ] \
+        && ! lsinitrd "$TESTDIR"/initramfs.testing | grep -E ' usr/lib[^/]*/libfido2\.so\.1\b' > /dev/null; then
+        echo "Error: libfido2.so.1 should have been included in the initramfs" >&2
+        return 1
+    fi
 }
 
 # shellcheck disable=SC1090

--- a/test/dracut.conf.d/test/test.conf
+++ b/test/dracut.conf.d/test/test.conf
@@ -7,3 +7,6 @@ hostonly_cmdline="no"
 
 # systemd on arm64 on GitHub CI needs the 2 min timeout
 kernel_cmdline=" rd.retry=10 rd.timeout=120 rd.info rd.shell=0 "
+
+# test the dlopen dependencies support
+add_dlopen_features+=" libsystemd-shared-*.so:fido2 "


### PR DESCRIPTION
## Changes

Brace yourselves, it's a big one. :sweat_smile: I will summarise here. Further details are in the commit messages and code comments.

As suggested in #154, this checks ELF headers for `.note.dlopen` entries that state which libraries may be `dlopen`ed by the binary. At this time, only systemd uses this convention.

This metadata is in JSON format, so also as suggested, this makes use of libsystemd's newly exposed sd-json API. If libsystemd is too old or not present at all, then this dlopen handling is simply skipped.

Unconditionally installing all such dlopen dependencies would probably result in larger images rather than smaller ones, so modules can express which features they need through `add_dlopen_features`, and users can append to this too. Conversely, users can opt out of features enabled by default using `omit_dlopen_features`.

Unfortunately, systemd's dlopen features were named after their respective libraries, which seems unhelpful to me. For example, `pcre2` and `ip4tc` could have been called `regex` and `iptables`. Changing this now may not be worthwhile though.

The metadata references sonames rather than full paths, so Dracut needs to determine the full paths by itself. It cannot use ldd to do this as that relies on `DT_NEEDED`. The code to do this makes up the bulk of these changes.

Since ldd is not cross-friendly anyway (see the other issues), it made sense to go the extra mile and remove all existing use of ldd in favour of this new code. Dracut will now be able to reliably handle dependencies across different architectures, memory width, and endianness for glibc and musl without any crude ldd replacements. ldconfig still needs to be executed via QEMU for glibc in order to generate the cache.

I have added a new test for `--sysroot` based on the basic test. Ideally, this would use an image for a different architecture, but that would be more intensive. I have also extended the systemd test to cover `add_dlopen_features`, but the test will effectively be skipped until the container includes a new enough systemd-devel and libfido2.

I have tested it manually as much as I can. That testing included running it under Valgrind and dealing with any leaks. I had some trouble running some of the integration tests locally, so I'm not expecting CI to pass first time. :crossed_fingers: 

I can appreciate that so many changes can be hard to review in one go, so I have committed this in these phases:

1. Implement the .note.dlopen handling.
2. Extend that code to replace ldd calls in dracut-install.
3. Replace all remaining usage of ldd.
4. Allow modules and users to choose which dlopen dependencies they want.

This is obviously a lot of new code that will need to be maintained going forwards. I am a maintainer for two Linux distributions that use Dracut, and one of these is my day job. I am therefore happy to maintain this code for the foreseeable future.

There are potentially more changes that could be done to make Dracut more cross-friendly, such as removing the need to install it into the sysroot and not executing dracut-install from the sysroot by default, but these can be addressed separately.

## Checklist
- [X] I have tested it locally
- [X] I have reviewed and updated any documentation if relevant
- [X] I am providing new code and test(s) for it

Fixes #154, #338, #1257