### PR TITLE
ci(opensuse): make sure cpio is explicitelly installed

### DIFF
--- a/test/container/Dockerfile-opensuse
+++ b/test/container/Dockerfile-opensuse
@@ -16,6 +16,7 @@ RUN zypper --non-interactive install --no-recommends \
     bash-completion \
     btrfsprogs \
     cargo \
+    cpio \
     cryptsetup \
     dhcp-client \
     dhcp-server \


### PR DESCRIPTION
## Changes

arm64 CI started to fail with cpio binary missing.

See https://github.com/dracut-ng/dracut-ng/actions/runs/14553893920


## Checklist
- [ ] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it

Fixes #
