### PR TITLE
fix(dracut-functions.sh): let check_vol_slaves_all return 1 when checks on all slaves fail

### DIFF
--- a/dracut-functions.sh
+++ b/dracut-functions.sh
@@ -691,7 +691,7 @@ check_vol_slaves() {
 }
 
 check_vol_slaves_all() {
-    local _vg _pv _majmin _dm
+    local _vg _pv _majmin _dm _ret=1
     _majmin="$2"
     _dm=$(get_lvm_dm_dev "$_majmin")
     [[ -z $_dm ]] && return 1 # not an LVM device-mapper device
@@ -705,11 +705,10 @@ check_vol_slaves_all() {
         fi
 
         for _pv in $(lvm vgs --noheadings -o pv_name "$_vg" 2> /dev/null); do
-            check_block_and_slaves_all "$1" "$(get_maj_min "$_pv")"
+            check_block_and_slaves_all "$1" "$(get_maj_min "$_pv")" && _ret=0
         done
-        return 0
     fi
-    return 1
+    return $_ret
 }
 
 # fs_get_option <filesystem options> <search for option>


### PR DESCRIPTION

Currently check_vol_slaves_all return 0 even after checks on all slaves fail. And this leads to an issue that "dracut -hostonly-mode strict" gets stuck forever because instmods keeps waiting for user input when it's passed empty argument in the kernel-modules module.

Fixes: c7c8c498 ("dracut-functions.sh: catch all lvm slaves")
Reported-by: Tomáš Bžatek <tbzatek@redhat.com>

 
 
## Checklist
- [x] I have tested it locally
- [x] I have reviewed and updated any documentation if relevant
 
 