### PR TITLE
fix(debian): remove Debian 12 support

### DIFF
--- a/test/container/Dockerfile-debian
+++ b/test/container/Dockerfile-debian
@@ -24,16 +24,6 @@ ENV V=2
 # Install dracut as a linux-initramfs-tool provider so that the default initramfs-tool package does not get installed
 RUN apt-get update -y -qq && apt-get upgrade -y -qq && apt-get install -y -qq --no-install-recommends dracut
 
-# extra packages for sid, rolling, devel
-RUN if [ "$DISTRIBUTION" = "debian:sid" ] || [ "$DISTRIBUTION" = "ubuntu:rolling" ] || [ "$DISTRIBUTION" = "ubuntu:devel" ] ; then \
-    DEBIAN_FRONTEND=noninteractive apt-get install -y -qq --no-install-recommends -o Dpkg::Use-Pty=0 \
-    plymouth-themes \
-    network-manager \
-    systemd-cryptsetup \
-    systemd-repart \
-    systemd-ukify \
-    ; fi
-
 RUN \
     DEBIAN_FRONTEND=noninteractive apt-get install -y -qq --no-install-recommends -o Dpkg::Use-Pty=0 \
     asciidoctor \
@@ -70,6 +60,7 @@ RUN \
     multipath-tools \
     nbd-client \
     nbd-server \
+    network-manager \
     nfs-kernel-server \
     ntfs-3g \
     nvme-cli \
@@ -78,6 +69,7 @@ RUN \
     parted \
     pcscd \
     pkg-config \
+    plymouth-themes \
     procps \
     qemu-efi-aarch64 \
     qemu-kvm \
@@ -88,9 +80,12 @@ RUN \
     systemd-boot-efi \
     systemd-container \
     systemd-coredump \
+    systemd-cryptsetup \
+    systemd-repart \
     systemd-resolved \
     systemd-sysv \
     systemd-timesyncd \
+    systemd-ukify \
     tgt \
     thin-provisioning-tools \
     tpm2-tools \


### PR DESCRIPTION
## Changes

Debian v13 (Trixie) is now the minimal Debian version supported by the CI.
    
## Checklist
- [ ] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it

Fixes #1458
