### PR TITLE
fix(udev-rules): exclude udev rules from snapd

### DIFF
--- a/modules.d/74udev-rules/module-setup.sh
+++ b/modules.d/74udev-rules/module-setup.sh
@@ -102,9 +102,19 @@ install() {
     # Install the hosts local user configurations if enabled.
     if [[ $hostonly ]]; then
         inst_dir "$udevconfdir"
+
+        declare -a udevrules=()
+        for rule in "$udevrulesconfdir"/*.rules; do
+            [ -e "$rule" ] || continue
+            if [[ $rule =~ "$udevrulesconfdir"/70-snap.*.rules ]]; then
+                continue
+            fi
+            udevrules+=("$rule")
+        done
+
         inst_multiple -H -o \
             "$udevconfdir"/udev.conf \
             "$udevconfdir/udev.conf.d/*.conf" \
-            "$udevrulesconfdir/*.rules"
+            "${udevrules[@]}"
     fi
 }


### PR DESCRIPTION
## Changes

There are no snaps in the initrd and these udev rules generated by snapd can cause warning messages. So just exclude udev rules in `/etc` that have `70-snap` in the name.

## Checklist
- [x] I have tested it locally
- [x] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it