### PR TITLE
docs: Consistent use of "initramfs"

### DIFF
--- a/doc_site/modules/ROOT/pages/index.adoc
+++ b/doc_site/modules/ROOT/pages/index.adoc
@@ -60,7 +60,7 @@ dracut creates _initramfs_ archives.
 
 == dracut's approach
 
-dracut creates an initrd image by copying tools and files from an installed
+dracut creates an initramfs archive by copying tools and files from an installed
 system and combining it with dracut modules, usually found on an installed
 system in `/usr/lib/dracut/modules.d`.
 


### PR DESCRIPTION
It was a little bit comical to read "dracut creates _initramfs_ archives." and then "dracut creates an initrd image..." :slightly_smiling_face: 

## Checklist
- [ ] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it