### PR TITLE
fix(dracut-init.sh): support DRACUT_NO_XATTR being unset

### DIFF
--- a/dracut-init.sh
+++ b/dracut-init.sh
@@ -19,7 +19,7 @@
 #
 export LC_MESSAGES=C
 
-if [[ $EUID == "0" ]] && ! [[ $DRACUT_NO_XATTR ]]; then
+if [[ $EUID == "0" ]] && ! [[ ${DRACUT_NO_XATTR-} ]]; then
     export DRACUT_CP="cp --reflink=auto --sparse=auto --preserve=mode,timestamps,xattr,links -dfr"
 else
     export DRACUT_CP="cp --reflink=auto --sparse=auto --preserve=mode,timestamps,links -dfr"


### PR DESCRIPTION
## Changes

Support `DRACUT_NO_XATTR` being unset when using `set -u`.

## Checklist
- [ ] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it

Fixes #
