### PR TITLE
Various dracut-install ELF parsing fixes

### DIFF
--- a/src/install/dracut-install.c
+++ b/src/install/dracut-install.c
@@ -1638,7 +1638,7 @@ static int parse_argv(int argc, char *argv[])
                 {NULL, 0, NULL, 0}
         };
 
-        while ((c = getopt_long(argc, argv, "madfhlL:oD:Hr:Rp:P:s:S:N:v", options, NULL)) != -1) {
+        while ((c = getopt_long(argc, argv, "madfhlL:oD:Hr:Rp:P:s:S:N:vn", options, NULL)) != -1) {
                 switch (c) {
                 case ARG_VERSION:
                         puts(PROGRAM_VERSION_STRING);


### PR DESCRIPTION
## Changes

This fixes the following in dracut-install:

* The -n short option for --dry-run
* RUNPATH expansion returning empty strings
* [The handling of absolute paths in sonames](https://bugs.gentoo.org/961101)

## Checklist
- [X] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant -- N/A
- [ ] I am providing new code and test(s) for it