### PR TITLE
feat(systemd-networkd): do not require bash

### DIFF
--- a/modules.d/11systemd-networkd/module-setup.sh
+++ b/modules.d/11systemd-networkd/module-setup.sh
@@ -22,7 +22,7 @@ check() {
 depends() {
 
     # This module has external dependency on other module(s).
-    echo net-lib kernel-network-modules systemd-sysusers systemd bash initqueue
+    echo net-lib kernel-network-modules systemd-sysusers systemd initqueue
     # Return 0 to include the dependent module(s) in the initramfs.
     return 0
 

--- a/modules.d/11systemd-networkd/networkd-run.sh
+++ b/modules.d/11systemd-networkd/networkd-run.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/sh
 
 command -v source_hook > /dev/null || . /lib/dracut-lib.sh
 


### PR DESCRIPTION
## Changes

The systemd-networkd module ships `networkd-run.sh` that uses bash, but there is no bash specific code inside this script. So drop the bash requirement.

## Checklist
- [ ] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it

Fixes #
