### PR TITLE
fix(man): --include can be specified multiple times

### DIFF
--- a/man/dracut.usage.adoc
+++ b/man/dracut.usage.adoc
@@ -249,8 +249,7 @@ For example
 # dracut --include cmdline-preset /etc/cmdline.d/mycmdline.conf initramfs-cmdline-pre.img
 ----
 will create an initramfs image, where the file cmdline-preset will be copied
-inside the initramfs to _/etc/cmdline.d/mycmdline.conf_. --include can only
-be specified once.
+inside the initramfs to _/etc/cmdline.d/mycmdline.conf_.
 
 [,console]
 ----


### PR DESCRIPTION
Seems this documentation bug was there from the very beginning - see 2d9f5858b

## Checklist
- [ ] I have tested it locally
- [X] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it

Fixes #957
