### PR TITLE
fix(74nvmf): remove netroot=nbft

### DIFF
--- a/modules.d/74nvmf/module-setup.sh
+++ b/modules.d/74nvmf/module-setup.sh
@@ -148,7 +148,6 @@ install() {
     inst_multiple ip sed
 
     inst_script "${moddir}/nvmf-autoconnect.sh" /sbin/nvmf-autoconnect.sh
-    inst_script "${moddir}/nbftroot.sh" /sbin/nbftroot
 
     inst_multiple nvme jq
     inst_hook cmdline 92 "$moddir/parse-nvmf-boot-connections.sh"

--- a/modules.d/74nvmf/nbftroot.sh
+++ b/modules.d/74nvmf/nbftroot.sh
@@ -1,5 +1,0 @@
-#! /bin/sh
-# This script is called from /sbin/netroot
-
-/sbin/nvmf-autoconnect.sh online
-exit 0

--- a/modules.d/74nvmf/parse-nvmf-boot-connections.sh
+++ b/modules.d/74nvmf/parse-nvmf-boot-connections.sh
@@ -318,9 +318,6 @@ done
 
 if [ -e /tmp/nvmf_needs_network ] || [ -e /tmp/valid_nbft_entry_found ]; then
     echo "rd.neednet=1" > /etc/cmdline.d/nvmf-neednet.conf
-    # netroot is a global variable that is present in all "sourced" scripts
-    # shellcheck disable=SC2034
-    netroot=nbft
     rm -f /tmp/nvmf_needs_network
 fi
 


### PR DESCRIPTION
Setting netroot causes further issues with stripped down strict hostonly initramfs (e.g. kdump initramfs) and it appears there's no strong reason to have it set.

```
[   23.599862] dracut: FATAL: No or empty root= argument
[   23.604956] dracut: Refusing to continue
```

It also causes excessive connection attempts as a result of network interface events (e.g. link up/interface ready) with NetworkManager, significantly delaying boot (observed ~12 minutes) due to connection attempts of unavailable subsystems and timing out for each such attempt.

Cc: @mwilck 

We're still not 100% certain what effects exactly does setting `netroot` have, this removal proposal is based upon lots of testing and experiments. The module appears to be working just fine without it.

## Checklist
- [x] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] ~I am providing new code and test(s) for it~
