### PR TITLE
fix(dracut-initramfs-restore): check for Debian initrd.img symlink

### DIFF
--- a/dracut-initramfs-restore.sh
+++ b/dracut-initramfs-restore.sh
@@ -58,6 +58,10 @@ IMG=$(find_initrd_for_kernel_version "$KERNEL_VERSION")
 if [ -z "$IMG" ]; then
     if [[ -f /boot/initramfs-linux.img ]]; then
         IMG="/boot/initramfs-linux.img"
+    elif [[ -f /boot/initrd.img ]]; then
+        IMG="/boot/initrd.img"
+    elif [[ -f /initrd.img ]]; then
+        IMG="/initrd.img"
     else
         echo "No initramfs image found to restore!"
         exit 1


### PR DESCRIPTION
## Changes

In case no initrd was found for the kernel version, also check the the symlinks `/boot/initrd.img` (for Ubuntu) and `/initrd.img` (for Debian).

## Checklist
- [ ] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it

Fixes #
