### PR TITLE
fix: support DRACUT_SYSTEMD being unset

### DIFF
--- a/modules.d/11fips/fips.sh
+++ b/modules.d/11fips/fips.sh
@@ -4,7 +4,7 @@ command -v getarg > /dev/null || . /lib/dracut-lib.sh
 
 # systemd lets stdout go to journal only, but the system
 # has to halt when the integrity check fails to satisfy FIPS.
-if [ -z "$DRACUT_SYSTEMD" ]; then
+if [ -z "${DRACUT_SYSTEMD-}" ]; then
     fips_info() {
         info "$*"
     }

--- a/modules.d/20i18n/console_init.sh
+++ b/modules.d/20i18n/console_init.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 
-[ -n "$DRACUT_SYSTEMD" ] && exit 0
+[ -n "${DRACUT_SYSTEMD-}" ] && exit 0
 
 if [ -x "$systemdutildir"/systemd-vconsole-setup ]; then
     "$systemdutildir"/systemd-vconsole-setup "$@"

--- a/modules.d/35connman/cm-config.sh
+++ b/modules.d/35connman/cm-config.sh
@@ -7,7 +7,7 @@ if [ -n "$netroot" ] || [ -e /tmp/net.ifaces ]; then
 fi
 
 if getargbool 0 rd.debug; then
-    if [ -n "$DRACUT_SYSTEMD" ]; then
+    if [ -n "${DRACUT_SYSTEMD-}" ]; then
         # Enable tty output if a usable console is found
         # shellcheck disable=SC2217
         if [ -w /dev/console ] && (echo < /dev/console) > /dev/null 2> /dev/null; then

--- a/modules.d/35network-legacy/net-genrules.sh
+++ b/modules.d/35network-legacy/net-genrules.sh
@@ -102,7 +102,7 @@ command -v fix_bootif > /dev/null || . /lib/net-lib.sh
 
         for iface in $IFACES; do
             if [ "$bootdev" = "$iface" ] || [ "$NEEDNET" = "1" ]; then
-                if [ -n "$netroot" ] && [ -n "$DRACUT_SYSTEMD" ]; then
+                if [ -n "$netroot" ] && [ -n "${DRACUT_SYSTEMD-}" ]; then
                     echo "systemctl is-active initrd-root-device.target || [ -f /tmp/net.${iface}.did-setup ]"
                 else
                     echo "[ -f /tmp/net.${iface}.did-setup ]"

--- a/modules.d/35network-manager/nm-config.sh
+++ b/modules.d/35network-manager/nm-config.sh
@@ -21,7 +21,7 @@ if getargbool 0 rd.debug; then
         echo 'level=TRACE'
     ) > /run/NetworkManager/conf.d/initrd-logging.conf
 
-    if [ -n "$DRACUT_SYSTEMD" ]; then
+    if [ -n "${DRACUT_SYSTEMD-}" ]; then
         # Enable tty output if a usable console is found
         # See https://github.com/coreos/fedora-coreos-tracker/issues/943
         # shellcheck disable=SC2217

--- a/modules.d/35network-manager/nm-lib.sh
+++ b/modules.d/35network-manager/nm-lib.sh
@@ -33,7 +33,7 @@ nm_generate_connections() {
 }
 
 nm_reload_connections() {
-    [ -n "$DRACUT_SYSTEMD" ] \
+    [ -n "${DRACUT_SYSTEMD-}" ] \
         && systemctl -q is-active nm-initrd.service NetworkManager-initrd.service \
         && nmcli connection reload
 }

--- a/modules.d/35network-manager/nm-run.sh
+++ b/modules.d/35network-manager/nm-run.sh
@@ -2,7 +2,7 @@
 
 command -v source_hook > /dev/null || . /lib/dracut-lib.sh
 
