### PR TITLE
test: remove unnecessary drivers from test dracut modules.

### DIFF
--- a/test/modules.d/70test-makeroot/module-setup.sh
+++ b/test/modules.d/70test-makeroot/module-setup.sh
@@ -9,10 +9,6 @@ depends() {
     echo "rootfs-block kernel-modules qemu"
 }
 
-installkernel() {
-    hostonly='' instmods piix ide-gd_mod ata_piix ext4 sd_mod
-}
-
 install() {
     inst_multiple cp umount sync mkfs.ext4
 

--- a/test/modules.d/70test/module-setup.sh
+++ b/test/modules.d/70test/module-setup.sh
@@ -6,17 +6,11 @@ check() {
 }
 
 depends() {
-    echo "base debug qemu watchdog"
+    echo "base debug qemu watchdog kernel-modules"
 }
 
+# testsuite assumes ext4 for convenience
 installkernel() {
     hostonly='' instmods \
-        ata_piix \
-        ext4 \
-        i6300esb \
-        ide-gd_mod \
-        piix \
-        sd_mod \
-        virtio_pci \
-        virtio_scsi
+        ext4
 }


### PR DESCRIPTION
## Changes

To increase test coverage for kernel-modules and instead of hard-coding required Linux kernel modules,
use the kernel-modules dracut module instead.

This change is enabled by 8730476 .

## Checklist
- [ ] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it

Fixes #1324
