### PR TITLE
 chore: always set hostonly and hostonly_mode variables

### DIFF
--- a/doc_site/modules/ROOT/pages/developer/modules.adoc
+++ b/doc_site/modules/ROOT/pages/developer/modules.adoc
@@ -75,6 +75,16 @@ module implements onto the initrd.  For the most part, this amounts
 to copying files from the host system onto the initrd in a controlled
 manner.
 
+The following are the most commonly used shell variables used inside
+drauct modules. These shell variables are always declared and assigned
+values (the assigned value might be an empty string). There is a
+compatibility promise on these variables between dracut releases.
+Module should only read (and not write) these variables.
+ * `$hostonly` (could be an empty string)
+ * `$hostonly_mode` (could be an empty string)
+ * `$hostonly_cmdline` (not an empty string)
+ * `$moddir` (not an empty string)
+
 ==== `module-setup.sh` function API
 
 `install()`::

--- a/dracut.sh
+++ b/dracut.sh
@@ -1338,6 +1338,10 @@ case $hostonly_mode in
         ;;
 esac
 
+# make sure these variables are never unset
+hostonly=${hostonly-}
+hostonly_mode=${hostonly_mode-}
+
 if [[ $reproducible == yes ]] && [[ -z ${SOURCE_DATE_EPOCH-} ]]; then
     SOURCE_DATE_EPOCH=$(stat -c %Y "$dracutbasedir/dracut-functions.sh")
 fi

