### PR TITLE
fix(livenet): drop stray command call

### DIFF
--- a/modules.d/70livenet/parse-livenet.sh
+++ b/modules.d/70livenet/parse-livenet.sh
@@ -3,7 +3,7 @@
 # root=live:[url-to-backing-file]
 
 [ -z "$root" ] && root=$(getarg root=)
-get_url_handler
+
 command -v get_url_handler > /dev/null || . /lib/url-lib.sh
 
 # live updates


### PR DESCRIPTION
This fixes a regression from commit 8b71a80edfca725e8aa281a4f91c55ff6234cc82 .

## Changes
Drop `get_url_handler` call that was evidently added by a mistake.

## Checklist
- [ ] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it

Fixes #1240