### PR TITLE
fix(debian.conf): re-enable hostonly_cmdline

### DIFF
--- a/dracut.conf.d/debian/10-debian.conf
+++ b/dracut.conf.d/debian/10-debian.conf
@@ -1,3 +1,2 @@
 # Debian/Ubuntu specific Dracut configuration
 hostonly="yes"
-hostonly_cmdline="no"


### PR DESCRIPTION
## Changes

Do not set hostonly_cmdline to no for Debian-based distributions and let dracut modules store generated cmdline inside the initrd.

## Checklist
- [ ] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it

Fixes: https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=1103457

