### PR TITLE
fix(crypt): always install s390 crypto modules

### DIFF
--- a/modules.d/90crypt/module-setup.sh
+++ b/modules.d/90crypt/module-setup.sh
@@ -23,7 +23,13 @@ depends() {
 
 # called by dracut
 installkernel() {
-    hostonly="" instmods drbg dm_crypt
+    local _arch=${DRACUT_ARCH:-$(uname -m)}
+    local _s390drivers=
+    if [[ $_arch == "s390" ]] || [[ $_arch == "s390x" ]]; then
+        _s390drivers="=drivers/s390/crypto"
+    fi
+
+    hostonly="" instmods drbg dm_crypt ${_s390drivers:+"$_s390drivers"}
 
     # in case some of the crypto modules moved from compiled in
     # to module based, try to install those modules


### PR DESCRIPTION
Not only are the specific encryption modules not being installed on s390/s390x in non-hostonly mode, but also it's failing the detection of the kernel modules needed to decrypt PAES-encrypted volumes in hostonly mode via dmsetup. So, since the increase in size is not that much (~ 150K), always add all the drivers under s390/crypto in this architecture.

## Checklist
- [ ] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it

