### PR TITLE
ci(opensuse): install zstd as that is the configured compression method

### DIFF
--- a/test/container/Dockerfile-opensuse
+++ b/test/container/Dockerfile-opensuse
@@ -7,6 +7,7 @@
 # - rdma out of tree dracut module
 # - dbus-broker
 # - network: network-legacy, network-manager
+# - zstd compression
 
 FROM registry.opensuse.org/opensuse/tumbleweed:latest
 
@@ -55,6 +56,7 @@ RUN zypper --non-interactive install --no-recommends \
     tpm2.0-tools \
     util-linux-systemd \
     xorriso \
+    zstd \
     && zypper --non-interactive dist-upgrade --no-recommends
 
 # workaround for openSUSE on arm64


### PR DESCRIPTION
Commit eada0fb exposed that even though openSUSE configures zstd compression, it is not installed in the CI container.

This commit eliminates the following warning during tests

```
dracut[E]: Cannot execute compression command 'zstd -3 -T0 -q', falling back to default
```

## Checklist
- [ ] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it

Fixes #
