### PR TITLE
fix(kernel-modules-extra): remove stray \ before /

### DIFF
--- a/modules.d/70kernel-modules-extra/module-setup.sh
+++ b/modules.d/70kernel-modules-extra/module-setup.sh
@@ -35,7 +35,7 @@ installkernel() {
     # Escape a string for usage as a part of extended regular expression.
     # $1 - string to escape
     re_escape() {
-        printf "%s" "$1" | sed 's/\([.+?^$\/\\|()\[]\|\]\)/\\\0/'
+        printf "%s" "$1" | sed 's/\([.+?^$\\|()\[]\|\]\)/\\\0/'
     }
 
     local cfg


### PR DESCRIPTION
## Changes

Fixes grep warning:
```grep: warning: stray \ before /```

Introduced in grep version 3.11.

Ref: https://issues.redhat.com/browse/RHEL-96152

## Checklist
- [ ] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it

Fixes #
