### PR TITLE
feat(systemd): drop unnecessary dependency on libgcrypt

### DIFF
--- a/modules.d/11systemd-journald/module-setup.sh
+++ b/modules.d/11systemd-journald/module-setup.sh
@@ -59,7 +59,6 @@ install() {
     # Install library file(s)
     if [[ ! $USE_SYSTEMD_DLOPEN_DEPS ]]; then
         inst_libdir_file \
-            {"tls/$DRACUT_ARCH/",tls/,"$DRACUT_ARCH/",}"libgcrypt.so*" \
             {"tls/$DRACUT_ARCH/",tls/,"$DRACUT_ARCH/",}"liblz4.so.*" \
             {"tls/$DRACUT_ARCH/",tls/,"$DRACUT_ARCH/",}"liblzma.so.*" \
             {"tls/$DRACUT_ARCH/",tls/,"$DRACUT_ARCH/",}"libzstd.so.*"


### PR DESCRIPTION
## Changes

I am not sure whether other distro use it, but we don't need it anymore in Centos Stream (and probably Fedora).

Ref: https://issues.redhat.com/browse/RHEL-95542

## Checklist
- [ ] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it

Fixes #
