### PR TITLE
fix(btrfs): write cmdline in install()

### DIFF
--- a/modules.d/70btrfs/module-setup.sh
+++ b/modules.d/70btrfs/module-setup.sh
@@ -32,7 +32,6 @@ cmdline() {
 # called by dracut
 installkernel() {
     hostonly='' instmods btrfs
-    printf "%s\n" "$(cmdline)" > "${initdir}/etc/cmdline.d/00-btrfs.conf"
 }
 
 # called by dracut
@@ -57,4 +56,8 @@ install() {
 
     inst_multiple -o btrfsck btrfs-zero-log btrfstune
     inst btrfs /sbin/btrfs
+
+    if [[ $hostonly_cmdline == "yes" ]]; then
+        printf "%s\n" "$(cmdline)" > "${initdir}/etc/cmdline.d/00-btrfs.conf"
+    fi
 }


### PR DESCRIPTION
This fixes the build with `--kernel-only` option.

```
$ dracut -f --kernel-only
...
dracut[I]: *** Including module: btrfs ***
/usr/lib/dracut/modules.d/90btrfs/module-setup.sh: line 35: /var/tmp/dracut.dqV4ugj/initramfs/etc/cmdline.d/00-btrfs.conf: No such file or directory
```

## Checklist
- [ ] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it