### PR TITLE
test(SYSTEMD-INITRD): be more careful with `set -e` and subshells

### DIFF
--- a/test/TEST-42-SYSTEMD-INITRD/test.sh
+++ b/test/TEST-42-SYSTEMD-INITRD/test.sh
@@ -92,7 +92,10 @@ test_setup() {
     (
         cd "$TESTDIR"/initrd/dracut.*/initramfs/usr/lib/systemd/system/
         for f in dracut*.service; do
-            [ -e "$f" ] && echo "unexpected dracut service found: $f" && return 1
+            if [ -e "$f" ]; then
+                echo "unexpected dracut service found: $f"
+                return 1
+            fi
         done
     )
 


### PR DESCRIPTION
When the condition in the subshell fails (i.e. none of the dracut*.service files is found), it doesn't trigger shell exit due to `set -e` as it's a part of a larger condition (&& ...), but since it's the last command of that subshell, it sets the subshell error code to 1. This is then treated by the parent shell as an error and the test is incorrectly interrupted and marked as failed.

For comparison:
```
$ (set -ex; echo begin; (for f in dracut*.service; do [[ -e "$f" ]] && echo fail; done); echo end); echo $?
+ echo begin begin
+ for f in dracut*.service
+ [[ -e dracut*.service ]] 1
```
```
$ (set -ex; echo begin; (for f in dracut*.service; do if [[ -e "$f" ]]; then echo nope; fi; done); echo end); echo $?
+ echo begin begin
+ for f in dracut*.service
+ [[ -e dracut*.service ]]
+ echo end end
0
```
Follow-up for 80350104949708c60806a255765e87d7b1d5a98c

## Checklist
- [x] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it
