### PR TITLE
feat(Makefile): introduce distclean target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -65,7 +65,7 @@ man8pages = man/dracut.8 \
 
 manpages = $(man1pages) $(man5pages) $(man7pages) $(man8pages)
 
-.PHONY: install clean archive test all check AUTHORS CONTRIBUTORS doc
+.PHONY: install clean distclean archive test all check AUTHORS CONTRIBUTORS doc
 
 all: dracut.pc dracut-install src/skipcpio/skipcpio dracut-util
 
@@ -292,6 +292,9 @@ clean:
 	$(RM) dracut-cpio src/dracut-cpio/target/release/dracut-cpio*
 	$(RM) -rf build/ doc_site/modules/ROOT/pages/man/*
 	$(MAKE) -C test clean
+
+distclean: clean
+	$(RM) Makefile.inc
 
 syncheck:
 	@ret=0;for i in dracut-initramfs-restore.sh modules.d/*/*.sh; do \


### PR DESCRIPTION
## Changes

Add a `distclean` target to remove all generated files including the one (`Makefile.inc`) created by `configure`. Calling `make distclean` should have the same result as `git clean -fdx`.

## Checklist
- [x] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it

Fixes #
