### PR TITLE
fix(systemd-portabled, initqueue): enable systemd type units

### DIFF
--- a/modules.d/11systemd-portabled/module-setup.sh
+++ b/modules.d/11systemd-portabled/module-setup.sh
@@ -54,6 +54,7 @@ install() {
         "$systemdutildir/portable/profile/strict/*.conf" \
         "$systemdutildir/portable/profile/trusted/*.conf" \
         "$systemdsystemunitdir"/systemd-portabled.service \
+        "$systemdsystemunitdir"/initrd.target.wants/systemd-portabled.service \
         "$systemdsystemunitdir/systemd-portabled.service.d/*.conf" \
         "$systemdsystemunitdir"/dbus-org.freedesktop.portable1.service \
         portablectl
@@ -62,7 +63,6 @@ install() {
     touch "$initdir"/etc/resolv.conf
 
     # Enable systemd type unit(s)
-    $SYSTEMCTL -q --root "$initdir" add-wants initrd.target systemd-portabled.service
     $SYSTEMCTL -q --root "$initdir" enable systemd-portabled.service
 
     # Install the hosts local user configurations if enabled.

--- a/modules.d/77initqueue/module-setup.sh
+++ b/modules.d/77initqueue/module-setup.sh
@@ -14,7 +14,10 @@ install() {
     if dracut_module_included "systemd"; then
         inst_script "$moddir/dracut-initqueue.sh" /usr/bin/dracut-initqueue
         inst_simple "$moddir/dracut-initqueue.service" "$systemdsystemunitdir/dracut-initqueue.service"
-        $SYSTEMCTL -q --root "$initdir" add-wants initrd.target dracut-initqueue.service
+        inst_simple "$systemdsystemunitdir"/initrd.target.wants/dracut-initqueue.service
+
+        # Enable systemd type unit(s)
+        $SYSTEMCTL -q --root "$initdir" enable dracut-initqueue.service
     fi
 
     dracut_need_initqueue


### PR DESCRIPTION
## Changes

Use systemctl enable command (instead of add-wants command) to enable systemd type units.

Without these changes the following error message is seen on TEST-FULL-SYSTEMD:

```
Failed to add dependency on unit: Unit initrd.target does not exist
Failed to add dependency on unit: Unit initrd.target does not exist
```

## Checklist
- [ ] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it

Fixes #
