### PR TITLE
ci(azurelinux): disable multipath dracut module

### DIFF
--- a/test/container/Dockerfile-azurelinux
+++ b/test/container/Dockerfile-azurelinux
@@ -56,5 +56,7 @@ RUN tdnf -y install --setopt=install_weak_deps=False \
     && tdnf clean all
 
 # disable systemd-portabled - it is optional and allows to pass the CI
+# disable multipath dracut module - it interferes with the CI on azurelinux
 RUN \
-    rm -rf /usr/bin/portablectl /usr/lib/systemd/systemd-portabled
+    rm -rf /usr/bin/portablectl /usr/lib/systemd/systemd-portabled ;\
+    echo 'omit_dracutmodules+=" multipath "' > /usr/lib/dracut/dracut.conf.d/02-dist.conf


### PR DESCRIPTION
Multipath dracut module interferes with FULL-SYSTEMD test on azurelinux.

Instead of disabling the test, let's instead omit the multipath dracut module.

This commit improves the workaround for https://github.com/dracut-ng/dracut-ng/issues/1315 .

CC @trungams

## Checklist
- [ ] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it

