### PR TITLE
ci(azure): reenable FULL-SYSTEMD on azurelinux:3.0

### DIFF
--- a/.github/workflows/integration-extra.yml
+++ b/.github/workflows/integration-extra.yml
@@ -65,9 +65,6 @@ jobs:
                     # https://github.com/dracut-ng/dracut-ng/issues/1590
                     - container: ubuntu:rolling
                       test: "30"
-                    # https://github.com/dracut-ng/dracut-ng/issues/1315
-                    - container: azurelinux:3.0
-                      test: "41"
                     # https://github.com/dracut-ng/dracut-ng/issues/1314
                     - container: azurelinux:3.0
                       test: "43"


### PR DESCRIPTION
## Changes

Since `multipath` dracut module is disabled in azurelinux CI container FULL-SYSTEMD can be reenabled.

## Checklist
- [ ] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it
