### PR TITLE
fix(dracut-logger.sh): initialize errmsg in dlog_init

### DIFF
--- a/dracut-logger.sh
+++ b/dracut-logger.sh
@@ -103,7 +103,7 @@ export __DRACUT_LOGGER__=1
 dlog_init() {
     local __oldumask
     local ret=0
-    local errmsg
+    local errmsg=
     [ -z "$stdloglvl" ] && stdloglvl=4
     [ -z "$sysloglvl" ] && sysloglvl=0
     [ -z "$kmsgloglvl" ] && kmsgloglvl=0


### PR DESCRIPTION
## Changes

Initialize the local variable `errmsg` in `dlog_init` to make the function work with `set -u`.

## Checklist
- [ ] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it

Fixes #
