### PR TITLE
fix(base): dracut-lib.sh soft depends on poweroff/reboot/halt

### DIFF
--- a/modules.d/80base/module-setup.sh
+++ b/modules.d/80base/module-setup.sh
@@ -50,6 +50,9 @@ install() {
         findmnt \
         kmod \
         less \
+        halt \
+        poweroff \
+        reboot \
         sysctl
 
     inst_binary "${dracutbasedir}/dracut-util" "/usr/bin/dracut-util"

--- a/test/modules.d/70test-makeroot/module-setup.sh
+++ b/test/modules.d/70test-makeroot/module-setup.sh
@@ -14,7 +14,7 @@ installkernel() {
 }
 
 install() {
-    inst_multiple poweroff cp umount sync mkfs.ext4
+    inst_multiple cp umount sync mkfs.ext4
 
     # prefer the coreutils version of dd over the busybox version for testing
     inst /bin/dd /usr/sbin/dd

--- a/test/modules.d/70test/module-setup.sh
+++ b/test/modules.d/70test/module-setup.sh
@@ -22,7 +22,6 @@ installkernel() {
 }
 
 install() {
-    inst poweroff
     inst_hook shutdown-emergency 000 "$moddir/hard-off.sh"
     inst_hook emergency 000 "$moddir/hard-off.sh"
 }


### PR DESCRIPTION
## Changes

Currently base module does not include poweroff/reboot/halt even though dracut-lib.sh could call these binaries. Dracut should make it easier to create an initramfs that has all the dependent binaries.

After this change we can remove poweroff - which was a workaround for the base module bug - from test modules.    

## Checklist
- [ ] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it


