### PR TITLE
fix(dracut-init): assign real path to srcmods

### DIFF
--- a/dracut-init.sh
+++ b/dracut-init.sh
@@ -58,7 +58,7 @@ if ! [[ $kernel ]]; then
     export kernel
 fi
 
-srcmods="$dracutsysrootdir/lib/modules/$kernel/"
+srcmods="$(realpath -e "$dracutsysrootdir/lib/modules/$kernel")"
 
 [[ $drivers_dir ]] && {
     if ! command -v kmod &> /dev/null && vercmp "$(modprobe --version | cut -d' ' -f3)" lt 3.7; then


### PR DESCRIPTION
On usrmerge systems, `/lib` is a symlink to `/usr/lib`, so the real path of the kernel directory is `/usr/lib/modules/<kver>`. The issue on these systems is that a kernel module can be added to the initrd (via dracut-install) by different dracut modules using both paths, and that causes libkmod to display the following type of errors in the middle of the dracut build:

```
libkmod: ERROR: kmod_module_new_from_path: kmod_module 'nvidia' already exists with different path: new-path='/lib/modules/6.14.1-1-default//weak-updates/updates/nvidia-open-driver-G06-signed-570.133.07/nvidia.ko.zst' old-path='/usr/lib/modules/6.14.1-1-default/weak-updates/updates/nvidia-open-driver-G06-signed-570.133.07/nvidia.ko.zst'
libkmod: ERROR: kmod_module_parse_depline: ctx=0x560bbacad8f0 path=/lib/modules/6.14.1-1-default//weak-updates/updates/nvidia-open-driver-G06-signed-570.133.07/nvidia.ko.zst error=File exists
```

openSUSE bug report: https://bugzilla.opensuse.org/show_bug.cgi?id=1241114

PS: this dracut issue is also documented by nvidia, see https://docs.nvidia.com/networking/display/connectx4lxenocp2/linux+driver+installation

## Checklist
- [ ] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it
