### PR TITLE
ci(gentoo): remove workaround for forcing hostonly mode

### DIFF
--- a/test/container/Dockerfile-gentoo
+++ b/test/container/Dockerfile-gentoo
@@ -36,9 +36,6 @@ RUN \
     echo 'sys-apps/systemd fido2 ukify qrcode cryptsetup' >> /etc/portage/package.use/systemd ;\
     # Support thin volumes and build all of LVM2 including daemons and tools like lvchange \
     echo 'sys-fs/lvm2 thin lvm' >> /etc/portage/package.use/lvm2 ;\
-    # force hostonly mode as this is the config recommended by https://wiki.gentoo.org/wiki/Dracut \
-    mkdir -p /usr/lib/dracut/dracut.conf.d/ ;\
-    echo 'hostonly="yes"' > /usr/lib/dracut/dracut.conf.d/50-hostonly.conf ;\
     # Ensure everything is up to date before we start \
     emerge --quiet --update --deep --newuse --autounmask-continue=y --with-bdeps=y @world
 


### PR DESCRIPTION
## Changes

Forcing `hostonly` mode for Gentoo was introduced in commit 9fc9128, as a step towards enabling `hostonly` mode by default for all distributions.

After 62fdf59 this workaround for Gentoo is no longer needed to be maintained as now hostonly is the default for all Linux installation (set in configure).

CC @Nowa-Ammerlaan @LaszloGombos @bdrung 

## Checklist
- [ ] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it

