### PR TITLE
test: sync only relevant files

### DIFF
--- a/test/TEST-10-BASIC/test.sh
+++ b/test/TEST-10-BASIC/test.sh
@@ -26,8 +26,8 @@ test_setup() {
         --add-confdir test-root \
         -f "$TESTDIR"/initramfs.root "$KVERSION"
 
-    dd if=/dev/zero of="$TESTDIR"/root.img bs=200MiB count=1 status=none && sync
-    mkfs.ext4 -q -L dracut -d "$TESTDIR"/dracut.*/initramfs/ "$TESTDIR"/root.img && sync
+    dd if=/dev/zero of="$TESTDIR"/root.img bs=200MiB count=1 status=none && sync "$TESTDIR"/root.img
+    mkfs.ext4 -q -L dracut -d "$TESTDIR"/dracut.*/initramfs/ "$TESTDIR"/root.img && sync "$TESTDIR"/root.img
 
     test_dracut
 }

--- a/test/TEST-13-SYSROOT/test.sh
+++ b/test/TEST-13-SYSROOT/test.sh
@@ -26,8 +26,8 @@ test_setup() {
         --add-confdir test-root \
         -f "$TESTDIR"/initramfs.root "$KVERSION"
 
-    dd if=/dev/zero of="$TESTDIR"/root.img bs=200MiB count=1 status=none && sync
-    mkfs.ext4 -q -L dracut -d "$TESTDIR"/dracut.*/initramfs/ "$TESTDIR"/root.img && sync
+    dd if=/dev/zero of="$TESTDIR"/root.img bs=200MiB count=1 status=none && sync "$TESTDIR"/root.img
+    mkfs.ext4 -q -L dracut -d "$TESTDIR"/dracut.*/initramfs/ "$TESTDIR"/root.img && sync "$TESTDIR"/root.img
 
     ln -s / "$TESTDIR"/sysroot
     test_dracut --sysroot "$TESTDIR"/sysroot

--- a/test/TEST-20-STORAGE/create-root.sh
+++ b/test/TEST-20-STORAGE/create-root.sh
@@ -86,5 +86,5 @@ fi
     echo "ID_FS_UUID=$ID_FS_UUID"
 } | dd oflag=direct,dsync of=/dev/disk/by-id/scsi-0QEMU_QEMU_HARDDISK_marker status=none
 
-sync
+sync /dev/disk/by-id/scsi-0QEMU_QEMU_HARDDISK_marker
 poweroff -f

--- a/test/TEST-23-IMSM/create-root.sh
+++ b/test/TEST-23-IMSM/create-root.sh
@@ -65,5 +65,5 @@ echo "MD_UUID=$MD_UUID"
     echo MD_UUID="$MD_UUID"
 } | dd oflag=direct,dsync of=/dev/disk/by-id/scsi-0QEMU_QEMU_HARDDISK_marker status=none
 mdadm --wait-clean /dev/md0
-sync
+sync /dev/disk/by-id/scsi-0QEMU_QEMU_HARDDISK_marker
 poweroff -f

--- a/test/TEST-26-ENC-RAID-LVM/create-root.sh
+++ b/test/TEST-26-ENC-RAID-LVM/create-root.sh
@@ -33,5 +33,5 @@ cryptsetup luksClose /dev/mapper/dracut_disk2
         udevadm info --query=property --name="$i" | grep -F 'ID_FS_UUID='
     done
 } | dd oflag=direct,dsync of=/dev/disk/by-id/scsi-0QEMU_QEMU_HARDDISK_marker status=none
-sync
+sync /dev/disk/by-id/scsi-0QEMU_QEMU_HARDDISK_marker
 poweroff -f

