### PR TITLE
docs: promote usage of splash over rhgb

### DIFF
--- a/man/dracut.cmdline.7.adoc
+++ b/man/dracut.cmdline.7.adoc
@@ -122,11 +122,11 @@ by copying the original kernel cmdline parameters.
 [listing]
 .Example
 --
-menuentry 'Live Fedora 20' --class fedora --class gnu-linux --class gnu --class os {
-    set isolabel=Fedora-Live-LXDE-x86_64-20-1
-    set isofile="/boot/iso/Fedora-Live-LXDE-x86_64-20-1.iso"
+menuentry 'Live' --class gnu-linux --class gnu --class os {
+    set isolabel=Live-x86_64
+    set isofile="/boot/iso/Live-x86_64.iso"
     loopback loop $isofile
-    linux (loop)/isolinux/vmlinuz0 boot=isolinux iso-scan/filename=$isofile root=live:LABEL=$isolabel ro rd.live.image quiet rhgb
+    linux (loop)/isolinux/vmlinuz0 boot=isolinux iso-scan/filename=$isofile root=live:LABEL=$isolabel ro rd.live.image quiet
     initrd (loop)/isolinux/initrd0.img
 }
 --

--- a/man/dracut.usage.adoc
+++ b/man/dracut.usage.adoc
@@ -333,7 +333,7 @@ situation.
 
 [[identifying-your-problem-area]]
 == Identifying your problem area
-. Remove ''rhgb'' and ''quiet'' from the kernel command line
+. Remove ''splash'' and ''quiet'' from the kernel command line
 . Add ''rd.shell'' to the kernel command line. This will present a shell should
 dracut be unable to locate your root device
 . Add ''rd.shell rd.debug log_buf_len=1M'' to the kernel command line so that
@@ -441,7 +441,7 @@ locate your root filesystem. To enable the shell:
 
 . Add the boot parameter ''rd.shell'' to your bootloader configuration file
 (e.g. _/boot/grub2/grub.cfg_)
-. Remove the boot arguments ''rhgb'' and ''quiet''
+. Remove the boot arguments ''splash'' and ''quiet''
 +
 A sample _/boot/grub2/grub.cfg_ bootloader configuration file is listed below.
 +


### PR DESCRIPTION
## Changes

This is a documentation only change.

The rhgb command line option will continue to be supported.

Also remove some distribution specific details from the example that is not essentail for understanding the example.

Relevant plymouth documentation - https://linux.die.net/man/8/plymouth

```
In order for the configured default plymouth theme to be loaded during boot, the option 'splash' (or 'rhgb' for backward compatibility with the RHGB boot splash) must be provided at the kernel command line.
```

## Checklist
- [ ] I have tested it locally
- [X] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it

Fixes #1305
