### PR TITLE
fix(test-makeroot): make it dependent on initqueue

### DIFF
--- a/test/modules.d/70test-makeroot/module-setup.sh
+++ b/test/modules.d/70test-makeroot/module-setup.sh
@@ -6,7 +6,7 @@ check() {
 }
 
 depends() {
-    echo "rootfs-block kernel-modules qemu"
+    echo "rootfs-block kernel-modules qemu initqueue"
 }
 
 install() {


### PR DESCRIPTION
In its current form test-makeroot dracut module depends on the initqueue module.

## Checklist
- [ ] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it
