### PR TITLE
ci(openSUSE): revert cce3ba8

### DIFF
--- a/test/container/Dockerfile-fedora
+++ b/test/container/Dockerfile-fedora
@@ -1,6 +1,6 @@
 # Test coverage provided by this container:
 # - arm64
-# - default hostonly
+# - strict hostonly
 # - xfs
 # - memstrack
 # - ndctl (for nvdimm)

--- a/test/container/Dockerfile-opensuse
+++ b/test/container/Dockerfile-opensuse
@@ -1,6 +1,6 @@
 # Test coverage provided by this container:
 # - arm64
-# - strict hostonly
+# - hostonly
 # - network-legacy
 # - mkosi-initrd
 # - hmaccalc (fido)
@@ -60,8 +60,6 @@ RUN zypper --non-interactive install --no-recommends \
     && zypper --non-interactive dist-upgrade --no-recommends
 
 # workaround for openSUSE on arm64
-# force strict hostonly mode to increase test coverage
 RUN \
-    echo 'hostonly_mode="strict"' > /usr/lib/dracut/dracut.conf.d/02-dist.conf ;\
     KVERSION="$(cd /lib/modules && ls -1 | tail -1)" \
     && if [ "$(arch)"="aarch64" ] && [ -e /usr/lib/modules/"$KVERSION"/Image ]; then ln -sf /usr/lib/modules/"$KVERSION"/Image /usr/lib/modules/"$KVERSION"/vmlinuz; fi


### PR DESCRIPTION
Fedora provides CI coverage for strict hostonly.

## Checklist
- [ ] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it

