### PR TITLE
docs: document keep configuration option

### DIFF
--- a/man/dracut.conf.5.adoc
+++ b/man/dracut.conf.5.adoc
@@ -400,6 +400,9 @@ Defaults to _initramfs-$\{kernel\}.img_.
 Let kernel-install create a rescue image (default=no).
 This configuration option applies only to kernel-install.
 
+*keep=*"__{yes|no}__"::
+Keep (do not delete) the temporary initramfs directory for debugging purposes.
+
 == Files
 _/etc/dracut.conf_::
 Old configuration file. It is recommended to use individual files in


### PR DESCRIPTION
The `keep` configuration option keeps (does not delete) the temporary initramfs directory for debugging purposes.


## Checklist
- [ ] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it

Fixes #
