### PR TITLE
ci: disable running arm64 tests on Fedora

### DIFF
--- a/.github/workflows/integration-extra-arm64.yml
+++ b/.github/workflows/integration-extra-arm64.yml
@@ -25,7 +25,6 @@ jobs:
             matrix:
                 container:
                     - debian
-                    - fedora
                     - opensuse
                     - ubuntu
                     - void


### PR DESCRIPTION
## Changes

If CI is not kept green, than it is hard to separate regressions caused by PRs from regressions not caused by PRs.                                                                                                                                                                                     

The primary purpose of the CI is to help contributors to highlight  regressions caused by PRs. Leaving tests broken caused by changes in distributions and not by dracut changes would make it  harder to contribute to dracut.                                                                                                                                                                                                       
                                                          
Ideally we want to respond changes in distributions,  but for this the project is leaning on specific Linux distribution contributors (Fedora in this case)  to help out who are more familiar with distribution   specific regressions and changes. 
                                                                                                                                                                                                                                      
Issue filed https://github.com/dracut-ng/dracut-ng/issues/1406  

CC @AdamWill @pvalena @Conan-Kudo @dtardon 

