### PR TITLE
fix: loongarch architecture support

### DIFF
--- a/dracut.sh
+++ b/dracut.sh
@@ -1629,6 +1629,9 @@ if [[ ! $print_cmdline ]]; then
             riscv64)
                 EFI_MACHINE_TYPE_NAME=riscv64
                 ;;
+            loongarch64)
+                EFI_MACHINE_TYPE_NAME=loongarch64
+                ;;
             *)
                 dfatal "Architecture '${DRACUT_ARCH:-$(uname -m)}' not supported to create a UEFI executable"
                 exit 1

--- a/modules.d/70kernel-modules/module-setup.sh
+++ b/modules.d/70kernel-modules/module-setup.sh
@@ -137,6 +137,7 @@ installkernel() {
         [[ $arch == x86_64 ]] && arch=x86
         [[ $arch == s390x ]] && arch=s390
         [[ $arch == aarch64 ]] && arch=arm64
+        [[ $arch == loongarch64 ]] && arch=loongarch
         hostonly='' instmods "=crypto"
         hostonly=$(optional_hostonly) instmods "=arch/$arch/crypto" "=drivers/crypto"
     fi


### PR DESCRIPTION
Add ```loongarch``` support, the new architecture launched by China's ```Loongson```. It can be compiled and run normally under ```loongarch``` architecture. [loongarch cpuinfo](https://github.com/torvalds/linux/blob/master/arch/loongarch/kernel/proc.c#L49-L64)

