### PR TITLE
ci: watchdog should not be required for non-networking tests

### DIFF
--- a/dracut.conf.d/test/test.conf
+++ b/dracut.conf.d/test/test.conf
@@ -1,4 +1,4 @@
-add_dracutmodules+=" base debug qemu watchdog kernel-modules "
+add_dracutmodules+=" base debug qemu kernel-modules "
 
 # test the dlopen dependencies support
 add_dlopen_features+=" libsystemd-shared-*.so:fido2 "

--- a/test/TEST-60-NFS/test.sh
+++ b/test/TEST-60-NFS/test.sh
@@ -296,7 +296,7 @@ test_setup() {
     test_dracut \
         --no-hostonly --no-hostonly-cmdline \
         --include ./client.link /etc/systemd/network/01-client.link \
-        -a "dmsquash-live ${USE_NETWORK}"
+        -a "watchdog dmsquash-live ${USE_NETWORK}"
 
     # Make server's dracut image
     "$DRACUT" -i "$TESTDIR"/overlay / \

--- a/test/TEST-70-ISCSI/test.sh
+++ b/test/TEST-70-ISCSI/test.sh
@@ -220,7 +220,7 @@ test_setup() {
     # Make client's dracut image
     test_dracut \
         --no-hostonly --no-hostonly-cmdline \
-        --add "$USE_NETWORK" \
+        --add "watchdog $USE_NETWORK" \
         --include "./client-persistent-lan0.link" "/etc/systemd/network/01-persistent-lan0.link" \
         --include "./client-persistent-lan1.link" "/etc/systemd/network/01-persistent-lan1.link" \
         --kernel-cmdline "rw rd.auto"

--- a/test/TEST-71-ISCSI-MULTI/test.sh
+++ b/test/TEST-71-ISCSI-MULTI/test.sh
@@ -220,7 +220,7 @@ test_setup() {
     # Make client's dracut image
     test_dracut \
         --no-hostonly --no-hostonly-cmdline \
-        --add "$USE_NETWORK" \
+        --add "watchdog $USE_NETWORK" \
         -i ./client-persistent-lan0.link /etc/systemd/network/01-persistent-lan0.link \
         -i ./client-persistent-lan1.link /etc/systemd/network/01-persistent-lan1.link
 

--- a/test/TEST-72-NBD/test.sh
+++ b/test/TEST-72-NBD/test.sh
@@ -321,7 +321,7 @@ test_setup() {
 
     test_dracut \
         --no-hostonly --no-hostonly-cmdline \
-        -a "${USE_NETWORK}" \
+        -a "watchdog ${USE_NETWORK}" \
         -i "./client.link" "/etc/systemd/network/01-client.link" \
         -i "/tmp/crypttab" "/etc/crypttab" \
         -i "/tmp/key" "/etc/key"


### PR DESCRIPTION
Strengthen the test suite by omitting the watchdog dracut module for non-networking tests.

## Checklist
- [ ] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it

Fixes #
