### PR TITLE
feat(qemu): install sd_mod driver

### DIFF
--- a/dracut.conf.d/test-makeroot/test-makeroot.conf
+++ b/dracut.conf.d/test-makeroot/test-makeroot.conf
@@ -9,4 +9,4 @@ stdloglvl=2
 mdadmconf="no"
 
 # testsuite assumes the following drivers for convenience
-add_drivers+=" ext4 sd_mod "
+add_drivers+=" ext4 "

--- a/dracut.conf.d/test-root/test-root.conf
+++ b/dracut.conf.d/test-root/test-root.conf
@@ -9,4 +9,4 @@ stdloglvl=2
 keep=yes
 
 # testsuite assumes the following drivers for convenience
-add_drivers+=" ext4 sd_mod "
+add_drivers+=" ext4 "

--- a/dracut.conf.d/test/test.conf
+++ b/dracut.conf.d/test/test.conf
@@ -4,4 +4,4 @@ add_dracutmodules+=" qemu "
 add_dlopen_features+=" libsystemd-shared-*.so:fido2 "
 
 # testsuite assumes the following drivers for convenience
-add_drivers+=" ext4 sd_mod "
+add_drivers+=" ext4 "

--- a/modules.d/70qemu/module-setup.sh
+++ b/modules.d/70qemu/module-setup.sh
@@ -15,7 +15,7 @@ check() {
 installkernel() {
     # qemu specific modules
     hostonly='' instmods \
-        ata_piix ata_generic pata_acpi cdrom sr_mod ahci \
+        ata_piix ata_generic pata_acpi cdrom sr_mod sd_mod ahci \
         virtio_blk virtio virtio_crypto virtio_ring virtio_pci \
         virtio_scsi virtio_console virtio_rng virtio_mem \
         spapr-vscsi \


### PR DESCRIPTION
It is very common to use `sd_mod` driver inside qemu.

Let's install the `sd_mod` driver when qemu dracut module is included.

## Checklist
- [ ] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it

Fixes #
