### PR TITLE
feat(network-manager): remove support for ifcfg-rh

### DIFF
--- a/modules.d/35network-manager/module-setup.sh
+++ b/modules.d/35network-manager/module-setup.sh
@@ -95,10 +95,6 @@ install() {
         echo "${UUID//-/}" > "$initdir/etc/machine-id"
     fi
 
-    # We don't install the ifcfg files from the host automatically.
-    # But the user might choose to include them, so we pull in the machinery to read them.
-    inst_libdir_file "NetworkManager/$_nm_version/libnm-settings-plugin-ifcfg-rh.so"
-
     _arch=${DRACUT_ARCH:-$(uname -m)}
 
     inst_libdir_file {"tls/$_arch/",tls/,"$_arch/",}"libnss_dns.so.*" \

--- a/modules.d/35network-manager/nm-initrd.service
+++ b/modules.d/35network-manager/nm-initrd.service
@@ -10,7 +10,6 @@ ConditionPathExists=/run/NetworkManager/initrd/neednet
 ConditionPathExistsGlob=|/usr/lib/NetworkManager/system-connections/*
 ConditionPathExistsGlob=|/run/NetworkManager/system-connections/*
 ConditionPathExistsGlob=|/etc/NetworkManager/system-connections/*
-ConditionPathExistsGlob=|/etc/sysconfig/network-scripts/ifcfg-*
 
 [Service]
 Type=dbus

--- a/modules.d/35network-manager/nm-lib.sh
+++ b/modules.d/35network-manager/nm-lib.sh
@@ -20,8 +20,7 @@ nm_generate_connections() {
         if getargbool 0 rd.neednet; then
             for i in /usr/lib/NetworkManager/system-connections/* \
                 /run/NetworkManager/system-connections/* \
-                /etc/NetworkManager/system-connections/* \
-                /etc/sysconfig/network-scripts/ifcfg-*; do
+                /etc/NetworkManager/system-connections/*; do
                 [ -f "$i" ] || continue
                 echo '[ -f /tmp/nm.done ]' > "$hookdir"/initqueue/finished/nm.sh
                 mkdir -p /run/NetworkManager/initrd

--- a/modules.d/35network-manager/nm-run.sh
+++ b/modules.d/35network-manager/nm-run.sh
@@ -7,8 +7,7 @@ if [ -z "$DRACUT_SYSTEMD" ]; then
     if [ -e /run/NetworkManager/initrd/neednet ]; then
         for i in /usr/lib/NetworkManager/system-connections/* \
             /run/NetworkManager/system-connections/* \
-            /etc/NetworkManager/system-connections/* \
-            /etc/sysconfig/network-scripts/ifcfg-*; do
+            /etc/NetworkManager/system-connections/*; do
             [ -f "$i" ] || continue
             /usr/sbin/NetworkManager --configure-and-quit=initrd --no-daemon
             break


### PR DESCRIPTION
## Changes

Follow-up to 8ba8d55 .

This commit removes the dracut module for the NetworkManager fcfg-rh plugin (`nm-fcfg-rh`), effectively discontinuing its support within dracut.

### Understanding the NetworkManager fcfg-rh Plugin

The `fcfg-rh` plugin for NetworkManager provides backward compatibility with the legacy `ifcfg` network configuration format. This format, traditionally found in `/etc/sysconfig/network-scripts/`, was the standard method for configuring network interfaces on Red Hat-based distributions for many years. It relies on a collection of shell-script-like files to define network connections.

While functional for basic configurations, the `ifcfg` format has several limitations in the context of modern networking and the capabilities of NetworkManager.

### The Rationale for Removal

The removal of the `nm-fcfg-rh` support from dracut is a forward-looking change that aligns with the broader trend in the Linux ecosystem to modernize network configuration. The key reasons for this decision are as follows:

* **Deprecation by Upstream and Distributions:** The `fcfg-rh` plugin is considered deprecated by the NetworkManager project and major Linux distributions, such as Fedora and its derivatives. These distributions are actively migrating users away from the legacy `ifcfg` format in favor of the more robust `keyfile` format.

* **Superiority of the Keyfile Format:** NetworkManager's native `keyfile` format is a more structured and extensible INI-style configuration format. It offers several advantages over `ifcfg`:
    * **Full Feature Support:** The `keyfile` format supports all of NetworkManager's features, whereas the `fcfg-rh` plugin has limitations in expressing more advanced networking configurations.
    * **Predictability and Reliability:** The `keyfile` format is more predictable and less prone to the parsing and ordering issues that can arise with the shell-script-based `ifcfg` files.
    * **Easier for Tooling:** The structured nature of the `keyfile` format makes it significantly easier for other tools and scripts to parse and manipulate network configurations reliably.

* **Simplification and Modernization:** By removing support for the legacy `fcfg-rh` plugin, dracut is simplified, and its network configuration handling is modernized. This reduces the maintenance burden and potential for bugs associated with supporting a deprecated format. This change encourages the use of the `keyfile` format, which is the current best practice for configuring networks with NetworkManager.

* **Consistency with Modern Systems:** On contemporary systems, NetworkManager defaults to and often exclusively uses the `keyfile` format. Continuing to support the `fcfg-rh` plugin within the initramfs can lead to an inconsistent and potentially confusing network configuration environment.

This change is a deliberate step towards a more streamlined and modern approach to network configuration within the initramfs, reflecting the direction of the broader Linux networking landscape. Users are encouraged to adopt the `keyfile` format for their NetworkManager connection profiles.

See https://networkmanager.dev/docs/api/latest/nm-settings-ifcfg-rh.html.

CC @Conan-Kudo @LaszloGombos @bengal @dtardon 

## Checklist
- [ ] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it
