### PR TITLE
fix(dracut): decrease logging by default

### DIFF
--- a/dracut.sh
+++ b/dracut.sh
@@ -1116,7 +1116,7 @@ export SYSTEMCTL=${SYSTEMCTL:-systemctl}
 ((${#libdirs_l[@]})) && libdirs="${libdirs_l[*]}"
 
 [[ $stdloglvl_l ]] && stdloglvl=$stdloglvl_l
-[[ ! ${stdloglvl-} ]] && stdloglvl=4
+[[ ! ${stdloglvl-} ]] && stdloglvl=3
 stdloglvl=$((stdloglvl + verbosity_mod_l))
 ((stdloglvl > 6)) && stdloglvl=6
 ((stdloglvl < 0)) && stdloglvl=0

--- a/man/dracut.8.adoc
+++ b/man/dracut.8.adoc
@@ -306,13 +306,15 @@ example:
     Output debug information of the build process.
 
 **-v, --verbose**::
-    Increase verbosity level (default is info(4)).
+    Increase verbosity level (default is warnings(3)).
+    Could be specified multiple times.
 
 **--version**::
     Display version and exit.
 
 **-q, --quiet**::
-    Decrease verbosity level (default is info(4)).
+    Decrease verbosity level (default is warnings(3)).
+    Could be specified multiple times.
 
 **-c, --conf** _<dracut configuration file>_::
     Specify configuration file to use.

--- a/man/dracut.conf.5.adoc
+++ b/man/dracut.conf.5.adoc
@@ -253,7 +253,7 @@ Directory to search for ACPI tables if acpi_override= is set to yes.
 Combine early microcode with ramdisk (default=yes).
 
 *stdloglvl*="__\{0-6\}__"::
-Specify logging level for standard error (default=4).
+Specify logging level for standard error (default=3).
 +
 .Logging Levels
 [cols="1,1"]


### PR DESCRIPTION
## Changes

The current default set in dracut is "4". All distributions (except Debian), sets the default to "3".

Instead of relying on good defaults only within distribution configurations, let's set the dracut default to be less verbose.

Most users new to dracut perceive the verbose dracut logs as errors. This change will help prevent and eliminate user confusion and improve the user experience.

## Checklist
- [ ] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it

