### PR TITLE
ci: disable failing extra integration tests

### DIFF
--- a/.github/workflows/integration-extra.yml
+++ b/.github/workflows/integration-extra.yml
@@ -56,6 +56,16 @@ jobs:
                     - "80"
                     - "81"
                     - "82"
+                exclude:
+                    # https://github.com/dracut-ng/dracut-ng/issues/1224
+                    - container: gentoo:amd64-openrc
+                    test: "43"
+                    # https://github.com/dracut-ng/dracut-ng/issues/1315
+                    - container: azurelinux:3.0
+                    test: "41"
+                    # https://github.com/dracut-ng/dracut-ng/issues/1314
+                    - container: azurelinux:3.0
+                    test: "43"
         container:
             image: ghcr.io/dracut-ng/${{ matrix.container }}-amd
             options: '--device=/dev/kvm --privileged'


### PR DESCRIPTION
## Changes

These tests are known to fail for weeks, so let's stop running them.

Related
 - https://github.com/dracut-ng/dracut-ng/issues/1224
 - https://github.com/dracut-ng/dracut-ng/issues/1314
 - https://github.com/dracut-ng/dracut-ng/issues/1315

## Checklist
- [ ] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it

