### PR TITLE
feat(nfs): use nfsroot-generator if available

### DIFF
--- a/modules.d/77dracut-systemd/dracut-cmdline.sh
+++ b/modules.d/77dracut-systemd/dracut-cmdline.sh
@@ -61,6 +61,10 @@ case "${root#block:}${root_unset}" in
         root="block:${root#block:}"
         rootok=1
         ;;
+    nfs*)
+        [ -e /usr/lib/systemd/system-generators/nfsroot-generator ] \
+            && rootok=1
+        ;;
     UNSET | gpt-auto | tmpfs)
         # systemd's gpt-auto-generator/fstab-generator handles this case.
         rootok=1


### PR DESCRIPTION
nfs-utils-2.8.4 will provide its own nfsroot-generator [1] to allow mounting the real rootfs via NFSv4. If it's available, and there is not any filesystem mounted with NFS < v4, use it instead of dracut's custom implementation.

[1] http://git.linux-nfs.org/?p=steved/nfs-utils.git;a=commit;h=ed86ea08dadafbac948c6a45629a6f3282a77233

## Checklist
- [ ] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it