### PR TITLE
chore: remove dead code that is no longer expected to be executed

### DIFF
--- a/dracut.sh
+++ b/dracut.sh
@@ -974,8 +974,6 @@ if ! [[ $kernel ]] && [[ $regenerate_all_l != "yes" ]]; then
     else
         # shellcheck disable=SC2012
         kernel="$(cd /lib/modules && ls -1v | tail -1)"
-        # shellcheck disable=SC2012
-        [[ $kernel ]] || kernel="$(cd /usr/lib/modules && ls -1v | tail -1)"
     fi
 fi
 

--- a/lsinitrd.sh
+++ b/lsinitrd.sh
@@ -102,8 +102,6 @@ if ! [[ $KERNEL_VERSION ]]; then
     else
         # shellcheck disable=SC2012
         KERNEL_VERSION="$(cd /lib/modules && ls -1v | tail -1)"
-        # shellcheck disable=SC2012
-        [[ $KERNEL_VERSION ]] || KERNEL_VERSION="$(cd /usr/lib/modules && ls -1v | tail -1)"
     fi
 fi
 


### PR DESCRIPTION
## Changes

`/lib/modules` should always exists, which is consistent with the assumptions made in the rest of the dracut mode.

## Checklist
- [ ] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it

