### PR TITLE
feat: add Debian/Ubuntu specific Dracut configuration

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -188,6 +188,7 @@ install: all
 	install -m 0755 dracut-logger.sh $(DESTDIR)$(pkglibdir)/dracut-logger.sh
 	install -m 0755 dracut-initramfs-restore.sh $(DESTDIR)$(pkglibdir)/dracut-initramfs-restore
 	cp -arx modules.d dracut.conf.d $(DESTDIR)$(pkglibdir)
+	rm -r $(DESTDIR)$(pkglibdir)/dracut.conf.d/debian/
 	for i in $(configprofile) ; do \
 		cp -arx dracut.conf.d/$$i/* $(DESTDIR)$(pkglibdir)/dracut.conf.d/ ;\
 	done

--- a/dracut.conf.d/debian/10-debian.conf
+++ b/dracut.conf.d/debian/10-debian.conf
@@ -1,0 +1,3 @@
+# Debian/Ubuntu specific Dracut configuration
+hostonly="yes"
+hostonly_cmdline="no"


### PR DESCRIPTION
## Changes

Add the Debian/Ubuntu specific Dracut configuration, but do not install this configuration by default. It is meant to be used via `./configure --configprofile debian` during Debian/Ubuntu package build.

## Checklist
- [ ] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it

Fixes #
