### PR TITLE
test(SYSTEMD-INITRD): demonstrate boot without initqueue

### DIFF
--- a/test/TEST-42-SYSTEMD-INITRD/test.sh
+++ b/test/TEST-42-SYSTEMD-INITRD/test.sh
@@ -72,18 +72,20 @@ test_setup() {
     test_marker_check dracut-root-block-created
     rm -- "$TESTDIR"/marker.img
 
-    # initrd for test infra and required kernel modules
+    # initrd for required kernel modules
     # Improve boot time by generating two initrds. Do not re-compress kernel modules
-    test_dracut \
+    "$DRACUT" \
         --no-compress \
-        -m "kernel-modules" \
-        "$TESTDIR"/initramfs-test
+        --kernel-only \
+        -m "kernel-modules qemu" \
+        -d "ext4" \
+        -f "$TESTDIR"/initramfs-test "$KVERSION"
 
     # vanilla kernel-independent systemd-based minimal initrd without dracut specific customizations
     # since dracut-systemd is not included in the generated initrd, only systemd options are supported during boot
     test_dracut --no-kernel \
         --omit "test systemd-sysctl systemd-modules-load" \
-        -m "systemd-initrd" \
+        -m "systemd-initrd base" \
         "$TESTDIR"/initramfs-systemd-initrd
 
     # verify that dracut systemd services are not included


### PR DESCRIPTION
## Changes

Follow-up to 3daf678 .

This is a test-only change.

After this change initqueue dracut module is no longer used in the initramfs for test SYSTEMD-INITRD.

initqueue was added as a dependency of the watchdog module, which was added as a dependency of the test dracut module.

## Checklist
- [ ] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it

CC @dtardon @LaszloGombos 
