### PR TITLE
feat(dracut): support setting compression level separately

### DIFF
--- a/dracut.conf.d/opensuse/01-dist.conf
+++ b/dracut.conf.d/opensuse/01-dist.conf
@@ -8,7 +8,8 @@ hostonly="yes"
 hostonly_cmdline="yes"
 
 initrdname="initrd-$kernel"
-compress="zstd -3 -T0 -q"
+compress="zstd"
+compress_level_zstd="3"
 
 i18n_vars="/etc/sysconfig/language:RC_LANG-LANG,RC_LC_ALL-LC_ALL /etc/sysconfig/console:CONSOLE_UNICODEMAP-FONT_UNIMAP,CONSOLE_FONT-FONT,CONSOLE_SCREENMAP-FONT_MAP /etc/sysconfig/keyboard:KEYTABLE-KEYMAP"
 omit_drivers+=" i2o_scsi "

--- a/man/dracut.conf.5.adoc
+++ b/man/dracut.conf.5.adoc
@@ -130,6 +130,27 @@ kernel cannot decompress.
 +
 To disable compression, use "cat".
 
+*compress_level_bzip2=*"__\{1-9\}__"::
+Compression level when using bzip2 compression (default=9).
+
+*compress_level_gzip=*"__\{1-9\}__"::
+Compression level when using gzip compression (default=9).
+
+*compress_level_lz4=*"__\{1-12\}__"::
+Compression level when using lz4 compression (default=9).
+
+*compress_level_lzma=*"__\{0-9\}__"::
+Compression level when using lzma compression (default=9).
+
+*compress_level_lzop=*"__\{1-9\}__"::
+Compression level when using lzop compression (default=9).
+
+*compress_level_xz=*"__\{0-9\}__"::
+Compression level when using xz compression (default=unset, i.e. use xz default).
+
+*compress_level_zstd=*"__\{1-19\}__"::
+Compression level when using zstd compression (default=15).
+
 *squash_compress=*"__{<compressor [args ...]>}__"::
 Compress the squashfs image using the passed compressor and compressor specific
 options for `mksquashfs`.  You can refer to `mksquashfs` manual for supported

--- a/shell-completion/bash/dracut
+++ b/shell-completion/bash/dracut
@@ -47,7 +47,7 @@ _dracut() {
             --kernel-cmdline --sshkey --persistent-policy --install-optional
             --loginstall --uefi-stub --kernel-image --squash-compressor
             --sysroot --hostonly-mode --hostonly-nics --include --logfile
-            --uefi-splash-image --sbat --add-confdir
+            --uefi-splash-image --sbat --add-confdir --compress-level
             '
     )
 
@@ -65,6 +65,9 @@ _dracut() {
                 ;;
             -a | -m | -o | --add | --modules | --omit)
                 comps=$(dracut --list-modules 2> /dev/null)
+                ;;
+            --compress-level)
+                comps="0 1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16 17 18 19"
                 ;;
             --persistent-policy)
                 comps=$(


### PR DESCRIPTION
## Changes

Extend the Dracut configuration to configure the default compression level for each compression format (e. g. `compress_level_zstd` for zstd). Add `--compress-level` option to `dracut` to override the compression level from the configuration.

Then users could just call `dracut --zstd --compress-level 3` instead of `dracut --compress="zstd -3 -T0 -q"`.

## Checklist
- [ ] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it

Fixes #
