### PR TITLE
chore(rootfs-block, usrmount): align systemd and non-systemd initramfs

### DIFF
--- a/modules.d/74rootfs-block/mount-root.sh
+++ b/modules.d/74rootfs-block/mount-root.sh
@@ -27,36 +27,11 @@ mount_root() {
     done
 
     fsckoptions=
-    if [ -f "$NEWROOT"/etc/sysconfig/readonly-root ]; then
-        # shellcheck disable=SC1090
-        . "$NEWROOT"/etc/sysconfig/readonly-root
-    fi
-
-    if [ -f "$NEWROOT"/fastboot ]; then
-        fastboot=yes
-    fi
 
     if ! getargbool 0 rd.skipfsck; then
-        if [ -f "$NEWROOT"/fsckoptions ]; then
-            read -r fsckoptions < "$NEWROOT"/fsckoptions
-        fi
 
-        if [ -f "$NEWROOT"/forcefsck ] || getargbool 0 forcefsck; then
+        if getargbool 0 forcefsck; then
             fsckoptions="-f $fsckoptions"
-        elif [ -f "$NEWROOT"/.autofsck ]; then
-            # shellcheck disable=SC1090
-            [ -f "$NEWROOT"/etc/sysconfig/autofsck ] \
-                && . "$NEWROOT"/etc/sysconfig/autofsck
-            if [ "$AUTOFSCK_DEF_CHECK" = "yes" ]; then
-                AUTOFSCK_OPT="$AUTOFSCK_OPT -f"
-            fi
-            if [ -n "$AUTOFSCK_SINGLEUSER" ]; then
-                warn "*** Warning -- the system did not shut down cleanly. "
-                warn "*** Dropping you to a shell; the system will continue"
-                warn "*** when you leave the shell."
-                emergency_shell
-            fi
-            fsckoptions="$AUTOFSCK_OPT $fsckoptions"
         fi
     fi
 
@@ -109,11 +84,6 @@ mount_root() {
     elif ! are_lists_eq , "$rflags" "$_rflags_ro" defaults; then
         info "Remounting ${root#block:} with -o ${rflags}"
         mount -o remount "$NEWROOT" 2>&1 | vinfo
-    fi
-
-    if ! getargbool 0 rd.skipfsck; then
-        [ -f "$NEWROOT"/forcefsck ] && rm -f -- "$NEWROOT"/forcefsck 2> /dev/null
-        [ -f "$NEWROOT"/.autofsck ] && rm -f -- "$NEWROOT"/.autofsck 2> /dev/null
     fi
 }
 

--- a/modules.d/77usrmount/mount-usr.sh
+++ b/modules.d/77usrmount/mount-usr.sh
@@ -25,25 +25,8 @@ fsck_usr() {
     local _fsopts="$3"
     local _fsckoptions
 
-    if [ -f "$NEWROOT"/fsckoptions ]; then
-        read -r _fsckoptions < "$NEWROOT"/fsckoptions
-    fi
-
-    if [ -f "$NEWROOT"/forcefsck ] || getargbool 0 forcefsck; then
+    if getargbool 0 forcefsck; then
         _fsckoptions="-f $_fsckoptions"
-    elif [ -f "$NEWROOT"/.autofsck ]; then
-        # shellcheck disable=SC1090
-        [ -f "$NEWROOT"/etc/sysconfig/autofsck ] && . "$NEWROOT"/etc/sysconfig/autofsck
-        if [ "$AUTOFSCK_DEF_CHECK" = "yes" ]; then
-            AUTOFSCK_OPT="$AUTOFSCK_OPT -f"
-        fi
-        if [ -n "$AUTOFSCK_SINGLEUSER" ]; then
-            warn "*** Warning -- the system did not shut down cleanly. "
-            warn "*** Dropping you to a shell; the system will continue"
-            warn "*** when you leave the shell."
-            emergency_shell
-        fi
-        _fsckoptions="$AUTOFSCK_OPT $_fsckoptions"
     fi
 
     fsck_single "$_dev" "$_fs" "$_fsopts" "$_fsckoptions"


### PR DESCRIPTION
`rootfs-block/mount-root.sh` and `usrmount/mount-usr.sh ` are only included in the initramfs if systemd is _not_ included.

`systemd` does not poke into `NEWROOT` to determine fsck options.

Let's do the same for non-systemd initramfs. Lot of the related path - e.g. `/etc/sysconfig/autofsck` are distribution specific anyways.

`systemd` reference: https://github.com/systemd/systemd/blob/main/src/fsck/fsck.c

## Checklist
- [ ] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it

