### PR TITLE
feat(dracut): look for both vmlinuz and vmlinux for UKI creation

### DIFF
--- a/dracut.sh
+++ b/dracut.sh
@@ -1686,7 +1686,8 @@ if [[ ! $print_cmdline ]]; then
         fi
 
         if ! [[ $kernel_image ]]; then
-            for kernel_image in "${dracutsysrootdir-}/lib/modules/$kernel/vmlinuz" "${dracutsysrootdir-}/boot/vmlinuz-$kernel"; do
+            for kernel_image in "${dracutsysrootdir-}/lib/modules/$kernel/vmlinuz" "${dracutsysrootdir-}/boot/vmlinuz-$kernel" \
+                "${dracutsysrootdir-}/lib/modules/$kernel/vmlinux" "${dracutsysrootdir-}/boot/vmlinux-$kernel"; do
                 [[ -s $kernel_image ]] || continue
                 break
             done


### PR DESCRIPTION
## Changes

Dracut does not look for or find kernels named vmlinux-${kernel} in uefi mode.

## Checklist
- [ ] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it

Fixes #1366
