### PR TITLE
fix(dracut): use "-name" to avoid find matching temporary directory

### DIFF
--- a/dracut.sh
+++ b/dracut.sh
@@ -2214,7 +2214,7 @@ if [[ $kernel_only != yes ]]; then
     if [[ ${DRACUT_RESOLVE_LAZY-} ]] && [[ $DRACUT_INSTALL ]]; then
         dinfo "*** Resolving executable dependencies ***"
         # shellcheck disable=SC2086
-        find "$initdir" -type f -perm /0111 -not -path '*.ko*' -print0 \
+        find "$initdir" -type f -perm /0111 -not -name '*.ko*' -print0 \
             | xargs -r -0 $DRACUT_INSTALL ${initdir:+-D "$initdir"} ${dracutsysrootdir:+-r "$dracutsysrootdir"} -R ${DRACUT_FIPS_MODE:+-f} --
         # shellcheck disable=SC2181
         if (($? == 0)); then


### PR DESCRIPTION
$initdir includes a temporary directory, and the "-path" option of find attempts to match the entire path. If the temporary directory happens to contain ".ko", e.g.
  initdir=/var/tmp/dracut.ko79pT/initramfs
this can lead to a incorrect match, finally all executable files are excluded.

This pull request changes...

## Changes

## Checklist
- [x] I have tested it locally
- [x] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it

Fixes #
