### PR TITLE
fix: place dracut generated cmdline conf files in the 10-49 range

### DIFF
--- a/dracut.sh
+++ b/dracut.sh
@@ -2176,7 +2176,7 @@ if [[ $kernel_only != yes ]]; then
     ((${#install_optional_items[@]} > 0)) && inst_multiple -o ${install_optional_items[@]}
 
     if [[ $kernel_cmdline ]] && [[ $uefi != yes ]]; then
-        printf "%s\n" "$kernel_cmdline" >> "${initdir}/etc/cmdline.d/01-default.conf"
+        printf "%s\n" "$kernel_cmdline" >> "${initdir}/etc/cmdline.d/10-default.conf"
     fi
 
     for line in "${fstab_lines[@]}"; do

--- a/man/dracut.8.adoc
+++ b/man/dracut.8.adoc
@@ -786,7 +786,9 @@ _/etc/cmdline_::
     /etc/cmdline.d/*.conf.
 
 _/etc/cmdline.d/*.conf_::
-    Can contain additional command line options.
+    Can contain additional command line options. It is recomended to use an
+    ordering schema for these conf files in the range of 50-59.
+    Dracut generated conf files are placed in the 10-49 and 60-99 ordering range.
 
 AVAILABILITY
 ------------

--- a/man/dracut.usage.adoc
+++ b/man/dracut.usage.adoc
@@ -246,23 +246,23 @@ For example
 
 [,console]
 ----
-# dracut --include cmdline-preset /etc/cmdline.d/mycmdline.conf initramfs-cmdline-pre.img
+# dracut --include cmdline-preset /etc/cmdline.d/50-mycmdline.conf initramfs-cmdline-pre.img
 ----
 will create an initramfs image, where the file cmdline-preset will be copied
-inside the initramfs to _/etc/cmdline.d/mycmdline.conf_.
+inside the initramfs to _/etc/cmdline.d/50-mycmdline.conf_.
 
 [,console]
 ----
 # mkdir -p rd.live.overlay/etc/cmdline.d
 # mkdir -p rd.live.overlay/etc/conf.d
-# echo "ip=dhcp" >> rd.live.overlay/etc/cmdline.d/mycmdline.conf
+# echo "ip=dhcp" >> rd.live.overlay/etc/cmdline.d/50-mycmdline.conf
 # echo export FOO=testtest >> rd.live.overlay/etc/conf.d/testvar.conf
 # echo export BAR=testtest >> rd.live.overlay/etc/conf.d/testvar.conf
 # tree rd.live.overlay/
 rd.live.overlay/
 `-- etc
     |-- cmdline.d
-    |   `-- mycmdline.conf
+    |   `-- 50-mycmdline.conf
     `-- conf.d
         `-- testvar.conf
 
@@ -297,7 +297,7 @@ server about the ip address for the machine. The dhcp server can also serve an
 additional root-path, which will set the root device for dracut. With this
 mechanism, you have static configuration on your client machine and a
 centralized boot configuration on your TFTP/DHCP server. If you can't pass a
-kernel command line, then you can inject _/etc/cmdline.d/mycmdline.conf_, with a
+kernel command line, then you can inject _/etc/cmdline.d/50-mycmdline.conf_, with a
 method described in <<Injecting>>.
 
 === Reducing the Image Size

--- a/modules.d/11systemd-networkd/networkd-config.sh
+++ b/modules.d/11systemd-networkd/networkd-config.sh
@@ -27,7 +27,7 @@ done
 systemctl try-reload-or-restart systemd-networkd.service
 
 if [ -n "$netroot" ] || [ -e /tmp/net.ifaces ]; then
-    echo rd.neednet >> /etc/cmdline.d/networkd.conf
+    echo rd.neednet >> /etc/cmdline.d/20-networkd.conf
 fi
 
 if getargbool 0 rd.neednet; then

--- a/modules.d/14watchdog-modules/module-setup.sh
+++ b/modules.d/14watchdog-modules/module-setup.sh
@@ -25,7 +25,7 @@ installkernel() {
         echo "rd.driver.pre=\"$(
             IFS=,
             echo "${!_drivers[*]}"
-        )\"" > "${initdir}"/etc/cmdline.d/00-watchdog.conf
+        )\"" > "${initdir}"/etc/cmdline.d/20-watchdog.conf
     fi
     return 0
 }

--- a/modules.d/35connman/cm-config.sh
+++ b/modules.d/35connman/cm-config.sh
@@ -3,7 +3,7 @@
 command -v cm_generate_connections > /dev/null || . /lib/cm-lib.sh
 
 if [ -n "$netroot" ] || [ -e /tmp/net.ifaces ]; then
-    echo rd.neednet >> /etc/cmdline.d/connman.conf
+    echo rd.neednet >> /etc/cmdline.d/20-connman.conf
 fi
 
 if getargbool 0 rd.debug; then

--- a/modules.d/35network-legacy/parse-ip-opts.sh
+++ b/modules.d/35network-legacy/parse-ip-opts.sh
@@ -42,7 +42,7 @@ BOOTDEV=$(getarg bootdev=)
 
 if [ -n "$NEEDBOOTDEV" ] && getargbool 1 rd.neednet; then
     #[ -z "$BOOTDEV" ] && warn "Please supply bootdev argument for multiple ip= lines"
-    echo "rd.neednet=1" > /etc/cmdline.d/dracut-neednet.conf
+    echo "rd.neednet=1" > /etc/cmdline.d/20-dracut-neednet.conf
     info "Multiple ip= arguments: assuming rd.neednet=1"
 else
     unset NEEDBOOTDEV
@@ -130,7 +130,7 @@ for p in $(getargs ip=); do
             "$(expr substr "$dev" 9 2)" \
             "$(expr substr "$dev" 11 2)" \
             "$(expr substr "$dev" 13 2)" \
-            >> /etc/cmdline.d/80-enx.conf
+            >> /etc/cmdline.d/20-enx.conf
     fi
 done
 

--- a/modules.d/35network-manager/nm-config.sh
+++ b/modules.d/35network-manager/nm-config.sh
@@ -7,7 +7,7 @@ command -v getargbool > /dev/null || . /lib/dracut-lib.sh
     || nm_service_name="nm-initrd"
 
 if [ -n "$netroot" ] || [ -e /tmp/net.ifaces ]; then
-    echo rd.neednet >> /etc/cmdline.d/35-neednet.conf
+    echo rd.neednet >> /etc/cmdline.d/20-neednet.conf
 fi
 
 if getargbool 0 rd.debug; then

--- a/modules.d/45net-lib/net-lib.sh
+++ b/modules.d/45net-lib/net-lib.sh
@@ -236,7 +236,7 @@ set_ifname() {
         done
         break
     done
-    echo "ifname=$name$num:$mac" >> /etc/cmdline.d/45-ifname.conf
+    echo "ifname=$name$num:$mac" >> /etc/cmdline.d/20-ifname.conf
     echo "$num" > "/tmp/set_ifname_$name"
     echo "$name$num"
 }
@@ -355,7 +355,7 @@ ibft_to_cmdline() {
             fi
 
         done
-    ) >> /etc/cmdline.d/40-ibft.conf
+    ) >> /etc/cmdline.d/20-ibft.conf
 }
 
 parse_iscsi_root() {

--- a/modules.d/68cms/cmsifup.sh
+++ b/modules.d/68cms/cmsifup.sh
@@ -28,7 +28,7 @@ fi
     for i in $DNS1 $DNS2; do
         echo "nameserver=$i"
     done
-} > /etc/cmdline.d/80-cms.conf
+} > /etc/cmdline.d/20-cms.conf
 
 [ -e "/tmp/net.ifaces" ] && read -r IFACES < /tmp/net.ifaces
 IFACES="$IFACES $DEVICE"

--- a/modules.d/69cio_ignore/module-setup.sh
+++ b/modules.d/69cio_ignore/module-setup.sh
@@ -33,7 +33,7 @@ install() {
     if [[ $hostonly_cmdline == "yes" ]]; then
         local _cio_accept
         _cio_accept=$(cmdline)
-        [[ $_cio_accept ]] && printf "%s\n" "$_cio_accept" >> "${initdir}/etc/cmdline.d/01cio_accept.conf"
+        [[ $_cio_accept ]] && printf "%s\n" "$_cio_accept" >> "${initdir}/etc/cmdline.d/20-cio_accept.conf"
     fi
 
     inst_hook cmdline 20 "$moddir/parse-cio_accept.sh"

--- a/modules.d/70btrfs/module-setup.sh
+++ b/modules.d/70btrfs/module-setup.sh
@@ -58,6 +58,6 @@ install() {
     inst btrfs /sbin/btrfs
 
     if [[ $hostonly_cmdline == "yes" ]]; then
-        printf "%s\n" "$(cmdline)" > "${initdir}/etc/cmdline.d/00-btrfs.conf"
+        printf "%s\n" "$(cmdline)" > "${initdir}/etc/cmdline.d/20-btrfs.conf"
     fi
 }

--- a/modules.d/70crypt/module-setup.sh
+++ b/modules.d/70crypt/module-setup.sh
@@ -81,7 +81,7 @@ install() {
     if [[ $hostonly_cmdline == "yes" ]]; then
         local _cryptconf
         _cryptconf=$(cmdline)
-        [[ $_cryptconf ]] && printf "%s\n" "$_cryptconf" >> "${initdir}/etc/cmdline.d/90crypt.conf"
+        [[ $_cryptconf ]] && printf "%s\n" "$_cryptconf" >> "${initdir}/etc/cmdline.d/20-crypt.conf"
     fi
 
     inst_hook cmdline 30 "$moddir/parse-crypt.sh"

--- a/modules.d/70dmraid/module-setup.sh
+++ b/modules.d/70dmraid/module-setup.sh
@@ -68,7 +68,7 @@ install() {
 
     if [[ $hostonly_cmdline == "yes" ]]; then
         _raidconf=$(cmdline)
-        [[ $_raidconf ]] && printf "%s\n" "$_raidconf" >> "${initdir}/etc/cmdline.d/90dmraid.conf"
+        [[ $_raidconf ]] && printf "%s\n" "$_raidconf" >> "${initdir}/etc/cmdline.d/20-dmraid.conf"
     fi
 
     inst_multiple dmraid

--- a/modules.d/70dmsquash-live/dmsquash-live-root.sh
+++ b/modules.d/70dmsquash-live/dmsquash-live-root.sh
@@ -416,7 +416,7 @@ fi
 ROOTFLAGS="$(getarg rootflags)"
 
 if [ "$overlayfs" = required ]; then
-    echo "rd.live.overlay.overlayfs=1" > /etc/cmdline.d/dmsquash-need-overlay.conf
+    echo "rd.live.overlay.overlayfs=1" > /etc/cmdline.d/20-dmsquash-need-overlay.conf
 fi
 
 if [ -n "$overlayfs" ]; then

--- a/modules.d/70lvm/module-setup.sh
+++ b/modules.d/70lvm/module-setup.sh
@@ -53,7 +53,7 @@ install() {
     if [[ $hostonly_cmdline == "yes" ]]; then
         local _lvmconf
         _lvmconf=$(cmdline)
-        [[ $_lvmconf ]] && printf "%s\n" "$_lvmconf" >> "${initdir}/etc/cmdline.d/90lvm.conf"
+        [[ $_lvmconf ]] && printf "%s\n" "$_lvmconf" >> "${initdir}/etc/cmdline.d/20-lvm.conf"
     fi
 
     inst_rules "$moddir/64-lvm.rules"

--- a/modules.d/70mdraid/module-setup.sh
+++ b/modules.d/70mdraid/module-setup.sh
@@ -73,7 +73,7 @@ install() {
     if [[ $hostonly_cmdline == "yes" ]]; then
         local _raidconf
         _raidconf=$(cmdline)
-        [[ $_raidconf ]] && printf "%s\n" "$_raidconf" >> "${initdir}/etc/cmdline.d/90mdraid.conf"
+        [[ $_raidconf ]] && printf "%s\n" "$_raidconf" >> "${initdir}/etc/cmdline.d/20-mdraid.conf"
     fi
 
     inst_rules 63-md-raid-arrays.rules 64-md-raid-assembly.rules

--- a/modules.d/70multipath/module-setup.sh
+++ b/modules.d/70multipath/module-setup.sh
@@ -144,7 +144,7 @@ EOF
     if [[ $hostonly_cmdline == "yes" ]]; then
         local _conf
         _conf=$(cmdline)
-        [[ $_conf ]] && echo "$_conf" >> "${initdir}/etc/cmdline.d/90multipath.conf"
+        [[ $_conf ]] && echo "$_conf" >> "${initdir}/etc/cmdline.d/20-multipath.conf"
     fi
 
     if dracut_module_included "systemd"; then

--- a/modules.d/73zipl/install_zipl_cmdline.sh
+++ b/modules.d/73zipl/install_zipl_cmdline.sh
@@ -18,7 +18,7 @@ if ! mount -o ro "${DEV}" ${MNT}; then
 fi
 
 if [ -f ${MNT}/dracut-cmdline.conf ]; then
-    cp ${MNT}/dracut-cmdline.conf /etc/cmdline.d/99zipl.conf
+    cp ${MNT}/dracut-cmdline.conf /etc/cmdline.d/20-zipl.conf
 fi
 
 if [ -f ${MNT}/active_devices.txt ]; then
@@ -30,7 +30,7 @@ fi
 
 umount ${MNT}
 
-if [ -f /etc/cmdline.d/99zipl.conf ]; then
+if [ -f /etc/cmdline.d/20-zipl.conf ]; then
     systemctl restart dracut-cmdline.service
     systemctl restart systemd-udev-trigger.service
 fi

--- a/modules.d/73zipl/module-setup.sh
+++ b/modules.d/73zipl/module-setup.sh
@@ -61,6 +61,6 @@ install() {
         local _zipl
         _zipl=$(cmdline)
 
-        [[ $_zipl ]] && printf "%s\n" "$_zipl" > "${initdir}/etc/cmdline.d/91zipl.conf"
+        [[ $_zipl ]] && printf "%s\n" "$_zipl" > "${initdir}/etc/cmdline.d/19-zipl.conf"
     fi
 }

--- a/modules.d/74fcoe-uefi/parse-uefifcoe.sh
+++ b/modules.d/74fcoe-uefi/parse-uefifcoe.sh
@@ -31,5 +31,5 @@ print_fcoe_uefi_conf() {
 
 for i in /sys/firmware/efi/efivars/FcoeBootDevice-*; do
     [ -e "$i" ] || continue
-    print_fcoe_uefi_conf "$i" > /etc/cmdline.d/40-fcoe-uefi.conf && break
+    print_fcoe_uefi_conf "$i" > /etc/cmdline.d/20-fcoe-uefi.conf && break
 done

--- a/modules.d/74fcoe/module-setup.sh
+++ b/modules.d/74fcoe/module-setup.sh
@@ -109,7 +109,7 @@ install() {
     if [[ $hostonly_cmdline == "yes" ]]; then
         local _fcoeconf
         _fcoeconf=$(cmdline)
-        [[ $_fcoeconf ]] && printf "%s\n" "$_fcoeconf" >> "${initdir}/etc/cmdline.d/95fcoe.conf"
+        [[ $_fcoeconf ]] && printf "%s\n" "$_fcoeconf" >> "${initdir}/etc/cmdline.d/20-fcoe.conf"
     fi
     inst_multiple "/etc/fcoe/cfg-*"
 

--- a/modules.d/74iscsi/module-setup.sh
+++ b/modules.d/74iscsi/module-setup.sh
@@ -201,7 +201,7 @@ install() {
     if [[ $hostonly_cmdline == "yes" ]]; then
         local _iscsiconf
         _iscsiconf=$(cmdline)
-        [[ $_iscsiconf ]] && printf "%s\n" "$_iscsiconf" >> "${initdir}/etc/cmdline.d/95iscsi.conf"
+        [[ $_iscsiconf ]] && printf "%s\n" "$_iscsiconf" >> "${initdir}/etc/cmdline.d/20-iscsi.conf"
     fi
 
     inst_hook cmdline 90 "$moddir/parse-iscsiroot.sh"

--- a/modules.d/74lunmask/module-setup.sh
+++ b/modules.d/74lunmask/module-setup.sh
@@ -63,7 +63,7 @@ install() {
         local _lunmask
 
         for _lunmask in $(cmdline); do
-            printf "%s\n" "$_lunmask" >> "${initdir}/etc/cmdline.d/95lunmask.conf"
+            printf "%s\n" "$_lunmask" >> "${initdir}/etc/cmdline.d/20-lunmask.conf"
         done
     fi
 }

--- a/modules.d/74nfs/module-setup.sh
+++ b/modules.d/74nfs/module-setup.sh
@@ -84,7 +84,7 @@ install() {
     if [[ $hostonly_cmdline == "yes" ]]; then
         local _netconf
         _netconf="$(cmdline)"
-        [[ $_netconf ]] && printf "%s\n" "$_netconf" >> "${initdir}/etc/cmdline.d/95nfs.conf"
+        [[ $_netconf ]] && printf "%s\n" "$_netconf" >> "${initdir}/etc/cmdline.d/20-nfs.conf"
     fi
 
     if [[ -f "${dracutsysrootdir-}/lib/modprobe.d/nfs.conf" ]]; then

--- a/modules.d/74nvmf/module-setup.sh
+++ b/modules.d/74nvmf/module-setup.sh
@@ -140,7 +140,7 @@ install() {
     if [[ $hostonly_cmdline == "yes" ]]; then
         local _nvmf_args
         _nvmf_args=$(cmdline)
-        [[ "$_nvmf_args" ]] && printf "%s" "$_nvmf_args" >> "${initdir}/etc/cmdline.d/95nvmf-args.conf"
+        [[ "$_nvmf_args" ]] && printf "%s" "$_nvmf_args" >> "${initdir}/etc/cmdline.d/20-nvmf-args.conf"
     fi
     inst_simple -H "/etc/nvme/hostnqn"
     inst_simple -H "/etc/nvme/hostid"

--- a/modules.d/74nvmf/parse-nvmf-boot-connections.sh
+++ b/modules.d/74nvmf/parse-nvmf-boot-connections.sh
@@ -214,7 +214,7 @@ nbft_parse() {
             i=$((i + 1))
         done
         j=$((j + 1))
-    done >> /etc/cmdline.d/40-nbft.conf
+    done >> /etc/cmdline.d/20-nbft.conf
 }
 
 if getargbool 0 rd.nonvmf; then
@@ -223,7 +223,7 @@ if getargbool 0 rd.nonvmf; then
 fi
 
 if getargbool 0 rd.nvmf.nostatic; then
-    rm -f /etc/cmdline.d/95nvmf-args.conf
+    rm -f /etc/cmdline.d/20-nvmf-args.conf
     rm -f /etc/nvme/discovery.conf /etc/nvme/config.json
 fi
 
@@ -317,7 +317,7 @@ for d in $(getargs rd.nvmf.discover -d nvmf.discover=); do
 done
 
 if [ -e /tmp/nvmf_needs_network ] || [ -e /tmp/valid_nbft_entry_found ]; then
-    echo "rd.neednet=1" > /etc/cmdline.d/nvmf-neednet.conf
+    echo "rd.neednet=1" > /etc/cmdline.d/20-nvmf-neednet.conf
     # netroot is a global variable that is present in all "sourced" scripts
     # shellcheck disable=SC2034
     netroot=nbft

--- a/modules.d/74resume/module-setup.sh
+++ b/modules.d/74resume/module-setup.sh
@@ -63,7 +63,7 @@ install() {
 
     if [[ $hostonly_cmdline == "yes" ]]; then
         _resumeconf=$(cmdline)
-        [[ $_resumeconf ]] && printf "%s\n" "$_resumeconf" >> "${initdir}/etc/cmdline.d/95resume.conf"
+        [[ $_resumeconf ]] && printf "%s\n" "$_resumeconf" >> "${initdir}/etc/cmdline.d/20-resume.conf"
     fi
 
     # if systemd is included and has the hibernate-resume tool, use it and nothing else

--- a/modules.d/74rootfs-block/module-setup.sh
+++ b/modules.d/74rootfs-block/module-setup.sh
@@ -67,10 +67,10 @@ install() {
     if [[ $hostonly_cmdline == "yes" ]]; then
         local _journaldev
         _journaldev=$(cmdline_journal)
-        [[ $_journaldev ]] && printf "%s\n" "$_journaldev" >> "${initdir}/etc/cmdline.d/95root-journaldev.conf"
+        [[ $_journaldev ]] && printf "%s\n" "$_journaldev" >> "${initdir}/etc/cmdline.d/20-root-journaldev.conf"
         local _rootdev
         _rootdev=$(cmdline_rootfs)
-        [[ $_rootdev ]] && printf "%s\n" "$_rootdev" >> "${initdir}/etc/cmdline.d/95root-dev.conf"
+        [[ $_rootdev ]] && printf "%s\n" "$_rootdev" >> "${initdir}/etc/cmdline.d/20-root-dev.conf"
     fi
 
     inst_multiple umount

--- a/modules.d/77dracut-systemd/dracut-shutdown.service.8.adoc
+++ b/modules.d/77dracut-systemd/dracut-shutdown.service.8.adoc
@@ -41,7 +41,7 @@ To debug the shutdown process, you can get a shell in the shutdown procedure
 by injecting "rd.break=pre-shutdown rd.shell" or "rd.break=shutdown rd.shell".
 ----
 # mkdir -p /run/initramfs/etc/cmdline.d
-# echo "rd.break=pre-shutdown rd.shell" > /run/initramfs/etc/cmdline.d/debug.conf
+# echo "rd.break=pre-shutdown rd.shell" > /run/initramfs/etc/cmdline.d/50-debug.conf
 # touch /run/initramfs/.need_shutdown
 ----
 

--- a/modules.d/80base/module-setup.sh
+++ b/modules.d/80base/module-setup.sh
@@ -119,7 +119,7 @@ install() {
 
     ln -fs /proc/self/mounts "$initdir/etc/mtab"
     if [[ $ro_mnt == yes ]]; then
-        echo ro >> "${initdir}/etc/cmdline.d/base.conf"
+        echo ro >> "${initdir}/etc/cmdline.d/20-base.conf"
     fi
 
     echo "dracut-$DRACUT_VERSION" > "$initdir/lib/dracut/dracut-$DRACUT_VERSION"


### PR DESCRIPTION
## Changes

The main motivation of this PR is to make it easier to reason about the ordering numbers of dracut generated cmdline conf files.

Prefix almost all dracut generated cmdline conf file in the 20 ordering as the ordering is usually not significant for these cmdline conf file.

Document that 50-59 is the recommended ordering range for 3rd party cmdline conf files to make it consistent with e.g. 3rd party dracut modules recommendation.

## Checklist
- [ ] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it

Fixes #1489
