### PR TITLE
fix(kernel-modules): add Cadence USB driver to base

### DIFF
--- a/modules.d/70kernel-modules/module-setup.sh
+++ b/modules.d/70kernel-modules/module-setup.sh
@@ -93,6 +93,7 @@ installkernel() {
                 "=drivers/soc" \
                 "=drivers/spi" \
                 "=drivers/spmi" \
+                "=drivers/usb/cdns3" \
                 "=drivers/usb/chipidea" \
                 "=drivers/usb/dwc2" \
                 "=drivers/usb/dwc3" \


### PR DESCRIPTION
## Changes

Installed Debian Trixie d-i rc2 (dvd-1) on USB storage on Pine64 Star64 is not bootable due to missing modules `cdns3_starfive` and `cdns3` from initramfs.

Note the above USB support on Pine64 Star64 is directly part of StarFive JH7110 CPU and differs from StarFive VisionFive2 which uses an external controller attached to the PCIe bus.

Bug-Debian: https://bugs.debian.org/1108924

## Checklist
- [ ] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it

Fixes #
