### PR TITLE
fix: network-manager dracut module no longer depends on systemd

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -234,7 +234,7 @@ endif
 	if ! [ -n "$(systemdsystemunitdir)" ]; then \
 		rm -rf $(DESTDIR)$(pkglibdir)/test/TEST-[0-9][0-9]-*SYSTEMD* ;\
 		rm -rf $(DESTDIR)$(pkglibdir)/modules.d/*systemd* $(DESTDIR)$(mandir)/*.service.* ; \
-		for i in bluetooth connman dbus* fido2 lvmmerge lvmthinpool-monitor memstrack network-manager pcsc pkcs11 rngd squash* tpm2-tss; do \
+		for i in bluetooth connman dbus* fido2 lvmmerge lvmthinpool-monitor memstrack pcsc pkcs11 rngd squash* tpm2-tss; do \
 			rm -rf $(DESTDIR)$(pkglibdir)/modules.d/[0-9][0-9]$${i}; \
 		done \
 	fi


### PR DESCRIPTION
## Changes

Previously dracut network-manager module only worked with systemd.

Now after 58baf86, network-manager dracut module should work in non-systemd Linux distributions as well, such as Void Linux.

This commit re-enables network-manager dracut module for all Linux distributions.

CC @classabbyamp @chenxiaolong 

## Checklist
- [ ] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it
