### PR TITLE
 test: fix Linux kernel detection for qemu runs

### DIFF
--- a/test/run-qemu
+++ b/test/run-qemu
@@ -29,10 +29,10 @@ set_vmlinux_env() {
                 VMLINUZ="/boot/Image-${KVERSION}"
             fi
         fi
-    else
-        VMLINUZ=$(find /boot/vmlinuz-* -type f 2> /dev/null | tail -1)
-        ! [ -f "$VMLINUZ" ] && VMLINUZ=$(find /lib/modules/ -type f -name vmlinuz 2> /dev/null | tail -1)
     fi
+
+    ! [ -f "${VMLINUZ-}" ] && VMLINUZ=$(find /boot/vmlinuz-* -type f 2> /dev/null | tail -1)
+    ! [ -f "${VMLINUZ-}" ] && VMLINUZ=$(find /lib/modules/ -type f -name vmlinuz 2> /dev/null | tail -1)
 
     if ! [ -f "$VMLINUZ" ]; then
         echo "Could not find a Linux kernel version to test with!" >&2
@@ -90,6 +90,11 @@ fi
 
 # only set -kernel if -initrd is specified
 if [[ $* == *-initrd* ]]; then
+    for arg in "$@"; do
+        [[ $1 == *-initrd* ]] && break
+    done
+
+    KVERSION=$(lsinitrd "$arg" | grep modules.dep | head -1 | rev | cut -d'/' -f2 | rev)
     set_vmlinux_env
     ARGS+=(-kernel "$VMLINUZ")
 fi


### PR DESCRIPTION
## Changes

Determine KVERSION from the generated initramfs for qemu runs. Extend fallback detection even when KVERSION is specified.
 
Resolves CI regression (on [arm daily integration tests](https://github.com/dracut-ng/dracut-ng/actions/workflows/integration-extra-arm64.yml)) introduced by db608c3 .

## Checklist
- [ ] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it

