### PR TITLE
fix(systemd-repart): allow partition format

### DIFF
--- a/modules.d/01systemd-repart/module-setup.sh
+++ b/modules.d/01systemd-repart/module-setup.sh
@@ -20,6 +20,16 @@ install() {
         "$systemdsystemunitdir"/initrd-root-fs.target.wants/systemd-repart.service \
         systemd-repart
 
+    # Systemd-repart is capable of also formatting the created partition.
+    # Support all filesystems that repart.d supports.
+    inst_multiple -o \
+        "mkfs.ext4" \
+        "mkfs.btrfs" \
+        "mkfs.xfs" \
+        "mkfs.vfat" \
+        "mkfs.erofs" \
+        "mksquashfs"
+
     # Install the hosts local user configurations if enabled.
     if [[ $hostonly ]]; then
         inst_multiple -H -o \


### PR DESCRIPTION
systemd-repart is capable not only of creating a partition, but also of formatting it. According with repart.d, it is able to create the following filesystems: ext4, btrfs, xfs, vfat, erofs and squashfs.

Add support in the systemd-repart module for the underlying tools to allow systemd-repart to format the partition.

Failure to do so would make systemd-repart initramfs unit fail, if Format= option is provided in a repart.d config file.


## Checklist
- [x] I have tested it locally
- [x] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it

