### PR TITLE
ci: do not force no-hostonly-cmdline during testing

### DIFF
--- a/test/TEST-40-SYSTEMD/test.sh
+++ b/test/TEST-40-SYSTEMD/test.sh
@@ -38,7 +38,7 @@ test_setup() {
         --add-confdir "test-makeroot" \
         -i ./create-root.sh /lib/dracut/hooks/initqueue/01-create-root.sh \
         --nomdadmconf \
-        --no-hostonly-cmdline -N \
+        -N \
         -f "$TESTDIR"/initramfs.makeroot
 
     declare -a disk_args=()

--- a/test/TEST-42-SYSTEMD-INITRD/test.sh
+++ b/test/TEST-42-SYSTEMD-INITRD/test.sh
@@ -54,7 +54,7 @@ test_setup() {
         --add-confdir test-makeroot \
         -i ./create-root.sh /lib/dracut/hooks/initqueue/01-create-root.sh \
         --nomdadmconf \
-        --no-hostonly-cmdline -N \
+        -N \
         -f "$TESTDIR"/initramfs.makeroot
 
     declare -a disk_args=()

--- a/test/TEST-60-NFS/test.sh
+++ b/test/TEST-60-NFS/test.sh
@@ -270,7 +270,7 @@ test_setup() {
         -I "mkfs.ext4" \
         -i ./create-root.sh /lib/dracut/hooks/initqueue/01-create-root.sh \
         --nomdadmconf \
-        --no-hostonly-cmdline -N \
+        -N \
         -f "$TESTDIR"/initramfs.makeroot
     rm -rf -- "$TESTDIR"/server
 
@@ -289,7 +289,7 @@ test_setup() {
 
     # Make client's dracut image
     test_dracut \
-        --no-hostonly --no-hostonly-cmdline \
+        --no-hostonly \
         --include ./client.link /etc/systemd/network/01-client.link \
         -a "watchdog dmsquash-live ${USE_NETWORK}"
 
@@ -299,7 +299,7 @@ test_setup() {
         --include ./server.link /etc/systemd/network/01-server.link \
         --include ./wait-if-server.sh /lib/dracut/hooks/pre-mount/99-wait-if-server.sh \
         --add-drivers "ext4" \
-        --no-hostonly-cmdline -N \
+        -N \
         -f "$TESTDIR"/initramfs.server
 }
 

--- a/test/TEST-70-ISCSI/test.sh
+++ b/test/TEST-70-ISCSI/test.sh
@@ -147,7 +147,7 @@ test_setup() {
         -a "crypt lvm mdraid" \
         -I "setsid blockdev" \
         -i ./create-client-root.sh /lib/dracut/hooks/initqueue/01-create-client-root.sh \
-        --no-hostonly-cmdline -N \
+        -N \
         -f "$TESTDIR"/initramfs.makeroot
     rm -rf -- "$TESTDIR"/overlay
 
@@ -210,12 +210,12 @@ test_setup() {
         -d "piix ide-gd_mod ata_piix ext4 sd_mod drbg virtio_net virtio_pci virtio_scsi" \
         -i "./server.link" "/etc/systemd/network/01-server.link" \
         -i ./wait-if-server.sh /lib/dracut/hooks/pre-mount/99-wait-if-server.sh \
-        --no-hostonly-cmdline -N \
+        -N \
         -f "$TESTDIR"/initramfs.server
 
     # Make client's dracut image
     test_dracut \
-        --no-hostonly --no-hostonly-cmdline \
+        --no-hostonly \
         --add "watchdog $USE_NETWORK" \
         --include "./client-persistent-lan0.link" "/etc/systemd/network/01-persistent-lan0.link" \
         --include "./client-persistent-lan1.link" "/etc/systemd/network/01-persistent-lan1.link" \

--- a/test/TEST-71-ISCSI-MULTI/test.sh
+++ b/test/TEST-71-ISCSI-MULTI/test.sh
@@ -141,7 +141,7 @@ test_setup() {
     "$DRACUT" --keep --tmpdir "$TESTDIR" \
         --add-confdir test-root \
         -I "ip grep setsid" \
-        --no-hostonly --no-hostonly-cmdline --nohardlink \
+        --no-hostonly \
         -f "$TESTDIR"/initramfs.root
     mkdir -p "$TESTDIR"/overlay/source && mv "$TESTDIR"/dracut.*/initramfs/* "$TESTDIR"/overlay/source && rm -rf "$TESTDIR"/dracut.*
     mkdir -p -- "$TESTDIR"/overlay/source/var/lib/nfs/rpc_pipefs
@@ -155,7 +155,7 @@ test_setup() {
         -a "crypt lvm mdraid" \
         -I "setsid blockdev" \
         -i ./create-client-root.sh /lib/dracut/hooks/initqueue/01-create-client-root.sh \
-        --no-hostonly-cmdline -N \
+        -N \
         -f "$TESTDIR"/initramfs.makeroot
     rm -rf -- "$TESTDIR"/overlay
 
@@ -214,7 +214,7 @@ test_setup() {
 
     # Make client's dracut image
     test_dracut \
-        --no-hostonly --no-hostonly-cmdline \
+        --no-hostonly \
         --add "watchdog $USE_NETWORK" \
         -i ./client-persistent-lan0.link /etc/systemd/network/01-persistent-lan0.link \
         -i ./client-persistent-lan1.link /etc/systemd/network/01-persistent-lan1.link
@@ -226,7 +226,7 @@ test_setup() {
         -d "af_packet piix ide-gd_mod ata_piix ext4 sd_mod drbg virtio_net" \
         -i "./server.link" "/etc/systemd/network/01-server.link" \
         -i "./wait-if-server.sh" "/lib/dracut/hooks/pre-mount/99-wait-if-server.sh" \
-        --no-hostonly-cmdline -N \
+        -N \
         -f "$TESTDIR"/initramfs.server
 }
 

--- a/test/TEST-72-NBD/test.sh
+++ b/test/TEST-72-NBD/test.sh
@@ -180,7 +180,7 @@ make_encrypted_root() {
     "$DRACUT" --keep --tmpdir "$TESTDIR" \
         --add-confdir test-root \
         -I "ip grep" \
-        --no-hostonly --no-hostonly-cmdline --nohardlink \
+        --no-hostonly \
         -f "$TESTDIR"/initramfs.root
     mkdir -p "$TESTDIR"/overlay/source && mv "$TESTDIR"/dracut.*/initramfs/* "$TESTDIR"/overlay/source && rm -rf "$TESTDIR"/dracut.*
     cp ./client-init.sh "$TESTDIR"/overlay/source/sbin/init
@@ -193,7 +193,7 @@ make_encrypted_root() {
         -a "crypt lvm mdraid" \
         -I "cryptsetup" \
         -i ./create-encrypted-root.sh /lib/dracut/hooks/initqueue/01-create-encrypted-root.sh \
-        --no-hostonly-cmdline -N \
+        -N \
         -f "$TESTDIR"/initramfs.makeroot
     rm -rf -- "$TESTDIR"/overlay
 
@@ -216,7 +216,7 @@ make_client_root() {
     "$DRACUT" --keep --tmpdir "$TESTDIR" \
         --add-confdir test-root \
         -I "ip" \
-        --no-hostonly --no-hostonly-cmdline --nohardlink \
+        --no-hostonly \
         -f "$TESTDIR"/initramfs.root
     mkdir -p "$TESTDIR"/overlay/source && mv "$TESTDIR"/dracut.*/initramfs/* "$TESTDIR"/overlay/source && rm -rf "$TESTDIR"/dracut.*
     cp ./client-init.sh "$TESTDIR"/overlay/source/sbin/init
@@ -228,7 +228,7 @@ make_client_root() {
         --add-confdir test-makeroot \
         -i ./create-client-root.sh /lib/dracut/hooks/initqueue/01-create-client-root.sh \
         --nomdadmconf \
-        --no-hostonly-cmdline -N \
+        -N \
         -f "$TESTDIR"/initramfs.makeroot
 
     declare -a disk_args=()
@@ -267,7 +267,7 @@ EOF
         --install-optional "/etc/netconfig dhcpd /etc/group /etc/nsswitch.conf /etc/rpc /etc/protocols /etc/services /usr/etc/nsswitch.conf /usr/etc/rpc /usr/etc/protocols /usr/etc/services" \
         -i /tmp/config /etc/nbd-server/config \
         -i "./dhcpd.conf" "/etc/dhcpd.conf" \
-        --no-hostonly --no-hostonly-cmdline --nohardlink \
+        --no-hostonly \
         -f "$TESTDIR"/initramfs.root
     mkdir -p "$TESTDIR"/overlay/source && mv "$TESTDIR"/dracut.*/initramfs/* "$TESTDIR"/overlay/source && rm -rf "$TESTDIR"/dracut.*
 
@@ -282,7 +282,7 @@ EOF
         -a "$USE_NETWORK" \
         -i ./create-server-root.sh /lib/dracut/hooks/initqueue/01-create-server-root.sh \
         --nomdadmconf \
-        --no-hostonly-cmdline -N \
+        -N \
         -f "$TESTDIR"/initramfs.makeroot
 
     declare -a disk_args=()
@@ -315,7 +315,7 @@ test_setup() {
     echo -n test > /tmp/key
 
     test_dracut \
-        --no-hostonly --no-hostonly-cmdline \
+        --no-hostonly \
         -a "watchdog ${USE_NETWORK}" \
         -i "./client.link" "/etc/systemd/network/01-client.link" \
         -i "/tmp/crypttab" "/etc/crypttab" \


### PR DESCRIPTION
## Changes

There is no longer a need to force additional no-hostonly-cmdline dracut command line option during test case runs.

## Checklist
- [ ] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it

Fixes #
