### PR TITLE
ci(ubuntu): exclude TEST-30

### DIFF
--- a/.github/workflows/integration-extra.yml
+++ b/.github/workflows/integration-extra.yml
@@ -59,6 +59,12 @@ jobs:
                     # https://github.com/dracut-ng/dracut-ng/issues/1224
                     - container: gentoo:amd64-openrc
                       test: "43"
+                    # https://github.com/dracut-ng/dracut-ng/issues/1590
+                    - container: ubuntu:devel
+                      test: "30"
+                    # https://github.com/dracut-ng/dracut-ng/issues/1590
+                    - container: ubuntu:rolling
+                      test: "30"
                     # https://github.com/dracut-ng/dracut-ng/issues/1315
                     - container: azurelinux:3.0
                       test: "41"

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -98,6 +98,10 @@ jobs:
               uses: actions/checkout@v5
             - name: "${{ matrix.container }} TEST-${{ matrix.test }}"
               run: ./test/test-container.sh "TEST-${{ matrix.test }}" ${{ matrix.test }}
+        exclude:
+            # https://github.com/dracut-ng/dracut-ng/issues/1590
+            - container: ubuntu:devel
+              test: "30"
 
     extended-systemd:
         needs: basic


### PR DESCRIPTION
TEST-30 is passing on all other CI containers including debian:sid.

This is likely not a dracut issue, so let's exclude it from the CI for now.

Related: https://github.com/dracut-ng/dracut-ng/issues/1590

## Checklist
- [ ] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it

