### PR TITLE
fix(fedora): always include chroot binary

### DIFF
--- a/dracut.conf.d/fedora/01-dist.conf
+++ b/dracut.conf.d/fedora/01-dist.conf
@@ -8,7 +8,10 @@ i18n_install_all="yes"
 
 stdloglvl=3
 sysloglvl=5
-install_optional_items+=" vi /usr/libexec/vi /etc/virc ps grep cat rm "
+
+# always install the following binaries to allow to debug and correct initrds in rescue shell
+install_optional_items+=" vi /usr/libexec/vi /etc/virc ps grep cat rm chroot "
+
 prefix="/"
 environment=/usr/lib/environment.d
 environmentconfdir=/etc/environment.d


### PR DESCRIPTION
## Changes

It seems RedHat requires chroot, which is addressed by a commit revert currently instead of a proper permanent solution, see https://github.com/redhat-plumbers/dracut-rhel10/pull/49

This commit provides a long term permanent solution that does not require a downstream revert.

CC @dtardon @pvalena @Conan-Kudo 

## Checklist
- [ ] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it

Fixes #
