### PR TITLE
ci(debian): install 3cpio on Ubuntu

### DIFF
--- a/test/container/Dockerfile-debian
+++ b/test/container/Dockerfile-debian
@@ -24,6 +24,12 @@ ENV V=2
 # Install dracut as a linux-initramfs-tool provider so that the default initramfs-tool package does not get installed
 RUN apt-get update -y -qq && apt-get upgrade -y -qq && apt-get install -y -qq --no-install-recommends dracut
 
+# Install 3cpio where available
+RUN if [ "$DISTRIBUTION" = "ubuntu:rolling" ] || [ "$DISTRIBUTION" = "ubuntu:devel" ] ; then \
+    DEBIAN_FRONTEND=noninteractive apt-get install -y -qq --no-install-recommends -o Dpkg::Use-Pty=0 \
+    3cpio \
+    ; fi
+
 RUN \
     DEBIAN_FRONTEND=noninteractive apt-get install -y -qq --no-install-recommends -o Dpkg::Use-Pty=0 \
     asciidoctor \


### PR DESCRIPTION
## Changes

In preparation for supporting 3cpio, install it on the Ubuntu containers.

## Checklist
- [ ] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it

Fixes #
