### PR TITLE
feat(debian.conf): default to initrd.img-${kernel} on Debian/Ubuntu

### DIFF
--- a/dracut.conf.d/debian/01-debian.conf
+++ b/dracut.conf.d/debian/01-debian.conf
@@ -1,2 +1,3 @@
 # Debian/Ubuntu specific Dracut configuration
 i18n_vars="/etc/locale.conf:LANG /etc/default/console-setup:FONT,FONT_MAP,CONSOLE_MAP-FONT_UNIMAP /etc/default/keyboard:XKBLAYOUT-KEYMAP,XKBVARIANT-EXT_KEYMAPS"
+initrdname="initrd.img-${kernel}"


### PR DESCRIPTION
## Changes

Add an example configuration that Debian/Ubuntu can ship to change the default `initrdname` to `initrd.img-${kernel}`. This is done to keep the name the same as initramfs-tools which has been the default for a long time. This change will be carried for quite some time to ease the switch from initramfs-tools to dracut.

## Checklist
- [ ] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it

Fixes #
