### PR TITLE
fix(squash-erofs): fix configuration in order to match SquashFS

### DIFF
--- a/modules.d/95squash-erofs/module-setup.sh
+++ b/modules.d/95squash-erofs/module-setup.sh
@@ -22,13 +22,21 @@ erofs_installpost() {
 
     # --exclude-path requires a relative path
     _erofs_args+=("--exclude-path=${squashdir#"$initdir"/}")
+    # In order to match the default SquashFS "block size"
+    _erofs_args+=("-C" "65536")
     _erofs_args+=("-E" "fragments")
+    # In order to match the SquashFS `-no-xattrs`
+    _erofs_args+=("-x" "-1")
+    # Clear UUID instead of randomness for the image reproducibility
+    _erofs_args+=("-U" "00000000-0000-0000-0000-000000000000")
+    # Clear inode timestamps for smaller image size
+    _erofs_args+=("-T" "0")
 
     if [[ -n $squash_compress ]]; then
         if mkfs.erofs "${_erofs_args[@]}" -z "$squash_compress" "$_img" "$initdir" &> /dev/null; then
             return
         fi
-        dwarn "mkfs.erofs doesn't support compressor '$squash_compress', failing back to default compressor."
+        dwarn "mkfs.erofs doesn't support compressor '$squash_compress', failing back to no compression."
     fi
 
     if ! mkfs.erofs "${_erofs_args[@]}" "$_img" "$initdir" &> /dev/null; then


### PR DESCRIPTION
This pull request changes...

## Changes
 - `-C 65536` should be specified to match the default setup `-b 131072` for SquashFS;

 - `-x -1` should be specified to match the SquashFS `-no-xattrs`;

 - `-U 00000000-0000-0000-0000-000000000000` for reproducibility;

 - `-T 0` can be specified to clear all inode timestamps for reduced metadata since I'm not sure timestamps are needed for dracut.

## Checklist
- [ ] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it

Fixes #
