### PR TITLE
ci(opensuse.conf.example): change log levels

### DIFF
--- a/dracut.conf.d/opensuse.conf.example
+++ b/dracut.conf.d/opensuse.conf.example
@@ -12,3 +12,6 @@ compress="zstd -3 -T0 -q"
 
 i18n_vars="/etc/sysconfig/language:RC_LANG-LANG,RC_LC_ALL-LC_ALL /etc/sysconfig/console:CONSOLE_UNICODEMAP-FONT_UNIMAP,CONSOLE_FONT-FONT,CONSOLE_SCREENMAP-FONT_MAP /etc/sysconfig/keyboard:KEYTABLE-KEYMAP"
 omit_drivers+=" i2o_scsi "
+
+stdloglvl=3
+sysloglvl=4


### PR DESCRIPTION
Upstream new log levels in openSUSE, present in Tumbleweed since snapshot 20250612. Reduce default standard log verbosity from `info` to `warning`, and increase syslog verbosity from none to `info`.

## Checklist
- [ ] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it