### PR TITLE
fix(systemd-sysusers): set passwd and group permission to 644

### DIFF
--- a/modules.d/68systemd-sysusers/module-setup.sh
+++ b/modules.d/68systemd-sysusers/module-setup.sh
@@ -28,4 +28,7 @@ install() {
     # set read and write permission for the current user
     [[ -f "$initdir/etc/gshadow" ]] && chmod u+rw "$initdir/etc/gshadow"
     [[ -f "$initdir/etc/shadow" ]] && chmod u+rw "$initdir/etc/shadow"
+
+    [[ -f "$initdir/etc/passwd" ]] && chmod 644 "$initdir/etc/passwd"
+    [[ -f "$initdir/etc/group" ]] && chmod 644 "$initdir/etc/group"
 }


### PR DESCRIPTION
## Changes

The `/etc/passwd` and `/etc/group` that get created in the initrd by `systemd-sysusers` have the wrong permissions - they're 600, when they should be 644.

This is an issue for e.g. dbus-daemon as it is started as the messagebus user - so it can't read them.

## Checklist
- [ ] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it

Fixes #1474
