### PR TITLE
ci: adopt test configuration without test module

### DIFF
--- a/test/TEST-71-ISCSI-MULTI/test.sh
+++ b/test/TEST-71-ISCSI-MULTI/test.sh
@@ -228,7 +228,8 @@ test_setup() {
 
     # Make server's dracut image
     "$DRACUT" -i "$TESTDIR"/overlay / \
-        -a "test rootfs-block kernel-modules network-legacy ${SERVER_DEBUG:+debug}" \
+        --add-confdir test \
+        -a "rootfs-block kernel-modules network-legacy ${SERVER_DEBUG:+debug}" \
         -d "af_packet piix ide-gd_mod ata_piix ext4 sd_mod drbg virtio_net" \
         -i "./server.link" "/etc/systemd/network/01-server.link" \
         -i "./wait-if-server.sh" "/lib/dracut/hooks/pre-mount/99-wait-if-server.sh" \

--- a/test/TEST-72-NBD/test.sh
+++ b/test/TEST-72-NBD/test.sh
@@ -330,7 +330,8 @@ test_setup() {
         -i "/tmp/key" "/etc/key"
 
     "$DRACUT" -N -i "$TESTDIR"/overlay / \
-        -a "test network-legacy ${SERVER_DEBUG:+debug}" \
+        --add-confdir test \
+        -a "network-legacy ${SERVER_DEBUG:+debug}" \
         -d "af_packet piix ide-gd_mod ata_piix ext4 sd_mod drbg virtio_net" \
         -i "./server.link" "/etc/systemd/network/01-server.link" \
         -i "./wait-if-server.sh" "/lib/dracut/hooks/pre-mount/99-wait-if-server.sh" \


### PR DESCRIPTION
## Changes

Test module no longer exists. This is a follow-up to 4598998 .

## Checklist
- [ ] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it


