### PR TITLE
fix(Makefile): drop setting KVERSION

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -14,8 +14,6 @@ HAVE_SHFMT ?= $(shell command -v shfmt >/dev/null  2>&1 && echo yes)
 
 -include Makefile.inc
 
-KVERSION ?= $(shell uname -r)
-
 prefix ?= /usr
 libdir ?= ${prefix}/lib
 datadir ?= ${prefix}/share


### PR DESCRIPTION
## Changes

The variable `KVERSION` is not used any more in the Makefile.

## Checklist
- [ ] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it

Fixes: 9bf0294fead7 ("chore: remove remaining old test infrastructure")
