### PR TITLE
feat: set hostonly_cmdline config to no by default

### DIFF
--- a/dracut.conf.d/hostonly/50-hostonly.conf
+++ b/dracut.conf.d/hostonly/50-hostonly.conf
@@ -1,2 +1,3 @@
 # optimize initrd to be as small as possible for faster boot performance, tailored to the current host
 hostonly="yes"
+hostonly_cmdline=no


### PR DESCRIPTION
## Changes

`hostonly_cmdline=no` is already the default on Fedora, see https://github.com/dracut-ng/dracut-ng/blob/main/dracut.conf.d/fedora.conf.example#L44

## Checklist
- [ ] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it

Fixes #1326

CC @LaszloGombos @bdrung @Nowa-Ammerlaan @AlexanderKurtz @dalto8 