### PR TITLE
ci(integration-extra): disable UEFI test on debian:sid

### DIFF
--- a/.github/workflows/integration-extra.yml
+++ b/.github/workflows/integration-extra.yml
@@ -59,6 +59,9 @@ jobs:
                     # https://github.com/dracut-ng/dracut-ng/issues/1224
                     - container: gentoo:amd64-openrc
                       test: "43"
+                    # https://github.com/dracut-ng/dracut-ng/issues/1407
+                    - container: debian:sid
+                      test: "12"
                     # https://github.com/dracut-ng/dracut-ng/issues/1590
                     - container: ubuntu:devel
                       test: "30"


### PR DESCRIPTION
## Changes

This test has been failing on debian:sid for a while and passing on all other test containers.

I was unable to find a root cause and what is even more interesting is that the test is passing on debian:latest (trixie).

At this point of time debian:sid and debian:latest (trixie) should be very similar, so there is a decent chance that this is a distribution issue and not a dracut issue.

This is the last remaining failure to make the integration-extra GA green.

## Checklist
- [ ] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it


