### PR TITLE
ci(opensuse): typo that regressed arm runners

### DIFF
--- a/test/container/Dockerfile-opensuse
+++ b/test/container/Dockerfile-opensuse
@@ -60,6 +60,6 @@ RUN zypper --non-interactive install --no-recommends \
 # workaround for openSUSE on arm64
 # force strict hostonly mode to increase test coverage
 RUN \
-    echo 'hostonly_mode="strict"' > /usr/lib/dracut/dracut.conf.d/02-dist.conf \
+    echo 'hostonly_mode="strict"' > /usr/lib/dracut/dracut.conf.d/02-dist.conf ;\
     KVERSION="$(cd /lib/modules && ls -1 | tail -1)" \
     && if [ "$(arch)"="aarch64" ] && [ -e /usr/lib/modules/"$KVERSION"/Image ]; then ln -sf /usr/lib/modules/"$KVERSION"/Image /usr/lib/modules/"$KVERSION"/vmlinuz; fi


### PR DESCRIPTION
Follow-up fix for cce3ba858ae2aab998443efa31497baee93352d3

## Checklist
- [ ] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it

Fixes #
