### PR TITLE
ci(azurelinux): make sure tar is installed

### DIFF
--- a/test/container/Dockerfile-azurelinux
+++ b/test/container/Dockerfile-azurelinux
@@ -49,6 +49,7 @@ RUN tdnf -y install --setopt=install_weak_deps=False \
     squashfs-tools \
     swtpm \
     systemd-resolved \
+    tar \
     tpm2-tools \
     xfsprogs \
     xorriso \


### PR DESCRIPTION
## Changes

tar is required to download dracut source code before a build.

See https://github.com/dracut-ng/dracut-ng/actions/runs/14553898345

CC @trungams @LaszloGombos @Conan-Kudo 

## Checklist
- [ ] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it

