### PR TITLE
fix(man): move the documentation hostonly and hostonly_mode variables

### DIFF
--- a/doc_site/modules/ROOT/pages/developer/modules.adoc
+++ b/doc_site/modules/ROOT/pages/developer/modules.adoc
@@ -75,16 +75,6 @@ module implements onto the initrd.  For the most part, this amounts
 to copying files from the host system onto the initrd in a controlled
 manner.
 
-The following are the most commonly used shell variables used inside
-drauct modules. These shell variables are always declared and assigned
-values (the assigned value might be an empty string). There is a
-compatibility promise on these variables between dracut releases.
-Module should only read (and not write) these variables.
- * `$hostonly` (could be an empty string)
- * `$hostonly_mode` (could be an empty string)
- * `$hostonly_cmdline` (not an empty string)
- * `$moddir` (not an empty string)
-
 ==== `module-setup.sh` function API
 
 `install()`::

--- a/man/dracut.modules.7.adoc
+++ b/man/dracut.modules.7.adoc
@@ -156,6 +156,16 @@ after udev has settled and the basic device drivers have been loaded.
 
 All module installation information is in the file module-setup.sh.
 
+The following are the most commonly used shell variables used inside
+drauct modules. These shell variables are always declared and assigned
+values (the assigned value might be an empty string). There is a
+compatibility promise on these variables between dracut releases.
+Module should only read (and not write) these variables.
+ * `$hostonly` (could be an empty string)
+ * `$hostonly_mode` (could be an empty string)
+ * `$hostonly_cmdline` (not an empty string)
+ * `$moddir` (not an empty string)
+
 First we create a check() function, which just exits with 0 indicating that this
 module should be included by default.
 


### PR DESCRIPTION
Move the documentation block to the man pages.

## Checklist
- [ ] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it

