### PR TITLE
feat(dracut): drop DRACUT_PATH and rely on PATH

### DIFF
--- a/dracut-functions.sh
+++ b/dracut-functions.sh
@@ -80,13 +80,13 @@ find_binary() {
             return 0
         fi
     fi
-    for p in $DRACUT_PATH; do
+    while read -r -d ':' p; do
         _path="${p}${_delim}${1}"
         if [[ -L ${dracutsysrootdir-}${_path} ]] || [[ -x ${dracutsysrootdir-}${_path} ]]; then
             printf "%s\n" "${_path}"
             return 0
         fi
-    done
+    done <<< "$PATH"
 
     [[ -n ${dracutsysrootdir-} ]] && return 1
     type -P "${1##*/}"

--- a/dracut.sh
+++ b/dracut.sh
@@ -1082,20 +1082,12 @@ if ! [[ $kernel ]]; then
     [[ $kernel ]] || kernel="$(uname -r)"
 fi
 
-DRACUT_PATH=${DRACUT_PATH:-/sbin /bin /usr/sbin /usr/bin}
-
-for i in $DRACUT_PATH; do
-    rl=$i
-    if [ -L "${dracutsysrootdir-}$i" ]; then
-        rl=$(readlink -f "${dracutsysrootdir-}$i")
-    fi
-    rl="${rl#"${dracutsysrootdir-}"}"
-    if [[ $NPATH != *:$rl* ]]; then
-        NPATH+=":$rl"
+# Ensure that the standard search paths are searched.
+for path in /usr/sbin /usr/bin /sbin /bin; do
+    if ! [[ ":${PATH}:" =~ .*:${path}:.* ]]; then
+        PATH="${PATH:+${PATH}:}$path"
     fi
 done
-[[ -z ${dracutsysrootdir-} ]] && export PATH="${NPATH#:}"
-unset NPATH
 
 export SYSTEMCTL=${SYSTEMCTL:-systemctl}
 


### PR DESCRIPTION
## Changes

This reverts commit eab9b75c8a9b ("dracut.sh: add DRACUT_PATH").

Drop `DRACUT_PATH` and rely on `PATH` instead to avoid user confusion and behave like most other programs.

To avoid failing on misconfiguration (e.g. when `/usr/sbin` is not in `PATH`), ensure that the common default paths `/usr/sbin`, `/usr/bin`, `/sbin`, and `/bin` are included in `PATH`.

## Checklist
- [ ] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it

Fixes: https://github.com/dracut-ng/dracut-ng/issues/1467