### PR TITLE
test: drop setting DRACUT_PATH

### DIFF
--- a/test/TEST-61-MULTINIC/test.sh
+++ b/test/TEST-61-MULTINIC/test.sh
@@ -178,7 +178,6 @@ test_client() {
 }
 
 test_setup() {
-    DRACUT_PATH=${DRACUT_PATH:-/sbin /bin /usr/sbin /usr/bin}
     # shellcheck disable=SC2153
     export kernel=$KVERSION
     export no_kernel=

--- a/test/TEST-62-BONDBRIDGEVLAN/test.sh
+++ b/test/TEST-62-BONDBRIDGEVLAN/test.sh
@@ -214,7 +214,6 @@ bootdev=br0
 }
 
 test_setup() {
-    DRACUT_PATH=${DRACUT_PATH:-/sbin /bin /usr/sbin /usr/bin}
     # shellcheck disable=SC2153
     export kernel=$KVERSION
     export no_kernel=


### PR DESCRIPTION
## Changes

Commit 2606f985d6f3 ("feat(dracut): drop DRACUT_PATH and rely on PATH") removed the `DRACUT_PATH` variable. So `DRACUT_PATH` does not need to be set in the tests any more.

@LaszloGombos @Conan-Kudo 

## Checklist
- [ ] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it

Fixes #
