### PR TITLE
fix(doc_site): remove reference to udev < 143

### DIFF
--- a/doc_site/modules/ROOT/pages/developer/modules.adoc
+++ b/doc_site/modules/ROOT/pages/developer/modules.adoc
@@ -142,7 +142,7 @@ Udev events can add scripts here with `/sbin/initqueue`.
 If `/sbin/initqueue` is called with the `--onetime` option, the script
 will be removed after it was run.
 +
-If `/lib/dracut/hooks/initqueue/work` is created and `udev >= 143` then
+If `/lib/dracut/hooks/initqueue/work` is created then
 this loop can process the jobs in parallel to the udevtrigger.
 +
 If the udev queue is empty and no root device is found or no root


### PR DESCRIPTION
## Changes

Let's keep the documentation fresh and do not reference an udev version that is more than a decade old.

## Checklist
- [ ] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it

Fixes #
