### PR TITLE
ci: switching the main CI to ubuntu:devel from ubuntu:rolling

### DIFF
--- a/.github/workflows/container.yml
+++ b/.github/workflows/container.yml
@@ -39,7 +39,7 @@ jobs:
                     - {dockerfile: 'Dockerfile-fedora', tag: 'fedora:latest'}
                     - {dockerfile: 'Dockerfile-opensuse', tag: 'opensuse:latest'}
                     - {dockerfile: 'Dockerfile-arch', tag: 'arch:latest'}
-                    - {dockerfile: 'Dockerfile-debian', tag: 'ubuntu:rolling'}
+                    - {dockerfile: 'Dockerfile-debian', tag: 'ubuntu:devel'}
                     - {dockerfile: 'Dockerfile-alpine', tag: 'alpine:latest'}
                     - {dockerfile: 'Dockerfile-void', tag: 'void:latest'}
                 exclude:

--- a/.github/workflows/doc.yml
+++ b/.github/workflows/doc.yml
@@ -28,7 +28,7 @@ jobs:
                     - fedora:latest
                     - gentoo:latest
                     - opensuse:latest
-                    - ubuntu:rolling
+                    - ubuntu:devel
                     - void:latest
         container:
             image: ghcr.io/dracut-ng/${{ matrix.container }}-amd

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -36,7 +36,7 @@ jobs:
                     - fedora:latest
                     - gentoo:latest
                     - opensuse:latest
-                    - ubuntu:rolling
+                    - ubuntu:devel
                     - void:latest
                 test:
                     - "10"
@@ -78,7 +78,7 @@ jobs:
                     - fedora:latest
                     - gentoo:latest
                     - opensuse:latest
-                    - ubuntu:rolling
+                    - ubuntu:devel
                     - void:latest
                 test:
                     - "11"
@@ -115,7 +115,7 @@ jobs:
                     - fedora:latest
                     - gentoo:latest
                     - opensuse:latest
-                    - ubuntu:rolling
+                    - ubuntu:devel
                 test:
                     - "40"
                     - "41"
@@ -171,7 +171,7 @@ jobs:
                     - fedora:latest
                     - gentoo:latest
                     - opensuse:latest
-                    - ubuntu:rolling
+                    - ubuntu:devel
                 test:
                     - "60"
                     - "61"


### PR DESCRIPTION
Switch the main CI to `ubuntu:devel` as it seems more stable and more forward looking at this time.

Continue to test ubuntu:rolling as part of Daily Integration test.

This commit does not change the test coverage - it just changes to run tests on `ubuntu:deve`l more frequently.

## Checklist
- [ ] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it

