### PR TITLE
test: remove determine kernel version from test suite

### DIFF
--- a/test/test-functions
+++ b/test/test-functions
@@ -49,7 +49,7 @@ test_dracut() {
     fi
 
     # pick up configuration from $TESTDIR/dracut.conf.d when running the tests
-    TEST_DRACUT_ARGS+=" --confdir $TESTDIR/dracut.conf.d --add-confdir test --keep --tmpdir $TESTDIR/initrd --kver $KVERSION"
+    TEST_DRACUT_ARGS+=" --confdir $TESTDIR/dracut.conf.d --add-confdir test --keep --tmpdir $TESTDIR/initrd"
 
     # include $TESTDIR"/overlay if exists
     if [ -d "$TESTDIR"/overlay ]; then
@@ -99,19 +99,6 @@ ovmf_code() {
     done
 }
 
-determine_kernel_version() {
-    # inspired by kernel version detection in lsinitrd.sh
-
-    # Some test containers do not include systemd-detect-virt, so let's just assume
-    # we are running inside a container already
-
-    # shellcheck disable=SC2012
-    [[ ${KVERSION-} ]] || KVERSION="$(cd /lib/modules && ls -1v | tail -1)"
-    # shellcheck disable=SC2012
-    [[ ${KVERSION-} ]] || KVERSION="$(cd /usr/lib/modules && ls -1v | tail -1)"
-    [[ ${KVERSION-} ]] || KVERSION="$(uname -r)"
-}
-
 set_vmlinux_env() {
     VMLINUZ=${VMLINUZ-"/lib/modules/${KVERSION}/vmlinuz"}
     if ! [ -f "$VMLINUZ" ]; then
@@ -148,7 +135,6 @@ set_vmlinux_env() {
 }
 
 set_test_envonment_variables() {
-    determine_kernel_version
     set_vmlinux_env
 }
 


### PR DESCRIPTION
## Changes

Now that dracut kernel version detection is [fixed](2b2debd), we can remove the kernel version detection workaround from the test suite.

This commit also partially resolves the review [feedback](https://github.com/dracut-ng/dracut-ng/pull/1456#issuecomment-3083732755) and removes code duplication.

## Checklist
- [ ] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it

