### PR TITLE
revert(efaee44): hostonly_cmdline should continue to default to yes

### DIFF
--- a/dracut.conf.d/hostonly/10-hostonly.conf
+++ b/dracut.conf.d/hostonly/10-hostonly.conf
@@ -1,3 +1,2 @@
 # optimize initrd to be as small as possible for faster boot performance, tailored to the current host
 hostonly="yes"
-hostonly_cmdline=no


### PR DESCRIPTION
Despite the Fedora setting (to `no`), let's keep the default to `yes` for distributions that do not wish to overwrite the default.

## Checklist
- [ ] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it

Fixes #1567, #1535
