### PR TITLE
fix(dmsquash-live): erofs collision with latest util-linux

### DIFF
--- a/modules.d/70dmsquash-live/dmsquash-live-root.sh
+++ b/modules.d/70dmsquash-live/dmsquash-live-root.sh
@@ -422,7 +422,11 @@ fi
 if [ -n "$overlayfs" ]; then
     if [ -n "$FSIMG" ]; then
         mkdir -m 0755 -p /run/rootfsbase
-        mount -r "$FSIMG" /run/rootfsbase
+        if [ "$FSIMG" = "$SQUASHED" ]; then
+            mount --bind /run/initramfs/squashfs /run/rootfsbase
+        else
+            mount -r "$FSIMG" /run/rootfsbase
+        fi
     else
         ln -sf /run/initramfs/live /run/rootfsbase
     fi


### PR DESCRIPTION
## Changes

This PR fixes the issue that recent kernels can mount EROFS directly without loop devices, and this feature is enabled in Fedora kernels (>=6.12; CONFIG_EROFS_FS_BACKED_BY_FILE=y). This feature is now supported by mount/libmount, too.

I think the best approach would be to avoid the second mount altogether, independently of the util-linux version.
It is more robust to use a bind mount there than to attempt to create a second instance of the same file system.

## Checklist
- [ ] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it

Fixes #1384

CC @FGrose @karelzak 
