### PR TITLE
chore: rename suse.conf.example to opensuse.conf.example

### DIFF
--- a/dracut.conf.d/opensuse.conf.example
+++ b/dracut.conf.d/opensuse.conf.example
@@ -1,6 +1,6 @@
-# SUSE specific dracut settings
+# openSUSE specific dracut settings
 #
-# SUSE by default always builds as small as possible initrd for performance
+# openSUSE by default always builds as small as possible initrd for performance
 # and resource reasons.
 # If you like to build a generic initrd which works on other platforms than
 # on the one dracut got called comment out below setting(s).


### PR DESCRIPTION
## Changes

opensuse is a more inclusive and more appropriate name for this example file.

CC @mwilck @Conan-Kudo 

## Checklist
- [ ] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it

