### PR TITLE
fix(base): base module failure if root password is already set

### DIFF
--- a/modules.d/80base/module-setup.sh
+++ b/modules.d/80base/module-setup.sh
@@ -71,14 +71,13 @@ install() {
     if [[ ${hostonly-} ]]; then
         # check if other dracut modules already created an entry for root in /etc/shadow
         if grep -q '^root:' "$initdir/etc/shadow"; then
-            # replace root password in the existing entry in etc/shadow
-            # root password from host takes precedence over root password set by systemd-sysuser in hostonly mode
-            root_password=$(grep '^root:' "${dracutsysrootdir-}"/etc/shadow | cut -d':' -f2)
-            sed -i "/^root:/s/:[^:]*:/:$root_password:/" "$initdir/etc/shadow"
-        else
-            # create a new entry for root in /etc/shadow
-            grep '^root:' "${dracutsysrootdir-}"/etc/shadow >> "$initdir/etc/shadow"
+            grep -v '^root:' "$initdir/etc/shadow" > "$initdir/etc/shadow-"
+            mv "$initdir/etc/shadow-" "$initdir/etc/shadow"
         fi
+        # replace root password in the existing entry in etc/shadow
+        # root password from host takes precedence over root password set by systemd-sysuser in hostonly mode
+        # create a new entry for root in /etc/shadow
+        grep '^root:' "${dracutsysrootdir-}"/etc/shadow >> "$initdir/etc/shadow"
     fi
 
     # install our scripts and hooks

--- a/test/TEST-13-SYSROOT/test.sh
+++ b/test/TEST-13-SYSROOT/test.sh
@@ -31,6 +31,21 @@ test_setup() {
 
     ln -s / "$TESTDIR"/sysroot
     test_dracut --sysroot "$TESTDIR"/sysroot
+
+    if grep -q '^root:' /etc/shadow; then
+        if ! grep -q '^root:' "$TESTDIR"/initrd/dracut.*/initramfs/etc/shadow; then
+            echo "Entry for root in /etc/shadow is missing, failing the test."
+            rm "$TESTDIR"/initramfs.testing
+        fi
+
+        root_password=$(grep '^root:' "/etc/shadow" | cut -d':' -f2)
+        initramfs_root_password=$(grep '^root:' "$TESTDIR"/initrd/dracut.*/initramfs/etc/shadow | cut -d':' -f2)
+
+        if [ "$root_password" != "$initramfs_root_password" ]; then
+            echo "The password for root does not match, failing the test."
+            rm "$TESTDIR"/initramfs.testing
+        fi
+    fi
 }
 
 # shellcheck disable=SC1090


### PR DESCRIPTION
## Changes

Replace `sed` with `grep` and simplify logic by removing a conditional and if needed simply copying the line from the host shadow file to the initramfs shadow file.

Add test coverage for root entry in /etc/shadow. 

## Checklist
- [ ] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it

Fixes #1478
