### PR TITLE
fix: make sure final hostonly value is computed before reading it

### DIFF
--- a/dracut.sh
+++ b/dracut.sh
@@ -1316,6 +1316,15 @@ check_kernel_compress_support() {
 [[ ${hostonly-} == yes ]] && hostonly="-h"
 [[ ${hostonly-} != "-h" ]] && unset hostonly
 
+if [[ ${hostonly-} ]]; then
+    for i in /sys /proc /run /dev; do
+        if ! findmnt --target "$i" &> /dev/null; then
+            dwarning "Turning off host-only mode: '$i' is not mounted!"
+            unset hostonly
+        fi
+    done
+fi
+
 case $hostonly_mode in
     '')
         [[ ${hostonly-} ]] && hostonly_mode="sloppy"
@@ -1726,15 +1735,6 @@ fi
 
 # Need to be able to have non-root users read stuff (rpcbind etc)
 chmod 755 "$initdir"
-
-if [[ ${hostonly-} ]]; then
-    for i in /sys /proc /run /dev; do
-        if ! findmnt --target "$i" &> /dev/null; then
-            dwarning "Turning off host-only mode: '$i' is not mounted!"
-            unset hostonly
-        fi
-    done
-fi
 
 declare -A host_fs_types=()
 declare -a host_devs=()


### PR DESCRIPTION
## Changes

`hostonly` variable is unset later in a later code block after decisions are made based on the value of the `hostonly` variable which is unexpected, hard to reason about and inconsistent.

Fix it by rearranging the order of execution of the code blocks.

## Checklist
- [ ] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it

