### PR TITLE
fix: improve hostonly sloppy mode

### DIFF
--- a/modules.d/01systemd-cryptsetup/module-setup.sh
+++ b/modules.d/01systemd-cryptsetup/module-setup.sh
@@ -6,7 +6,7 @@ check() {
     # if cryptsetup is not installed, then we cannot support encrypted devices.
     require_binaries "$systemdutildir"/systemd-cryptsetup || return 1
 
-    [[ $hostonly ]] || [[ $mount_needs ]] && {
+    [[ $hostonly_mode == "strict" ]] || [[ $mount_needs ]] && {
         for fs in "${host_fs_types[@]}"; do
             [[ $fs == "crypto_LUKS" ]] && return 0
         done

--- a/modules.d/90btrfs/module-setup.sh
+++ b/modules.d/90btrfs/module-setup.sh
@@ -6,7 +6,7 @@ check() {
     # no point in trying to support it in the initramfs.
     require_binaries btrfs || return 1
 
-    [[ $hostonly ]] || [[ $mount_needs ]] && {
+    [[ $hostonly_mode == "strict" ]] || [[ $mount_needs ]] && {
         for fs in "${host_fs_types[@]}"; do
             [[ $fs == "btrfs" ]] && return 0
         done

--- a/modules.d/90crypt/module-setup.sh
+++ b/modules.d/90crypt/module-setup.sh
@@ -6,7 +6,7 @@ check() {
     # if cryptsetup is not installed, then we cannot support encrypted devices.
     require_any_binary "$systemdutildir"/systemd-cryptsetup cryptsetup || return 1
 
-    [[ $hostonly ]] || [[ $mount_needs ]] && {
+    [[ $hostonly_mode == "strict" ]] || [[ $mount_needs ]] && {
         for fs in "${host_fs_types[@]}"; do
             [[ $fs == "crypto_LUKS" ]] && return 0
         done
@@ -34,7 +34,7 @@ installkernel() {
     # in case some of the crypto modules moved from compiled in
     # to module based, try to install those modules
     # best guess
-    if [[ $hostonly ]] || [[ $mount_needs ]]; then
+    if [[ $hostonly_mode == "strict" ]] || [[ $mount_needs ]]; then
         # dmsetup returns s.th. like
         # cryptvol: 0 2064384 crypt aes-xts-plain64 :64:logon:cryptsetup:....
         dmsetup table | while read -r name _ _ is_crypt cipher _; do

--- a/modules.d/90dmraid/module-setup.sh
+++ b/modules.d/90dmraid/module-setup.sh
@@ -10,7 +10,7 @@ check() {
     require_binaries dmraid || return 1
     require_binaries kpartx || return 1
 
-    [[ $hostonly ]] || [[ $mount_needs ]] && {
+    [[ $hostonly_mode == "strict" ]] || [[ $mount_needs ]] && {
         for dev in "${!host_fs_types[@]}"; do
             [[ ${host_fs_types[$dev]} != *_raid_member ]] && continue
 

--- a/modules.d/90kernel-modules/module-setup.sh
+++ b/modules.d/90kernel-modules/module-setup.sh
@@ -120,9 +120,9 @@ installkernel() {
             fi
         fi
 
-        # if not on hostonly mode, install all known filesystems,
+        # if not on strict hostonly mode, install all known filesystems,
         # if the required list is not set via the filesystems variable
-        if ! [[ $hostonly ]]; then
+        if [[ $hostonly_mode != "strict" ]]; then
             if [[ -z $filesystems ]]; then
                 dracut_instmods -o -P ".*/(kernel/fs/nfs|kernel/fs/nfsd|kernel/fs/lockd)/.*" '=fs'
             fi

--- a/modules.d/90lvm/module-setup.sh
+++ b/modules.d/90lvm/module-setup.sh
@@ -5,7 +5,7 @@ check() {
     # No point trying to support lvm if the binaries are missing
     require_binaries lvm grep || return 1
 
-    [[ $hostonly ]] || [[ $mount_needs ]] && {
+    [[ $hostonly_mode == "strict" ]] || [[ $mount_needs ]] && {
         for fs in "${host_fs_types[@]}"; do
             [[ $fs == LVM*_member ]] && return 0
         done

--- a/modules.d/90mdraid/module-setup.sh
+++ b/modules.d/90mdraid/module-setup.sh
@@ -7,7 +7,7 @@ check() {
     # No mdadm?  No mdraid support.
     require_binaries mdadm expr || return 1
 
-    [[ $hostonly ]] || [[ $mount_needs ]] && {
+    [[ $hostonly_mode == "strict" ]] || [[ $mount_needs ]] && {
         for dev in "${!host_fs_types[@]}"; do
             [[ ${host_fs_types[$dev]} != *_raid_member ]] && continue
 

--- a/modules.d/90multipath/module-setup.sh
+++ b/modules.d/90multipath/module-setup.sh
@@ -25,7 +25,7 @@ check() {
     require_binaries multipath || return 1
     require_binaries kpartx || return 1
 
-    [[ $hostonly ]] || [[ $mount_needs ]] && {
+    [[ $hostonly_mode == "strict" ]] || [[ $mount_needs ]] && {
         for_each_host_dev_and_slaves is_mpath || return 255
     }
 

--- a/modules.d/90qemu-net/module-setup.sh
+++ b/modules.d/90qemu-net/module-setup.sh
@@ -4,7 +4,7 @@
 check() {
     is_qemu_virtualized && return 0
 
-    if [[ $hostonly ]] || [[ $mount_needs ]]; then
+    if [[ $hostonly_mode == "strict" ]] || [[ $mount_needs ]]; then
         return 255
     fi
 

--- a/modules.d/90qemu/module-setup.sh
+++ b/modules.d/90qemu/module-setup.sh
@@ -4,7 +4,7 @@
 check() {
     is_qemu_virtualized && return 0
 
-    if [[ $hostonly ]] || [[ $mount_needs ]]; then
+    if [[ $hostonly_mode == "strict" ]] || [[ $mount_needs ]]; then
         return 255
     fi
 

--- a/modules.d/95cifs/module-setup.sh
+++ b/modules.d/95cifs/module-setup.sh
@@ -5,7 +5,7 @@ check() {
     # If our prerequisites are not met, fail anyways.
     require_binaries mount.cifs || return 1
 
-    [[ $hostonly ]] || [[ $mount_needs ]] && {
+    [[ $hostonly_mode == "strict" ]] || [[ $mount_needs ]] && {
         for fs in "${host_fs_types[@]}"; do
             [[ $fs == "cifs" ]] && return 0
         done

--- a/modules.d/95fcoe-uefi/module-setup.sh
+++ b/modules.d/95fcoe-uefi/module-setup.sh
@@ -7,7 +7,7 @@ check() {
         block_is_fcoe "$1" || return 1
     }
 
-    [[ $hostonly ]] || [[ $mount_needs ]] && {
+    [[ $hostonly_mode == "strict" ]] || [[ $mount_needs ]] && {
         for_each_host_dev_and_slaves is_fcoe || return 255
         [ -d /sys/firmware/efi ] || return 255
     }

--- a/modules.d/95fcoe/module-setup.sh
+++ b/modules.d/95fcoe/module-setup.sh
@@ -7,7 +7,7 @@ check() {
         block_is_fcoe "$1" || return 1
     }
 
-    [[ $hostonly ]] || [[ $mount_needs ]] && {
+    [[ $hostonly_mode == "strict" ]] || [[ $mount_needs ]] && {
         for_each_host_dev_and_slaves is_fcoe || return 255
     }
 

--- a/modules.d/95iscsi/module-setup.sh
+++ b/modules.d/95iscsi/module-setup.sh
@@ -6,9 +6,9 @@ check() {
     require_binaries iscsi-iname iscsiadm iscsid || return 1
     require_kernel_modules iscsi_tcp || return 1
 
-    # If hostonly was requested, fail the check if we are not actually
+    # If hostonly strict was requested, fail the check if we are not actually
     # booting from root.
-    [[ $hostonly ]] || [[ $mount_needs ]] && {
+    [[ $hostonly_mode == "strict" ]] || [[ $mount_needs ]] && {
         pushd . > /dev/null
         for_each_host_dev_and_slaves block_is_iscsi
         local _is_iscsi=$?

--- a/modules.d/95lunmask/module-setup.sh
+++ b/modules.d/95lunmask/module-setup.sh
@@ -45,7 +45,7 @@ cmdline() {
 
 # called by dracut
 check() {
-    [[ $hostonly ]] || [[ $mount_needs ]] && {
+    [[ $hostonly_mode == "strict" ]] || [[ $mount_needs ]] && {
         [ -w /sys/module/scsi_mod/parameters/scan ] || return 255
         read -r scan_type < /sys/module/scsi_mod/parameters/scan
         [ "$scan_type" = "manual" ] && return 0

--- a/modules.d/95nbd/module-setup.sh
+++ b/modules.d/95nbd/module-setup.sh
@@ -6,7 +6,7 @@ check() {
 
     # if an nbd device is not somewhere in the chain of devices root is
     # mounted on, fail the hostonly check.
-    [[ $hostonly ]] || [[ $mount_needs ]] && {
+    [[ $hostonly_mode == "strict" ]] || [[ $mount_needs ]] && {
         _rootdev=$(find_root_block_device)
         [[ -b /dev/block/$_rootdev ]] || return 1
         check_block_and_slaves block_is_nbd "$_rootdev" || return 255

--- a/modules.d/95nfs/module-setup.sh
+++ b/modules.d/95nfs/module-setup.sh
@@ -23,7 +23,7 @@ check() {
     require_any_binary rpcbind portmap || return 1
     require_binaries rpc.statd mount.nfs mount.nfs4 umount sed chmod chown || return 1
 
-    [[ $hostonly ]] || [[ $mount_needs ]] && {
+    [[ $hostonly_mode == "strict" ]] || [[ $mount_needs ]] && {
         [[ "$(get_nfs_type)" ]] && return 0
         return 255
     }

--- a/modules.d/95nvmf/module-setup.sh
+++ b/modules.d/95nvmf/module-setup.sh
@@ -42,7 +42,7 @@ check() {
         [[ $found ]]
     }
 
-    [[ $hostonly ]] || [[ $mount_needs ]] && {
+    [[ $hostonly_mode == "strict" ]] || [[ $mount_needs ]] && {
         [ -f /etc/nvme/hostnqn ] || return 255
         [ -f /etc/nvme/hostid ] || return 255
         pushd . > /dev/null

--- a/modules.d/95virtiofs/module-setup.sh
+++ b/modules.d/95virtiofs/module-setup.sh
@@ -2,7 +2,7 @@
 
 # called by dracut
 check() {
-    [[ $hostonly ]] || [[ $mount_needs ]] && {
+    [[ $hostonly_mode == "strict" ]] || [[ $mount_needs ]] && {
         is_qemu_virtualized && return 0
 
         for fs in "${host_fs_types[@]}"; do

--- a/modules.d/99fs-lib/module-setup.sh
+++ b/modules.d/99fs-lib/module-setup.sh
@@ -36,7 +36,7 @@ include_fs_helper_modules() {
 # called by dracut
 installkernel() {
     # xfs/btrfs/ext4 need crc32c, f2fs needs crc32
-    if [[ $hostonly ]]; then
+    if [[ $hostonly_mode == "strict" ]]; then
         for_each_host_dev_fs include_fs_helper_modules
         :
     else
@@ -59,7 +59,7 @@ install() {
             xfs_db xfs_check xfs_repair xfs_metadump
             e2fsck jfs_fsck btrfsck
         )
-        if [[ $hostonly ]]; then
+        if [[ $hostonly_mode == "strict" ]]; then
             read -r -a _helpers < <(for_each_host_dev_fs echo_fs_helper)
         fi
     else


### PR DESCRIPTION
## Changes

Sloppy mode is the original hostonly mode.
    
Strict mode was newly introduced much later in 2018 ([v048](https://github.com/dracut-ng/dracut-ng/blob/main/NEWS.md#dracut-048)) as a non-default opt-in special optimization mode to allow modules to ignore more drivers or do some extra job to save memory and disk space, while making the image less portable.
    
This PR includes more dracut modules (and with that more kernel modules) in sloppy mode.

## Checklist
- [ ] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it

Fixes #
