### PR TITLE
fix(i18n): remove Gentoo workaround that is no longer needed

### DIFF
--- a/modules.d/20i18n/module-setup.sh
+++ b/modules.d/20i18n/module-setup.sh
@@ -243,9 +243,6 @@ install() {
         fi
         shopt -q -u nocasematch
 
-        # Gentoo user may have KEYMAP set to something like "-u pl2",
-        KEYMAP=${KEYMAP#-* }
-
         # openSUSE user may have KEYMAP set to something like ".gz"
         KEYMAP=${KEYMAP/.gz/}
 


### PR DESCRIPTION
## Changes

Gentoo no longer sets KEYMAP to something like "-u pl2", instead it is set to "pl12".

This piece of code is part of the very original commit of the i18n dracut module from 2010 - 87122af                                                                                                                                                                                             
                                                                                                                                                                                                                              
There is no mention of '-u' in the oldest version of the wiki from 2013 https://wiki.gentoo.org/index.php?title=Keyboard_layout_switching&diff=1320347&oldid=16937

Remove this workaround that is no longer used or tested to make it easier to reason about the code.

## Checklist
- [ ] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it

