### PR TITLE
ci: remove kernel command line workarounds from test config

### DIFF
--- a/dracut.conf.d/test/test.conf
+++ b/dracut.conf.d/test/test.conf
@@ -4,9 +4,6 @@ do_strip="no"
 do_hardlink="no"
 early_microcode="no"
 
-# systemd on arm64 on GitHub CI needs the 2 min timeout
-kernel_cmdline=" rd.retry=10 rd.timeout=120 rd.info rd.shell=0 "
-
 # test the dlopen dependencies support
 add_dlopen_features+=" libsystemd-shared-*.so:fido2 "
 


### PR DESCRIPTION
This commit makes the test suite runs less opinionated and closer to actual user's environment.

Some of these workarounds have been added to the CI as patch work, this is a good time to reevaluate if these are still needed.

## Checklist
- [ ] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it
