### PR TITLE
ci: install NetworkManager into the Void CI container

### DIFF
--- a/test/container/Dockerfile-void
+++ b/test/container/Dockerfile-void
@@ -48,6 +48,7 @@ RUN xbps-install -Syu xbps && xbps-install -yu \
     lvm2 \
     make \
     mdadm \
+    NetworkManager \
     nfs-utils \
     nvme-cli \
     parted \


### PR DESCRIPTION
## Changes

Previously dracut network-manager package only worked with systemd. Now after 58baf86, network-manager dracut package should work in non-systemd Linux distributions as well, such as Void Linux.

Install NetworkManager into the Void CI container to enable testing it on the CI.

CC @classabbyamp

## Checklist
- [ ] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it


