### PR TITLE
fix: load essential storage kernel modules in sloppy hostonly mode

### DIFF
--- a/modules.d/70kernel-modules/module-setup.sh
+++ b/modules.d/70kernel-modules/module-setup.sh
@@ -107,9 +107,9 @@ installkernel() {
 
         awk -F: '/^\// {print $1}' "$srcmods/modules.dep" 2> /dev/null | instmods
 
-        # if not on hostonly mode, or there are hostonly block device
+        # if not on strict hostonly mode, or there are hostonly block device
         # install block drivers
-        if ! [[ ${hostonly-} ]] \
+        if [[ $hostonly_mode != "strict" ]] \
             || for_each_host_dev_and_slaves_all record_block_dev_drv; then
             hostonly='' instmods sg sr_mod sd_mod scsi_dh ata_piix
 


### PR DESCRIPTION
## Changes

Essential storage kernel modules (e.g. sd_mod, nvme) should be always included unless hostonly_mode is set to strict.
    
This PR installs even more drivers in hostonly sloppy mode as a follow-up to 8519dcd .

These drivers are already always installed in `non-hostonly` (`generic`) mode.
    
## Checklist
- [x] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it

Fixes #748
