### PR TITLE
test: do not force set hostonly_cmdline to no

### DIFF
--- a/dracut.conf.d/test/test.conf
+++ b/dracut.conf.d/test/test.conf
@@ -3,7 +3,6 @@ add_dracutmodules+=" base debug qemu watchdog kernel-modules "
 do_strip="no"
 do_hardlink="no"
 early_microcode="no"
-hostonly_cmdline="no"
 
 # systemd on arm64 on GitHub CI needs the 2 min timeout
 kernel_cmdline=" rd.retry=10 rd.timeout=120 rd.info rd.shell=0 "


### PR DESCRIPTION
## Changes

`hostonly_cmdline=yes` is not tested by the CI as CI force sets it to no.

Make the test case less opinionated and go with the distribution default configuration, to test both `hostonly_cmdline` set to `no` and `yes`.

## Checklist
- [ ] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it

