### PR TITLE
chore: version lock commisery-action

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -13,7 +13,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Run Commisery
-        uses: tomtom-international/commisery-action@master
+        uses: tomtom-international/commisery-action@v3
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           # don't validate the pull request title


### PR DESCRIPTION
@master seems to report the folloeing error                                                                                                                                                                                           
                                                                                                                                                                                                                                      
Error: Resource not accessible by integration                                                                                                                                                                                         
                                                                                                                                                                                                                                      
Switch to @v3, as it is the last stable version.

## Checklist
- [ ] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it
