### PR TITLE
feat(rdma): dracut module for rdma

### DIFF
--- a/modules.d/70rdma/module-setup.sh
+++ b/modules.d/70rdma/module-setup.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 check() {
-    [ -n "$hostonly" ] && [ -c /sys/class/infiniband_verbs/uverbs0 ] && return 0
+    [ -n "$hostonly" ] && [ -e /sys/class/infiniband_verbs/uverbs0 ] && return 0
     [ -n "$hostonly" ] && return 255
     return 0
 }


### PR DESCRIPTION
## Changes

Unify and improve dracut rdma module.

An addition this version of the module code:
 - moves the dracut module ordering from distro specific packaging files to common
 - adds supports for distributions not explicitly supported by https://github.com/linux-rdma/rdma-core, such as Arch, Debian
 - fixes dracut dependency and shellcheck issues

The intention of this PR is _increase_ the adaption of rdma and dracut. It is obvious (to me) that it is not desired to have a copy of this module both in https://github.com/linux-rdma/rdma-core and in here. Let's see if we can work together to achieve this goal.

CC @jgunthorpe @rleon @bdrung @yishaih 

Ps.: The very initial trigger for this conversation is the issue with the rdma module ordering. The current '05' value will not work. If this module is continue to be maintained by https://github.com/linux-rdma/rdma-core, than the module ordering should be `50`, see https://github.com/dracut-ng/dracut-ng/issues/1520#issuecomment-3164321429

## Checklist
- [ ] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it

