### PR TITLE
fix(simpledrm): add =drivers/gpu/drm/panel on ARM

### DIFF
--- a/modules.d/45simpledrm/module-setup.sh
+++ b/modules.d/45simpledrm/module-setup.sh
@@ -8,7 +8,7 @@ check() {
 # called by dracut
 installkernel() {
     # Include simple DRM driver
-    hostonly='' instmods simpledrm
+    hostonly='' instmods simpledrm =drivers/gpu/drm/panel
 
     if [[ $hostonly_mode == "strict" ]]; then
         # if there is a privacy screen then its driver must be loaded before the


### PR DESCRIPTION
## Changes

On Qualcomm CRD the display only turns on after the initrd. The initrd seems to be missing the panel module.

So install `=drivers/gpu/drm/panel` on ARM also in the simpledrm module (similar to the drm module).

Bug-Ubuntu: https://launchpad.net/bugs/2107477

## Checklist
- [ ] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it
