### PR TITLE
fix(dracut-init.sh): initialize _files in inst_libdir_file

### DIFF
--- a/dracut-init.sh
+++ b/dracut-init.sh
@@ -606,7 +606,7 @@ inst_libdir_dir() {
 # Install a <file> located on a lib directory to the initramfs image
 # -n <pattern> install matching files
 inst_libdir_file() {
-    local -a _files
+    local -a _files=()
     if [[ $1 == "-n" ]]; then
         local _pattern=$2
         shift 2


### PR DESCRIPTION
## Changes

Initialize the local variable `_files` in `inst_libdir_file` to make the function work with `set -u`.

## Checklist
- [ ] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it

Fixes #
