### PR TITLE
fix(dracut): only call uname -r as last resort

### DIFF
--- a/dracut.sh
+++ b/dracut.sh
@@ -1073,13 +1073,12 @@ if [[ $regenerate_all == "yes" ]]; then
 fi
 
 if ! [[ $kernel ]]; then
-    if type -P systemd-detect-virt &> /dev/null && ! systemd-detect-virt -c &> /dev/null; then
+    # shellcheck disable=SC2012
+    kernel="$(cd /lib/modules && ls -1v | tail -1)"
+    # shellcheck disable=SC2012
+    [[ $kernel ]] || kernel="$(cd /usr/lib/modules && ls -1v | tail -1)"
+    if ! [[ $kernel ]] && type -P systemd-detect-virt &> /dev/null && ! systemd-detect-virt -c &> /dev/null; then
         kernel="$(uname -r)"
-    else
-        # shellcheck disable=SC2012
-        kernel="$(cd /lib/modules && ls -1v | tail -1)"
-        # shellcheck disable=SC2012
-        [[ $kernel ]] || kernel="$(cd /usr/lib/modules && ls -1v | tail -1)"
     fi
 fi
 

--- a/lsinitrd.sh
+++ b/lsinitrd.sh
@@ -97,13 +97,12 @@ while (($# > 0)); do
 done
 
 if ! [[ $KERNEL_VERSION ]]; then
-    if type -P systemd-detect-virt &> /dev/null && ! systemd-detect-virt -c &> /dev/null; then
+    # shellcheck disable=SC2012
+    KERNEL_VERSION="$(cd /lib/modules && ls -1v | tail -1)"
+    # shellcheck disable=SC2012
+    [[ $KERNEL_VERSION ]] || KERNEL_VERSION="$(cd /usr/lib/modules && ls -1v | tail -1)"
+    if ! [[ $KERNEL_VERSION ]] && type -P systemd-detect-virt &> /dev/null && ! systemd-detect-virt -c &> /dev/null; then
         KERNEL_VERSION="$(uname -r)"
-    else
-        # shellcheck disable=SC2012
-        KERNEL_VERSION="$(cd /lib/modules && ls -1v | tail -1)"
-        # shellcheck disable=SC2012
-        [[ $KERNEL_VERSION ]] || KERNEL_VERSION="$(cd /usr/lib/modules && ls -1v | tail -1)"
     fi
 fi
 


### PR DESCRIPTION
## Changes

Running dracut in a schroot environment with `systemd-detect-virt` installed will pick `uname -r` as kernel version despite that kernel not being available. The same could happen inside containers without `systemd-detect-virt` installed.

So always check `/lib/modules` and `/usr/lib/modules` before falling back to calling `uname -r`.

## Checklist
- [ ] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it

Fixes #
