### PR TITLE
fix(dracut-install): sort output of --modalias

### DIFF
--- a/src/install/dracut-install.c
+++ b/src/install/dracut-install.c
@@ -2895,6 +2895,16 @@ oom2:
         return -ENOMEM;
 }
 
+static void print_values(Hashmap *h)
+{
+        Iterator i;
+        char *name;
+
+        HASHMAP_FOREACH(name, h, i) {
+                printf("%s\n", name);
+        }
+}
+
 int main(int argc, char **argv)
 {
         int r;
@@ -2912,15 +2922,10 @@ int main(int argc, char **argv)
 
         modules_loaded = hashmap_new(string_hash_func, string_compare_func);
         if (arg_modalias) {
-                Iterator i;
-                char *name;
                 _cleanup_kmod_unref_ struct kmod_ctx *ctx = NULL;
                 ctx = kmod_new(kerneldir, NULL);
-
                 modalias_list(ctx);
-                HASHMAP_FOREACH(name, modules_loaded, i) {
-                        printf("%s\n", name);
-                }
+                print_values(modules_loaded);
                 exit(0);
         }
 

--- a/src/install/dracut-install.c
+++ b/src/install/dracut-install.c
@@ -2895,14 +2895,20 @@ oom2:
         return -ENOMEM;
 }
 
-static void print_values(Hashmap *h)
+static void print_values_sorted(Hashmap *h)
 {
         Iterator i;
-        char *name;
+        char *name, **nameptr;
+        _cleanup_free_ char **names = NULL;
 
+        names = calloc(hashmap_size(h) + 1, sizeof(char *));
+        nameptr = names;
         HASHMAP_FOREACH(name, h, i) {
-                printf("%s\n", name);
+                *nameptr = name;
+                nameptr++;
         }
+        strv_sort(names);
+        strv_print(names);
 }
 
 int main(int argc, char **argv)
@@ -2925,7 +2931,7 @@ int main(int argc, char **argv)
                 _cleanup_kmod_unref_ struct kmod_ctx *ctx = NULL;
                 ctx = kmod_new(kerneldir, NULL);
                 modalias_list(ctx);
-                print_values(modules_loaded);
+                print_values_sorted(modules_loaded);
                 exit(0);
         }
 


### PR DESCRIPTION
Calling `dracut-install --modalias` will print kernel modules in an unstable order. This breaks reproducible builds, because the output is stored inside the initrd as `lib/dracut/hostonly-kernel-modules.txt`.

## Changes

So sort the output of `--modalias` to be reproducible and easier to diff.

## Checklist
- [x] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it

Partially fixes https://github.com/dracut-ng/dracut-ng/issues/1409
