### PR TITLE
fix(Makefile): use install for installing files

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -203,12 +203,19 @@ install: all
 	ln -fs dracut-functions.sh $(DESTDIR)$(pkglibdir)/dracut-functions
 	install -m 0755 dracut-logger.sh $(DESTDIR)$(pkglibdir)/dracut-logger.sh
 	install -m 0755 dracut-initramfs-restore.sh $(DESTDIR)$(pkglibdir)/dracut-initramfs-restore
-	cp -arx modules.d $(DESTDIR)$(pkglibdir)
+	for module in modules.d/*; do \
+		if test -L "$$module"; then cp -d "$$module" "$(DESTDIR)$(pkglibdir)/modules.d"; continue; fi; \
+		install -m 0755 -d "$$module" "$(DESTDIR)$(pkglibdir)/$$module"; \
+		for file in "$$module"/*; do \
+			mode=0755; test -x "$$file" || mode=0644; \
+			install -m "$$mode" "$$file" "$(DESTDIR)$(pkglibdir)/$$file"; \
+		done; \
+	done
 	for conf in $(configs); do \
 		install -D -m 0644 "dracut.conf.d/$$conf" "$(DESTDIR)$(pkglibdir)/dracut.conf.d/$$conf"; \
 	done
 	for i in $(configprofile) ; do \
-		cp -arx dracut.conf.d/$$i/* $(DESTDIR)$(pkglibdir)/dracut.conf.d/ ;\
+		install -m 0644 dracut.conf.d/$$i/* $(DESTDIR)$(pkglibdir)/dracut.conf.d/ ;\
 	done
 ifeq ($(enable_test),yes)
 	cp -arx test $(DESTDIR)$(pkglibdir)


### PR DESCRIPTION
## Changes

The `cp` command will copy the file/directory permissions from the source files. The local source files might have group write permission set which should not be applied to the installation.

Tighten the file/directory permission by using the `install` command with specifying the mode.

Please review and merge https://github.com/dracut-ng/dracut-ng/pull/1521 first.

## Checklist
- [ ] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it

Fixes #
