### PR TITLE
ci(pr): run job only on pull_request main branch

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -2,7 +2,7 @@
 name: Commisery
 on:  # yamllint disable-line rule:truthy
   pull_request:
-    types: [edited, opened, synchronize, reopened]
+    branches: [main]
 
 jobs:
   commit-message:


### PR DESCRIPTION
## Changes

I noticed that commisery job runs even when commit is not changed. Align job with the rest of the GA.

## Checklist
- [ ] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it

Fixes #
