### PR TITLE
fix(dracut.sh): do not use uname to detect kernel version in a container

### DIFF
--- a/dracut.sh
+++ b/dracut.sh
@@ -1076,9 +1076,9 @@ if ! [[ $kernel ]]; then
     if type -P systemd-detect-virt &> /dev/null && container=$(systemd-detect-virt -c) &> /dev/null; then
         dinfo "*** Detected container: $container ***"
         # shellcheck disable=SC2012
-        kernel="$(cd /lib/modules && ls -1 | tail -1)"
+        kernel="$(cd /lib/modules && ls -1v | tail -1)"
         # shellcheck disable=SC2012
-        [[ $kernel ]] || kernel="$(cd /usr/lib/modules && ls -1 | tail -1)"
+        [[ $kernel ]] || kernel="$(cd /usr/lib/modules && ls -1v | tail -1)"
     fi
     [[ $kernel ]] || kernel="$(uname -r)"
 fi

--- a/lsinitrd.sh
+++ b/lsinitrd.sh
@@ -99,9 +99,9 @@ done
 if ! [[ $KERNEL_VERSION ]]; then
     if type -P systemd-detect-virt &> /dev/null && systemd-detect-virt -c &> /dev/null; then
         # shellcheck disable=SC2012
-        KERNEL_VERSION="$(cd /lib/modules && ls -1 | tail -1)"
+        KERNEL_VERSION="$(cd /lib/modules && ls -1v | tail -1)"
         # shellcheck disable=SC2012
-        [[ $KERNEL_VERSION ]] || KERNEL_VERSION="$(cd /usr/lib/modules && ls -1 | tail -1)"
+        [[ $KERNEL_VERSION ]] || KERNEL_VERSION="$(cd /usr/lib/modules && ls -1v | tail -1)"
     fi
     [[ $KERNEL_VERSION ]] || KERNEL_VERSION="$(uname -r)"
 fi

--- a/test/test-functions
+++ b/test/test-functions
@@ -106,9 +106,9 @@ determine_kernel_version() {
     # we are running inside a container already
 
     # shellcheck disable=SC2012
-    [[ ${KVERSION-} ]] || KVERSION="$(cd /lib/modules && ls -1 | tail -1)"
+    [[ ${KVERSION-} ]] || KVERSION="$(cd /lib/modules && ls -1v | tail -1)"
     # shellcheck disable=SC2012
-    [[ ${KVERSION-} ]] || KVERSION="$(cd /usr/lib/modules && ls -1 | tail -1)"
+    [[ ${KVERSION-} ]] || KVERSION="$(cd /usr/lib/modules && ls -1v | tail -1)"
     [[ ${KVERSION-} ]] || KVERSION="$(uname -r)"
 }
 


### PR DESCRIPTION
## Changes

A big general papercut with dracut right now in that it always assumes the kernel it's running on is the kernel to target.

This commit lets dracut to detect that it's in a container (e.g. systemd-detect-virt -c), and check for a single /usr/lib/modules/$kver directory and automatically use that kernel.

Currently this kernel version detection has three copies in the source (dracut.sh, lsinitrd.sh,test-functions). This commit keeps the logic for the three copies the same. As a follow-up commit, we should try to actually share the code for this logic instead of copying it.

CC @cgwalters 

## Checklist
- [ ] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it

Fixes #1455
