### PR TITLE
test: drop requiring iscsiuio.socket

### DIFF
--- a/.github/workflows/integration-extra.yml
+++ b/.github/workflows/integration-extra.yml
@@ -128,13 +128,6 @@ jobs:
                     - "70"
                     - "71"
                     - "72"
-                exclude:
-                    # https://github.com/dracut-ng/dracut-ng/issues/446
-                    - container: debian:sid
-                      test: "70"
-                    # https://github.com/dracut-ng/dracut-ng/issues/446
-                    - container: debian:sid
-                      test: "71"
         container:
             image: ghcr.io/dracut-ng/${{ matrix.container }}-amd
             options: '--device=/dev/kvm'

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -198,11 +198,17 @@ jobs:
             matrix:
                 container:
                     - arch:latest
+                    - debian:latest
                     - opensuse:latest
+                    - ubuntu:devel
                 test:
                     - "70"
                     - "71"
                     - "72"
+                exclude:
+                    # https://github.com/dracut-ng/dracut-ng/issues/1815
+                    - container: ubuntu:devel
+                      test: "72"
         container:
             image: ghcr.io/dracut-ng/${{ matrix.container }}-amd
             options: '--device=/dev/kvm'

--- a/test/TEST-70-ISCSI/test.sh
+++ b/test/TEST-70-ISCSI/test.sh
@@ -122,10 +122,6 @@ test_check() {
         echo "Need tgtd and tgtadm from scsi-target-utils"
         return 1
     fi
-    if ! [ -f /lib/systemd/system/iscsiuio.socket ]; then
-        echo "Need iscsiuio.socket to run this test"
-        return 1
-    fi
 }
 
 test_setup() {

--- a/test/TEST-71-ISCSI-MULTI/test.sh
+++ b/test/TEST-71-ISCSI-MULTI/test.sh
@@ -129,10 +129,6 @@ test_check() {
         echo "Need tgtd and tgtadm from scsi-target-utils"
         return 1
     fi
-    if ! [ -f /lib/systemd/system/iscsiuio.socket ]; then
-        echo "Need iscsiuio.socket to run this test"
-        return 1
-    fi
 }
 
 test_setup() {


### PR DESCRIPTION
## Changes

The iscsiuio socket/service is only needed on specific hardware. It is not needed for the ISCSI and ISCSI-MULTI test cases. Without this check the tests will succeed on Debian and Ubuntu.

This needs https://github.com/dracut-ng/dracut-ng/pull/1528 to succeed.

## Checklist
- [x] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it

Fixes #
