### PR TITLE
feat: tests are not packaged by default to simplify packaging

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -176,7 +176,7 @@ install: all
 	for i in $(configprofile) ; do \
 		cp -arx dracut.conf.d/$$i/* $(DESTDIR)$(pkglibdir)/dracut.conf.d/ ;\
 	done
-ifneq ($(enable_test),no)
+ifeq ($(enable_test),yes)
 	cp -arx test $(DESTDIR)$(pkglibdir)
 else
 	rm -rf $(DESTDIR)$(pkglibdir)/modules.d/80test*

--- a/configure
+++ b/configure
@@ -65,6 +65,7 @@ while (($# > 0)); do
         --bashcompletiondir) read_arg bashcompletiondir "$@" || shift ;;
         --enable-dracut-cpio) enable_dracut_cpio=yes ;;
         --disable-dracut-cpio) enable_dracut_cpio=no ;;
+        --enable-test) enable_test=yes ;;
         --configprofile) read_arg configprofile "$@" || shift ;;
         *) echo "Ignoring unknown option '$1'" ;;
     esac
@@ -189,6 +190,7 @@ sysconfdir ?= ${sysconfdir:-${prefix}/etc}
 sbindir ?= ${sbindir:-${prefix}/sbin}
 mandir ?= ${mandir:-${prefix}/share/man}
 enable_documentation ?= ${enable_documentation:-yes}
+enable_test ?= ${enable_test:-no}
 enable_dracut_cpio ?= ${enable_dracut_cpio}
 bindir ?= ${bindir:-${prefix}/bin}
 KMOD_CFLAGS ?= $(${PKG_CONFIG} --cflags " libkmod >= 23 ") ${KMOD_CFLAGS_EXTRA}

--- a/test/test-container.sh
+++ b/test/test-container.sh
@@ -25,7 +25,7 @@ if [ "$V" = "2" ]; then set -x; fi
 [ -z "$enable_documentation" ] && export enable_documentation=no
 
 # shellcheck disable=SC2086
-./configure $CONFIGURE_ARG
+./configure --enable-test $CONFIGURE_ARG
 
 # treat warnings as error
 # shellcheck disable=SC2086


### PR DESCRIPTION
## Changes

If it is desired to package tests, set `enable_test=yes` .

## Checklist
- [ ] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it

Fixes #1327

CC @bdrung @Nowa-Ammerlaan @LaszloGombos 
