### PR TITLE
fix(multipath): disable user_friendly_names with mpathconf

### DIFF
--- a/modules.d/90multipath/multipathd-configure.service
+++ b/modules.d/90multipath/multipathd-configure.service
@@ -15,7 +15,7 @@ Type=oneshot
 RemainAfterExit=yes
 # mpathconf requires /etc/multipath to already exist
 ExecStartPre=-/usr/bin/mkdir -p /etc/multipath
-ExecStart=/usr/sbin/mpathconf --enable
+ExecStart=/usr/sbin/mpathconf --enable --user_friendly_names n
 
 [Install]
 WantedBy=sysinit.target

--- a/modules.d/90multipath/multipathd.sh
+++ b/modules.d/90multipath/multipathd.sh
@@ -5,7 +5,7 @@ command -v getarg > /dev/null || . /lib/dracut-lib.sh
 if [ "$(getarg rd.multipath)" = "default" ] && [ ! -e /etc/multipath.conf ]; then
     # mpathconf requires /etc/multipath to already exist
     mkdir -p /etc/multipath
-    mpathconf --enable
+    mpathconf --enable --user_friendly_names n
 fi
 
 if getargbool 1 rd.multipath && [ -e /etc/multipath.conf ]; then


### PR DESCRIPTION
If dracut is creating /etc/multipath.conf by calling mpathconf in either multipathd-configure.service or multipathd.sh, there is a chance that the multipath config in the real root differs. Specifically, it might have chosen different user_friendly_names for the devices. When the systems switches to the real root, multipath may not be able to switch the devices to their configured names because those might already be in use. To avoid this, call mpathconf with "--user_friendly_names n" to create a multipath.conf with user_friendly_names disabled. If all devices use WWID names, it is always possible for multipath to rename them later.

Fixes b8a92b715 ("multipath: add automatic configuration for multipath")

This pull request changes...

## Changes

## Checklist
- [x] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it

Fixes #
