### PR TITLE
ci: enable controlling TEST_FSTYPE as part of container test run

### DIFF
--- a/doc_site/modules/ROOT/pages/developer/hacking.adoc
+++ b/doc_site/modules/ROOT/pages/developer/hacking.adoc
@@ -137,6 +137,13 @@ Run test in extra verbose mode (enabled for debug logging):: {empty}
 $ V=2 test/test.sh
 ----
 
+Run test 20 with `btrfs` omitting `systemd` dracut module on `debian` :: {empty}
++
+[,console]
+----
+$ TESTS="20" TEST_FSTYPE=btrfs TEST_DRACUT_ARGS="--omit systemd" test/test.sh debian
+----
+
 === On bare metal
 
 For the testsuite to pass, you will have to install at least the software packages

--- a/test/test.sh
+++ b/test/test.sh
@@ -49,7 +49,7 @@ fi
 # clear previous test run
 TARGETS='clean all install check' "$PODMAN" run --rm -it \
     --device=/dev/kvm --privileged \
-    -e V -e TESTS -e TEST_RUN_ID -e TARGETS -e MAKEFLAGS -e TEST_DRACUT_ARGS \
+    -e V -e TESTS -e TEST_RUN_ID -e TARGETS -e MAKEFLAGS -e TEST_DRACUT_ARGS -e TEST_FSTYPE \
     -v "$PWD"/:/z \
     "$CONTAINER" \
     /z/test/test-container.sh


### PR DESCRIPTION
Pass TEST_FSTYPE to the test container and document a more complex test run using TEST_FSTYPE.

## Checklist
- [ ] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it


