### PR TITLE
fix(dracut.sh): don't pass empty string as dir

### DIFF
--- a/dracut.sh
+++ b/dracut.sh
@@ -972,7 +972,7 @@ if [[ -f $conffile ]]; then
 fi
 
 # source our config dir
-for f in $(dropindirs_sort ".conf" "$confdir" "$add_confdir" "$dracutbasedir/dracut.conf.d"); do
+for f in $(dropindirs_sort ".conf" "$confdir" ${add_confdir:+"$add_confdir"} "$dracutbasedir/dracut.conf.d"); do
     check_conf_file "$f"
     # shellcheck disable=SC1090
     [[ -e $f ]] && . "$f"


### PR DESCRIPTION
If an empty string is passed to `dropindirs_sort()`, it looks for `.conf` files in `/` due to expansion:
```sh
for d in "$@"; do
    for i in "$d/"*"$suffix"; do
```

## Changes
Pass the optional `$add_confdir` to `dropindirs_sort()` only if it's defined.

## Checklist
- [x] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it

Fixes #1275