### PR TITLE
ci(azurelinux): remove some binaries to workaround test failures

### DIFF
--- a/test/TEST-41-FULL-SYSTEMD/test.sh
+++ b/test/TEST-41-FULL-SYSTEMD/test.sh
@@ -71,7 +71,7 @@ test_setup() {
     trap "$(shopt -p globstar)" RETURN
     shopt -q -s globstar
 
-    local dracut_modules="resume systemd-udevd systemd-journald systemd-tmpfiles systemd-cryptsetup systemd-emergency systemd-ac-power systemd-coredump systemd-creds systemd-integritysetup systemd-ldconfig systemd-pstore systemd-repart systemd-sysext systemd-veritysetup systemd-hostnamed systemd-portabled systemd-timedated"
+    local dracut_modules="resume systemd-udevd systemd-journald systemd-tmpfiles systemd-cryptsetup systemd-emergency systemd-ac-power systemd-coredump systemd-creds systemd-integritysetup systemd-ldconfig systemd-pstore systemd-repart systemd-sysext systemd-veritysetup systemd-hostnamed systemd-timedated"
 
     # TODO - this workaround should not be needed and should be removed
     if [ -f /usr/bin/dbus-broker ]; then
@@ -92,6 +92,9 @@ test_setup() {
     fi
     if [ -f /usr/lib/systemd/systemd-pcrextend ]; then
         dracut_modules="$dracut_modules systemd-pcrphase"
+    fi
+    if [ -f /usr/lib/systemd/systemd-portabled ]; then
+        dracut_modules="$dracut_modules systemd-portabled"
     fi
 
     # Create what will eventually be our root filesystem onto an overlay

--- a/test/container/Dockerfile-azurelinux
+++ b/test/container/Dockerfile-azurelinux
@@ -18,7 +18,6 @@ RUN tdnf -y install --setopt=install_weak_deps=False \
     chrony \
     cifs-utils \
     cryptsetup \
-    device-mapper-multipath \
     dhcpcd \
     e2fsprogs \
     fuse3 \
@@ -54,3 +53,7 @@ RUN tdnf -y install --setopt=install_weak_deps=False \
     xfsprogs \
     xorriso \
     && tdnf clean all
+
+# disable systemd-portabled - it is optional and allows to pass the CI
+RUN \
+    rm -rf /usr/bin/portablectl /usr/lib/systemd/systemd-portabled


### PR DESCRIPTION
## Changes

TEST-41 is failing on azurelinux due to issues with multipath and systemd-portabled dracut modules.

Since this test is passing on many other Linux environments already, this is unlikely an issue with dracut or with the test suite.

Remove binaries to prevent multipath and systemd-portabled dracut modules to be tested until the issues are resolved with the azurelinux container.

CC @trungams 

The failures can be observed at this GH Action - https://github.com/dracut-ng/dracut-ng/actions/workflows/integration-extra.yml

## Checklist
- [ ] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it

Fixes #
