### PR TITLE
ci: remove testing with ubuntu:latest

### DIFF
--- a/.github/workflows/container-extra.yml
+++ b/.github/workflows/container-extra.yml
@@ -40,7 +40,6 @@ jobs:
                 config:
                     - {dockerfile: 'Dockerfile-debian', tag: 'debian:sid'}
                     - {dockerfile: 'Dockerfile-debian', tag: 'ubuntu:devel'}
-                    - {dockerfile: 'Dockerfile-debian', tag: 'ubuntu:rolling'}
                     - {dockerfile: 'Dockerfile-alpine', tag: 'alpine:edge'}
                     - {dockerfile: 'Dockerfile-gentoo', tag: 'gentoo:latest', option: 'systemd'}
                     - {dockerfile: 'Dockerfile-gentoo', tag: 'gentoo:amd64-openrc', option: 'amd64-openrc'}

--- a/.github/workflows/container.yml
+++ b/.github/workflows/container.yml
@@ -39,7 +39,7 @@ jobs:
                     - {dockerfile: 'Dockerfile-fedora', tag: 'fedora:latest'}
                     - {dockerfile: 'Dockerfile-opensuse', tag: 'opensuse:latest'}
                     - {dockerfile: 'Dockerfile-arch', tag: 'arch:latest'}
-                    - {dockerfile: 'Dockerfile-debian', tag: 'ubuntu:latest'}
+                    - {dockerfile: 'Dockerfile-debian', tag: 'ubuntu:rolling'}
                     - {dockerfile: 'Dockerfile-alpine', tag: 'alpine:latest'}
                     - {dockerfile: 'Dockerfile-void', tag: 'void:latest'}
                 exclude:

--- a/.github/workflows/integration-extra.yml
+++ b/.github/workflows/integration-extra.yml
@@ -37,7 +37,6 @@ jobs:
                     - gentoo:latest
                     - gentoo:amd64-openrc
                     - opensuse:latest
-                    - ubuntu:latest
                     - ubuntu:devel
                     - ubuntu:rolling
                     - void:latest

--- a/.github/workflows/manualtest.yml
+++ b/.github/workflows/manualtest.yml
@@ -22,7 +22,6 @@ on:  # yamllint disable-line rule:truthy
                     - "arch:latest"
                     - "debian:latest"
                     - "debian:sid"
-                    - "ubuntu:latest"
                     - "ubuntu:devel"
                     - "ubuntu:rolling"
                     - "opensuse:latest"


### PR DESCRIPTION
## Changes

ubuntu:latest could be as old as two years old, and, while testing with debian:stable makes sense, testing with ubuntu:latest seems redundant.

Ubuntu is now well integrated with dracut and dracut usptream main no longer needs to target (or backported) to ubuntu:latest.

## Checklist
- [ ] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it

Fixes #
