### PR TITLE
fix(release): force push (for updating)

### DIFF
--- a/tools/release.sh
+++ b/tools/release.sh
@@ -65,7 +65,7 @@ fi
 git commit -m "docs: update NEWS.md and AUTHORS for release $NEW_VERSION" NEWS.md AUTHORS dracut-version.sh
 
 # git push can fail due to insufficient permissions
-if ! git push -u origin release; then
+if ! git push --force -u origin release; then
     exit $?
 fi
 


### PR DESCRIPTION
## Changes

In case the `release` branch already exists, `tools/release.sh` will fail instead of pushing an updated version.

## Checklist
- [ ] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it

Fixes #