--- a/modules.d/10systemd/module-setup.sh
+++ b/modules.d/10systemd/module-setup.sh
@@ -96,7 +96,7 @@ install() {
         systemd-run systemd-escape \
         systemd-cgls
 
-    if [[ ${hostonly-} ]]; then
+    if [[ $hostonly ]]; then
         inst_multiple -H -o \
             "$systemdutilconfdir"/system.conf \
             "$systemdutilconfdir"/system.conf.d/*.conf \

--- a/modules.d/11fips/module-setup.sh
+++ b/modules.d/11fips/module-setup.sh
@@ -42,7 +42,7 @@ installkernel() {
     done
 
     # with hostonly_default_device fs module for /boot is not installed by default
-    if [[ ${hostonly-} ]] && [[ $hostonly_default_device == "no" ]]; then
+    if [[ $hostonly ]] && [[ $hostonly_default_device == "no" ]]; then
         _bootfstype=$(find_mp_fstype /boot)
         if [[ -n $_bootfstype ]]; then
             hostonly='' instmods "$_bootfstype"

--- a/modules.d/11systemd-ask-password/module-setup.sh
+++ b/modules.d/11systemd-ask-password/module-setup.sh
@@ -19,7 +19,7 @@ check() {
 # Module dependency requirements.
 depends() {
 
-    if [[ ${hostonly-} ]]; then
+    if [[ $hostonly ]]; then
         # A password cannot be entered if there is no graphical output during boot,
         # as is the case in aarch64, where efifb does not work with qemu-system-aarch64:
         # - virtio-gpu-pci does not expose a linear framebuffer

--- a/modules.d/11systemd-coredump/module-setup.sh
+++ b/modules.d/11systemd-coredump/module-setup.sh
@@ -57,7 +57,7 @@ install() {
     fi
 
     # Install the hosts local user configurations if enabled.
-    if [[ ${hostonly-} ]]; then
+    if [[ $hostonly ]]; then
         inst_multiple -H -o \
             "$systemdutilconfdir"/coredump.conf \
             "$systemdutilconfdir/coredump.conf.d/*.conf" \

--- a/modules.d/11systemd-creds/module-setup.sh
+++ b/modules.d/11systemd-creds/module-setup.sh
@@ -37,7 +37,7 @@ install() {
         systemd-creds
 
     # Install the hosts local user configurations if enabled.
-    if [[ ${hostonly-} ]]; then
+    if [[ $hostonly ]]; then
         inst_multiple -H -o \
             "/etc/credstore/*" \
             "/etc/credstore.encrypted/*"

--- a/modules.d/11systemd-cryptsetup/module-setup.sh
+++ b/modules.d/11systemd-cryptsetup/module-setup.sh
@@ -20,7 +20,7 @@ check() {
 depends() {
     local deps
     deps="dm rootfs-block crypt systemd-ask-password"
-    if [[ ${hostonly-} && -f "${dracutsysrootdir-}"/etc/crypttab ]]; then
+    if [[ $hostonly && -f "${dracutsysrootdir-}"/etc/crypttab ]]; then
         if grep -q -e "fido2-device=" -e "fido2-cid=" "${dracutsysrootdir-}"/etc/crypttab; then
             deps+=" fido2"
         fi
@@ -30,7 +30,7 @@ depends() {
         if grep -q "tpm2-device=" "${dracutsysrootdir-}"/etc/crypttab; then
             deps+=" tpm2-tss"
         fi
-    elif [[ ! ${hostonly-} ]]; then
+    elif [[ ! $hostonly ]]; then
         for module in fido2 pkcs11 tpm2-tss; do
             module_check $module > /dev/null 2>&1
             if [[ $? == 255 ]] && ! [[ " $omit_dracutmodules " == *\ $module\ * ]]; then
@@ -56,7 +56,7 @@ install() {
         "$systemdsystemunitdir"/remote-cryptsetup.target \
         "$systemdsystemunitdir"/initrd-root-device.target.wants/remote-cryptsetup.target
 
-    if [[ ${hostonly-} ]] && [[ -f $initdir/etc/crypttab ]]; then
+    if [[ $hostonly ]] && [[ -f $initdir/etc/crypttab ]]; then
         # for each entry in /etc/crypttab check if the key file is backed by a socket unit and if so,
         # include it along with its corresponding service unit.
         while read -r _mapper _dev _luksfile _luksoptions || [[ -n $_mapper ]]; do

--- a/modules.d/11systemd-hostnamed/module-setup.sh
+++ b/modules.d/11systemd-hostnamed/module-setup.sh
@@ -46,7 +46,7 @@ install() {
         hostnamectl
 
     # Install the hosts local user configurations if enabled.
-    if [[ ${hostonly-} ]]; then
+    if [[ $hostonly ]]; then
         inst_multiple -H -o \
             /etc/hostname \
             "$systemdsystemconfdir"/systemd-hostnamed.service \

--- a/modules.d/11systemd-integritysetup/module-setup.sh
+++ b/modules.d/11systemd-integritysetup/module-setup.sh
@@ -49,7 +49,7 @@ install() {
         "$systemdsystemunitdir"/initrd-root-device.target.wants/remote-integritysetup.target
 
     # Install the hosts local user configurations if enabled.
-    if [[ ${hostonly-} ]]; then
+    if [[ $hostonly ]]; then
         inst_multiple -H -o \
             /etc/integritytab \
             "$systemdsystemconfdir"/integritysetup.target \

--- a/modules.d/11systemd-journald/module-setup.sh
+++ b/modules.d/11systemd-journald/module-setup.sh
@@ -67,7 +67,7 @@ install() {
     fi
 
     # Install the hosts local user configurations if enabled.
-    if [[ ${hostonly-} ]]; then
+    if [[ $hostonly ]]; then
         inst_multiple -H -o \
             "$systemdutilconfdir"/journald.conf \
             "$systemdutilconfdir/journald.conf.d/*.conf" \

--- a/modules.d/11systemd-ldconfig/module-setup.sh
+++ b/modules.d/11systemd-ldconfig/module-setup.sh
@@ -41,7 +41,7 @@ install() {
     inst_libdir_file {"tls/$_arch/",tls/,"$_arch/",}"ld.so"
 
     # Install the hosts local user configurations if enabled.
-    if [[ ${hostonly-} ]]; then
+    if [[ $hostonly ]]; then
         inst_multiple -H -o \
             "$systemdsystemconfdir"/ldconfig.service \
             "$systemdsystemconfdir/ldconfig.service.d/*.conf"

--- a/modules.d/11systemd-modules-load/module-setup.sh
+++ b/modules.d/11systemd-modules-load/module-setup.sh
@@ -38,7 +38,7 @@ installkernel() {
         hostonly='' instmods "${_mods[@]}"
     fi
 
-    if [[ ${hostonly-} ]]; then
+    if [[ $hostonly ]]; then
         mapfile -t _mods < <(modules_load_get "$modulesloadconfdir")
         if [[ ${#_mods[@]} -gt 0 ]]; then
             hostonly='' instmods "${_mods[@]}"
@@ -65,7 +65,7 @@ install() {
     $SYSTEMCTL -q --root "$initdir" enable systemd-modules-load.service
 
     # Install the hosts local user configurations if enabled.
-    if [[ ${hostonly-} ]]; then
+    if [[ $hostonly ]]; then
         inst_multiple -H -o \
             /etc/modules-load.d/*.conf \
             "$modulesloadconfdir/*.conf" \

--- a/modules.d/11systemd-networkd/module-setup.sh
+++ b/modules.d/11systemd-networkd/module-setup.sh
@@ -78,7 +78,7 @@ install() {
     done
 
     # Install the hosts local user configurations if enabled.
-    if [[ ${hostonly-} ]]; then
+    if [[ $hostonly ]]; then
         inst_multiple -H -o \
             "$systemdutilconfdir"/networkd.conf \
             "$systemdutilconfdir/networkd.conf.d/*.conf" \

--- a/modules.d/11systemd-pcrphase/module-setup.sh
+++ b/modules.d/11systemd-pcrphase/module-setup.sh
@@ -43,7 +43,7 @@ install() {
         "$systemdsystemunitdir"/initrd.target.wants/systemd-pcrphase-initrd.service
 
     # Install the hosts local user configurations if enabled.
-    if [[ ${hostonly-} ]]; then
+    if [[ $hostonly ]]; then
         inst_multiple -H -o \
             "$systemdsystemconfdir"/systemd-pcrphase-initrd.service \
             "$systemdsystemconfdir/systemd-pcrphase-initrd.service.d/*.conf" \

--- a/modules.d/11systemd-portabled/module-setup.sh
+++ b/modules.d/11systemd-portabled/module-setup.sh
@@ -66,7 +66,7 @@ install() {
     $SYSTEMCTL -q --root "$initdir" enable systemd-portabled.service
 
     # Install the hosts local user configurations if enabled.
-    if [[ ${hostonly-} ]]; then
+    if [[ $hostonly ]]; then
         inst_multiple -H -o \
             "/etc/portables/*.raw" \
             "$systemdutilconfdir/system.attached/*" \

--- a/modules.d/11systemd-pstore/module-setup.sh
+++ b/modules.d/11systemd-pstore/module-setup.sh
@@ -44,7 +44,7 @@ install() {
     $SYSTEMCTL -q --root "$initdir" enable systemd-pstore.service
 
     # Install the hosts local user configurations if enabled.
-    if [[ ${hostonly-} ]]; then
+    if [[ $hostonly ]]; then
         inst_multiple -H -o \
             "$systemdutilconfdir"/pstore.conf \
             "$systemdutilconfdir/pstore.conf.d/*.conf" \

--- a/modules.d/11systemd-repart/module-setup.sh
+++ b/modules.d/11systemd-repart/module-setup.sh
@@ -31,7 +31,7 @@ install() {
         "mksquashfs"
 
     # Install the hosts local user configurations if enabled.
-    if [[ ${hostonly-} ]]; then
+    if [[ $hostonly ]]; then
         inst_multiple -H -o \
             "/etc/repart.d/*.conf" \
             "$systemdsystemconfdir"/systemd-repart.service \

--- a/modules.d/11systemd-resolved/module-setup.sh
+++ b/modules.d/11systemd-resolved/module-setup.sh
@@ -48,7 +48,7 @@ install() {
     $SYSTEMCTL -q --root "$initdir" enable systemd-resolved.service
 
     # Install the hosts local user configurations if enabled.
-    if [[ ${hostonly-} ]]; then
+    if [[ $hostonly ]]; then
         inst_multiple -H -o \
             "$systemdutilconfdir"/resolv.conf \
             "$systemdutilconfdir"/resolved.conf \

--- a/modules.d/11systemd-sysctl/module-setup.sh
+++ b/modules.d/11systemd-sysctl/module-setup.sh
@@ -23,7 +23,7 @@ install() {
         "$systemdutildir"/systemd-sysctl
 
     # Install the hosts local user configurations if enabled.
-    if [[ ${hostonly-} ]]; then
+    if [[ $hostonly ]]; then
         inst_multiple -H -o \
             /etc/sysctl.conf \
             /etc/sysctl.d/*.conf \

--- a/modules.d/11systemd-sysext/module-setup.sh
+++ b/modules.d/11systemd-sysext/module-setup.sh
@@ -57,7 +57,7 @@ install() {
     done
 
     # Install the hosts local user configurations if enabled.
-    if [[ ${hostonly-} ]]; then
+    if [[ $hostonly ]]; then
         inst_multiple -H -o \
             "/etc/extensions/*.raw" \
             "/etc/extension-release.d/extension-release.*" \

--- a/modules.d/11systemd-timedated/module-setup.sh
+++ b/modules.d/11systemd-timedated/module-setup.sh
@@ -38,7 +38,7 @@ install() {
         timedatectl
 
     # Install the hosts local user configurations if enabled.
-    if [[ ${hostonly-} ]]; then
+    if [[ $hostonly ]]; then
         inst_multiple -H -o \
             "$systemdsystemconfdir"/systemd-timedated.service \
             "$systemdsystemconfdir/systemd-timedated.service.d/*.conf"

--- a/modules.d/11systemd-timesyncd/module-setup.sh
+++ b/modules.d/11systemd-timesyncd/module-setup.sh
@@ -55,7 +55,7 @@ install() {
     done
 
     # Install the hosts local user configurations if enabled.
-    if [[ ${hostonly-} ]]; then
+    if [[ $hostonly ]]; then
         inst_multiple -H -o \
             "$systemdntpunitsconfdir/*.list" \
             "$systemdutilconfdir"/timesyncd.conf \

--- a/modules.d/11systemd-tmpfiles/module-setup.sh
+++ b/modules.d/11systemd-tmpfiles/module-setup.sh
@@ -43,7 +43,7 @@ install() {
         systemd-tmpfiles
 
     # Install the hosts local user configurations if enabled.
-    if [[ ${hostonly-} ]]; then
+    if [[ $hostonly ]]; then
         inst_multiple -H -o \
             "$tmpfilesconfdir/*.conf" \
             "$systemdsystemconfdir"/systemd-tmpfiles-clean.service \

--- a/modules.d/11systemd-udevd/module-setup.sh
+++ b/modules.d/11systemd-udevd/module-setup.sh
@@ -51,7 +51,7 @@ install() {
         "$systemdsystemunitdir"/sysinit.target.wants/systemd-udev-trigger.service
 
     # Install the hosts local user configurations if enabled.
-    if [[ ${hostonly-} ]]; then
+    if [[ $hostonly ]]; then
         inst_multiple -H -o \
             "$systemdsystemconfdir"/systemd-udevd.service \
             "$systemdsystemconfdir/systemd-udevd.service.d/*.conf" \

--- a/modules.d/11systemd-veritysetup/module-setup.sh
+++ b/modules.d/11systemd-veritysetup/module-setup.sh
@@ -49,7 +49,7 @@ install() {
         "$systemdsystemunitdir"/initrd-root-device.target.wants/remote-veritysetup.target
 
     # Install the hosts local user configurations if enabled.
-    if [[ ${hostonly-} ]]; then
+    if [[ $hostonly ]]; then
         inst_multiple -H -o \
             /etc/veritytab \
             "$systemdsystemconfdir"/veritysetup.target \

--- a/modules.d/13modsign/module-setup.sh
+++ b/modules.d/13modsign/module-setup.sh
@@ -11,7 +11,7 @@ check() {
 
     # do not include module in hostonly mode,
     # if no keys are present
-    if [[ ${hostonly-} ]]; then
+    if [[ $hostonly ]]; then
         x=$(echo "${dracutsysrootdir-}"/lib/modules/keys/*)
         [[ ${x} == "${dracutsysrootdir-}/lib/modules/keys/*" ]] && return 255
     fi

--- a/modules.d/16dbus-broker/module-setup.sh
+++ b/modules.d/16dbus-broker/module-setup.sh
@@ -71,7 +71,7 @@ install() {
     $SYSTEMCTL -q --root "$initdir" enable dbus-broker.service
 
     # Install the hosts local user configurations if enabled.
-    if [[ ${hostonly-} ]]; then
+    if [[ $hostonly ]]; then
         inst_multiple -H -o \
             "$dbusconfdir"/session.conf \
             "$dbusconfdir"/system.conf \

--- a/modules.d/16dbus-daemon/module-setup.sh
+++ b/modules.d/16dbus-daemon/module-setup.sh
@@ -77,7 +77,7 @@ install() {
     grep '^\(d\|message\)bus:' "${dracutsysrootdir-}"/etc/group >> "$initdir/etc/group"
 
     # Install the hosts local user configurations if enabled.
-    if [[ ${hostonly-} ]]; then
+    if [[ $hostonly ]]; then
         inst_multiple -H -o \
             "$dbusconfdir"/system.conf \
             "$systemdsystemconfdir"/dbus.socket \

--- a/modules.d/20i18n/module-setup.sh
+++ b/modules.d/20i18n/module-setup.sh
@@ -299,7 +299,7 @@ install() {
         [[ "$kbddir" ]] || return 1
 
         [[ -f ${dracutsysrootdir-}$I18N_CONF ]] \
-            || [[ ! ${hostonly-} || ${i18n_vars-} ]] || {
+            || [[ ! $hostonly || ${i18n_vars-} ]] || {
             derror 'i18n_vars not set!  Please set up i18n_vars in ' \
                 'configuration file.'
         }
@@ -309,7 +309,7 @@ install() {
     if checks; then
         install_base
 
-        if [[ ${hostonly-} ]] && ! [[ ${i18n_install_all} == "yes" ]]; then
+        if [[ $hostonly ]] && ! [[ ${i18n_install_all} == "yes" ]]; then
             install_local_i18n || install_all_kbd
         else
             install_all_kbd

--- a/modules.d/35connman/module-setup.sh
+++ b/modules.d/35connman/module-setup.sh
@@ -24,7 +24,7 @@ install() {
     inst connmanctl
     inst connmand-wait-online
     inst "$dbussystem"/connman.conf
-    [[ ${hostonly-} ]] && [[ -f ${dracutsysrootdir-}/etc/connman/main.conf ]] && inst /etc/connman/main.conf
+    [[ $hostonly ]] && [[ -f ${dracutsysrootdir-}/etc/connman/main.conf ]] && inst /etc/connman/main.conf
     inst_dir /usr/lib/connman/plugins
     inst_dir /var/lib/connman
 

--- a/modules.d/35network-legacy/module-setup.sh
+++ b/modules.d/35network-legacy/module-setup.sh
@@ -29,7 +29,7 @@ install() {
         inst_multiple -o \
             "${systemdnetwork}/99-default.link" \
             "${systemdnetwork}/98-default-mac-none.link"
-        [[ ${hostonly-} ]] && inst_multiple -H -o "${systemdnetworkconfdir}/*.link"
+        [[ $hostonly ]] && inst_multiple -H -o "${systemdnetworkconfdir}/*.link"
     fi
 
     inst_multiple ip dhclient sed awk grep pgrep tr expr

--- a/modules.d/35network-manager/module-setup.sh
+++ b/modules.d/35network-manager/module-setup.sh
@@ -78,7 +78,7 @@ install() {
         inst_multiple -o \
             "${systemdnetwork}/99-default.link" \
             "${systemdnetwork}/98-default-mac-none.link"
-        [[ ${hostonly-} ]] && inst_multiple -H -o "${systemdnetworkconfdir}/*.link"
+        [[ $hostonly ]] && inst_multiple -H -o "${systemdnetworkconfdir}/*.link"
     fi
 
     inst_hook initqueue/settled 99 "$moddir/nm-run.sh"

--- a/modules.d/45drm/module-setup.sh
+++ b/modules.d/45drm/module-setup.sh
@@ -23,7 +23,7 @@ installkernel() {
     # if the hardware is present, include module even if it is not currently loaded,
     # as we could e.g. be in the installer; nokmsboot boot parameter will disable
     # loading of the driver if needed
-    if [[ ${hostonly-} ]]; then
+    if [[ $hostonly ]]; then
         local -a _mods
         local i modlink modname
 

--- a/modules.d/45plymouth/plymouth-populate-initrd.sh
+++ b/modules.d/45plymouth/plymouth-populate-initrd.sh
@@ -12,7 +12,7 @@ mkdir -m 0755 -p "${initdir}/usr/share/plymouth"
 
 inst_libdir_file "plymouth/text.so" "plymouth/details.so"
 
-if [[ ${hostonly-} ]]; then
+if [[ $hostonly ]]; then
     inst_multiple \
         "/usr/share/plymouth/themes/details/details.plymouth" \
         "/usr/share/plymouth/themes/text/text.plymouth"

--- a/modules.d/70bluetooth/module-setup.sh
+++ b/modules.d/70bluetooth/module-setup.sh
@@ -7,7 +7,7 @@ check() {
     # If the binary(s) requirements are not fulfilled the module can't be installed
     require_any_binary /usr/lib/bluetooth/bluetoothd /usr/libexec/bluetooth/bluetoothd || return 1
 
-    if [[ ${hostonly-} ]]; then
+    if [[ $hostonly ]]; then
         # Warn user if bluetooth kernel module is loaded
         # and if Peripheral (0x500) is found of minor class:
         #  * Keyboard (0x40)
@@ -68,7 +68,7 @@ install() {
         /usr/libexec/bluetooth/bluetoothd \
         /usr/lib/bluetooth/bluetoothd
 
-    if [[ ${hostonly-} ]]; then
+    if [[ $hostonly ]]; then
         var_lib_files=("${dracutsysrootdir-}"/var/lib/bluetooth/**)
 
         inst_multiple -o \

--- a/modules.d/70crypt/module-setup.sh
+++ b/modules.d/70crypt/module-setup.sh
@@ -93,7 +93,7 @@ install() {
         inst_hook cleanup 30 "$moddir/crypt-cleanup.sh"
     fi
 
-    if [[ ${hostonly-} ]] && [[ -f "${dracutsysrootdir-}/etc/crypttab" ]]; then
+    if [[ $hostonly ]] && [[ -f "${dracutsysrootdir-}/etc/crypttab" ]]; then
         # filter /etc/crypttab for the devices we need
         while read -r _mapper _dev _luksfile _luksoptions || [ -n "$_mapper" ]; do
             [[ $_mapper == \#* ]] && continue

--- a/modules.d/70dmsquash-live-autooverlay/module-setup.sh
+++ b/modules.d/70dmsquash-live-autooverlay/module-setup.sh
@@ -2,7 +2,7 @@
 
 check() {
     # including a module dedicated to live environments in a host-only initrd doesn't make sense
-    [[ ${hostonly-} ]] && return 1
+    [[ $hostonly ]] && return 1
     return 255
 }
 

--- a/modules.d/70dmsquash-live/module-setup.sh
+++ b/modules.d/70dmsquash-live/module-setup.sh
@@ -3,7 +3,7 @@
 # called by dracut
 check() {
     # a live host-only image doesn't really make a lot of sense
-    [[ ${hostonly-} ]] && return 1
+    [[ $hostonly ]] && return 1
     return 255
 }
 

--- a/modules.d/70kernel-modules/module-setup.sh
+++ b/modules.d/70kernel-modules/module-setup.sh
@@ -126,7 +126,7 @@ installkernel() {
             dracut_instmods -o -P ".*/(kernel/fs/nfs|kernel/fs/nfsd|kernel/fs/lockd)/.*" '=fs'
         fi
 
-        if [[ ${hostonly-} ]] && [[ "${host_fs_types[*]}" ]]; then
+        if [[ $hostonly ]] && [[ "${host_fs_types[*]}" ]]; then
             hostonly='' instmods "${host_fs_types[@]}"
         fi
 
@@ -143,7 +143,7 @@ installkernel() {
     fi
 
     inst_multiple -o "$depmodd/*.conf"
-    if [[ ${hostonly-} ]]; then
+    if [[ $hostonly ]]; then
         inst_multiple -H -o "$depmodconfdir/*.conf"
     fi
     :

--- a/modules.d/70lvm/module-setup.sh
+++ b/modules.d/70lvm/module-setup.sh
@@ -58,7 +58,7 @@ install() {
 
     inst_rules "$moddir/64-lvm.rules"
 
-    if [[ ${hostonly-} ]] || [[ $lvmconf == "yes" ]]; then
+    if [[ $hostonly ]] || [[ $lvmconf == "yes" ]]; then
         if [[ -f "${dracutsysrootdir-}/etc/lvm/lvm.conf" ]]; then
             inst_simple -H /etc/lvm/lvm.conf
         fi
@@ -89,7 +89,7 @@ install() {
     inst_script "$moddir/lvm_scan.sh" /sbin/lvm_scan
     inst_hook cmdline 30 "$moddir/parse-lvm.sh"
 
-    if [[ ${hostonly-} ]] && find_binary lvs &> /dev/null; then
+    if [[ $hostonly ]] && find_binary lvs &> /dev/null; then
         for dev in "${!host_fs_types[@]}"; do
             [[ -e /sys/block/${dev#/dev/}/dm/name ]] || continue
             dev=$(< "/sys/block/${dev#/dev/}/dm/name")
@@ -107,7 +107,7 @@ install() {
         done
     fi
 
-    if ! [[ ${hostonly-} ]]; then
+    if ! [[ $hostonly ]]; then
         inst_multiple -o thin_dump thin_restore thin_check thin_repair \
             cache_dump cache_restore cache_check cache_repair \
             era_check era_dump era_invalidate era_restore

--- a/modules.d/70mdraid/module-setup.sh
+++ b/modules.d/70mdraid/module-setup.sh
@@ -91,7 +91,7 @@ install() {
 
     inst_rules "$moddir/59-persistent-storage-md.rules"
 
-    if [[ ${hostonly-} ]] || [[ $mdadmconf == "yes" ]]; then
+    if [[ $hostonly ]] || [[ $mdadmconf == "yes" ]]; then
         if [[ -f "${dracutsysrootdir-}/etc/mdadm.conf" ]]; then
             inst -H /etc/mdadm.conf
         else

--- a/modules.d/70multipath/module-setup.sh
+++ b/modules.d/70multipath/module-setup.sh
@@ -111,7 +111,7 @@ install() {
         "$tmpfilesdir/multipath.conf"
 
     mpathconf_installed \
-        && [[ ${hostonly-} ]] && [[ $hostonly_mode == "strict" ]] && {
+        && [[ $hostonly ]] && [[ $hostonly_mode == "strict" ]] && {
         for_each_host_dev_and_slaves_all add_hostonly_mpath_conf
         if ((${#_allow[@]} > 0)); then
             local -a _args
@@ -123,7 +123,7 @@ install() {
         fi
     }
 
-    [[ ${hostonly-} ]] || mpathconf_installed || {
+    [[ $hostonly ]] || mpathconf_installed || {
         for_each_host_dev_and_slaves is_mpath \
             || [[ -f /etc/multipath.conf ]] || {
             cat > "${initdir}"/etc/multipath.conf << EOF

--- a/modules.d/70nvdimm/module-setup.sh
+++ b/modules.d/70nvdimm/module-setup.sh
@@ -2,7 +2,7 @@
 
 # called by dracut
 check() {
-    if [[ ! ${hostonly-} ]]; then
+    if [[ ! $hostonly ]]; then
         return 0
     fi
     [[ $DRACUT_KERNEL_MODALIASES && -f $DRACUT_KERNEL_MODALIASES ]] \

--- a/modules.d/70pcmcia/module-setup.sh
+++ b/modules.d/70pcmcia/module-setup.sh
@@ -26,7 +26,7 @@ install() {
         "${udevdir}"/pcmcia-check-broken-cis
 
     # Install the hosts local user configurations if enabled.
-    if [[ ${hostonly-} ]]; then
+    if [[ $hostonly ]]; then
         inst_multiple -H -o \
             /etc/pcmcia/config.opts
     fi

--- a/modules.d/70ppcmac/module-setup.sh
+++ b/modules.d/70ppcmac/module-setup.sh
@@ -33,7 +33,7 @@ installkernel() {
 
     # only PowerMac3,6 has a module, special case
     if [[ ${DRACUT_ARCH:-$(uname -m)} != ppc64* ]]; then
-        if [[ $hostonly_mode != "strict" ]] || [[ ${hostonly-} && "$(pmac_model)" == "PowerMac3,6" ]]; then
+        if [[ $hostonly_mode != "strict" ]] || [[ $hostonly && "$(pmac_model)" == "PowerMac3,6" ]]; then
             hostonly=$(optional_hostonly) instmods therm_windtunnel
         fi
         return 0

--- a/modules.d/73pcsc/module-setup.sh
+++ b/modules.d/73pcsc/module-setup.sh
@@ -55,7 +55,7 @@ install() {
         {"tls/$_arch/",tls/,"$_arch/",}"libpcsclite_real.so.*"
 
     # Install the hosts local user configurations if enabled.
-    if [[ ${hostonly-} ]]; then
+    if [[ $hostonly ]]; then
         inst_multiple -H -o \
             /etc/opensc.conf \
             "/etc/reader.conf.d/*"

--- a/modules.d/74dasd/module-setup.sh
+++ b/modules.d/74dasd/module-setup.sh
@@ -12,7 +12,7 @@ check() {
 install() {
     inst_multiple dasdconf.sh
     conf=/etc/dasd.conf
-    if [[ ${hostonly-} && -f $conf ]]; then
+    if [[ $hostonly && -f $conf ]]; then
         inst -H $conf
     fi
     inst_rules 56-dasd.rules

--- a/modules.d/74dcssblk/module-setup.sh
+++ b/modules.d/74dcssblk/module-setup.sh
@@ -11,7 +11,7 @@ check() {
 
 # called by dracut
 installkernel() {
-    if [[ ${hostonly-} ]]; then
+    if [[ $hostonly ]]; then
         for dev in /sys/devices/dcssblk/*/block/dcssblk*; do
             [[ -e $dev ]] || continue
             hostonly='' instmods dcssblk
@@ -28,7 +28,7 @@ install() {
     # If there is a config file which contains avail (best only of root device)
     # disks to activate add it and use it during boot -> then we do not need
     # a kernel param anymore
-    #if [[ ${hostonly-} ]]; then
+    #if [[ $hostonly ]]; then
     #    inst /etc/dcssblk.conf
     #fi
 }

--- a/modules.d/74hwdb/module-setup.sh
+++ b/modules.d/74hwdb/module-setup.sh
@@ -16,7 +16,7 @@ install() {
         "${udevdir}"/hwdb.bin
 
     # Install the hosts local user configurations if enabled.
-    if [[ ${hostonly-} ]]; then
+    if [[ $hostonly ]]; then
         inst_multiple -H -o \
             "$udevconfdir"/hwdb.bin
     fi

--- a/modules.d/74iscsi/module-setup.sh
+++ b/modules.d/74iscsi/module-setup.sh
@@ -193,7 +193,7 @@ install() {
     inst_binary sort
 
     inst_simple /etc/iscsi/iscsid.conf
-    if [[ ${hostonly-} ]]; then
+    if [[ $hostonly ]]; then
         inst_simple /etc/iscsi/initiatorname.iscsi
     fi
 

--- a/modules.d/74lunmask/module-setup.sh
+++ b/modules.d/74lunmask/module-setup.sh
@@ -38,7 +38,7 @@ cmdline() {
         fi
         return 1
     }
-    [[ ${hostonly-} ]] || [[ $mount_needs ]] && {
+    [[ $hostonly ]] || [[ $mount_needs ]] && {
         for_each_host_dev_and_slaves_all get_lunmask
     } | sort | uniq
 }

--- a/modules.d/74nvmf/module-setup.sh
+++ b/modules.d/74nvmf/module-setup.sh
@@ -128,7 +128,7 @@ cmdline() {
         echo -n " rd.nvmf.hostid=${_hostid}"
     fi
 
-    [[ ${hostonly-} ]] || [[ $mount_needs ]] && {
+    [[ $hostonly ]] || [[ $mount_needs ]] && {
         pushd . > /dev/null
         for_each_host_dev_and_slaves gen_nvmf_cmdline
         popd > /dev/null || exit

--- a/modules.d/74resume/module-setup.sh
+++ b/modules.d/74resume/module-setup.sh
@@ -11,7 +11,7 @@ check() {
     }
 
     # If hostonly check if we want to include the resume module
-    if [[ ${hostonly-} ]] || [[ $mount_needs ]]; then
+    if [[ $hostonly ]] || [[ $mount_needs ]]; then
         # Resuming won't work if swap is on a netdevice
         swap_on_netdevice && return 255
         if grep -rq 'resume=' /proc/cmdline /etc/cmdline /etc/cmdline.d /etc/kernel/cmdline /usr/lib/kernel/cmdline 2> /dev/null; then
@@ -80,7 +80,7 @@ install() {
     for _bin in /usr/sbin/resume /usr/lib/suspend/resume /usr/lib64/suspend/resume /usr/lib/uswsusp/resume /usr/lib64/uswsusp/resume; do
         [[ -x "${dracutsysrootdir-}${_bin}" ]] && {
             inst "${_bin}" /usr/sbin/resume
-            [[ ${hostonly-} ]] && [[ -f "${dracutsysrootdir-}/etc/suspend.conf" ]] && inst -H /etc/suspend.conf
+            [[ $hostonly ]] && [[ -f "${dracutsysrootdir-}/etc/suspend.conf" ]] && inst -H /etc/suspend.conf
             break
         }
     done

--- a/modules.d/74rootfs-block/module-setup.sh
+++ b/modules.d/74rootfs-block/module-setup.sh
@@ -6,7 +6,7 @@ depends() {
 }
 
 cmdline_journal() {
-    if [[ ${hostonly-} ]]; then
+    if [[ $hostonly ]]; then
         for dev in "${!host_fs_types[@]}"; do
             [[ ${host_fs_types[$dev]} == "xfs" ]] || continue
             rootopts=$(find_dev_fsopts "$dev")

--- a/modules.d/74udev-rules/module-setup.sh
+++ b/modules.d/74udev-rules/module-setup.sh
@@ -100,7 +100,7 @@ install() {
         {"tls/$_arch/",tls/,"$_arch/",}"libnss_files*"
 
     # Install the hosts local user configurations if enabled.
-    if [[ ${hostonly-} ]]; then
+    if [[ $hostonly ]]; then
         inst_dir "$udevconfdir"
         inst_multiple -H -o \
             "$udevconfdir"/udev.conf \

--- a/modules.d/74virtfs/module-setup.sh
+++ b/modules.d/74virtfs/module-setup.sh
@@ -2,7 +2,7 @@
 
 # called by dracut
 check() {
-    [[ ${hostonly-} ]] || [[ $mount_needs ]] && {
+    [[ $hostonly ]] || [[ $mount_needs ]] && {
         for fs in "${host_fs_types[@]}"; do
             [[ $fs == "9p" ]] && return 0
         done

--- a/modules.d/74zfcp/module-setup.sh
+++ b/modules.d/74zfcp/module-setup.sh
@@ -23,7 +23,7 @@ install() {
     inst_script /sbin/zfcpconf.sh
     inst_rules 56-zfcp.rules
 
-    if [[ ${hostonly-} ]]; then
+    if [[ $hostonly ]]; then
         inst_simple -H /etc/zfcp.conf
     fi
 }

--- a/modules.d/74znet/module-setup.sh
+++ b/modules.d/74znet/module-setup.sh
@@ -25,7 +25,7 @@ installkernel() {
 install() {
     inst_hook cmdline 30 "$moddir/parse-ccw.sh"
     inst_multiple grep sed seq readlink chzdev
-    if [[ ${hostonly-} ]]; then
+    if [[ $hostonly ]]; then
         local _tempfile
         _tempfile=$(mktemp --tmpdir="${DRACUT_TMPDIR}" dracut-zdev.XXXXXX)
         {

--- a/modules.d/76masterkey/module-setup.sh
+++ b/modules.d/76masterkey/module-setup.sh
@@ -2,7 +2,7 @@
 
 # called by dracut
 check() {
-    [[ ${hostonly-} ]] && {
+    [[ $hostonly ]] && {
         require_binaries keyctl uname || return 1
     }
 

--- a/modules.d/80base/module-setup.sh
+++ b/modules.d/80base/module-setup.sh
@@ -65,10 +65,10 @@ install() {
 
     # add common users in /etc/passwd, it will be used by nfs/ssh currently
     # use password for hostonly images to facilitate secure sulogin in emergency console
-    [[ ${hostonly-} ]] && pwshadow='x'
+    [[ $hostonly ]] && pwshadow='x'
     grep '^root:' "$initdir/etc/passwd" > /dev/null 2>&1 || echo "root:$pwshadow:0:0::/root:/bin/sh" >> "$initdir/etc/passwd"
 
-    if [[ ${hostonly-} ]]; then
+    if [[ $hostonly ]]; then
         # check if other dracut modules already created an entry for root in /etc/shadow
         if grep -q '^root:' "$initdir/etc/shadow" > /dev/null 2>&1; then
             grep -v '^root:' "$initdir/etc/shadow" > "$initdir/etc/shadow-"
@@ -99,7 +99,7 @@ install() {
 
     [[ -d /lib/modprobe.d ]] && inst_multiple -o "/lib/modprobe.d/*.conf"
     [[ -d /usr/lib/modprobe.d ]] && inst_multiple -o "/usr/lib/modprobe.d/*.conf"
-    [[ ${hostonly-} ]] && inst_multiple -H -o /etc/modprobe.d/*.conf /etc/modprobe.conf
+    [[ $hostonly ]] && inst_multiple -H -o /etc/modprobe.d/*.conf /etc/modprobe.conf
 
     inst_simple "$moddir/insmodpost.sh" /sbin/insmodpost.sh
 


### PR DESCRIPTION
It makes it easier to reason both for built-in and out-of-tree dracut modules with the assumption that `hostonly` and `hostonly_mode` variables are always set.
    
Document most commonly used shell variables for dracut modules and document that they are always set.

Partial revert of c85c93245bf .

Note: Run the following in the `modules.d` directory

```
sed -i 's/\${hostonly\-}/hostonly/g' 
```

## Checklist
- [ ] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it

