### PR TITLE
ci: do not include additional dracut modules in the tested initramfs

### DIFF
--- a/dracut.conf.d/test/test.conf
+++ b/dracut.conf.d/test/test.conf
@@ -1,4 +1,4 @@
-add_dracutmodules+=" base debug qemu kernel-modules "
+add_dracutmodules+=" qemu "
 
 # test the dlopen dependencies support
 add_dlopen_features+=" libsystemd-shared-*.so:fido2 "

--- a/test/TEST-40-SYSTEMD/test.sh
+++ b/test/TEST-40-SYSTEMD/test.sh
@@ -63,6 +63,7 @@ test_setup() {
     test_dracut \
         --omit "fido2 initqueue" \
         --omit-drivers 'a b c d e f g h i j k l m n o p q r s t u v w x y z' \
+        -I systemd-analyze \
         -i ./systemd-analyze.sh /lib/dracut/hooks/pre-pivot/00-systemd-analyze.sh \
         -i "/bin/true" "/usr/bin/man"
 


### PR DESCRIPTION
Test dracut's module detection capabilities and do not force additional dracut modules.

## Checklist
- [ ] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it

Fixes #
