### PR TITLE
test: remove hard-off test hooks hooks

### DIFF
--- a/test/TEST-60-NFS/hard-off.sh
+++ b/test/TEST-60-NFS/hard-off.sh
@@ -1,3 +1,0 @@
-#!/bin/sh
-getargbool 0 rd.shell || poweroff -f
-getargbool 0 failme && poweroff -f

--- a/test/TEST-60-NFS/test.sh
+++ b/test/TEST-60-NFS/test.sh
@@ -354,8 +354,6 @@ test_setup() {
         # shellcheck disable=SC1090
         . "$PKGLIBDIR"/dracut-init.sh
         inst_multiple poweroff shutdown
-        inst_hook shutdown-emergency 000 ./hard-off.sh
-        inst_hook emergency 000 ./hard-off.sh
         inst_simple ./client.link /etc/systemd/network/01-client.link
     )
 

--- a/test/TEST-61-MULTINIC/hard-off.sh
+++ b/test/TEST-61-MULTINIC/hard-off.sh
@@ -1,3 +1,0 @@
-#!/bin/sh
-getargbool 0 rd.shell || poweroff -f
-getargbool 0 failme && poweroff -f

--- a/test/TEST-61-MULTINIC/test.sh
+++ b/test/TEST-61-MULTINIC/test.sh
@@ -330,8 +330,6 @@ test_setup() {
         # shellcheck disable=SC1090
         . "$PKGLIBDIR"/dracut-init.sh
         inst_multiple poweroff shutdown
-        inst_hook shutdown-emergency 000 ./hard-off.sh
-        inst_hook emergency 000 ./hard-off.sh
         inst_simple ./client-persistent-lan0.link /etc/systemd/network/01-persistent-lan0.link
         inst_simple ./client-persistent-lan1.link /etc/systemd/network/01-persistent-lan1.link
         inst_simple ./client-persistent-lan2.link /etc/systemd/network/01-persistent-lan2.link

--- a/test/TEST-62-BONDBRIDGEVLAN/hard-off.sh
+++ b/test/TEST-62-BONDBRIDGEVLAN/hard-off.sh
@@ -1,3 +1,0 @@
-#!/bin/sh
-getarg rd.shell || poweroff -f
-getarg failme && poweroff -f

--- a/test/TEST-62-BONDBRIDGEVLAN/test.sh
+++ b/test/TEST-62-BONDBRIDGEVLAN/test.sh
@@ -373,7 +373,6 @@ test_setup() {
         # shellcheck disable=SC1090
         . "$PKGLIBDIR"/dracut-init.sh
         inst_multiple poweroff shutdown
-        inst_hook emergency 000 ./hard-off.sh
         inst_simple ./client.link /etc/systemd/network/01-client.link
     )
     # Make client's dracut image

--- a/test/modules.d/70test/hard-off.sh
+++ b/test/modules.d/70test/hard-off.sh
@@ -1,3 +1,0 @@
-#!/bin/sh
-getargbool 0 rd.shell || poweroff -f
-! getargbool 0 rd.break && getargbool 0 failme && poweroff -f

--- a/test/modules.d/70test/module-setup.sh
+++ b/test/modules.d/70test/module-setup.sh
@@ -20,8 +20,3 @@ installkernel() {
         virtio_pci \
         virtio_scsi
 }
-
-install() {
-    inst_hook shutdown-emergency 000 "$moddir/hard-off.sh"
-    inst_hook emergency 000 "$moddir/hard-off.sh"
-}


### PR DESCRIPTION
## Changes

These hard-off test hooks make the test shut down in a non-graceful way.
    
These hooks are no longer required.
    
Removing these hooks would make the test run similarly to production environments.

## Checklist
- [ ] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it
