### PR TITLE
fix(dracut-lib.sh): initialize variables in getargs

### DIFF
--- a/modules.d/80base/dracut-lib.sh
+++ b/modules.d/80base/dracut-lib.sh
@@ -274,9 +274,8 @@ getargs() {
     debug_off
     CMDLINE=$(getcmdline)
     export CMDLINE
-    local _val _i _gfound _deprecated
+    local _val _i _gfound="" _deprecated=""
     unset _val
-    unset _gfound
     _newoption="$1"
     for _i in "$@"; do
         if [ "$_i" = "-d" ]; then


### PR DESCRIPTION
## Changes

Initialize the variables in `getargs` to make the function work with `set -u`.

## Checklist
- [ ] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it

Fixes #
