### PR TITLE
test(debian): enable url-lib dracut module testing

### DIFF
--- a/test/container/Dockerfile-debian
+++ b/test/container/Dockerfile-debian
@@ -1,6 +1,7 @@
 # Test coverage provided by this container:
 # - arm64
 # - dash default shell (instead of bash)
+# - curl (url-lib)
 # - mawk (instead of gawk)
 # - zstd compression
 # - verbose logging for tests
@@ -43,6 +44,7 @@ RUN \
     console-data \
     cpio \
     cryptsetup \
+    curl \
     docbook \
     docbook-xml \
     docbook-xsl \


### PR DESCRIPTION
## Changes

NFS test requires url-lib dracut module (and curl).

CC @bdrung @LaszloGombos 

## Checklist
- [ ] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it

