### PR TITLE
fix(lsinitrd, dracut-initramfs-restore): detect initrd for BLS Type #1 entries

### DIFF
--- a/dracut-initramfs-restore.sh
+++ b/dracut-initramfs-restore.sh
@@ -21,6 +21,28 @@ find_initrd_for_kernel_version() {
     local kernel_version="$1"
     local base_path files initrd machine_id
 
+    if command -v bootctl > /dev/null && command -v jq > /dev/null; then
+        # get proper path to $BOOT
+        base_path=$(bootctl -x)
+        # get initrd key of the selected bootloader entry (i.e., the one that
+        # is actually used to boot the system)
+        mapfile -t files < <(bootctl --json=pretty list 2> /dev/null | jq -r '.[] | select(.isSelected).initrd[]' 2> /dev/null)
+        if [[ ${#files[@]} -ge 1 ]] && [[ -e "${base_path}${files[0]}" ]]; then
+            echo "${base_path}${files[0]}"
+            return
+        fi
+        # if the selected bootloader entry does not have any initrd keys, check
+        # the default (maybe the current selected entry was removed)
+        # also check at least that the default bootloader entry has the same
+        # kernel version
+        mapfile -t files < <(bootctl --json=pretty list 2> /dev/null | jq -r '.[] | select(.isDefault).initrd[]' 2> /dev/null)
+        if [[ ${#files[@]} -ge 1 ]] && [[ -e "${base_path}${files[0]}" ]] \
+            && [[ ${files[0]} == *"${kernel_version}"* ]]; then
+            echo "${base_path}${files[0]}"
+            return
+        fi
+    fi
+
     if [[ -d /efi/Default ]] || [[ -d /boot/Default ]] || [[ -d /boot/efi/Default ]]; then
         machine_id="Default"
     elif [[ -s /etc/machine-id ]]; then


### PR DESCRIPTION
dracut is making wrong assumptions with BLS Type #1 entries.

- The ESP is not always used to store boot loader entries, there may be also an Extended Boot Loader Partition (XBOOTLDR). The spec defines the concept of the `$BOOT` partition placeholder, as the primary place to put boot menu entry resources into.

- The `machine-id` is not always used as subdirectory, it can be the `entry-token`.

- Also, although the name "initrd" is referenced in the examples, its use is not mandatory. E.g., in openSUSE we add a suffix with its hash value.

Manually implementing this autodetection logic can be complex, but all the necessary information is provided by `bootctl`, so use it if available.

More info: https://uapi-group.org/specifications/specs/boot_loader_specification

## Checklist
- [ ] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it
