### PR TITLE
fix(dracut): library directory creation in --kernel-only

### DIFF
--- a/dracut.sh
+++ b/dracut.sh
@@ -2025,7 +2025,7 @@ if [[ $kernel_only != yes ]]; then
     ln -sfn ../run "$initdir/var/run"
     ln -sfn ../run/lock "$initdir/var/lock"
 else
-    for d in lib "$libdirs"; do
+    for d in lib $libdirs; do
         [[ -e "${initdir}${prefix}/$d" ]] && continue
         if [ -h "/$d" ]; then
             inst "/$d" "${prefix}/$d"


### PR DESCRIPTION
## Changes

Create a initrd with `--kernel-only`. For example:

```
./configure
make
./dracut.sh -l --kernel-only -m kernel-modules -d "ext4 sd_mod" -f $(pwd)/test --keep
```

The resulting has directories with spaces:

```
$ ls -l /var/tmp/dracut.dS9eq2i/initramfs
total 0
drwxrwxr-x 3 root root 60 Aug 13 23:36 ' '
lrwxrwxrwx 1 root root  7 Aug 13 23:36  lib -> usr/lib
drwxr-xr-x 3 root root 60 Aug 13 23:36  usr
$ find /var/tmp/dracut.dS9eq2i/initramfs/\
/var/tmp/dracut.dS9eq2i/initramfs/
/var/tmp/dracut.dS9eq2i/initramfs/ /lib64
/var/tmp/dracut.dS9eq2i/initramfs/ /lib64 /usr
/var/tmp/dracut.dS9eq2i/initramfs/ /lib64 /usr/lib64
/var/tmp/dracut.dS9eq2i/initramfs/ /lib64 /usr/lib64 /lib
/var/tmp/dracut.dS9eq2i/initramfs/ /lib64 /usr/lib64 /lib /usr
/var/tmp/dracut.dS9eq2i/initramfs/ /lib64 /usr/lib64 /lib /usr/lib
/var/tmp/dracut.dS9eq2i/initramfs/ /lib64 /usr/lib64 /lib /usr/lib /lib
/var/tmp/dracut.dS9eq2i/initramfs/ /lib64 /usr/lib64 /lib /usr/lib /lib/x86_64-linux-gnu?
/var/tmp/dracut.dS9eq2i/initramfs/ /lib64 /usr/lib64 /lib /usr/lib /lib/x86_64-linux-gnu?/usr
/var/tmp/dracut.dS9eq2i/initramfs/ /lib64 /usr/lib64 /lib /usr/lib /lib/x86_64-linux-gnu?/usr/lib
/var/tmp/dracut.dS9eq2i/initramfs/ /lib64 /usr/lib64 /lib /usr/lib /lib/x86_64-linux-gnu?/usr/lib/x86_64-linux-gnu
/var/tmp/dracut.dS9eq2i/initramfs/ /lib64 /usr/lib64 /lib /usr/lib /lib/x86_64-linux-gnu?/usr/lib/x86_64-linux-gnu/libfakeroot
```

Do not quote `libdirs` when iterating over it since it contains a space-separated list of library directories.

## Checklist
- [x] I have tested it locally
- [x] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it

Fixes: https://github.com/dracut-ng/dracut-ng/issues/1570