### PR TITLE
ci: install packages needed to test upcoming dlopen features

### DIFF
--- a/test/container/Dockerfile-arch
+++ b/test/container/Dockerfile-arch
@@ -33,6 +33,7 @@ RUN pacman --noconfirm -Syu \
     erofs-utils \
     gcc \
     jq \
+    libfido2 \
     linux \
     lvm2 \
     make \

--- a/test/container/Dockerfile-arch
+++ b/test/container/Dockerfile-arch
@@ -55,6 +55,7 @@ RUN pacman --noconfirm -Syu \
     sbsigntools \
     squashfs-tools \
     swtpm \
+    systemd-libs \
     systemd-ukify \
     tgt \
     tpm2-tools \

--- a/test/container/Dockerfile-azurelinux
+++ b/test/container/Dockerfile-azurelinux
@@ -48,6 +48,7 @@ RUN tdnf -y install --setopt=install_weak_deps=False \
     rsyslog \
     squashfs-tools \
     swtpm \
+    systemd-devel \
     systemd-resolved \
     tar \
     tpm2-tools \

--- a/test/container/Dockerfile-debian
+++ b/test/container/Dockerfile-debian
@@ -58,6 +58,7 @@ RUN \
     jq \
     kbd \
     kmod \
+    libfido2-1 \
     libkmod-dev \
     libsystemd-dev \
     linux-image-generic \

--- a/test/container/Dockerfile-debian
+++ b/test/container/Dockerfile-debian
@@ -59,6 +59,7 @@ RUN \
     kbd \
     kmod \
     libkmod-dev \
+    libsystemd-dev \
     linux-image-generic \
     lvm2 \
     make \

--- a/test/container/Dockerfile-fedora
+++ b/test/container/Dockerfile-fedora
@@ -65,6 +65,7 @@ RUN dnf -y install --setopt=install_weak_deps=False \
     kdump-utils \
     kernel \
     kmod-devel \
+    libfido2 \
     libkcapi-hmaccalc \
     libselinux-utils \
     lvm2 \

--- a/test/container/Dockerfile-fedora
+++ b/test/container/Dockerfile-fedora
@@ -85,6 +85,7 @@ RUN dnf -y install --setopt=install_weak_deps=False \
     swtpm \
     systemd-boot-unsigned \
     systemd-container \
+    systemd-devel \
     systemd-resolved \
     systemd-ukify \
     tpm2-tools \

--- a/test/container/Dockerfile-gentoo
+++ b/test/container/Dockerfile-gentoo
@@ -66,6 +66,7 @@ if [ "$OPTION" = "systemd" ] ; then \
     app-misc/jq \
     dev-lang/perl \
     dev-lang/rust-bin \
+    dev-libs/libfido2 \
     dev-libs/libxslt \
     dev-libs/openssl \
     net-fs/nfs-utils \

--- a/test/container/Dockerfile-opensuse
+++ b/test/container/Dockerfile-opensuse
@@ -47,6 +47,7 @@ RUN zypper --non-interactive install --no-recommends \
     squashfs \
     swtpm \
     systemd-boot \
+    systemd-devel \
     systemd-experimental \
     systemd-portable \
     tgt \

--- a/test/container/Dockerfile-opensuse
+++ b/test/container/Dockerfile-opensuse
@@ -31,6 +31,7 @@ RUN zypper --non-interactive install --no-recommends \
     iscsiuio \
     kbd \
     kernel-vanilla \
+    libfido2 \
     libkmod-devel \
     lvm2 \
     make \


### PR DESCRIPTION
As requested in #1260.

systemd's fido2 feature is used for testing because nothing else is likely to pull in libfido2.so.1.