### PR TITLE
fix: support DRACUT_RESOLVE_LAZY being unset

### DIFF
--- a/dracut-init.sh
+++ b/dracut-init.sh
@@ -229,7 +229,7 @@ if [[ $hostonly == "-h" ]]; then
     fi
 fi
 
-[[ $DRACUT_RESOLVE_LAZY ]] || export DRACUT_RESOLVE_DEPS=1
+[[ ${DRACUT_RESOLVE_LAZY-} ]] || export DRACUT_RESOLVE_DEPS=1
 inst_dir() {
     local _ret
     [[ -e ${initdir}/"$1" ]] && return 0 # already there

--- a/dracut.sh
+++ b/dracut.sh
@@ -2192,7 +2192,7 @@ if [[ $kernel_only != yes ]]; then
         fi
     fi
 
-    if [[ $DRACUT_RESOLVE_LAZY ]] && [[ $DRACUT_INSTALL ]]; then
+    if [[ ${DRACUT_RESOLVE_LAZY-} ]] && [[ $DRACUT_INSTALL ]]; then
         dinfo "*** Resolving executable dependencies ***"
         # shellcheck disable=SC2086
         find "$initdir" -type f -perm /0111 -not -path '*.ko*' -print0 \


### PR DESCRIPTION
## Changes

Support `DRACUT_RESOLVE_LAZY` being unset when using `set -u`.

## Checklist
- [ ] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it

Fixes #
