### PR TITLE
feat: Add support for removing files/directories from initramfs

### DIFF
--- a/dracut.sh
+++ b/dracut.sh
@@ -233,6 +233,8 @@ Creates initial ramdisk images for preloading modules
                          in the final initramfs.
   -I, --install [LIST]  Install the space separated list of files into the
                          initramfs.
+  --remove      [LIST]  Remove a space-separated list of files and directories
+                        from the initramfs.
   --install-optional [LIST]
                         Install the space separated list of files into the
                          initramfs, if they exist.
@@ -484,6 +486,7 @@ rearrange_params() {
             --long hostonly-nics: \
             --long no-machineid \
             --long version \
+            --long remove: \
             -- "$@"
     )
 
@@ -658,6 +661,11 @@ while :; do
             ;;
         -I | --install)
             install_items_l+=("$2")
+            PARMS_TO_STORE+=" '$2'"
+            shift
+            ;;
+        --remove)
+            remove_items_l+=("$2")
             PARMS_TO_STORE+=" '$2'"
             shift
             ;;
@@ -1092,6 +1100,7 @@ export SYSTEMCTL=${SYSTEMCTL:-systemctl}
 ((${#fscks_l[@]})) && fscks+=" ${fscks_l[*]} "
 ((${#add_fstab_l[@]})) && add_fstab+=" ${add_fstab_l[*]} "
 ((${#install_items_l[@]})) && install_items+=" ${install_items_l[*]} "
+((${#remove_items_l[@]})) && remove_items+=" ${remove_items_l[*]} "
 ((${#install_optional_items_l[@]})) && install_optional_items+=" ${install_optional_items_l[*]} "
 ((${#hostonly_nics_l[@]})) && hostonly_nics+=" ${hostonly_nics_l[*]} "
 
@@ -2432,6 +2441,11 @@ if dracut_module_included "squash-lib"; then
     # Skip initramfs compress
     compress="cat"
 fi
+
+# remove items
+for items in $remove_items; do
+    rm -rf -- "${initdir:?}/${items:?}"
+done
 
 # protect existing output file against build errors
 if [[ -e $outfile ]]; then

--- a/man/dracut.8.adoc
+++ b/man/dracut.8.adoc
@@ -455,6 +455,9 @@ example:
 ----
 ===============================
 
+**--remove** _<file/dir list>_::
+    Remove a space-separated list of files and directories from the initramfs.
+
 **--install-optional** _<file list>_::
     Install the space separated list of files into the initramfs, if they exist.
 

--- a/man/dracut.conf.5.adoc
+++ b/man/dracut.conf.5.adoc
@@ -105,6 +105,13 @@ Specify a space-separated list of directories where to look for libraries.
 *install_items+=*" __<file>__[ __<file>__ ...] "::
 Specify additional files to include in the initramfs, separated by spaces.
 
+*remove_items+=*" __<file/dir>__[ __<file/dir>__ ...] "::
+Specify additional files or directories to remove from the generated initramfs,
+separated by spaces.
+Warning: Avoid manually removing files or directories, as you may inadvertently
+remove essential ones that dracut won't detect or warn you about.
+Using this option is not recommended and is at your own risk.
+
 *install_optional_items+=*" __<file>__[ __<file>__ ...] "::
 Specify additional files to include in the initramfs, separated by spaces,
 if they exist.


### PR DESCRIPTION
## Changes

Add support for removing files/directories from initramfs.

This enhancement adds a configuration option which mirrors the                                                                                                                                                                        
behavior of the `--include` command line option, but instead if adding                                                                                                                                                                  
files/directories, it removes them. 


## Checklist
- [ ] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it

Fixes #1297

CC @LaszloGombos @ericcurtin @nagmat84 
