### PR TITLE
ci(alpine): add networkmanager-initrd-generator package

### DIFF
--- a/test/container/Dockerfile-alpine
+++ b/test/container/Dockerfile-alpine
@@ -7,7 +7,7 @@
 # - busybox default shell (no dash installed)
 # - gzip compression
 # - dbus-daemon
-# - network: none
+# - network: networkmanager
 
 # Not installed
 # - cargo (to increase coverage)
@@ -17,7 +17,6 @@
 # - multipath-tools (does not work well)
 # - ovmf (systemd-boot-efistub, UEFI, UKI is not available)
 # - kernel-install is not available
-# - networkmanager (does not work with dracut)
 
 ARG DISTRIBUTION=alpine
 FROM docker.io/${DISTRIBUTION}
@@ -26,6 +25,7 @@ FROM docker.io/${DISTRIBUTION}
 ARG DISTRIBUTION
 
 # Packages to pass the BASIC test
+# Use dracut-tests package to install dependencies for test suite
 RUN apk add --no-cache \
     asciidoctor \
     dracut-tests \
@@ -38,29 +38,7 @@ RUN apk add --no-cache \
     musl-dev \
     musl-fts-dev
 
-# Packages for all tests, only enabled for alpine:edge
-RUN \
-if [ "$DISTRIBUTION" = "alpine:edge" ] ; then \
-    apk add --no-cache \
-    btrfs-progs \
-    cpio \
-    cryptsetup \
-    device-mapper \
-    elogind \
-    gpg \
-    jq \
-    kbd \
-    keyutils \
-    libcap-utils \
-    losetup \
-    lvm2 \
-    mdadm \
-    nvme-cli \
-    parted \
-    plymouth-themes \
-    procps \
-    squashfs-tools \
-    util-linux-misc \
-    util-linux-login \
-    xorriso \
-; fi
+# Packages for recent changes that are not yet released or packaged by dracut-tests
+RUN apk add --no-cache \
+    networkmanager-cli \
+    networkmanager-initrd-generator


### PR DESCRIPTION
NETWORK test now would pass on alpine as long as `networkmanager-initrd-generator` is installed.

This commit would expand test coverage for `network-manager` dracut module.

Dowstream alpine maintains a [dracut-tests package](https://pkgs.alpinelinux.org/package/edge/community/x86_64/dracut-tests) the already does a good job installing dracut test dependencies including `networkmanager-initrd-generator`.
    
Let's rely on `dracut-tests` package to further reduce the need to maintain alpine package lists here upstream.
    
See https://gitlab.alpinelinux.org/alpine/aports/-/blob/master/community/dracut/APKBUILD

## Checklist
- [x] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it

Fixes #
