### PR TITLE
fix(systemd-udevd): handle root=gpt-auto for systemd-v258

### DIFF
--- a/modules.d/11systemd-udevd/module-setup.sh
+++ b/modules.d/11systemd-udevd/module-setup.sh
@@ -34,6 +34,7 @@ depends() {
 # Install the required file(s) and directories for the module in the initramfs.
 install() {
     inst_multiple -o \
+        "$udevrulesdir"/90-image-dissect.rules \
         "$udevrulesdir"/99-systemd.rules \
         "$systemdutildir"/systemd-udevd \
         "$systemdsystemunitdir"/systemd-udevd.service \

--- a/modules.d/11systemd-udevd/module-setup.sh
+++ b/modules.d/11systemd-udevd/module-setup.sh
@@ -76,8 +76,6 @@ install() {
     inst_binary true
     ln_r "$(find_binary true)" "/usr/bin/loginctl"
     ln_r "$(find_binary true)" "/bin/loginctl"
-    inst_rules \
-        99-systemd.rules
 
     # Install required libraries.
     _arch=${DRACUT_ARCH:-$(uname -m)}


### PR DESCRIPTION
A new file `90-image-dissect.rules` was split from `99-systemd.rules` to handle gpt-root.

Since https://github.com/systemd/systemd/commit/e3f6ae1d09d28dbe31ccf67122486ad037d25ed0

## Checklist
- [ ] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it