### PR TITLE
fix(dracut): only call uname -r if it is safe to do

### DIFF
--- a/dracut.sh
+++ b/dracut.sh
@@ -1073,13 +1073,14 @@ if [[ $regenerate_all == "yes" ]]; then
 fi
 
 if ! [[ $kernel ]]; then
-    if type -P systemd-detect-virt &> /dev/null && systemd-detect-virt -c &> /dev/null; then
+    if type -P systemd-detect-virt &> /dev/null && ! systemd-detect-virt -c &> /dev/null; then
+        kernel="$(uname -r)"
+    else
         # shellcheck disable=SC2012
         kernel="$(cd /lib/modules && ls -1v | tail -1)"
         # shellcheck disable=SC2012
         [[ $kernel ]] || kernel="$(cd /usr/lib/modules && ls -1v | tail -1)"
     fi
-    [[ $kernel ]] || kernel="$(uname -r)"
 fi
 
 # Ensure that the standard search paths are searched.

--- a/lsinitrd.sh
+++ b/lsinitrd.sh
@@ -97,13 +97,14 @@ while (($# > 0)); do
 done
 
 if ! [[ $KERNEL_VERSION ]]; then
-    if type -P systemd-detect-virt &> /dev/null && systemd-detect-virt -c &> /dev/null; then
+    if type -P systemd-detect-virt &> /dev/null && ! systemd-detect-virt -c &> /dev/null; then
+        KERNEL_VERSION="$(uname -r)"
+    else
         # shellcheck disable=SC2012
         KERNEL_VERSION="$(cd /lib/modules && ls -1v | tail -1)"
         # shellcheck disable=SC2012
         [[ $KERNEL_VERSION ]] || KERNEL_VERSION="$(cd /usr/lib/modules && ls -1v | tail -1)"
     fi
-    [[ $KERNEL_VERSION ]] || KERNEL_VERSION="$(uname -r)"
 fi
 
 find_initrd_for_kernel_version() {


### PR DESCRIPTION
## Changes

Change the priority order to determine the kernel version of it is not specified on the command line.

Only call `uname -r` if it is safe to do, meaning if it is confirmed that dracut is not called from within a container.

Follow-up to 2b2debd.

## Checklist
- [ ] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it

Fixes #
