### PR TITLE
feat(dracut): make hostonly the default

### DIFF
--- a/configure
+++ b/configure
@@ -39,9 +39,6 @@ case " $ID $ID_LIKE " in
     *" suse "*)
         configprofile=opensuse
         ;;
-    *)
-        configprofile=hostonly
-        ;;
 esac
 
 # Little helper function for reading args from the commandline.

--- a/dracut.conf.d/debian/01-debian.conf
+++ b/dracut.conf.d/debian/01-debian.conf
@@ -1,2 +1,1 @@
 # Debian/Ubuntu specific Dracut configuration
-hostonly="yes"

--- a/dracut.sh
+++ b/dracut.sh
@@ -1319,8 +1319,12 @@ check_kernel_compress_support() {
     return $?
 }
 
-[[ ${hostonly-} == yes ]] && hostonly="-h"
-[[ ${hostonly-} != "-h" ]] && unset hostonly
+# hostonly shell variable defaults to "-h" if not specified
+if [[ ${hostonly-} == "no" ]]; then
+    unset hostonly
+else
+    hostonly="-h"
+fi
 
 if [[ ${hostonly-} ]]; then
     for i in /sys /proc /run /dev; do


### PR DESCRIPTION
## Changes

Hostonly is already the default in the last dracut release, but the default was set as a configuration file.

This commit changes that and sets the default inside the dracut.sh script (unless of course a distribution or user overrides the default).

The hostonly configuration file is kept intentionally, but it is now not used by the configure option by default.

## Checklist
- [ ] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it

