### PR TITLE
fix(dracut): detect if systemd-detect-virt is available before calling it

### DIFF
--- a/dracut.sh
+++ b/dracut.sh
@@ -1431,7 +1431,7 @@ else
     exit 1
 fi
 
-if container=$(systemd-detect-virt -c) &> /dev/null; then
+if type -P systemd-detect-virt &> /dev/null && container=$(systemd-detect-virt -c) &> /dev/null; then
     export DRACUT_NO_MKNOD=1
     dinfo "Detected $container container."
 fi


### PR DESCRIPTION
## Changes

When `systemd-detect-virt` is not available (e.g. in a non-systemd host) The following error is reported

```
/usr/sbin/dracut: line 1435: systemd-detect-virt: command not found
```

Let's detect if `systemd-detect-virt` is available before calling it.

Follow-up to 000f5db .

## Checklist
- [ ] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it

