### PR TITLE
ci: add more drivers to pass CI in strict hostonly mode as well

### DIFF
--- a/dracut.conf.d/test/test.conf
+++ b/dracut.conf.d/test/test.conf
@@ -1,7 +1,7 @@
-add_dracutmodules+=" qemu "
+add_dracutmodules+=" qemu qemu-net "
 
 # test the dlopen dependencies support
 add_dlopen_features+=" libsystemd-shared-*.so:fido2 "
 
-# testsuite assumes ext4 for convenience
-add_drivers+=" ext4 "
+# testsuite assumes the following drivers for convenience
+add_drivers+=" ext4 sd_mod "


### PR DESCRIPTION
## Changes

Strict hostonly mode is missing some drivers - especially when these drivers are not built into the Linux kernel (e.g. on CentOS or Alpine).

## Checklist
- [ ] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it

