### PR TITLE
test(UEFI): remove version check test for kernel-install

### DIFF
--- a/test/TEST-12-UEFI/test.sh
+++ b/test/TEST-12-UEFI/test.sh
@@ -52,14 +52,11 @@ test_setup() {
 
     mkdir -p "$TESTDIR"/ESP/EFI/BOOT "$TESTDIR"/dracut.conf.d
 
-    # This is the preferred way to build uki with dracut on a systenmd based system
-    # Currently this only works in a few distributions and architectures, but it is here
-    # for reference
+    # This is the preferred way to build uki with dracut on a systemd based system
     if command -v systemd-detect-virt &> /dev/null && systemd-detect-virt -c &> /dev/null \
         && command -v kernel-install &> /dev/null \
         && command -v systemctl &> /dev/null \
-        && command -v ukify &> /dev/null \
-        && [[ $(kernel-install --version | grep -oP '(?<=systemd )\d+') -gt 254 ]]; then
+        && command -v ukify &> /dev/null; then
 
         echo "Using ukify via kernel-install to create UKI"
 


### PR DESCRIPTION
## Changes

The current way of checking the version of kernel-install is not portable between distributions and it no longer adds any value to the CI.
    
Remove the version check to make it easier to reason about the test run and enable this subtest in more test environments.

## Checklist
- [ ] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it

