### PR TITLE
fix(UKI): Explicitly specify '--uname'

### DIFF
--- a/dracut.sh
+++ b/dracut.sh
@@ -2737,6 +2737,7 @@ if [[ $uefi == yes ]]; then
         if ukify build \
             --linux "$kernel_image" \
             --initrd "${DRACUT_TMPDIR}/initramfs.img" \
+            --uname "$kernel" \
             ${uefi_cmdline:+--cmdline @"$uefi_cmdline"} \
             ${uefi_osrelease:+--os-release @"$uefi_osrelease"} \
             ${uefi_splash_image:+--splash "$uefi_splash_image"} \


### PR DESCRIPTION
When '--uname' is not passed to 'ukify' it uses an autodetection mechanism which is "hacky as hell" (see commit 483c9c1b8a in systemd) and there's

 Kernel version not specified, starting autodetection 😖.

in the log. In some cases autodetection fails. As dracut has the required information already, there's no need to use it at all.

This pull request changes...

## Changes

## Checklist
- [ X ] I have tested it locally
- [ - ] I have reviewed and updated any documentation if relevant
- [ - ] I am providing new code and test(s) for it
