### PR TITLE
test: support some environment variables to be unset

### DIFF
--- a/test/TEST-41-FULL-SYSTEMD/test.sh
+++ b/test/TEST-41-FULL-SYSTEMD/test.sh
@@ -34,7 +34,7 @@ client_run() {
     test_marker_reset
     "$testdir"/run-qemu \
         "${disk_args[@]}" ${smbios:+-smbios "${smbios}"} \
-        -append "$TEST_KERNEL_CMDLINE mount.usr=LABEL=dracutusr mount.usrflags=subvol=usr $client_opts $DEBUGOUT" \
+        -append "$TEST_KERNEL_CMDLINE mount.usr=LABEL=dracutusr mount.usrflags=subvol=usr $client_opts ${DEBUGOUT-}" \
         -initrd "$TESTDIR"/initramfs.testing
 
     if ! test_marker_check; then

--- a/test/TEST-60-NFS/test.sh
+++ b/test/TEST-60-NFS/test.sh
@@ -43,7 +43,7 @@ run_server() {
         -pidfile "$TESTDIR"/server.pid -daemonize
     chmod 644 "$TESTDIR"/server.pid
 
-    if ! [[ $SERIAL ]]; then
+    if ! [[ ${SERIAL-} ]]; then
         wait_for_server_startup
     else
         echo Sleeping 10 seconds to give the server a head start

--- a/test/TEST-60-NFS/test.sh
+++ b/test/TEST-60-NFS/test.sh
@@ -38,7 +38,7 @@ run_server() {
         -net socket,listen=127.0.0.1:12320 \
         -net nic,macaddr=52:54:00:12:34:56,model=virtio \
         -serial "${SERIAL:-"file:$TESTDIR/server.log"}" \
-        -append "panic=1 oops=panic softlockup_panic=1 root=LABEL=dracut rootfstype=ext4 rw console=ttyS0,115200n81 $SERVER_DEBUG" \
+        -append "panic=1 oops=panic softlockup_panic=1 root=LABEL=dracut rootfstype=ext4 rw console=ttyS0,115200n81 ${SERVER_DEBUG-}" \
         -initrd "$TESTDIR"/initramfs.server \
         -pidfile "$TESTDIR"/server.pid -daemonize
     chmod 644 "$TESTDIR"/server.pid

--- a/test/TEST-61-MULTINIC/test.sh
+++ b/test/TEST-61-MULTINIC/test.sh
@@ -38,7 +38,7 @@ run_server() {
         -net socket,listen=127.0.0.1:12350 \
         -net nic,macaddr=52:54:00:42:00:01,model=virtio \
         -serial "${SERIAL:-"file:$TESTDIR/server.log"}" \
-        -append "panic=1 oops=panic softlockup_panic=1 systemd.crash_reboot root=LABEL=dracut rootfstype=ext4 rw console=ttyS0,115200n81 $SERVER_DEBUG" \
+        -append "panic=1 oops=panic softlockup_panic=1 systemd.crash_reboot root=LABEL=dracut rootfstype=ext4 rw console=ttyS0,115200n81 ${SERVER_DEBUG-}" \
         -initrd "$TESTDIR"/initramfs.server \
         -pidfile "$TESTDIR"/server.pid -daemonize
 

--- a/test/TEST-61-MULTINIC/test.sh
+++ b/test/TEST-61-MULTINIC/test.sh
@@ -44,7 +44,7 @@ run_server() {
 
     chmod 644 -- "$TESTDIR"/server.pid
 
-    if ! [[ $SERIAL ]]; then
+    if ! [[ ${SERIAL-} ]]; then
         wait_for_server_startup
     else
         echo Sleeping 10 seconds to give the server a head start

--- a/test/TEST-62-BONDBRIDGEVLAN/test.sh
+++ b/test/TEST-62-BONDBRIDGEVLAN/test.sh
@@ -66,7 +66,7 @@ run_server() {
         -pidfile "$TESTDIR"/server.pid -daemonize
     chmod 644 -- "$TESTDIR"/server.pid
 
-    if ! [[ $SERIAL ]]; then
+    if ! [[ ${SERIAL-} ]]; then
         wait_for_server_startup
     else
         echo Sleeping 10 seconds to give the server a head start

--- a/test/TEST-70-ISCSI/test.sh
+++ b/test/TEST-70-ISCSI/test.sh
@@ -27,7 +27,7 @@ run_server() {
         -net nic,macaddr=52:54:00:12:34:56,model=virtio \
         -net nic,macaddr=52:54:00:12:34:57,model=virtio \
         -net socket,listen=127.0.0.1:12330 \
-        -append "panic=1 oops=panic softlockup_panic=1 quiet root=/dev/disk/by-id/scsi-0QEMU_QEMU_HARDDISK_serverroot rw console=ttyS0,115200n81 $SERVER_DEBUG" \
+        -append "panic=1 oops=panic softlockup_panic=1 quiet root=/dev/disk/by-id/scsi-0QEMU_QEMU_HARDDISK_serverroot rw console=ttyS0,115200n81 ${SERVER_DEBUG-}" \
         -initrd "$TESTDIR"/initramfs.server \
         -pidfile "$TESTDIR"/server.pid -daemonize
     chmod 644 "$TESTDIR"/server.pid

--- a/test/TEST-70-ISCSI/test.sh
+++ b/test/TEST-70-ISCSI/test.sh
@@ -32,7 +32,7 @@ run_server() {
         -pidfile "$TESTDIR"/server.pid -daemonize
     chmod 644 "$TESTDIR"/server.pid
 
-    if ! [[ $SERIAL ]]; then
+    if ! [[ ${SERIAL-} ]]; then
         wait_for_server_startup
     else
         echo Sleeping 10 seconds to give the server a head start

--- a/test/TEST-71-ISCSI-MULTI/test.sh
+++ b/test/TEST-71-ISCSI-MULTI/test.sh
@@ -27,7 +27,7 @@ run_server() {
         -net nic,macaddr=52:54:00:12:34:56,model=virtio \
         -net nic,macaddr=52:54:00:12:34:57,model=virtio \
         -net socket,listen=127.0.0.1:12331 \
-        -append "panic=1 oops=panic softlockup_panic=1 systemd.crash_reboot root=/dev/disk/by-id/scsi-0QEMU_QEMU_HARDDISK_serverroot rootfstype=ext4 rw console=ttyS0,115200n81 $SERVER_DEBUG" \
+        -append "panic=1 oops=panic softlockup_panic=1 systemd.crash_reboot root=/dev/disk/by-id/scsi-0QEMU_QEMU_HARDDISK_serverroot rootfstype=ext4 rw console=ttyS0,115200n81 ${SERVER_DEBUG-}" \
         -initrd "$TESTDIR"/initramfs.server \
         -pidfile "$TESTDIR"/server.pid -daemonize
     chmod 644 "$TESTDIR"/server.pid

--- a/test/TEST-71-ISCSI-MULTI/test.sh
+++ b/test/TEST-71-ISCSI-MULTI/test.sh
@@ -32,7 +32,7 @@ run_server() {
         -pidfile "$TESTDIR"/server.pid -daemonize
     chmod 644 "$TESTDIR"/server.pid
 
-    if ! [[ $SERIAL ]]; then
+    if ! [[ ${SERIAL-} ]]; then
         wait_for_server_startup
     else
         echo Sleeping 10 seconds to give the server a head start

--- a/test/TEST-72-NBD/test.sh
+++ b/test/TEST-72-NBD/test.sh
@@ -46,7 +46,7 @@ run_server() {
         -serial "${SERIAL:-"file:$TESTDIR/server.log"}" \
         -net nic,macaddr=52:54:00:12:34:56,model=virtio \
         -net socket,listen=127.0.0.1:12340 \
-        -append "panic=1 oops=panic softlockup_panic=1 rd.luks=0 systemd.crash_reboot quiet root=/dev/disk/by-id/scsi-0QEMU_QEMU_HARDDISK_serverroot rootfstype=ext4 rw console=ttyS0,115200n81 $SERVER_DEBUG" \
+        -append "panic=1 oops=panic softlockup_panic=1 rd.luks=0 systemd.crash_reboot quiet root=/dev/disk/by-id/scsi-0QEMU_QEMU_HARDDISK_serverroot rootfstype=ext4 rw console=ttyS0,115200n81 ${SERVER_DEBUG-}" \
         -initrd "$TESTDIR"/initramfs.server \
         -pidfile "$TESTDIR"/server.pid -daemonize
     chmod 644 "$TESTDIR"/server.pid

--- a/test/TEST-72-NBD/test.sh
+++ b/test/TEST-72-NBD/test.sh
@@ -51,7 +51,7 @@ run_server() {
         -pidfile "$TESTDIR"/server.pid -daemonize
     chmod 644 "$TESTDIR"/server.pid
 
-    if ! [[ $SERIAL ]]; then
+    if ! [[ ${SERIAL-} ]]; then
         wait_for_server_startup
     else
         echo Sleeping 10 seconds to give the server a head start

--- a/test/TEST-81-SKIPCPIO/test.sh
+++ b/test/TEST-81-SKIPCPIO/test.sh
@@ -72,7 +72,7 @@ test_setup() {
 }
 
 test_cleanup() {
-    [ -d "$CPIO_TESTDIR" ] && rm -rf "$CPIO_TESTDIR"
+    [ -d "${CPIO_TESTDIR-}" ] && rm -rf "$CPIO_TESTDIR"
     return 0
 }
 

--- a/test/TEST-82-DRACUT-CPIO/test.sh
+++ b/test/TEST-82-DRACUT-CPIO/test.sh
@@ -72,7 +72,7 @@ test_setup() {
 }
 
 test_cleanup() {
-    [ -d "$CPIO_TESTDIR" ] && rm -rf "$CPIO_TESTDIR"
+    [ -d "${CPIO_TESTDIR-}" ] && rm -rf "$CPIO_TESTDIR"
     return 0
 }
 

--- a/test/modules.d/70test-root/module-setup.sh
+++ b/test/modules.d/70test-root/module-setup.sh
@@ -9,7 +9,7 @@ depends() {
     local deps
     deps="terminfo"
 
-    if [[ $V == "2" ]]; then
+    if [[ ${V-} == "2" ]]; then
         deps+=" debug"
     fi
 

--- a/test/test-container.sh
+++ b/test/test-container.sh
@@ -9,7 +9,7 @@ if command -v systemd-detect-virt > /dev/null && ! systemd-detect-virt -c &> /de
 fi
 
 set -e
-if [ "$V" = "2" ]; then set -x; fi
+if [ "${V-}" = "2" ]; then set -x; fi
 
 [[ -d ${0%/*} ]] && cd "${0%/*}"/../
 

--- a/test/test-functions
+++ b/test/test-functions
@@ -23,11 +23,11 @@ fi
 
 TEST_KERNEL_CMDLINE+=" root=LABEL=dracut panic=1 oops=panic softlockup_panic=1 systemd.crash_reboot $DEBUGFAIL "
 
-if [[ $V != "1" && $V != "2" ]]; then
+if [[ ${V-} != "1" && ${V-} != "2" ]]; then
     TEST_KERNEL_CMDLINE+="quiet "
 fi
 
-if [[ $V == "2" ]]; then
+if [[ ${V-} == "2" ]]; then
     TEST_KERNEL_CMDLINE+="rd.debug "
 fi
 
@@ -72,7 +72,7 @@ wait_for_server_startup() {
 
     echo "Waiting for the server to startup"
     while ! grep -q Serving "$TESTDIR"/server.log; do
-        if [ "$V" -ge 1 ]; then
+        if [ "${V-}" -ge 1 ]; then
             lines=$(wc -l "$TESTDIR"/server.log | cut -f 1 -d ' ')
             if [ "$lines" -gt "$printed_lines" ]; then
                 tail -n "+$((printed_lines + 1))" "$TESTDIR"/server.log
@@ -264,7 +264,7 @@ while (($# > 0)); do
         --all)
             set_test_envonment_variables
             if ! test_check 2 &> test${TEST_RUN_ID:+-$TEST_RUN_ID}.log; then
-                if [[ $V == "1" || $V == "2" ]]; then
+                if [[ ${V-} == "1" || ${V-} == "2" ]]; then
                     cat test${TEST_RUN_ID:+-$TEST_RUN_ID}.log
                 fi
                 echo -e "TEST: $TEST_DESCRIPTION " "$COLOR_WARNING" "[SKIPPED]" "$COLOR_NORMAL"
@@ -272,7 +272,7 @@ while (($# > 0)); do
             else
                 echo -e "TEST: $TEST_DESCRIPTION " "$COLOR_SUCCESS" "[STARTED]" "$COLOR_NORMAL"
             fi
-            if [[ $V == "1" || $V == "2" ]]; then
+            if [[ ${V-} == "1" || ${V-} == "2" ]]; then
                 tee_command="tee"
                 set -o pipefail
                 (
@@ -303,7 +303,7 @@ while (($# > 0)); do
                 echo -e "TEST: $TEST_DESCRIPTION " "$COLOR_SUCCESS" "[OK]" "$COLOR_NORMAL"
             else
                 echo -e "TEST: $TEST_DESCRIPTION " "$COLOR_FAILURE" "[FAILED]" "$COLOR_NORMAL"
-                if [ "$V" == "2" ]; then
+                if [ "${V-}" == "2" ]; then
                     tail -c 1048576 "$(pwd)/server${TEST_RUN_ID:+-$TEST_RUN_ID}.log" "$(pwd)/test${TEST_RUN_ID:+-$TEST_RUN_ID}.log"
                     echo -e "TEST: $TEST_DESCRIPTION " "$COLOR_FAILURE" "[FAILED]" "$COLOR_NORMAL"
                 else

--- a/test/test-functions
+++ b/test/test-functions
@@ -21,7 +21,7 @@ if [[ -f /etc/machine-id ]]; then
 fi
 [ -z "$TOKEN" ] && . /etc/os-release && TOKEN="$ID"
 
-TEST_KERNEL_CMDLINE+=" root=LABEL=dracut panic=1 oops=panic softlockup_panic=1 systemd.crash_reboot $DEBUGFAIL "
+TEST_KERNEL_CMDLINE+=" root=LABEL=dracut panic=1 oops=panic softlockup_panic=1 systemd.crash_reboot ${DEBUGFAIL-} "
 
 if [[ ${V-} != "1" && ${V-} != "2" ]]; then
     TEST_KERNEL_CMDLINE+="quiet "


### PR DESCRIPTION
## Changes

Support following environment variables to be unset (to support `set -u` in the future):
* SERIAL
* SERVER_DEBUG
* DEBUGOUT
* CPIO_TESTDIR
* V

## Checklist
- [ ] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it

Fixes #
