### PR TITLE
fix: always include modules required for networking

### DIFF
--- a/modules.d/35network-legacy/module-setup.sh
+++ b/modules.d/35network-legacy/module-setup.sh
@@ -15,12 +15,6 @@ depends() {
 }
 
 # called by dracut
-installkernel() {
-    # arping depends on af_packet
-    hostonly='' instmods af_packet
-}
-
-# called by dracut
 install() {
     local _arch
 

--- a/modules.d/35network-manager/module-setup.sh
+++ b/modules.d/35network-manager/module-setup.sh
@@ -19,7 +19,7 @@ depends() {
 
 # called by dracut
 installkernel() {
-    hostonly=$(optional_hostonly) instmods nf_tables nfnetlink nft_fwd_netdev
+    hostonly='' instmods nf_tables nfnetlink nft_fwd_netdev
 }
 
 # called by dracut

--- a/modules.d/45net-lib/module-setup.sh
+++ b/modules.d/45net-lib/module-setup.sh
@@ -10,6 +10,12 @@ depends() {
     return 0
 }
 
+# called by dracut
+installkernel() {
+    # arping depends on af_packet
+    hostonly='' instmods af_packet
+}
+
 install() {
     inst_script "$moddir/netroot.sh" "/sbin/netroot"
     inst_simple "$moddir/net-lib.sh" "/lib/net-lib.sh"

--- a/test/TEST-50-NETWORK/test.sh
+++ b/test/TEST-50-NETWORK/test.sh
@@ -35,8 +35,7 @@ test_setup() {
     dd if=/dev/zero of="$TESTDIR"/root.img bs=200MiB count=1 status=none && sync "$TESTDIR"/root.img
     mkfs.ext4 -q -L dracut -d "$TESTDIR"/dracut.*/initramfs/ "$TESTDIR"/root.img && sync "$TESTDIR"/root.img
 
-    # TODO: remove the requirement for hostonly-mode=sloppy
-    test_dracut --hostonly-mode=sloppy --add "$USE_NETWORK"
+    test_dracut --add-drivers "virtio_net" --add "$USE_NETWORK"
 }
 
 # shellcheck disable=SC1090


### PR DESCRIPTION
## Changes

For static IPv4 configurations, we use arping to check for duplicate IP addresses. arping requires the af_packet module to work, and if arping fails, the IP address will not be set and booting will fail. af_packet may not be loaded / required in the running system, for example if the system had been booted in an IPv6 configuration, or if it had been manually unloaded. Make sure it's included in initramfs in hostonly mode, too.

network-manager always requires nf_tables and other kernel modules in the generated initramfs to function, regardless if these modules are loaded on the host or not at the time of initramfs generation.

Remove the hostonly_mode=sloppy workaround. The NETWORK test now passes regardless of the value of `hostonly_mode`.      

Follow-up to b074216, 5e1fec168 and to de862885e .

## Checklist
- [ ] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it

Fixes #1437
