### PR TITLE
fix(network-manager): depend on dbus only when using systemd

### DIFF
--- a/modules.d/35network-manager/module-setup.sh
+++ b/modules.d/35network-manager/module-setup.sh
@@ -10,7 +10,10 @@ check() {
 
 # called by dracut
 depends() {
-    echo dbus bash net-lib kernel-network-modules initqueue
+    echo bash net-lib kernel-network-modules initqueue
+    if dracut_module_included systemd; then
+        echo dbus
+    fi
     return 0
 }
 


### PR DESCRIPTION
## Changes

network-manager does not require dbus to function when using the `--configure-and-quit=initrd` option. This should be guaranteed as it is documented behavior in the [NetworkManager.conf(5) manpage](https://man.archlinux.org/man/extra/networkmanager/NetworkManager.conf.5.en) and specifically mentions dracut's use case.

With this change, initramfs images that don't or can't use systemd can use network-manager instead of the old network-legacy module.

## Checklist
- [x] I have tested it locally
  - Tested with zfsbootmenu (no systemd) and Fedora (with systemd), both built from a Fedora 42 host
- [x] I have reviewed and updated any documentation if relevant
  - I don't believe there are any docs to update
- [ ] I am providing new code and test(s) for it

Fixes: #1422