### PR TITLE
fix(test): make sure $1 is not read as an unbound variable

### DIFF
--- a/test/test-container.sh
+++ b/test/test-container.sh
@@ -29,4 +29,4 @@ if [ "${V-}" = "2" ]; then set -x; fi
 
 # treat warnings as error
 # shellcheck disable=SC2086
-CFLAGS="-Wextra -Werror" make TEST_RUN_ID="${TEST_RUN_ID:=$1}" TESTS="${TESTS:=$2}" V="${V:=1}" ${MAKEFLAGS-} ${TARGETS:=all install check}
+CFLAGS="-Wextra -Werror" make TEST_RUN_ID="${TEST_RUN_ID:=${1-}}" TESTS="${TESTS:=${2-}}" V="${V:=1}" ${MAKEFLAGS-} ${TARGETS:=all install check}


### PR DESCRIPTION
## Changes

Document generation fails on the CI as test-container.sh is called with an empty $1.

Follow-up to 5c9230f.   

## Checklist
- [ ] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it


