### PR TITLE
feat(Makefile): set Dracut version on install

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -201,6 +201,7 @@ install: all
 	install -m 0755 dracut-init.sh $(DESTDIR)$(pkglibdir)/dracut-init.sh
 	install -m 0755 dracut-functions.sh $(DESTDIR)$(pkglibdir)/dracut-functions.sh
 	install -m 0755 dracut-version.sh $(DESTDIR)$(pkglibdir)/dracut-version.sh
+	sed -i 's;^\(DRACUT_VERSION=\).*;\1$(DRACUT_FULL_VERSION);' $(DESTDIR)$(pkglibdir)/dracut-version.sh
 	ln -fs dracut-functions.sh $(DESTDIR)$(pkglibdir)/dracut-functions
 	install -m 0755 dracut-logger.sh $(DESTDIR)$(pkglibdir)/dracut-logger.sh
 	install -m 0755 dracut-initramfs-restore.sh $(DESTDIR)$(pkglibdir)/dracut-initramfs-restore


### PR DESCRIPTION
## Changes

Distributions can override `DRACUT_VERSION` or `DRACUT_FULL_VERSION` to include the distribution's revision in the dracut version. This override is not reflected in the installed `dracut-version.sh` and needs to be modified by the distribution.

Persist the version in the installed `dracut-version.sh` during `make install`.

## Checklist
- [ ] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it

Fixes #
