### PR TITLE
test: setup test environment variables only when needed

### DIFF
--- a/test/TEST-10-BASIC/test.sh
+++ b/test/TEST-10-BASIC/test.sh
@@ -3,6 +3,10 @@ set -e
 # shellcheck disable=SC2034
 TEST_DESCRIPTION="root filesystem on ext4 filesystem"
 
+test_check() {
+    set_kversion_and_vmlinux
+}
+
 test_run() {
     declare -a disk_args=()
     # shellcheck disable=SC2034  # disk_index used in qemu_add_drive

--- a/test/TEST-11-USR-MOUNT/test.sh
+++ b/test/TEST-11-USR-MOUNT/test.sh
@@ -8,6 +8,7 @@ TEST_DESCRIPTION="root filesystem on a btrfs filesystem with /usr subvolume"
 #DEBUGFAIL="rd.shell rd.break"
 
 test_check() {
+    set_kversion_and_vmlinux
     if ! type -p mkfs.btrfs &> /dev/null; then
         echo "Test needs mkfs.btrfs.. Skipping"
         return 1

--- a/test/TEST-12-UEFI/test.sh
+++ b/test/TEST-12-UEFI/test.sh
@@ -5,6 +5,7 @@ set -e
 TEST_DESCRIPTION="UEFI boot (ukify, kernel-install)"
 
 test_check() {
+    set_kversion_and_vmlinux
     if ! type -p mksquashfs &> /dev/null; then
         echo "Test needs mksquashfs... Skipping"
         return 1

--- a/test/TEST-13-SYSROOT/test.sh
+++ b/test/TEST-13-SYSROOT/test.sh
@@ -3,6 +3,10 @@ set -e
 # shellcheck disable=SC2034
 TEST_DESCRIPTION="initramfs created from sysroot"
 
+test_check() {
+    set_kversion_and_vmlinux
+}
+
 test_run() {
     declare -a disk_args=()
     # shellcheck disable=SC2034  # disk_index used in qemu_add_drive

--- a/test/TEST-20-STORAGE/test.sh
+++ b/test/TEST-20-STORAGE/test.sh
@@ -7,6 +7,7 @@ set -e
 TEST_DESCRIPTION="root filesystem on multiple device $TEST_FSTYPE (on top of RAID and LUKS)"
 
 test_check() {
+    set_kversion_and_vmlinux
     (command -v zfs || (command -v lvm && command -v "mkfs.$TEST_FSTYPE")) &> /dev/null
 }
 

--- a/test/TEST-26-ENC-RAID-LVM/test.sh
+++ b/test/TEST-26-ENC-RAID-LVM/test.sh
@@ -9,6 +9,7 @@ TEST_DESCRIPTION="root filesystem on LVM on encrypted partitions of a RAID"
 #DEBUGFAIL="rd.shell loglevel=70 systemd.log_target=kmsg systemd.log_target=debug"
 
 test_check() {
+    set_kversion_and_vmlinux
     if ! type -p cryptsetup &> /dev/null; then
         echo "Test needs cryptsetup for crypt module... Skipping"
         return 1

--- a/test/TEST-30-DMSQUASH/test.sh
+++ b/test/TEST-30-DMSQUASH/test.sh
@@ -8,6 +8,7 @@ TEST_DESCRIPTION="live root on a squash filesystem"
 #DEBUGFAIL="rd.shell rd.debug rd.live.debug loglevel=7"
 
 test_check() {
+    set_kversion_and_vmlinux
     if ! type -p mksquashfs &> /dev/null; then
         echo "Test needs mksquashfs... Skipping"
         return 1

--- a/test/TEST-40-SYSTEMD/test.sh
+++ b/test/TEST-40-SYSTEMD/test.sh
@@ -4,6 +4,7 @@ set -e
 TEST_DESCRIPTION="root filesystem on a ext4 filesystem"
 
 test_check() {
+    set_kversion_and_vmlinux
     command -v systemctl &> /dev/null
 }
 

--- a/test/TEST-41-FULL-SYSTEMD/test.sh
+++ b/test/TEST-41-FULL-SYSTEMD/test.sh
@@ -5,6 +5,7 @@ set -e
 TEST_DESCRIPTION="Full systemd serialization/deserialization test with /usr mount"
 
 test_check() {
+    set_kversion_and_vmlinux
     if ! type -p mkfs.btrfs &> /dev/null; then
         echo "Test needs mkfs.btrfs.. Skipping"
         return 1

--- a/test/TEST-42-SYSTEMD-INITRD/test.sh
+++ b/test/TEST-42-SYSTEMD-INITRD/test.sh
@@ -5,6 +5,7 @@ set -e
 TEST_DESCRIPTION="root filesystem on a ext4 filesystem with systemd but without dracut-systemd"
 
 test_check() {
+    set_kversion_and_vmlinux
     command -v systemctl &> /dev/null
 }
 

--- a/test/TEST-43-KERNEL-INSTALL/test.sh
+++ b/test/TEST-43-KERNEL-INSTALL/test.sh
@@ -4,6 +4,7 @@ set -e
 TEST_DESCRIPTION="kernel-install with root filesystem on ext4 filesystem"
 
 test_check() {
+    set_kversion_and_vmlinux
     if command -v systemd-detect-virt > /dev/null && ! systemd-detect-virt -c &> /dev/null; then
         echo "This test assumes that it runs inside a CI container."
         return 1

--- a/test/TEST-60-NFS/test.sh
+++ b/test/TEST-60-NFS/test.sh
@@ -7,6 +7,7 @@ set -e
 TEST_DESCRIPTION="root filesystem on NFS with $USE_NETWORK"
 
 test_check() {
+    set_kversion_and_vmlinux
     if ! type -p dhclient &> /dev/null; then
         echo "Test needs dhclient for server networking... Skipping"
         return 1

--- a/test/TEST-61-MULTINIC/test.sh
+++ b/test/TEST-61-MULTINIC/test.sh
@@ -13,6 +13,7 @@ TEST_DESCRIPTION="root filesystem on NFS with multiple nics with $USE_NETWORK"
 
 # skip the test if ifcfg dracut module can not be installed
 test_check() {
+    set_kversion_and_vmlinux
     if ! type -p dhclient &> /dev/null; then
         echo "Test needs dhclient for server networking... Skipping"
         return 1

--- a/test/TEST-62-BONDBRIDGEVLAN/test.sh
+++ b/test/TEST-62-BONDBRIDGEVLAN/test.sh
@@ -15,6 +15,7 @@ TEST_DESCRIPTION="root filesystem on NFS with bridging/bonding/vlan with $USE_NE
 
 # skip the test if ifcfg dracut module can not be installed
 test_check() {
+    set_kversion_and_vmlinux
     if ! type -p dhclient &> /dev/null; then
         echo "Test needs dhclient for server networking... Skipping"
         return 1

--- a/test/TEST-70-ISCSI/test.sh
+++ b/test/TEST-70-ISCSI/test.sh
@@ -118,6 +118,7 @@ test_run() {
 }
 
 test_check() {
+    set_kversion_and_vmlinux
     if ! type -p dhclient &> /dev/null; then
         echo "Test needs dhclient for server networking... Skipping"
         return 1

--- a/test/TEST-71-ISCSI-MULTI/test.sh
+++ b/test/TEST-71-ISCSI-MULTI/test.sh
@@ -125,6 +125,7 @@ test_run() {
 }
 
 test_check() {
+    set_kversion_and_vmlinux
     if ! type -p dhclient &> /dev/null; then
         echo "Test needs dhclient for server networking... Skipping"
         return 1

--- a/test/TEST-72-NBD/test.sh
+++ b/test/TEST-72-NBD/test.sh
@@ -13,6 +13,7 @@ TEST_DESCRIPTION="root filesystem on NBD with $USE_NETWORK"
 #SERIAL="tcp:127.0.0.1:9999"
 
 test_check() {
+    set_kversion_and_vmlinux
     if ! type -p dhclient &> /dev/null; then
         echo "Test needs dhclient for server networking... Skipping"
         return 1

--- a/test/TEST-82-DRACUT-CPIO/test.sh
+++ b/test/TEST-82-DRACUT-CPIO/test.sh
@@ -8,6 +8,7 @@ TEST_DESCRIPTION="kernel cpio extraction tests for dracut-cpio"
 # see dracut-cpio source for unit tests
 
 test_check() {
+    set_kversion_and_vmlinux
     if ! [[ -x "$PKGLIBDIR/dracut-cpio" ]]; then
         echo "Test needs dracut-cpio... Skipping"
         return 1

--- a/test/test-functions
+++ b/test/test-functions
@@ -244,13 +244,11 @@ while (($# > 0)); do
     case $1 in
         --run)
             echo "TEST RUN: $TEST_DESCRIPTION"
-            set_kversion_and_vmlinux
             test_check && test_run
             exit $?
             ;;
         --setup)
             echo "TEST SETUP: $TEST_DESCRIPTION"
-            set_kversion_and_vmlinux
             test_check && test_setup
             exit $?
             ;;
@@ -262,7 +260,6 @@ while (($# > 0)); do
             exit $?
             ;;
         --all)
-            set_kversion_and_vmlinux
             if ! test_check 2 &> test${TEST_RUN_ID:+-$TEST_RUN_ID}.log; then
                 if [[ ${V-} == "1" || ${V-} == "2" ]]; then
                     cat test${TEST_RUN_ID:+-$TEST_RUN_ID}.log


### PR DESCRIPTION
## Changes

The function `set_test_envonment_variables` contains a spelling mistake. Rename it to `set_kversion_and_vmlinux` to make it more explicit.

The test environment variables `KVERSION` and `VMLINUZ` are only needed when calling `run-qemu` or using them directly. They are not needed for TEST-80-GETARG and TEST-81-SKIPCPIO.

So move the `set_kversion_and_vmlinux` call to the relevant `test_check` functions.

## Checklist
- [ ] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it

Fixes #
