### PR TITLE
feat(dracut.conf.d): rename hostonly config to default config

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -30,7 +30,7 @@ pkgconfigdatadir ?= $(datadir)/pkgconfig
 configs = \
 	fips/10-fips.conf \
 	generic/11-generic.conf \
-	hostonly/10-hostonly.conf \
+	default/10-default.conf \
 	ima/10-ima.conf \
 	no-network/10-no-network.conf \
 	no-xattr/10-no-xattr.conf \

--- a/configure
+++ b/configure
@@ -22,8 +22,8 @@ fi
 CC="${CC:-cc}"
 PKG_CONFIG="${PKG_CONFIG:-pkg-config}"
 
-# set hostonly by default
-configprofile="${configprofile:-hostonly}"
+# make the default config profile the default
+configprofile="${configprofile:-default}"
 
 # Little helper function for reading args from the commandline.
 # it automatically handles -a b and -a=b variants, and returns 1 if

--- a/dracut.conf.d/default/10-default.conf
+++ b/dracut.conf.d/default/10-default.conf
@@ -1,3 +1,6 @@
 # optimize initrd to be as small as possible for faster boot performance, tailored to the current host
 hostonly="yes"
 hostonly_cmdline=no
+
+# set standard log verbosity to `warning`
+stdloglvl=3


### PR DESCRIPTION
## Changes

Some distributions (such as Arch) do not provide default configuration. For those distributions, it would be an increased value to provide improve default beyond just setting hostonly.

This commit introduces the notion of default config (and eliminiates the idea for the need of independent hostonly config).

Distributions maintaining independent configurations default (e.g. Fedora) can choose to not package this default configuration.

Set the default log level to warning (matching current openSUSE and Fedora) defaults.

## Checklist
- [ ] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it

