### PR TITLE
test(SYSROOT): always run it in hostonly mode

### DIFF
--- a/test/TEST-13-SYSROOT/test.sh
+++ b/test/TEST-13-SYSROOT/test.sh
@@ -30,7 +30,7 @@ test_setup() {
     mkfs.ext4 -q -L dracut -d "$TESTDIR"/dracut.*/initramfs/ "$TESTDIR"/root.img && sync "$TESTDIR"/root.img
 
     ln -s / "$TESTDIR"/sysroot
-    test_dracut --sysroot "$TESTDIR"/sysroot
+    test_dracut --hostonly --sysroot "$TESTDIR"/sysroot
 
     if grep -q '^root:' /etc/shadow; then
         if ! grep -q '^root:' "$TESTDIR"/initrd/dracut.*/initramfs/etc/shadow; then


### PR DESCRIPTION
## Changes

The recent addition of root password test coverage only passing in hostonly mode. For now turn this test into hostonly test, as it does not reduce test coverage significantly (BASIC test is running a similar test without forcing hostonly).

## Checklist
- [ ] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it

