### PR TITLE
fix(lsinitrd): avoid rechecking for squash images

### DIFF
--- a/lsinitrd.sh
+++ b/lsinitrd.sh
@@ -216,7 +216,7 @@ extract_squash_img() {
     done
 
     if [[ -z $SQUASH_TMPFILE ]]; then
-        SQUASH_TMPFILE=none
+        SQUASH_TMPDIR=none
         return 1
     fi
 


### PR DESCRIPTION
## Changes

The function `extract_squash_img` uses `SQUASH_TMPDIR` to check that it was already called but did not find any squash image.

Instead of setting `SQUASH_TMPDIR` `SQUASH_TMPFILE` was set and therefore the cpio file is searched again on every `extract_squash_img` call.

## Checklist
- [x] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it

Fixes #
