### PR TITLE
fix(systemd): make checking for systemd availability consistent

### DIFF
--- a/modules.d/70dmsquash-live/module-setup.sh
+++ b/modules.d/70dmsquash-live/module-setup.sh
@@ -31,7 +31,7 @@ install() {
     inst_hook pre-pivot 20 "$moddir/apply-live-updates.sh"
     inst_script "$moddir/dmsquash-live-root.sh" "/sbin/dmsquash-live-root"
     inst_script "$moddir/iso-scan.sh" "/sbin/iso-scan"
-    if dracut_module_included "systemd-initrd"; then
+    if dracut_module_included "systemd"; then
         inst_script "$moddir/dmsquash-generator.sh" "$systemdutildir"/system-generators/dracut-dmsquash-generator
         inst_simple "$moddir/checkisomd5@.service" "/etc/systemd/system/checkisomd5@.service"
     fi

--- a/modules.d/70livenet/module-setup.sh
+++ b/modules.d/70livenet/module-setup.sh
@@ -17,7 +17,7 @@ install() {
     inst_hook cmdline 29 "$moddir/parse-livenet.sh"
     inst_hook initqueue/online 95 "$moddir/fetch-liveupdate.sh"
     inst_script "$moddir/livenetroot.sh" "/sbin/livenetroot"
-    if dracut_module_included "systemd-initrd"; then
+    if dracut_module_included "systemd"; then
         inst_script "$moddir/livenet-generator.sh" "$systemdutildir"/system-generators/dracut-livenet-generator
     fi
 }

--- a/modules.d/74nbd/module-setup.sh
+++ b/modules.d/74nbd/module-setup.sh
@@ -32,7 +32,7 @@ install() {
     inst nbd-client
     inst_hook cmdline 90 "$moddir/parse-nbdroot.sh"
     inst_script "$moddir/nbdroot.sh" "/sbin/nbdroot"
-    if dracut_module_included "systemd-initrd"; then
+    if dracut_module_included "systemd"; then
         inst_script "$moddir/nbd-generator.sh" "$systemdutildir"/system-generators/dracut-nbd-generator
     fi
 }


### PR DESCRIPTION
## Changes

The best way to check if systemd is available is to check for the systemd dracut module. Most of the existing code does this already, fix the remaining few places where it does not.

## Checklist
- [ ] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it

