### PR TITLE
fix(base): tighten /dev/pts permissions

### DIFF
--- a/modules.d/99base/init.sh
+++ b/modules.d/99base/init.sh
@@ -55,7 +55,7 @@ fi
 
 if ! ismounted /dev/pts; then
     mkdir -m 0755 -p /dev/pts
-    mount -t devpts -o gid=5,mode=620,noexec,nosuid devpts /dev/pts > /dev/null
+    mount -t devpts -o gid=5,mode=600,noexec,nosuid devpts /dev/pts > /dev/null
 fi
 
 if ! ismounted /dev/shm; then


### PR DESCRIPTION
## Changes

This PR only impacts non-systemd based initramfs.

Inspired by https://salsa.debian.org/kernel-team/initramfs-tools/-/commit/319cdc98f15d3213f58610141a84b5c67a8a1ebc

## Checklist
- [ ] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it

Fixes #
