### PR TITLE
fix broken symlink in dracut config examples

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -180,6 +180,7 @@ ifneq ($(enable_test),no)
 	cp -arx test $(DESTDIR)$(pkglibdir)
 else
 	rm -rf $(DESTDIR)$(pkglibdir)/modules.d/80test*
+	rm -rf $(DESTDIR)$(pkglibdir)/dracut.conf.d/test*
 endif
 ifneq ($(enable_documentation),no)
 	for i in $(man1pages); do install -m 0644 $$i $(DESTDIR)$(mandir)/man1/$${i##*/}; done


### PR DESCRIPTION
Due to commit [1], it installs dracut config examples under /usr. But while enable_test=no, the symlink of test in dracut config is broken ...
root@qemux86-64:~# ls /usr/lib/dracut/dracut.conf.d/test*  -ahl lrwxrwxrwx 1 root root 27 Apr  5  2011 /usr/lib/dracut/dracut.conf.d/test -> ../test/dracut.conf.d/test/ lrwxrwxrwx 1 root root 36 Apr  5  2011 /usr/lib/dracut/dracut.conf.d/test-makeroot -> ../test/dracut.conf.d/test-makeroot/ lrwxrwxrwx 1 root root 31 Apr  5  2011 /usr/lib/dracut/dracut.conf.d/test-root -> ../test/dracut.conf.d/test-root root@qemux86-64:~# realpath /usr/lib/dracut/dracut.conf.d/test* realpath: /usr/lib/dracut/dracut.conf.d/test: No such file or directory realpath: /usr/lib/dracut/dracut.conf.d/test-makeroot: No such file or directory realpath: /usr/lib/dracut/dracut.conf.d/test-root: No such file or directory ...

This commit cleans up test symlink if enable_test=no

[1] https://github.com/dracut-ng/dracut-ng/commit/0d369e3e30935dffe48dfff1e90463868e7f804a

This pull request changes...

## Changes

## Checklist
- [ ] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it

Fixes #
