### PR TITLE
fix(fips): make sha512hmac an optional requirement

### DIFF
--- a/modules.d/11fips/module-setup.sh
+++ b/modules.d/11fips/module-setup.sh
@@ -59,7 +59,9 @@ install() {
     inst_hook pre-udev 01 "$moddir/fips-load-crypto.sh"
     inst_script "$moddir/fips.sh" /sbin/fips.sh
 
-    inst_multiple sha512hmac rmmod insmod mount uname umount grep sed cut find sort cat tail tr
+    inst_multiple rmmod insmod mount uname umount grep sed cut find sort cat tail tr
+
+    inst_multiple -o sha512hmac
 
     inst_simple /etc/system-fips
 


### PR DESCRIPTION
## Changes

sha512hmac binary is not available on most Linux distributions, including openSUSE and it is not a hard requirement for the fips dracut module to function.

Install sha512hmac with an optional flag to not regress distributions that have sha512hmac installed and also enable distributions without sha512hmac to not fail.

## Checklist
- [ ] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it

CC @aafeijoo-suse @bdrung @Conan-Kudo 
