### PR TITLE
test: add --pbkdf pbkdf2 to luksFormat commands

### DIFF
--- a/test/TEST-20-STORAGE/create-root.sh
+++ b/test/TEST-20-STORAGE/create-root.sh
@@ -24,7 +24,7 @@ else
 
     if ! grep -qF 'rd.luks=0' /proc/cmdline && command -v cryptsetup > /dev/null; then
         printf test > keyfile
-        cryptsetup -q luksFormat /dev/md0 /keyfile
+        cryptsetup --pbkdf pbkdf2 -q luksFormat /dev/md0 /keyfile
         echo "The passphrase is test"
         cryptsetup luksOpen /dev/md0 dracut_crypt_test < /keyfile
         lvm pvcreate -ff -y /dev/mapper/dracut_crypt_test

--- a/test/TEST-26-ENC-RAID-LVM/create-root.sh
+++ b/test/TEST-26-ENC-RAID-LVM/create-root.sh
@@ -3,8 +3,8 @@
 trap 'poweroff -f' EXIT
 set -ex
 printf test > keyfile
-cryptsetup -q luksFormat /dev/disk/by-id/scsi-0QEMU_QEMU_HARDDISK_disk1 /keyfile
-cryptsetup -q luksFormat /dev/disk/by-id/scsi-0QEMU_QEMU_HARDDISK_disk2 /keyfile
+cryptsetup --pbkdf pbkdf2 -q luksFormat /dev/disk/by-id/scsi-0QEMU_QEMU_HARDDISK_disk1 /keyfile
+cryptsetup --pbkdf pbkdf2 -q luksFormat /dev/disk/by-id/scsi-0QEMU_QEMU_HARDDISK_disk2 /keyfile
 cryptsetup luksOpen /dev/disk/by-id/scsi-0QEMU_QEMU_HARDDISK_disk1 dracut_disk1 < /keyfile
 cryptsetup luksOpen /dev/disk/by-id/scsi-0QEMU_QEMU_HARDDISK_disk2 dracut_disk2 < /keyfile
 mdadm --create /dev/md0 --run --auto=yes --level=1 --metadata=0.90 --raid-devices=2 /dev/mapper/dracut_disk1 /dev/mapper/dracut_disk2

--- a/test/TEST-41-FULL-SYSTEMD/create-root.sh
+++ b/test/TEST-41-FULL-SYSTEMD/create-root.sh
@@ -6,7 +6,7 @@ set -e
 modprobe btrfs || :
 mkfs.btrfs -q -L dracut /dev/disk/by-id/scsi-0QEMU_QEMU_HARDDISK_root
 printf test > keyfile
-cryptsetup -q luksFormat /dev/disk/by-id/scsi-0QEMU_QEMU_HARDDISK_root_crypt /keyfile
+cryptsetup --pbkdf pbkdf2 -q luksFormat /dev/disk/by-id/scsi-0QEMU_QEMU_HARDDISK_root_crypt /keyfile
 cryptsetup luksOpen /dev/disk/by-id/scsi-0QEMU_QEMU_HARDDISK_root_crypt dracut_crypt_test < /keyfile
 mkfs.btrfs -q -L dracut_crypt /dev/mapper/dracut_crypt_test
 mkfs.btrfs -q -L dracutusr /dev/disk/by-id/scsi-0QEMU_QEMU_HARDDISK_usr

--- a/test/TEST-72-NBD/create-encrypted-root.sh
+++ b/test/TEST-72-NBD/create-encrypted-root.sh
@@ -4,7 +4,7 @@ trap 'poweroff -f' EXIT
 set -ex
 
 printf test > keyfile
-cryptsetup -q luksFormat /dev/disk/by-id/scsi-0QEMU_QEMU_HARDDISK_root /keyfile
+cryptsetup --pbkdf pbkdf2 -q luksFormat /dev/disk/by-id/scsi-0QEMU_QEMU_HARDDISK_root /keyfile
 echo "The passphrase is test"
 cryptsetup luksOpen /dev/disk/by-id/scsi-0QEMU_QEMU_HARDDISK_root dracut_crypt_test < /keyfile
 lvm pvcreate -ff -y /dev/mapper/dracut_crypt_test


### PR DESCRIPTION
## Changes

Make the test work with recent release (v2.8.0) of cryptsetup.

This PR keeps memory requirements for LUKS unlocking minimal, allowing test cases run in system with minimal memory.
The storage stack and boot process that is being tested, remains exactly the same.
Default for LUKS2 is now Argon2 (memory-hard KDF, so it means that it requires some amount of memory).

Fixes: https://github.com/dracut-ng/dracut-ng/issues/1389

## Checklist
- [ ] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it
