### PR TITLE
ci: add test coverage for omitting systemd on a systemd container

### DIFF
--- a/.github/workflows/integration-extra.yml
+++ b/.github/workflows/integration-extra.yml
@@ -133,3 +133,31 @@ jobs:
               uses: actions/checkout@v5
             - name: "${{ matrix.container }} TEST-${{ matrix.test }}"
               run: USE_NETWORK=${{ matrix.network }} ./test/test-container.sh "TEST-${{ matrix.test }}" ${{ matrix.test }}
+    omitsystemd:
+        # run this test on all containers
+        name: ${{ matrix.test }} on ${{ matrix.container }} with no systemd
+        runs-on: ubuntu-24.04
+        timeout-minutes: 20
+        concurrency:
+            group: omitsystemd-${{ github.workflow }}-${{ github.ref }}-${{ matrix.container }}-${{ matrix.test }}
+            cancel-in-progress: true
+        strategy:
+            fail-fast: false
+            matrix:
+                container:
+                    - arch:latest
+                test:
+                    - "10"
+                    - "11"
+                    - "12"
+                    - "20"
+                    - "26"
+                    - "30"
+        container:
+            image: ghcr.io/dracut-ng/${{ matrix.container }}-amd
+            options: '--device=/dev/kvm --privileged'
+        steps:
+            - name: "Checkout Repository"
+              uses: actions/checkout@v5
+            - name: "${{ matrix.container }} TEST-${{ matrix.test }}"
+              run: TEST_DRACUT_ARGS="--omit systemd" ./test/test-container.sh "TEST-${{ matrix.test }}" ${{ matrix.test }}

--- a/test/test.sh
+++ b/test/test.sh
@@ -49,7 +49,7 @@ fi
 # clear previous test run
 TARGETS='clean all install check' "$PODMAN" run --rm -it \
     --device=/dev/kvm --privileged \
-    -e V -e TESTS -e TEST_RUN_ID -e TARGETS -e MAKEFLAGS \
+    -e V -e TESTS -e TEST_RUN_ID -e TARGETS -e MAKEFLAGS -e TEST_DRACUT_ARGS \
     -v "$PWD"/:/z \
     "$CONTAINER" \
     /z/test/test-container.sh


### PR DESCRIPTION

Omitting systemd on a systemd enabled environment is supported, so let's add test coverage for this configuration.

## Checklist
- [ ] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it

Fixes #