-if [ -z "$DRACUT_SYSTEMD" ]; then
+if [ -z "${DRACUT_SYSTEMD-}" ]; then
     # Only start NM if networking is needed
     if [ -e /run/NetworkManager/initrd/neednet ]; then
         for i in /usr/lib/NetworkManager/system-connections/* \

--- a/modules.d/45plymouth/plymouth-newroot.sh
+++ b/modules.d/45plymouth/plymouth-newroot.sh
@@ -1,5 +1,5 @@
 #!/bin/sh
 
-if type plymouth > /dev/null 2>&1 && [ -z "$DRACUT_SYSTEMD" ]; then
+if type plymouth > /dev/null 2>&1 && [ -z "${DRACUT_SYSTEMD-}" ]; then
     plymouth --newroot="$NEWROOT"
 fi

--- a/modules.d/45plymouth/plymouth-pretrigger.sh
+++ b/modules.d/45plymouth/plymouth-pretrigger.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 
-if type plymouthd > /dev/null 2>&1 && [ -z "$DRACUT_SYSTEMD" ]; then
+if type plymouthd > /dev/null 2>&1 && [ -z "${DRACUT_SYSTEMD-}" ]; then
     if getargbool 1 plymouth.enable && getargbool 1 rd.plymouth; then
         # first trigger graphics subsystem
         udevadm trigger --action=add --attr-match=class=0x030000 > /dev/null 2>&1

--- a/modules.d/70crypt/crypt-run-generator.sh
+++ b/modules.d/70crypt/crypt-run-generator.sh
@@ -11,7 +11,7 @@ crypttab_contains "$luks" "$dev" && exit 0
 allowdiscards="-"
 
 # parse for allow-discards
-if [ -n "$DRACUT_SYSTEMD" ] || strstr "$(cryptsetup --help)" "allow-discards"; then
+if [ -n "${DRACUT_SYSTEMD-}" ] || strstr "$(cryptsetup --help)" "allow-discards"; then
     if discarduuids=$(getargs "rd.luks.allow-discards"); then
         discarduuids=$(str_replace "$discarduuids" 'luks-' '')
         if strstr " $discarduuids " " ${luks##luks-}"; then

--- a/modules.d/70crypt/parse-crypt.sh
+++ b/modules.d/70crypt/parse-crypt.sh
@@ -58,7 +58,7 @@ else
                 luksname="luks-$uuid"
             fi
 
-            if [ -z "$DRACUT_SYSTEMD" ]; then
+            if [ -z "${DRACUT_SYSTEMD-}" ]; then
                 {
                     printf -- 'ENV{ID_PART_ENTRY_UUID}=="*%s*", ' "$uuid"
                     printf -- 'RUN+="%s --settled --unique --onetime ' "$(command -v initqueue)"
@@ -98,7 +98,7 @@ else
                 luksname="luks-$serialid"
             fi
 
-            if [ -z "$DRACUT_SYSTEMD" ]; then
+            if [ -z "${DRACUT_SYSTEMD-}" ]; then
                 {
                     printf -- 'ENV{ID_SERIAL_SHORT}=="*%s*", ' "$serialid"
                     printf -- 'RUN+="%s --settled --unique --onetime ' "$(command -v initqueue)"
@@ -138,7 +138,7 @@ else
                 luksname="luks-$luksid"
             fi
 
-            if [ -z "$DRACUT_SYSTEMD" ]; then
+            if [ -z "${DRACUT_SYSTEMD-}" ]; then
                 {
                     printf -- 'ENV{ID_FS_TYPE}=="crypto_LUKS", '
                     printf -- 'ENV{ID_FS_UUID}=="*%s*", ' "$luksid"
@@ -175,7 +175,7 @@ else
             fi
         done
     elif getargbool 0 rd.auto; then
-        if [ -z "$DRACUT_SYSTEMD" ]; then
+        if [ -z "${DRACUT_SYSTEMD-}" ]; then
             {
                 printf -- 'ENV{ID_FS_TYPE}=="crypto_LUKS", RUN+="%s ' "$(command -v initqueue)"
                 printf -- '--unique --settled --onetime --name cryptroot-ask-%%k '

--- a/modules.d/70dmsquash-live/dmsquash-live-root.sh
+++ b/modules.d/70dmsquash-live/dmsquash-live-root.sh
@@ -73,7 +73,7 @@ if [ ! -f "$livedev" ]; then
     getarg rd.live.check || check=""
     if [ -n "$check" ]; then
         type plymouth > /dev/null 2>&1 && plymouth --hide-splash
-        if [ -n "$DRACUT_SYSTEMD" ]; then
+        if [ -n "${DRACUT_SYSTEMD-}" ]; then
             p=$(dev_unit_name "$check_dev")
             systemctl start checkisomd5@"${p}".service
         else
@@ -178,7 +178,7 @@ do_live_overlay() {
                 fi
                 if [ -n "$overlayfs" ]; then
                     unset -v overlayfs
-                    [ -n "$DRACUT_SYSTEMD" ] && reloadsysrootmountunit=":>/xor_overlayfs;"
+                    [ -n "${DRACUT_SYSTEMD-}" ] && reloadsysrootmountunit=":>/xor_overlayfs;"
                 fi
                 setup="yes"
             else
@@ -187,7 +187,7 @@ do_live_overlay() {
                     && [ -d /run/initramfs/overlayfs/ovlwork ]; then
                     ln -s /run/initramfs/overlayfs/overlayfs /run/overlayfs${readonly_overlay:+-r}
                     ln -s /run/initramfs/overlayfs/ovlwork /run/ovlwork${readonly_overlay:+-r}
-                    if [ -z "$overlayfs" ] && [ -n "$DRACUT_SYSTEMD" ]; then
+                    if [ -z "$overlayfs" ] && [ -n "${DRACUT_SYSTEMD-}" ]; then
                         reloadsysrootmountunit=":>/xor_overlayfs;"
                     fi
                     overlayfs="required"
@@ -198,7 +198,7 @@ do_live_overlay() {
             && [ -d "/run/initramfs/overlayfs$pathspec/../ovlwork" ]; then
             ln -s "/run/initramfs/overlayfs$pathspec" /run/overlayfs${readonly_overlay:+-r}
             ln -s "/run/initramfs/overlayfs$pathspec/../ovlwork" /run/ovlwork${readonly_overlay:+-r}
-            if [ -z "$overlayfs" ] && [ -n "$DRACUT_SYSTEMD" ]; then
+            if [ -z "$overlayfs" ] && [ -n "${DRACUT_SYSTEMD-}" ]; then
                 reloadsysrootmountunit=":>/xor_overlayfs;"
             fi
             overlayfs="required"
@@ -211,7 +211,7 @@ do_live_overlay() {
                 die "OverlayFS is required but not available."
                 exit 1
             fi
-            [ -n "$DRACUT_SYSTEMD" ] && reloadsysrootmountunit=":>/xor_overlayfs;"
+            [ -n "${DRACUT_SYSTEMD-}" ] && reloadsysrootmountunit=":>/xor_overlayfs;"
             m='OverlayFS is not available; using temporary Device-mapper overlay.'
             info "$m"
             unset -v overlayfs setup
@@ -228,7 +228,7 @@ do_live_overlay() {
       All root filesystem changes will be lost on shutdown.
          Press [Enter] to continue.'
             printf "\n\n\n\n%s\n\n\n" "${m}" > /dev/kmsg
-            if [ -n "$DRACUT_SYSTEMD" ]; then
+            if [ -n "${DRACUT_SYSTEMD-}" ]; then
                 if type plymouth > /dev/null 2>&1 && plymouth --ping; then
                     if getargbool 0 rhgb || getargbool 0 splash; then
                         m='>>>
@@ -261,7 +261,7 @@ do_live_overlay() {
             if [ -n "$readonly_overlay" ] && ! [ -h /run/overlayfs-r ]; then
                 info "No persistent overlay found."
                 unset -v readonly_overlay
-                [ -n "$DRACUT_SYSTEMD" ] && reloadsysrootmountunit="${reloadsysrootmountunit}:>/xor_readonly;"
+                [ -n "${DRACUT_SYSTEMD-}" ] && reloadsysrootmountunit="${reloadsysrootmountunit}:>/xor_readonly;"
             fi
         else
             dd if=/dev/null of=/overlay bs=1024 count=1 seek=$((overlay_size * 1024)) 2> /dev/null
@@ -346,7 +346,7 @@ if [ -e "$SQUASHED" ]; then
         fi
     elif [ -d /run/initramfs/squashfs/usr ]; then
         FSIMG=$SQUASHED
-        if [ -z "$overlayfs" ] && [ -n "$DRACUT_SYSTEMD" ]; then
+        if [ -z "$overlayfs" ] && [ -n "${DRACUT_SYSTEMD-}" ]; then
             reloadsysrootmountunit=":>/xor_overlayfs;"
         fi
         overlayfs="required"
@@ -427,7 +427,7 @@ if [ -n "$overlayfs" ]; then
         ln -sf /run/initramfs/live /run/rootfsbase
     fi
 else
-    if [ -z "$DRACUT_SYSTEMD" ]; then
+    if [ -z "${DRACUT_SYSTEMD-}" ]; then
         [ -n "$ROOTFLAGS" ] && ROOTFLAGS="-o $ROOTFLAGS"
         printf 'mount %s /dev/mapper/live-rw %s\n' "$ROOTFLAGS" "$NEWROOT" > "$hookdir"/mount/01-$$-live.sh
     fi

--- a/modules.d/74fcoe/cleanup-fcoe.sh
+++ b/modules.d/74fcoe/cleanup-fcoe.sh
@@ -6,7 +6,7 @@ if [ -e /var/run/lldpad.pid ]; then
     lldpad -k
     # with systemd version 230, this is not necessary anymore
     # systemd commit cacf980ed44a28e276a6cc7f8fc41f991e2ab354
-    if [ -z "$DRACUT_SYSTEMD" ]; then
+    if [ -z "${DRACUT_SYSTEMD-}" ]; then
         # shellcheck disable=SC2174
         mkdir -m 0755 -p /run/initramfs/state/dev/shm
         cp /dev/shm/lldpad.state /run/initramfs/state/dev/shm/ > /dev/null 2>&1

--- a/modules.d/74fstab-sys/mount-sys.sh
+++ b/modules.d/74fstab-sys/mount-sys.sh
@@ -27,7 +27,7 @@ fstab_mount() {
 
 # systemd will mount and run fsck from /etc/fstab and we don't want to
 # run into a race condition.
-if [ -z "$DRACUT_SYSTEMD" ]; then
+if [ -z "${DRACUT_SYSTEMD-}" ]; then
     [ -f /etc/fstab ] && fstab_mount /etc/fstab
 fi
 

--- a/modules.d/74iscsi/cleanup-iscsi.sh
+++ b/modules.d/74iscsi/cleanup-iscsi.sh
@@ -1,5 +1,5 @@
 #!/bin/sh
 
-if [ -z "${DRACUT_SYSTEMD}" ] && { [ -e /sys/module/bnx2i ] || [ -e /sys/module/qedi ]; }; then
+if [ -z "${DRACUT_SYSTEMD-}" ] && { [ -e /sys/module/bnx2i ] || [ -e /sys/module/qedi ]; }; then
     killproc iscsiuio
 fi

--- a/modules.d/74iscsi/iscsiroot.sh
+++ b/modules.d/74iscsi/iscsiroot.sh
@@ -37,7 +37,7 @@ iroot=${iroot#:}
 modprobe crc32c 2> /dev/null
 
 # start iscsiuio if needed
-if [ -z "${DRACUT_SYSTEMD}" ] \
+if [ -z "${DRACUT_SYSTEMD-}" ] \
     && { [ -e /sys/module/bnx2i ] || [ -e /sys/module/qedi ]; } \
     && ! [ -e /tmp/iscsiuio-started ]; then
     iscsiuio
@@ -149,7 +149,7 @@ handle_netroot() {
         mkdir -p /etc/iscsi
         ln -fs /run/initiatorname.iscsi /etc/iscsi/initiatorname.iscsi
         : > /tmp/iscsi_set_initiator
-        if [ -n "$DRACUT_SYSTEMD" ]; then
+        if [ -n "${DRACUT_SYSTEMD-}" ]; then
             systemctl try-restart iscsid
             # FIXME: iscsid is not yet ready, when the service is :-/
             sleep 1
@@ -170,7 +170,7 @@ handle_netroot() {
         mkdir -p /etc/iscsi
         ln -fs /run/initiatorname.iscsi /etc/iscsi/initiatorname.iscsi
         : > /tmp/iscsi_set_initiator
-        if [ -n "$DRACUT_SYSTEMD" ]; then
+        if [ -n "${DRACUT_SYSTEMD-}" ]; then
             systemctl try-restart iscsid
             # FIXME: iscsid is not yet ready, when the service is :-/
             sleep 1
@@ -194,14 +194,14 @@ handle_netroot() {
     if ! [ -e /etc/iscsi/initiatorname.iscsi ]; then
         mkdir -p /etc/iscsi
         ln -fs /run/initiatorname.iscsi /etc/iscsi/initiatorname.iscsi
-        if [ -n "$DRACUT_SYSTEMD" ]; then
+        if [ -n "${DRACUT_SYSTEMD-}" ]; then
             systemctl try-restart iscsid
             # FIXME: iscsid is not yet ready, when the service is :-/
             sleep 1
         fi
     fi
 
-    if [ -z "$DRACUT_SYSTEMD" ]; then
+    if [ -z "${DRACUT_SYSTEMD-}" ]; then
         iscsid
         sleep 2
     fi
@@ -216,7 +216,7 @@ handle_netroot() {
         wait_for_dev -n /dev/root
 
         # install mount script
-        [ -z "$DRACUT_SYSTEMD" ] \
+        [ -z "${DRACUT_SYSTEMD-}" ] \
             && echo "iscsi_lun=$iscsi_lun . /bin/mount-lun.sh " > "$hookdir"/mount/01-$$-iscsi.sh
     fi
 

--- a/modules.d/74iscsi/parse-iscsiroot.sh
+++ b/modules.d/74iscsi/parse-iscsiroot.sh
@@ -42,7 +42,7 @@ if [ "${root%%:*}" = "iscsi" ]; then
     netroot=$root
     # if root is not specified try to mount the whole iSCSI LUN
     printf 'ENV{DEVTYPE}!="partition", SYMLINK=="disk/by-path/*-iscsi-*-*", SYMLINK+="root"\n' >> /etc/udev/rules.d/99-iscsi-root.rules
-    [ -n "$DRACUT_SYSTEMD" ] && systemctl is-active systemd-udevd && udevadm control --reload-rules
+    [ -n "${DRACUT_SYSTEMD-}" ] && systemctl is-active systemd-udevd && udevadm control --reload-rules
     root=/dev/root
 
     write_fs_tab /dev/root
@@ -59,7 +59,7 @@ done
 if [ "${root}" = "/dev/root" ] && getarg "netroot=dhcp"; then
     # if root is not specified try to mount the whole iSCSI LUN
     printf 'ENV{DEVTYPE}!="partition", SYMLINK=="disk/by-path/*-iscsi-*-*", SYMLINK+="root"\n' >> /etc/udev/rules.d/99-iscsi-root.rules
-    [ -n "$DRACUT_SYSTEMD" ] && systemctl is-active systemd-udevd && udevadm control --reload-rules
+    [ -n "${DRACUT_SYSTEMD-}" ] && systemctl is-active systemd-udevd && udevadm control --reload-rules
 fi
 
 if [ -n "$iscsiroot" ]; then
@@ -116,7 +116,7 @@ if arg=$(getarg rd.iscsi.initiator -d iscsi_initiator=) && [ -n "$arg" ] && ! [ 
     rm -f /etc/iscsi/initiatorname.iscsi
     mkdir -p /etc/iscsi
     ln -fs /run/initiatorname.iscsi /etc/iscsi/initiatorname.iscsi
-    if [ -n "$DRACUT_SYSTEMD" ]; then
+    if [ -n "${DRACUT_SYSTEMD-}" ]; then
         systemctl try-restart iscsid
         # FIXME: iscsid is not yet ready, when the service is :-/
         sleep 1
@@ -132,7 +132,7 @@ if [ -z "$iscsi_initiator" ] && [ -f /sys/firmware/ibft/initiator/initiator-name
         mkdir -p /etc/iscsi
         ln -fs /run/initiatorname.iscsi /etc/iscsi/initiatorname.iscsi
         : > /tmp/iscsi_set_initiator
-        if [ -n "$DRACUT_SYSTEMD" ]; then
+        if [ -n "${DRACUT_SYSTEMD-}" ]; then
             systemctl try-restart iscsid
             # FIXME: iscsid is not yet ready, when the service is :-/
             sleep 1

--- a/modules.d/74nbd/nbdroot.sh
+++ b/modules.d/74nbd/nbdroot.sh
@@ -101,7 +101,7 @@ if [ "$root" = "block:/dev/root" ] || [ "$root" = "dhcp" ]; then
     udevadm control --reload
     wait_for_dev -n /dev/root
 
-    if [ -z "$DRACUT_SYSTEMD" ]; then
+    if [ -z "${DRACUT_SYSTEMD-}" ]; then
         command -v write_fs_tab > /dev/null || . /lib/fs-lib.sh
 
         write_fs_tab /dev/root "$nbdfstype" "$fsopts"

--- a/modules.d/80base/dracut-dev-lib.sh
+++ b/modules.d/80base/dracut-dev-lib.sh
@@ -56,7 +56,7 @@ set_systemd_timeout_for_dev() {
     local _noreload
     local _timeout
 
-    [ -z "$DRACUT_SYSTEMD" ] && return 0
+    [ -z "${DRACUT_SYSTEMD-}" ] && return 0
 
     if [ "$1" = "-n" ]; then
         _noreload=1
@@ -130,7 +130,7 @@ cancel_wait_for_dev() {
     _name="$(str_replace "$1" '/' '\x2f')"
     rm -f -- "$hookdir/initqueue/finished/devexists-${_name}.sh"
     rm -f -- "$hookdir/emergency/80-${_name}.sh"
-    if [ -n "$DRACUT_SYSTEMD" ]; then
+    if [ -n "${DRACUT_SYSTEMD-}" ]; then
         _name=$(dev_unit_name "$1")
         rm -f -- "${PREFIX}/etc/systemd/system/initrd.target.wants/${_name}.device"
         rm -f -- "${PREFIX}/etc/systemd/system/${_name}.device.d/timeout.conf"

--- a/modules.d/80base/dracut-lib.sh
+++ b/modules.d/80base/dracut-lib.sh
@@ -64,7 +64,7 @@ trim() {
     printf "%s" "$var"
 }
 
-if [ -z "$DRACUT_SYSTEMD" ]; then
+if [ -z "${DRACUT_SYSTEMD-}" ]; then
 
     warn() {
         check_quiet
@@ -422,7 +422,7 @@ die() {
         source_hook "shutdown-emergency"
     fi
 
-    if [ -n "$DRACUT_SYSTEMD" ]; then
+    if [ -n "${DRACUT_SYSTEMD-}" ]; then
         systemctl --no-block --force poweroff
     fi
 
@@ -834,7 +834,7 @@ fi
 
 _emergency_shell() {
     local _name="$1"
-    if [ -n "$DRACUT_SYSTEMD" ]; then
+    if [ -n "${DRACUT_SYSTEMD-}" ]; then
         : > /.console_lock
         echo "PS1=\"$_name:\\\${PWD}# \"" > /etc/profile
         systemctl start dracut-emergency.service


### PR DESCRIPTION
## Changes

Support `DRACUT_SYSTEMD` being unset when using `set -u`.

## Checklist
- [ ] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it

Fixes #
