### PR TITLE
fix(livenet): source img-lib.sh for check_live_ram

### DIFF
--- a/modules.d/70livenet/livenetroot.sh
+++ b/modules.d/70livenet/livenetroot.sh
@@ -3,6 +3,7 @@
 
 command -v getarg > /dev/null || . /lib/dracut-lib.sh
 command -v fetch_url > /dev/null || . /lib/url-lib.sh
+command -v check_live_ram > /dev/null || . /lib/img-lib.sh
 
 PATH=/usr/sbin:/usr/bin:/sbin:/bin
 RETRIES=${RETRIES:-100}


### PR DESCRIPTION
## Changes

When `livenetroot.sh` is called and tries to find the `check_live_ram()` function, `livenetroot.sh` cannot source from `img-lib.sh`.

## Checklist
- [ ] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it

Fixes #1523
