### PR TITLE
fix(Makefile): exclude hidden directories from shellcheck

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -315,7 +315,7 @@ syncheck:
 	done;exit $$ret
 ifeq ($(HAVE_SHELLCHECK),yes)
 ifeq ($(HAVE_SHFMT),yes)
-	shellcheck $$(shfmt -f .)
+	shellcheck $$(shfmt -f *)
 else
 	find . -name '*.sh' -print0 | xargs -0 shellcheck
 endif


### PR DESCRIPTION
## Changes

`shfmt -f .` also searches in hidden directories (like `.git` or `.pc`). The `.pc` is used on Debian for patch tracking and should not be searched for files.

So ignore the top-level hidden directories from shellcheck.

## Checklist
- [x] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it

Fixes #