--- a/test/TEST-30-DMSQUASH/test.sh
+++ b/test/TEST-30-DMSQUASH/test.sh
@@ -102,9 +102,9 @@ test_setup() {
 2048,652688
 EOF
 
-    sync
-    dd if=/dev/zero of="$TESTDIR"/ext4.img bs=512 count=652688 status=none && sync
-    mkfs.ext4 -q -L dracut -d "$TESTDIR"/rootfs/ "$TESTDIR"/ext4.img && sync
+    sync "$TESTDIR"/root.img
+    dd if=/dev/zero of="$TESTDIR"/ext4.img bs=512 count=652688 status=none && sync "$TESTDIR"/ext4.img
+    mkfs.ext4 -q -L dracut -d "$TESTDIR"/rootfs/ "$TESTDIR"/ext4.img && sync "$TESTDIR"/ext4.img
     dd if="$TESTDIR"/ext4.img of="$TESTDIR"/root.img bs=512 seek=2048 conv=noerror,sync,notrunc
 
     # erofs drive
@@ -122,7 +122,7 @@ EOF
     if command -v xorriso &> /dev/null; then
         mkdir "$TESTDIR"/iso
         xorriso -as mkisofs -output "$TESTDIR"/iso/linux.iso "$TESTDIR"/live/ -volid "ISO" -iso-level 3
-        mkfs.ext4 -q -L dracut_iso -d "$TESTDIR"/iso/ "$TESTDIR"/root_iso.img && sync
+        mkfs.ext4 -q -L dracut_iso -d "$TESTDIR"/iso/ "$TESTDIR"/root_iso.img && sync "$TESTDIR"/root_iso.img
     fi
 
     test_dracut \

--- a/test/TEST-43-KERNEL-INSTALL/test.sh
+++ b/test/TEST-43-KERNEL-INSTALL/test.sh
@@ -54,8 +54,8 @@ test_setup() {
         --add-confdir test-root \
         -f "$TESTDIR"/initramfs.root "$KVERSION"
 
-    dd if=/dev/zero of="$TESTDIR"/root.img bs=200MiB count=1 status=none && sync
-    mkfs.ext4 -q -L dracut -d "$TESTDIR"/dracut.*/initramfs/ "$TESTDIR"/root.img && sync
+    dd if=/dev/zero of="$TESTDIR"/root.img bs=200MiB count=1 status=none && sync "$TESTDIR"/root.img
+    mkfs.ext4 -q -L dracut -d "$TESTDIR"/dracut.*/initramfs/ "$TESTDIR"/root.img && sync "$TESTDIR"/root.img
 
     mkdir -p /run/kernel
     echo 'initrd_generator=dracut' >> /run/kernel/install.conf

--- a/test/TEST-60-NFS/client-init.sh
+++ b/test/TEST-60-NFS/client-init.sh
@@ -42,5 +42,5 @@ fi
 
 : > /dev/watchdog
 
-sync
+sync /dev/disk/by-id/scsi-0QEMU_QEMU_HARDDISK_marker /dev/disk/by-id/scsi-0QEMU_QEMU_HARDDISK_marker2
 poweroff -f

--- a/test/TEST-60-NFS/create-root.sh
+++ b/test/TEST-60-NFS/create-root.sh
@@ -19,5 +19,5 @@ cp -a -t /root /source/*
 mkdir -p /root/run
 umount /root
 echo "dracut-root-block-created" | dd oflag=direct,dsync of=/dev/disk/by-id/scsi-0QEMU_QEMU_HARDDISK_marker status=none
-sync
+sync /dev/disk/by-id/scsi-0QEMU_QEMU_HARDDISK_marker
 poweroff -f

--- a/test/TEST-61-MULTINIC/client-init.sh
+++ b/test/TEST-61-MULTINIC/client-init.sh
@@ -29,5 +29,5 @@ done
     echo "$IFACES"
 } | dd oflag=direct,dsync of=/dev/disk/by-id/scsi-0QEMU_QEMU_HARDDISK_marker status=none
 
-sync
+sync /dev/disk/by-id/scsi-0QEMU_QEMU_HARDDISK_marker
 poweroff -f

--- a/test/TEST-61-MULTINIC/create-root.sh
+++ b/test/TEST-61-MULTINIC/create-root.sh
@@ -10,5 +10,5 @@ cp -a -t /root /source/*
 mkdir -p /root/run
 umount /root
 echo "dracut-root-block-created" | dd oflag=direct,dsync of=/dev/disk/by-id/scsi-0QEMU_QEMU_HARDDISK_marker status=none
-sync
+sync /dev/disk/by-id/scsi-0QEMU_QEMU_HARDDISK_marker
 poweroff -f

--- a/test/TEST-62-BONDBRIDGEVLAN/create-root.sh
+++ b/test/TEST-62-BONDBRIDGEVLAN/create-root.sh
@@ -10,5 +10,5 @@ cp -a -t /root /source/*
 mkdir -p /root/run
 umount /root
 echo "dracut-root-block-created" | dd oflag=direct,dsync of=/dev/disk/by-id/scsi-0QEMU_QEMU_HARDDISK_marker status=none
-sync
+sync /dev/disk/by-id/scsi-0QEMU_QEMU_HARDDISK_marker
 poweroff -f

--- a/test/TEST-70-ISCSI/client-init.sh
+++ b/test/TEST-70-ISCSI/client-init.sh
@@ -10,5 +10,5 @@ while read -r dev _ fstype opts rest || [ -n "$dev" ]; do
     break
 done < /proc/mounts
 
-sync
+sync /dev/disk/by-id/scsi-0QEMU_QEMU_HARDDISK_marker
 poweroff -f

--- a/test/TEST-70-ISCSI/create-client-root.sh
+++ b/test/TEST-70-ISCSI/create-client-root.sh
@@ -20,5 +20,5 @@ cp -a -t /sysroot /source/*
 umount /sysroot
 lvm lvchange -a n /dev/dracut/root
 echo "dracut-root-block-created" | dd oflag=direct,dsync of=/dev/disk/by-id/scsi-0QEMU_QEMU_HARDDISK_marker status=none
-sync
+sync /dev/disk/by-id/scsi-0QEMU_QEMU_HARDDISK_marker
 poweroff -f

--- a/test/TEST-71-ISCSI-MULTI/client-init.sh
+++ b/test/TEST-71-ISCSI-MULTI/client-init.sh
@@ -10,5 +10,5 @@ while read -r dev _ fstype opts rest || [ -n "$dev" ]; do
     break
 done < /proc/mounts
 
-sync
+sync /dev/disk/by-id/scsi-0QEMU_QEMU_HARDDISK_marker
 poweroff -f

--- a/test/TEST-71-ISCSI-MULTI/create-client-root.sh
+++ b/test/TEST-71-ISCSI-MULTI/create-client-root.sh
@@ -20,5 +20,5 @@ cp -a -t /sysroot /source/*
 umount /sysroot
 lvm lvchange -a n /dev/dracut/root
 echo "dracut-root-block-created" | dd oflag=direct,dsync of=/dev/disk/by-id/scsi-0QEMU_QEMU_HARDDISK_marker status=none
-sync
+sync /dev/disk/by-id/scsi-0QEMU_QEMU_HARDDISK_marker
 poweroff -f

--- a/test/TEST-72-NBD/client-init.sh
+++ b/test/TEST-72-NBD/client-init.sh
@@ -15,5 +15,5 @@ echo "made it to the rootfs! Powering down."
 
 mount -n -o remount,ro /
 
-sync
+sync /dev/disk/by-id/scsi-0QEMU_QEMU_HARDDISK_marker
 poweroff -f

--- a/test/TEST-72-NBD/create-encrypted-root.sh
+++ b/test/TEST-72-NBD/create-encrypted-root.sh
@@ -28,5 +28,5 @@ eval "$(udevadm info --query=property --name=/dev/disk/by-id/scsi-0QEMU_QEMU_HAR
     echo "dracut-root-block-created"
     echo "ID_FS_UUID=$ID_FS_UUID"
 } | dd oflag=direct,dsync of=/dev/disk/by-id/scsi-0QEMU_QEMU_HARDDISK_marker status=none
-sync
+sync /dev/disk/by-id/scsi-0QEMU_QEMU_HARDDISK_marker
 poweroff -f

--- a/test/TEST-72-NBD/create-server-root.sh
+++ b/test/TEST-72-NBD/create-server-root.sh
@@ -13,5 +13,5 @@ umount /root
     echo "dracut-root-block-created"
     echo "ID_FS_UUID=$ID_FS_UUID"
 } | dd oflag=direct,dsync of=/dev/disk/by-id/scsi-0QEMU_QEMU_HARDDISK_marker status=none
-sync
+sync /dev/disk/by-id/scsi-0QEMU_QEMU_HARDDISK_marker
 poweroff -f

--- a/test/test-functions
+++ b/test/test-functions
@@ -215,7 +215,7 @@ qemu_add_drive() {
         fi
 
         dd if=/dev/zero of="${file}" bs=1MiB count="${size}" status=none
-        sync
+        sync "${file}"
     fi
 
     eval "${2}"'+=(' \
@@ -229,7 +229,7 @@ qemu_add_drive() {
 
 test_marker_reset() {
     dd if=/dev/zero of="$TESTDIR"/marker.img bs=1MiB count=1 status=none
-    sync
+    sync "$TESTDIR"/marker.img
 }
 
 test_marker_check() {


### PR DESCRIPTION
## Changes

The tests call `sync` without any parameters. This slows down the tests in case some unrelated disk writes happen somewhere else.

Specify the relevant files that should be synchronized to avoid unrelated writes to slow down the tests.

## Checklist
- [ ] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it
