### PR TITLE
fix(dracut): enforce that hostonly is set for hostonly_install

### DIFF
--- a/dracut-init.sh
+++ b/dracut-init.sh
@@ -240,7 +240,7 @@ inst_dir() {
 inst() {
     local dstdir="${dstdir:-"$initdir"}"
     local _ret _hostonly_install
-    if [[ $1 == "-H" ]]; then
+    if [[ $1 == "-H" ]] && [[ $hostonly ]]; then
         _hostonly_install="-H"
         shift
     fi
@@ -257,7 +257,7 @@ inst() {
 inst_simple() {
     local dstdir="${dstdir:-"$initdir"}"
     local _ret _hostonly_install
-    if [[ $1 == "-H" ]]; then
+    if [[ $1 == "-H" ]] && [[ $hostonly ]]; then
         _hostonly_install="-H"
         shift
     fi
@@ -278,7 +278,7 @@ inst_simple() {
 
 inst_symlink() {
     local _ret _hostonly_install
-    if [[ $1 == "-H" ]]; then
+    if [[ $1 == "-H" ]] && [[ $hostonly ]]; then
         _hostonly_install="-H"
         shift
     fi
@@ -296,7 +296,7 @@ inst_symlink() {
 inst_multiple() {
     local dstdir="${dstdir:-"$initdir"}"
     local _ret _hostonly_install
-    if [[ $1 == "-H" ]]; then
+    if [[ $1 == "-H" ]] && [[ $hostonly ]]; then
         _hostonly_install="-H"
         shift
     fi


### PR DESCRIPTION
## Changes

Before honoring `-H` command line argument, check if `hostonly` is actually set.

[Here](https://github.com/dracut-ng/dracut-ng/blob/main/modules.d/74nvmf/module-setup.sh#L145) is an example where `inst` is called even in generic mode which would result in picking up files from the host from the /etc directory.

```
inst_simple -H "/etc/nvme/hostnqn"
```

## Checklist
- [ ] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it

Fixes #
