### PR TITLE
ci: increase test coverage by not forcing additional config

### DIFF
--- a/dracut.conf.d/test/test.conf
+++ b/dracut.conf.d/test/test.conf
@@ -1,8 +1,4 @@
 add_dracutmodules+=" base debug qemu watchdog kernel-modules "
-# do not strip
-do_strip="no"
-do_hardlink="no"
-early_microcode="no"
 
 # test the dlopen dependencies support
 add_dlopen_features+=" libsystemd-shared-*.so:fido2 "


### PR DESCRIPTION
Test suite should also strip if it is enabled in the CI test container. Make the test case less opinionated to increase tests coverage.

## Checklist
- [ ] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it


