### PR TITLE
chore: eliminate overlapping functions

### DIFF
--- a/dracut-init.sh
+++ b/dracut-init.sh
@@ -345,20 +345,7 @@ dracut_instmods() {
 # this is not used within dracut itself, but external modules use it,
 # do not remove it!
 inst_library() {
-    local _ret _hostonly_install
-    if [[ $1 == "-H" ]]; then
-        _hostonly_install="-H"
-        shift
-    fi
-    [[ -e ${initdir}/"${2:-$1}" ]] && return 0 # already there
-    [[ -e $1 ]] || return 1                    # no source
-    if $DRACUT_INSTALL ${dracutsysrootdir:+-r "$dracutsysrootdir"} ${initdir:+-D "$initdir"} ${loginstall:+-L "$loginstall"} ${DRACUT_RESOLVE_DEPS:+-l} ${DRACUT_FIPS_MODE:+-f} ${_hostonly_install:+-H} "$@"; then
-        return 0
-    else
-        _ret=$?
-        derror FAILED: "$DRACUT_INSTALL" ${dracutsysrootdir:+-r "$dracutsysrootdir"} ${initdir:+-D "$initdir"} ${loginstall:+-L "$loginstall"} ${DRACUT_RESOLVE_DEPS:+-l} ${DRACUT_FIPS_MODE:+-f} ${_hostonly_install:+-H} "$@"
-        return $_ret
-    fi
+    inst "$@"
 }
 
 inst_binary() {


### PR DESCRIPTION
## Changes

In its current form `inst_library` function executes the same set of commands as the `inst` function.

Copying (instead of reusing code) is usually preferred, especially in this particular case where `inst_library` function is not used by dracut, so it is not tested by dracut CI.

After this commit, `inst_library` would just call `inst`, and `inst` is being used and as such tested by dracut CI, so it makes it less likely to egress out-of tree code depending on dracut.

## Checklist
- [ ] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it

