### PR TITLE
ci(fedora): test 61 (MULTINIC) is failing on Fedora

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -183,6 +183,9 @@ jobs:
                     # on openSUSE run tests with network-legacy
                     - container: "opensuse:latest"
                       network: "network-legacy"
+                exclude:
+                    - container: fedora:latest
+                      test: "61"
         container:
             image: ghcr.io/dracut-ng/${{ matrix.container }}-amd
             options: '--device=/dev/kvm'


### PR DESCRIPTION
## Changes

This test is only flaky on Fedora and it needs several times to retry on each PR.

Let's disable it and let the Fedora team investigate it.

Filed https://github.com/dracut-ng/dracut-ng/issues/1284 to reenable.

## Checklist
- [ ] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it

