### PR TITLE
fix(systemd-cryptsetup): improve PKCS#11 smart card support

### DIFF
--- a/modules.d/01systemd-cryptsetup/module-setup.sh
+++ b/modules.d/01systemd-cryptsetup/module-setup.sh
@@ -25,13 +25,13 @@ depends() {
             deps+=" fido2"
         fi
         if grep -q "pkcs11-uri" "$dracutsysrootdir"/etc/crypttab; then
-            deps+=" pkcs11"
+            deps+=" pkcs11 pcsc"
         fi
         if grep -q "tpm2-device=" "$dracutsysrootdir"/etc/crypttab; then
             deps+=" tpm2-tss"
         fi
     elif [[ ! $hostonly ]]; then
-        for module in fido2 pkcs11 tpm2-tss; do
+        for module in fido2 pkcs11 pcsc tpm2-tss; do
             module_check $module > /dev/null 2>&1
             if [[ $? == 255 ]]; then
                 deps+=" $module"


### PR DESCRIPTION
## Changes

When the need for `pkcs11` dracut module is detected from `/etc/crypttab` include `pcsc` dracut module as well.

## Checklist
- [ ] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it

CC @yrro @chewi 

Fixes #1298
