### PR TITLE
feat(systemd): add new systemd-validatefs@.service

### DIFF
--- a/modules.d/00systemd/module-setup.sh
+++ b/modules.d/00systemd/module-setup.sh
@@ -35,6 +35,7 @@ install() {
         "$systemdutildir"/systemd-shutdown \
         "$systemdutildir"/systemd-reply-password \
         "$systemdutildir"/systemd-fsck \
+        "$systemdutildir"/systemd-validatefs \
         "$systemdutildir"/systemd-volatile-root \
         "$systemdutildir"/systemd-sysroot-fstab-check \
         "$systemdutildir"/system-generators/systemd-debug-generator \
@@ -76,6 +77,7 @@ install() {
         "$systemdsystemunitdir"/systemd-reboot.service \
         "$systemdsystemunitdir"/systemd-kexec.service \
         "$systemdsystemunitdir"/systemd-fsck@.service \
+        "$systemdsystemunitdir"/systemd-validatefs@.service \
         "$systemdsystemunitdir"/systemd-volatile-root.service \
         "$systemdsystemunitdir"/ctrl-alt-del.target \
         "$systemdsystemunitdir"/syslog.socket \


### PR DESCRIPTION
Introduced in https://github.com/systemd/systemd/commit/0bdd5ccc8145af8dae9779751d3e7a34c4fa6aa5
Used internally in fstab-generator (new `x-systemd.validatefs` mount option) and gpt-auto-generator: https://github.com/systemd/systemd/commit/f872373a26dcaa0818b49220abfe35611d12fa82

## Checklist
- [ ] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it