### PR TITLE
test(GETARGS): initialize NEWROOT for dracut-lib.sh

### DIFF
--- a/test/TEST-80-GETARG/test.sh
+++ b/test/TEST-80-GETARG/test.sh
@@ -86,6 +86,10 @@ test_run() {
         [[ $val ]] && ret=$((ret + 1))
 
         export PATH=".:$PATH"
+        # shellcheck disable=SC2034  # NEWROOT defined for dracut-lib.sh, set by base/init.sh
+        NEWROOT=$(mktemp --directory -p "$TESTDIR" newroot.XXXXXXXXXX)
+        # shellcheck disable=SC2034  # PREFIX defined for dracut-lib.sh to avoid creating /run/initramfs
+        PREFIX=/nonexistent
 
         . dracut-dev-lib.sh
         . dracut-lib.sh


### PR DESCRIPTION
## Changes

Set `NEWROOT` to an existing directory to make sourcing `dracut-lib.sh` work with `set -u`.

## Checklist
- [ ] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it

Fixes #
