### PR TITLE
test: initialize bootindex in qemu_add_drive

### DIFF
--- a/test/test-functions
+++ b/test/test-functions
@@ -205,7 +205,7 @@ qemu_add_drive() {
     local file=$3
     local name=${4:-$index}
     local size=${5:-0}
-    local bootindex=$6
+    local bootindex=${6-}
 
     if [ "${size}" -ne 0 ]; then
         if [[ ${name} =~ "marker" ]]; then


### PR DESCRIPTION
## Changes

Initialize the optional variables in `bootindex` to make the function work with `set -u`.

## Checklist
- [ ] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it

Fixes #
