### PR TITLE
fix(lsinitrd): resolve initrd to real path

### DIFF
--- a/lsinitrd.sh
+++ b/lsinitrd.sh
@@ -173,6 +173,7 @@ if ! [[ -f $image ]]; then
     usage
     exit 1
 fi
+image=$(realpath "$image")
 
 TMPDIR="$(mktemp -d -t lsinitrd.XXXXXX)"
 # shellcheck disable=SC2064


### PR DESCRIPTION
`lsinitrd /boot/initrd.img` fails in case the initrd is zstd compressed:

```
$ dracut --zstd --no-early-microcode --force
$ 3cpio --examine /boot/initrd.img
0	zstd
$ lsinitrd /boot/initrd.img
Image: /boot/initrd.img: 0
========================================================================
Warning : /boot/initrd.img is a symbolic link, ignoring
Version:

Arguments:
dracut modules:
Warning : /boot/initrd.img is a symbolic link, ignoring
Warning : /boot/initrd.img is a symbolic link, ignoring
========================================================================
========================================================================
cpio: premature end of archive

dracut cmdline:
Warning : /boot/initrd.img is a symbolic link, ignoring
```

The `CAT` variable is `zstd -d -c`. The zstd man page says about the `--force` parameter: "disable input and output checks. Allows [...] operating on links". So this zstd behavior is intentional.

## Changes

Resolve the initrd path to the real path. Then `lsinitrd` prints the correct content and image size:

```
$ lsinitrd /boot/initrd.img
Image: /boot/initrd.img-6.14.0-23-generic: 15M
[...]
```

## Checklist
- [x] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it

Bug-Ubuntu: https://launchpad.net/bugs/2116183