### PR TITLE
feat(fstab-initramfs): add module to add a fstab to the initramfs

### DIFF
--- a/doc_site/modules/ROOT/pages/modules/core.adoc
+++ b/doc_site/modules/ROOT/pages/modules/core.adoc
@@ -109,6 +109,10 @@ code, there are no specific types or categories for dracut modules.
 | Arranges for arbitrary partitions to be mounted before rootfs
 |
 
+| fstab-initramfs
+| Provide an fstab for the initramfs
+|
+
 | hwdb
 | Includes hardware database
 | utils

--- a/modules.d/74fstab-initramfs/module-setup.sh
+++ b/modules.d/74fstab-initramfs/module-setup.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+
+# called by dracut
+check() {
+    [[ -f "${dracutsysrootdir-}/etc/fstab.initramfs" ]]
+}
+
+# called by dracut
+install() {
+    inst_simple /etc/fstab.initramfs /etc/fstab
+}


### PR DESCRIPTION
Add a simple module to provide the initramfs with an `/etc/fstab`.

My personal use-case is mounting a partition early in order to provide secrets for the boot process, including mounting the sysroot, which means fstab-sys comes in too late.

## Checklist
- [x] I have tested it locally
- [x] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it
