### PR TITLE
feat: add simpledrm module (as subset of drm module)

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -551,6 +551,10 @@ shutdown:
   - changed-files:
       - any-glob-to-any-file: 'modules.d/[0-9][0-9]shutdown/*'
 
+simpledrm:
+  - changed-files:
+      - any-glob-to-any-file: 'modules.d/[0-9][0-9]simpledrm/*'
+
 squash:
   - changed-files:
       - any-glob-to-any-file: 'modules.d/[0-9][0-9]squash/*'

--- a/modules.d/45simpledrm/module-setup.sh
+++ b/modules.d/45simpledrm/module-setup.sh
@@ -1,0 +1,28 @@
+#!/bin/bash
+
+# called by dracut
+check() {
+    return 255
+}
+
+# called by dracut
+installkernel() {
+    # Include simple DRM driver
+    instmods simpledrm
+
+    if [[ $hostonly ]]; then
+        # if there is a privacy screen then its driver must be loaded before the
+        # kms driver will bind, otherwise its probe() will return -EPROBE_DEFER
+        # note privacy screens always register, even with e.g. nokmsboot
+        for i in /sys/class/drm/privacy_screen-*/device/driver/module; do
+            [[ -L $i ]] || continue
+            modlink=$(readlink "$i")
+            modname=$(basename "$modlink")
+            instmods "$modname"
+        done
+    else
+        # include privacy screen providers (see above comment)
+        # atm all providers live under drivers/platform/x86
+        dracut_instmods -o -s "drm_privacy_screen_register" "=drivers/platform/x86"
+    fi
+}


### PR DESCRIPTION
## Changes

Plymouth doesn't always show a splash screen if DRM drivers are installed in initrd.

Provide a `simpledrm` module that only installs the SimpleDRM module and the potentially needed privacy screen providers. This `simpledrm` module is a subset of the `drm` module. It could be used instead of `drm` to avoid pulling in drivers like amdgpu, nouveau, or nvidia-drm.

Bug-Ubuntu: https://launchpad.net/bugs/2105377

## Checklist
- [x] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it