### PR TITLE
test(NFS): do not use rd.net.timeout.dhcp

### DIFF
--- a/test/TEST-60-NFS/test.sh
+++ b/test/TEST-60-NFS/test.sh
@@ -62,7 +62,6 @@ client_test() {
     declare -i disk_index=0
     qemu_add_drive disk_index disk_args "$TESTDIR"/marker.img marker 1
     qemu_add_drive disk_index disk_args "$TESTDIR"/marker2.img marker2 1
-    cmdline="$cmdline rd.net.timeout.dhcp=30"
 
     "$testdir"/run-qemu \
         "${disk_args[@]}" \


### PR DESCRIPTION
`rd.net.timeout.dhcp` is only understood by network-legacy dracut module.

We want to start migrating to network-manager from network-legacy, so stop using this command line option in tests.

## Checklist
- [ ] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it

Fixes #
