### PR TITLE
feat: dracut.sh: try $STRIP for $strip_cmd first

### DIFF
--- a/dracut.sh
+++ b/dracut.sh
@@ -2337,7 +2337,8 @@ done
 if [[ $do_strip == yes ]]; then
     # Prefer strip from elfutils for package size
     declare strip_cmd
-    strip_cmd=$(command -v eu-strip)
+    strip_cmd="${STRIP-}"
+    [ -z "$strip_cmd" ] && strip_cmd=$(command -v eu-strip)
     [ -z "$strip_cmd" ] && strip_cmd="strip"
 
     for p in "$strip_cmd" xargs find; do


### PR DESCRIPTION
## Changes
When using dracut in a cross enviroment, like OpenEmbedded, the host provided strip (or eu-strip) won't work, so try using the $STRIP variable from the shell environment first before falling back to path based lookups.

## Checklist
- [x ] I have tested it locally
