### PR TITLE
ci(debian): install open-iscsi

### DIFF
--- a/test/container/Dockerfile-debian
+++ b/test/container/Dockerfile-debian
@@ -9,7 +9,7 @@
 # - network: network-legacy, network-manager, systemd-networkd
 
 # Not installed
-# - iscsiuio, open-iscsi (not yet working with dracut, https://bugs.launchpad.net/ubuntu/+source/open-iscsi/+bug/2072484)
+# - iscsiuio (iscsiuio.socket missing, see https://bugs.debian.org/1056733)
 # - busybox-static
 
 ARG DISTRIBUTION=debian
@@ -73,6 +73,7 @@ RUN \
     nfs-kernel-server \
     ntfs-3g \
     nvme-cli \
+    open-iscsi \
     ovmf \
     parted \
     pcscd \


### PR DESCRIPTION
## Changes

Install `open-iscsi` in the Debian/Ubuntu container which is needed in the iscsi tests.

## Checklist
- [ ] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it

Fixes #
