### PR TITLE
fix(systemd-sysusers): remove (g)shadow created by systemd-sysusers

### DIFF
--- a/modules.d/68systemd-sysusers/module-setup.sh
+++ b/modules.d/68systemd-sysusers/module-setup.sh
@@ -23,4 +23,8 @@ install() {
         set -o pipefail
         systemd-sysusers --root="$initdir" 2>&1 >&3 | grep -v "^Creating " >&2
     } 3>&1
+
+    # delete shadow files as initramfs is not designed to ask for a non-root user password
+    # interactively and their permissions crashes the build.
+    rm -f "$initdir/etc/shadow" "$initdir/etc/gshadow"
 }


### PR DESCRIPTION
## Changes

The files `shadow` and `gshadow` do NOT exist when using the commit before f3dacc0.

This commit restores the earlier behavior.

## Checklist
- [x] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it

Fixes #1242
