### PR TITLE
revert: bump tomtom-international/commisery-action from 3 to 4

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -13,7 +13,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Run Commisery
-        uses: tomtom-international/commisery-action@v4
+        uses: tomtom-international/commisery-action@v3
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           # don't validate the pull request title


### PR DESCRIPTION
## Changes

Follow-up to 854ae51faf64 .

Why: v4 fails for this project, v3 does not fail.

## Checklist
- [ ] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it

