### PR TITLE
test(SYSTEMD): convert test to run without initqueue

### DIFF
--- a/test/TEST-40-SYSTEMD/test.sh
+++ b/test/TEST-40-SYSTEMD/test.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 set -e
 # shellcheck disable=SC2034
-TEST_DESCRIPTION="root filesystem on a ext4 filesystem"
+TEST_DESCRIPTION="root filesystem on a ext4 filesystem with systemd but without initqueue"
 
 test_check() {
     command -v systemctl &> /dev/null
@@ -62,7 +62,7 @@ test_setup() {
     #make sure --omit-drivers does not filter out drivers using regexp to test for an earlier regression (assuming there is no one letter linux kernel module needed to run the test)
 
     test_dracut \
-        --omit "fido2" \
+        --omit "fido2 initqueue" \
         --omit-drivers 'a b c d e f g h i j k l m n o p q r s t u v w x y z' \
         -i ./systemd-analyze.sh /lib/dracut/hooks/pre-pivot/00-systemd-analyze.sh \
         -i "/bin/true" "/usr/bin/man"


### PR DESCRIPTION
## Changes

Systemd itself provides similar functionality to the dracut initqueue module. It has been a long-standing criticism of dracut systemd integration that initqueue should not be necessary for most system boot scenarios.

While there is still a long way to go, we can start testing some of the common systemd boot scenarios without initqueue.

See https://github.com/dracut-ng/dracut-ng/issues/1191.

Commit 2676f1a allowed to make this change, without that commit this test case would fail.

CC @dtardon @keszybz 

## Checklist
- [ ] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it

Fixes #1191
