### PR TITLE
fix(systemd-cryptsetup): don't pull in fido2/pkcs11/tpm2-tss if omitted

### DIFF
--- a/modules.d/01systemd-cryptsetup/module-setup.sh
+++ b/modules.d/01systemd-cryptsetup/module-setup.sh
@@ -33,7 +33,7 @@ depends() {
     elif [[ ! $hostonly ]]; then
         for module in fido2 pkcs11 tpm2-tss; do
             module_check $module > /dev/null 2>&1
-            if [[ $? == 255 ]]; then
+            if [[ $? == 255 ]] && ! [[ " $omit_dracutmodules " == *\ $module\ * ]]; then
                 deps+=" $module"
             fi
         done


### PR DESCRIPTION
## Changes

These modules have some large dependencies. Allow users to explicitly omit them if desired. Other modules like systemd-udevd also do this.

## Checklist
- [X] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it
