### PR TITLE
fix: load more kernel modules in sloppy hostonly mode

### DIFF
--- a/man/dracut.modules.7.adoc
+++ b/man/dracut.modules.7.adoc
@@ -332,6 +332,15 @@ To install a kernel module regardless of the hostonly mode use the form:
 hostonly='' instmods <kernelmodule>
 ----
 
+a common pattern to call instmods is to use the following form:
+----
+`hostonly=$(optional_hostonly) instmods <kernelmodule>`
+----
+This statement installs the kernel module in either of the following conditions:
+* in non-hostonly mode (regardless of the host state)
+* in `sloppy` hostonly mode (regardless of the host state)
+* in hostonly mode if the kernel module is already loaded in the host
+
 options:
 
 -c:: check that kernel modules exists and can be installed (i.e., not optional).

--- a/modules.d/00systemd/module-setup.sh
+++ b/modules.d/00systemd/module-setup.sh
@@ -16,7 +16,7 @@ check() {
 
 installkernel() {
     hostonly='' instmods autofs4 ipv6 dmi-sysfs
-    instmods -s efivarfs
+    hostonly=$(optional_hostonly) instmods -s efivarfs
 }
 
 # called by dracut

--- a/modules.d/01systemd-integritysetup/module-setup.sh
+++ b/modules.d/01systemd-integritysetup/module-setup.sh
@@ -28,7 +28,7 @@ depends() {
 
 # Install kernel module(s).
 installkernel() {
-    instmods dm-integrity
+    hostonly='' instmods dm-integrity
 }
 
 # Install the required file(s) and directories for the module in the initramfs.

--- a/modules.d/01systemd-portabled/module-setup.sh
+++ b/modules.d/01systemd-portabled/module-setup.sh
@@ -28,7 +28,7 @@ depends() {
 
 # Install kernel module(s).
 installkernel() {
-    instmods loop squashfs
+    hostonly=$(optional_hostonly) instmods loop squashfs
 }
 
 # Install the required file(s) and directories for the module in the initramfs.

--- a/modules.d/01systemd-pstore/module-setup.sh
+++ b/modules.d/01systemd-pstore/module-setup.sh
@@ -25,7 +25,7 @@ depends() {
 
 # Install kernel module(s).
 installkernel() {
-    instmods efi-pstore
+    hostonly='' instmods efi-pstore
 }
 
 # Install the required file(s) and directories for the module in the initramfs.

--- a/modules.d/01systemd-veritysetup/module-setup.sh
+++ b/modules.d/01systemd-veritysetup/module-setup.sh
@@ -28,7 +28,7 @@ depends() {
 
 # Install kernel module(s).
 installkernel() {
-    instmods dm-verity
+    hostonly='' instmods dm-verity
 }
 
 # Install the required file(s) and directories for the module in the initramfs.

--- a/modules.d/04watchdog-modules/module-setup.sh
+++ b/modules.d/04watchdog-modules/module-setup.sh
@@ -13,7 +13,7 @@ installkernel() {
         ! [ -e "$_wd" ] && continue
         _wdtdrv=$(get_dev_module "$_wd")
         if [[ $_wdtdrv ]]; then
-            instmods "$_wdtdrv"
+            hostonly=$(optional_hostonly) instmods "$_wdtdrv"
             for i in $_wdtdrv; do
                 _drivers[$i]=1
             done

--- a/modules.d/35network-manager/module-setup.sh
+++ b/modules.d/35network-manager/module-setup.sh
@@ -16,7 +16,7 @@ depends() {
 
 # called by dracut
 installkernel() {
-    instmods nf_tables nfnetlink nft_fwd_netdev
+    hostonly=$(optional_hostonly) instmods nf_tables nfnetlink nft_fwd_netdev
 }
 
 # called by dracut

--- a/modules.d/45drm/module-setup.sh
+++ b/modules.d/45drm/module-setup.sh
@@ -11,14 +11,14 @@ installkernel() {
 
     if [[ ${DRACUT_ARCH:-$(uname -m)} == arm* || ${DRACUT_ARCH:-$(uname -m)} == aarch64 ]]; then
         # arm/aarch64 specific modules needed by drm
-        instmods \
+        hostonly=$(optional_hostonly) instmods \
             "=drivers/gpu/drm/i2c" \
             "=drivers/gpu/drm/panel" \
             "=drivers/gpu/drm/bridge" \
             "=drivers/video/backlight"
     fi
 
-    instmods amdkfd hyperv_fb "=drivers/pwm"
+    hostonly=$(optional_hostonly) instmods amdkfd hyperv_fb "=drivers/pwm"
 
     # if the hardware is present, include module even if it is not currently loaded,
     # as we could e.g. be in the installer; nokmsboot boot parameter will disable
@@ -47,7 +47,7 @@ installkernel() {
             [[ -L $i ]] || continue
             modlink=$(readlink "$i")
             modname=$(basename "$modlink")
-            instmods "$modname"
+            hostonly=$(optional_hostonly) instmods "$modname"
         done
     else
         dracut_instmods -o -s "drm_crtc_init|drm_dev_register|drm_encoder_init" "=drivers/gpu/drm" "=drivers/staging"

--- a/modules.d/45simpledrm/module-setup.sh
+++ b/modules.d/45simpledrm/module-setup.sh
@@ -8,9 +8,9 @@ check() {
 # called by dracut
 installkernel() {
     # Include simple DRM driver
-    instmods simpledrm
+    hostonly='' instmods simpledrm
 
-    if [[ $hostonly ]]; then
+    if [[ $hostonly_mode == "strict" ]]; then
         # if there is a privacy screen then its driver must be loaded before the
         # kms driver will bind, otherwise its probe() will return -EPROBE_DEFER
         # note privacy screens always register, even with e.g. nokmsboot
@@ -18,7 +18,7 @@ installkernel() {
             [[ -L $i ]] || continue
             modlink=$(readlink "$i")
             modname=$(basename "$modlink")
-            instmods "$modname"
+            hostonly='' instmods "$modname"
         done
     else
         # include privacy screen providers (see above comment)

--- a/modules.d/62bluetooth/module-setup.sh
+++ b/modules.d/62bluetooth/module-setup.sh
@@ -29,7 +29,7 @@ depends() {
 }
 
 installkernel() {
-    instmods bluetooth btrtl btintel btbcm bnep ath3k btusb rfcomm hidp
+    hostonly=$(optional_hostonly) instmods bluetooth btrtl btintel btbcm bnep ath3k btusb rfcomm hidp
     inst_multiple -o \
         /lib/firmware/ar3k/AthrBT* \
         /lib/firmware/ar3k/ramps* \

--- a/modules.d/90btrfs/module-setup.sh
+++ b/modules.d/90btrfs/module-setup.sh
@@ -31,7 +31,7 @@ cmdline() {
 
 # called by dracut
 installkernel() {
-    instmods btrfs
+    hostonly='' instmods btrfs
     printf "%s\n" "$(cmdline)" > "${initdir}/etc/cmdline.d/00-btrfs.conf"
 }
 

--- a/modules.d/90crypt/module-setup.sh
+++ b/modules.d/90crypt/module-setup.sh
@@ -51,7 +51,7 @@ installkernel() {
             fi
         done
     else
-        instmods "=crypto"
+        hostonly='' instmods "=crypto"
     fi
     return 0
 }

--- a/modules.d/90dm/module-setup.sh
+++ b/modules.d/90dm/module-setup.sh
@@ -8,7 +8,7 @@ check() {
 
 # called by dracut
 installkernel() {
-    instmods '=drivers/md' dm_mod dm-cache dm-cache-mq dm-cache-cleaner
+    hostonly=$(optional_hostonly) instmods '=drivers/md' dm_mod dm-cache dm-cache-mq dm-cache-cleaner
 }
 
 # called by dracut

--- a/modules.d/90dmsquash-live-autooverlay/module-setup.sh
+++ b/modules.d/90dmsquash-live-autooverlay/module-setup.sh
@@ -12,7 +12,7 @@ depends() {
 }
 
 installkernel() {
-    instmods btrfs ext4 xfs
+    hostonly='' instmods btrfs ext4 xfs
 }
 
 install() {

--- a/modules.d/90dmsquash-live/module-setup.sh
+++ b/modules.d/90dmsquash-live/module-setup.sh
@@ -17,7 +17,7 @@ depends() {
 
 # called by dracut
 installkernel() {
-    instmods squashfs loop iso9660 erofs
+    hostonly='' instmods squashfs loop iso9660 erofs
 }
 
 # called by dracut

--- a/modules.d/90kernel-modules/module-setup.sh
+++ b/modules.d/90kernel-modules/module-setup.sh
@@ -25,7 +25,7 @@ installkernel() {
     }
 
     install_block_modules() {
-        instmods \
+        hostonly=$(optional_hostonly) instmods \
             scsi_dh_rdac scsi_dh_emc scsi_dh_alua \
             =drivers/usb/storage \
             =ide nvme vmd \
@@ -58,7 +58,7 @@ installkernel() {
             "=drivers/usb/typec" \
             "=drivers/watchdog"
 
-        instmods \
+        hostonly=$(optional_hostonly) instmods \
             yenta_socket intel_lpss_pci spi_pxa2xx_platform \
             atkbd i8042 firewire-ohci hv-vmbus \
             virtio virtio_ring virtio_pci pci_hyperv \
@@ -67,7 +67,7 @@ installkernel() {
         if [[ ${DRACUT_ARCH:-$(uname -m)} == arm* || ${DRACUT_ARCH:-$(uname -m)} == aarch64 || ${DRACUT_ARCH:-$(uname -m)} == riscv* ]]; then
             # arm/aarch64 specific modules
             _blockfuncs+='|dw_mc_probe|dw_mci_pltfm_register|nvme_init_ctrl'
-            instmods \
+            hostonly=$(optional_hostonly) instmods \
                 "=drivers/clk" \
                 "=drivers/devfreq" \
                 "=drivers/dma" \
@@ -138,7 +138,7 @@ installkernel() {
         [[ $arch == s390x ]] && arch=s390
         [[ $arch == aarch64 ]] && arch=arm64
         hostonly='' instmods "=crypto"
-        instmods "=arch/$arch/crypto" "=drivers/crypto"
+        hostonly=$(optional_hostonly) instmods "=arch/$arch/crypto" "=drivers/crypto"
     fi
 
     inst_multiple -o "$depmodd/*.conf"

--- a/modules.d/90kernel-network-modules/module-setup.sh
+++ b/modules.d/90kernel-network-modules/module-setup.sh
@@ -31,7 +31,7 @@ installkernel() {
 
     dracut_instmods -o -P ".*${_unwanted_drivers}.*" -s "$_net_symbols" "=drivers/net"
     #instmods() will take care of hostonly
-    instmods \
+    hostonly=$(optional_hostonly) instmods \
         '=drivers/net/mdio' \
         '=drivers/net/phy' \
         '=drivers/net/team' \

--- a/modules.d/90mdraid/module-setup.sh
+++ b/modules.d/90mdraid/module-setup.sh
@@ -34,7 +34,7 @@ depends() {
 
 # called by dracut
 installkernel() {
-    instmods '=drivers/md'
+    hostonly=$(optional_hostonly) instmods '=drivers/md'
 }
 
 # called by dracut

--- a/modules.d/90pcmcia/module-setup.sh
+++ b/modules.d/90pcmcia/module-setup.sh
@@ -13,7 +13,7 @@ depends() {
 
 # called by dracut
 installkernel() {
-    instmods pcmcia \
+    hostonly=$(optional_hostonly) instmods pcmcia \
         "=drivers/pcmcia"
 }
 

--- a/modules.d/90ppcmac/module-setup.sh
+++ b/modules.d/90ppcmac/module-setup.sh
@@ -33,16 +33,16 @@ installkernel() {
 
     # only PowerMac3,6 has a module, special case
     if [[ ${DRACUT_ARCH:-$(uname -m)} != ppc64* ]]; then
-        if ! [[ $hostonly ]] || [[ "$(pmac_model)" == "PowerMac3,6" ]]; then
-            instmods therm_windtunnel
+        if [[ $hostonly_mode != "strict" ]] || [[ $hostonly && "$(pmac_model)" == "PowerMac3,6" ]]; then
+            hostonly=$(optional_hostonly) instmods therm_windtunnel
         fi
         return 0
     fi
 
     windfarm_modules() {
-        if ! [[ $hostonly ]]; then
-            # include all drivers when not hostonly
-            instmods \
+        if [[ $hostonly_mode != "strict" ]]; then
+            # include all drivers when not hostonly or sloppy hostonly
+            hostonly='' instmods \
                 windfarm_pm72 windfarm_pm81 windfarm_pm91 windfarm_pm112 \
                 windfarm_pm121 windfarm_rm31
         else

--- a/modules.d/91tpm2-tss/module-setup.sh
+++ b/modules.d/91tpm2-tss/module-setup.sh
@@ -25,7 +25,7 @@ depends() {
 
 # Install kernel module(s).
 installkernel() {
-    instmods '=drivers/char/tpm'
+    hostonly=$(optional_hostonly) instmods '=drivers/char/tpm'
 }
 
 # Install the required file(s) and directories for the module in the initramfs.

--- a/modules.d/95cifs/module-setup.sh
+++ b/modules.d/95cifs/module-setup.sh
@@ -23,13 +23,13 @@ depends() {
 
 # called by dracut
 installkernel() {
-    instmods cifs ipv6
+    hostonly=$(optional_hostonly) instmods cifs ipv6
     # hash algos
-    instmods md4 md5 sha256 sha512
+    hostonly=$(optional_hostonly) instmods md4 md5 sha256 sha512
     # ciphers
-    instmods aes arc4 des ecb gcm aead2
+    hostonly=$(optional_hostonly) instmods aes arc4 des ecb gcm aead2
     # macs
-    instmods hmac cmac ccm
+    hostonly=$(optional_hostonly) instmods hmac cmac ccm
 }
 
 # called by dracut

--- a/modules.d/95fcoe/module-setup.sh
+++ b/modules.d/95fcoe/module-setup.sh
@@ -23,7 +23,7 @@ depends() {
 
 # called by dracut
 installkernel() {
-    instmods fcoe libfcoe 8021q edd bnx2fc
+    hostonly=$(optional_hostonly) instmods fcoe libfcoe 8021q edd bnx2fc
 }
 
 get_vlan_parent() {

--- a/modules.d/95iscsi/module-setup.sh
+++ b/modules.d/95iscsi/module-setup.sh
@@ -162,7 +162,7 @@ installkernel() {
     local _arch=${DRACUT_ARCH:-$(uname -m)}
     local _funcs='iscsi_register_transport'
 
-    instmods bnx2i qla4xxx cxgb3i cxgb4i be2iscsi qedi
+    hostonly=$(optional_hostonly) instmods bnx2i qla4xxx cxgb3i cxgb4i be2iscsi qedi
     hostonly="" instmods iscsi_tcp iscsi_ibft crc32c iscsi_boot_sysfs 8021q
 
     if [ "$_arch" = "s390" ] || [ "$_arch" = "s390x" ]; then

--- a/modules.d/95nbd/module-setup.sh
+++ b/modules.d/95nbd/module-setup.sh
@@ -24,7 +24,7 @@ depends() {
 
 # called by dracut
 installkernel() {
-    instmods nbd
+    hostonly='' instmods nbd
 }
 
 # called by dracut

--- a/modules.d/95nvmf/module-setup.sh
+++ b/modules.d/95nvmf/module-setup.sh
@@ -69,7 +69,7 @@ depends() {
 
 # called by dracut
 installkernel() {
-    instmods nvme_fc nvme_tcp nvme_rdma lpfc qla2xxx
+    hostonly=$(optional_hostonly) instmods nvme_fc nvme_tcp nvme_rdma lpfc qla2xxx
     # 802.1q VLAN may be set up in Firmware later. Include the module always.
     hostonly="" instmods 8021q
 }

--- a/modules.d/95virtfs/module-setup.sh
+++ b/modules.d/95virtfs/module-setup.sh
@@ -16,7 +16,7 @@ check() {
 
 # called by dracut
 installkernel() {
-    instmods 9p 9pnet_virtio virtio_pci
+    hostonly=$(optional_hostonly) instmods 9p 9pnet_virtio virtio_pci
 }
 
 # called by dracut

--- a/modules.d/95virtiofs/module-setup.sh
+++ b/modules.d/95virtiofs/module-setup.sh
@@ -21,7 +21,7 @@ depends() {
 
 # called by dracut
 installkernel() {
-    instmods virtiofs virtio_pci
+    hostonly='' instmods virtiofs virtio_pci
 }
 
 # called by dracut

--- a/modules.d/97masterkey/module-setup.sh
+++ b/modules.d/97masterkey/module-setup.sh
@@ -11,7 +11,7 @@ check() {
 
 # called by dracut
 installkernel() {
-    instmods trusted encrypted
+    hostonly=$(optional_hostonly) instmods trusted encrypted
 }
 
 # called by dracut

--- a/modules.d/98ecryptfs/module-setup.sh
+++ b/modules.d/98ecryptfs/module-setup.sh
@@ -13,7 +13,7 @@ depends() {
 
 # called by dracut
 installkernel() {
-    instmods ecryptfs
+    hostonly='' instmods ecryptfs
 }
 
 # called by dracut

--- a/modules.d/99fs-lib/module-setup.sh
+++ b/modules.d/99fs-lib/module-setup.sh
@@ -40,7 +40,7 @@ installkernel() {
         for_each_host_dev_fs include_fs_helper_modules
         :
     else
-        instmods crc32c crc32
+        hostonly='' instmods crc32c crc32
     fi
 }
 


### PR DESCRIPTION
## Changes

When `hostonly_mode` is set (e.g. to either `sloppy` or `strict`) `instmods` consults the host for currently loaded kernel modules and refuses to copy the Linux kernel module into the generated initramfs unless the kernel module is already loaded on the host.

Let's set `hostonly` variable explicitly to handle `sloppy` better before calling `instmods`.

For compatibility, we should not change the default in the `instmods` function itself.

The `hostonly=$(optional_hostonly) instmods` pattern is already used in some modules - e.g. https://github.com/dracut-ng/dracut-ng/blob/main/modules.d/95nfs/module-setup.sh#L41

See also https://github.com/dracut-ng/dracut-ng/blob/main/dracut-init.sh#L380 

CC @dalto8  @ArrayBolt3  @bdrung @LaszloGombos @Conan-Kudo 

## Checklist
- [x] I have tested it locally
- [x] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it

Fixes #748 https://github.com/dracutdevs/dracut/issues/2687
