### PR TITLE
feat: change the default for hostonly_cmdline to no

### DIFF
--- a/dracut.conf.d/debian/10-debian.conf
+++ b/dracut.conf.d/debian/10-debian.conf
@@ -1,3 +1,2 @@
 # Debian/Ubuntu specific Dracut configuration
 hostonly="yes"
-hostonly_cmdline="no"

--- a/dracut.conf.d/hostonly/10-hostonly.conf
+++ b/dracut.conf.d/hostonly/10-hostonly.conf
@@ -1,3 +1,2 @@
 # optimize initrd to be as small as possible for faster boot performance, tailored to the current host
 hostonly="yes"
-hostonly_cmdline=no

--- a/dracut.conf.d/test-makeroot/test-makeroot.conf
+++ b/dracut.conf.d/test-makeroot/test-makeroot.conf
@@ -4,5 +4,4 @@ compress="cat"
 do_strip="no"
 do_hardlink="no"
 early_microcode="no"
-hostonly_cmdline="no"
 stdloglvl=2

--- a/dracut.conf.d/test-root/test-root.conf
+++ b/dracut.conf.d/test-root/test-root.conf
@@ -4,5 +4,4 @@ compress="cat"
 do_strip="no"
 do_hardlink="no"
 early_microcode="no"
-hostonly_cmdline="no"
 stdloglvl=2

--- a/dracut.conf.d/test/test.conf
+++ b/dracut.conf.d/test/test.conf
@@ -3,7 +3,6 @@ add_dracutmodules+=" test "
 do_strip="no"
 do_hardlink="no"
 early_microcode="no"
-hostonly_cmdline="no"
 
 # systemd on arm64 on GitHub CI needs the 2 min timeout
 kernel_cmdline=" rd.retry=10 rd.timeout=120 rd.info rd.shell=0 "

--- a/dracut.sh
+++ b/dracut.sh
@@ -1125,7 +1125,7 @@ drivers_dir="${drivers_dir%"${drivers_dir##*[!/]}"}"
 [[ $hostonly_l ]] && hostonly=$hostonly_l
 [[ $hostonly_cmdline_l ]] && hostonly_cmdline=$hostonly_cmdline_l
 [[ $hostonly_mode_l ]] && hostonly_mode=$hostonly_mode_l
-[[ ${hostonly-} == "yes" ]] && ! [[ $hostonly_cmdline ]] && hostonly_cmdline="yes"
+[[ ${hostonly-} == "yes" ]] && ! [[ $hostonly_cmdline ]] && hostonly_cmdline="no"
 # shellcheck disable=SC2034
 [[ $i18n_install_all_l ]] && i18n_install_all=$i18n_install_all_l
 # shellcheck disable=SC2034

--- a/man/dracut.conf.5.adoc
+++ b/man/dracut.conf.5.adoc
@@ -170,8 +170,8 @@ the image unbootable.
 
 *hostonly_cmdline=*"__{yes|no}__"::
 If set to "yes", store the kernel command line arguments needed in the
-initramfs. If **hostonly="yes"** and this option is not configured, it's
-automatically set to "yes". (default=no)
+initramfs. If this option is not configured, it's automatically set to "no"
+(default=no).
 
 *hostonly_nics+=*" [__<nic>__[ __<nic>__ ...]] "::
 Only enable listed NICs in the initramfs. The list can be empty, so other


### PR DESCRIPTION
## Changes

This change in theory break compatibility with earlier dracut releases.

In practice, Fedora-based and Debian-based distributions have all configured `hostonly_cmdline` to default to "no" already in their respective configuration files.

This configuration is set to "yes" in openSUSE based distributions. For those distributions that explicitly set this variable , this change in defaults will not make have an impact.

Intentionally did not modified Fedora default config, I think it is hard to get attention from the Fedora team to review.

## Checklist
- [ ] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it

Partially fixes #1536
