### PR TITLE
fix(rngd): adjust license to match the license of the whole project

### DIFF
--- a/modules.d/06rngd/module-setup.sh
+++ b/modules.d/06rngd/module-setup.sh
@@ -6,7 +6,7 @@
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
-# the Free Software Foundation, either version 3 of the License, or
+# the Free Software Foundation, either version 2 of the License, or
 # (at your option) any later version.
 #
 # This program is distributed in the hope that it will be useful,


### PR DESCRIPTION
As confirmed by the original author: @rmetrich `Renaud Métrich <rmetrich@redhat.com>` in https://github.com/dracut-ng/dracut-ng/issues/1286

This file was originally licensed under GPL-3+ but that was not intentional, instead relicense it under GPL-2+ to match the project license.

## Changes
Change license of  `modules.d/06rngd/module-setup.sh`

## Checklist
- [x] I have tested it locally
- [x] I have reviewed and updated any documentation if relevant
- [x] I am providing new code and test(s) for it

Fixes #1286
