### PR TITLE
fix(dracut): kernel module name normalization in drivers lists

### DIFF
--- a/dracut.sh
+++ b/dracut.sh
@@ -1436,16 +1436,16 @@ dracutfunctions=$dracutbasedir/dracut-functions.sh
 export dracutfunctions
 
 ((${#drivers_l[@]})) && drivers="${drivers_l[*]}"
-drivers=${drivers/-/_}
+drivers=${drivers//-/_}
 
 ((${#add_drivers_l[@]})) && add_drivers+=" ${add_drivers_l[*]} "
-add_drivers=${add_drivers/-/_}
+add_drivers=${add_drivers//-/_}
 
 ((${#force_drivers_l[@]})) && force_drivers+=" ${force_drivers_l[*]} "
-force_drivers=${force_drivers/-/_}
+force_drivers=${force_drivers//-/_}
 
 ((${#omit_drivers_l[@]})) && omit_drivers+=" ${omit_drivers_l[*]} "
-omit_drivers=${omit_drivers/-/_}
+omit_drivers=${omit_drivers//-/_}
 
 ((${#kernel_cmdline_l[@]})) && kernel_cmdline+=" ${kernel_cmdline_l[*]} "
 


### PR DESCRIPTION
## Changes
In drivers/add_drivers/force_drivers/omit_drivers kernel modules lists replace all occurrences of "-" with "_", not only the first one!

## Checklist
[x ] I have tested it locally
[ x] I have reviewed and updated any documentation if relevant

## Fixes 
The issue that kernel modules in drivers/add_drivers/force_drivers/omit_drivers modules lists with "-" in their name are ignored except the first module with only one "-" in its name.