### PR TITLE
ci(alpine): run tests on the newly introduced Alpine container

### DIFF
--- a/.github/workflows/integration-extra-arm64.yml
+++ b/.github/workflows/integration-extra-arm64.yml
@@ -24,6 +24,7 @@ jobs:
             fail-fast: false
             matrix:
                 container:
+                    - alpine
                     - debian
                     - opensuse
                     - ubuntu

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -223,6 +223,7 @@ jobs:
             fail-fast: false
             matrix:
                 container:
+                    - alpine:latest
                     - debian:latest
                     - opensuse:latest
                     - ubuntu:rolling


### PR DESCRIPTION
CI now builds CI Alpine container for arm64. Let's use this container to actually run tests on it.

## Checklist
- [ ] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it

Fixes #
