### PR TITLE
fix(ubuntu): set DISTRIBUTION when building container

### DIFF
--- a/.github/workflows/container.yml
+++ b/.github/workflows/container.yml
@@ -68,3 +68,6 @@ jobs:
                   tags: ghcr.io/${{env.repository_owner}}/${{ matrix.config.tag }}-${{ matrix.architecture.tag }}
                   push: ${{ github.event_name == 'push' ||  github.event_name == 'schedule' }}
                   platforms: ${{ matrix.architecture.platform }}
+                  build-args: |
+                      DISTRIBUTION=${{ matrix.config.tag }}
+                      PLATFORM=${{ matrix.config.platform }}


### PR DESCRIPTION
## Changes

The containers built with as part of container-extra GA set DISTRIBUTION variable when when building container.

Do the same for the container GA to make sure that ubuntu:rolling container is properly built.

## Checklist
- [ ] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it

Fixes #1581

CC @bdrung 
