### PR TITLE
fix(overlayfs): overlayfs should not use rootfsflags as mount options

### DIFF
--- a/modules.d/70overlayfs/mount-overlayfs.sh
+++ b/modules.d/70overlayfs/mount-overlayfs.sh
@@ -5,8 +5,6 @@ command -v getarg > /dev/null || . /lib/dracut-lib.sh
 getargbool 0 rd.live.overlay.overlayfs && overlayfs="yes"
 getargbool 0 rd.live.overlay.readonly && readonly_overlay="--readonly" || readonly_overlay=""
 
-ROOTFLAGS="$(getarg rootflags)"
-
 if [ -n "$overlayfs" ]; then
     if [ -n "$readonly_overlay" ] && [ -h /run/overlayfs-r ]; then
         ovlfs=lowerdir=/run/overlayfs-r:/run/rootfsbase
@@ -15,6 +13,6 @@ if [ -n "$overlayfs" ]; then
     fi
 
     if ! strstr "$(cat /proc/mounts)" LiveOS_rootfs; then
-        mount -t overlay LiveOS_rootfs -o "$ROOTFLAGS,$ovlfs",upperdir=/run/overlayfs,workdir=/run/ovlwork "$NEWROOT"
+        mount -t overlay LiveOS_rootfs -o "$ovlfs",upperdir=/run/overlayfs,workdir=/run/ovlwork "$NEWROOT"
     fi
 fi


### PR DESCRIPTION
## Changes

Do not pass all rootfsflags to overlay mount, as it breaks overlay mount, e.g. if subvol rootfsflags is used for mounting btrfs subvol.

Here is a simple example that demonstrates the problem (with ext4 rootfs, instead of btrfs, just to explain the impact of this bug)

```
rootflags='nodelalloc' ro rd.live.overlay.overlayfs=1
```

results in
```
 mount: /sysroot: fsconfig() failed: overlay: Unknown parameter ''nodelalloc''.
```

## Checklist
- [ ] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it

Fixes: #1603 (partially)
