### PR TITLE
ci: remove dhclient from Arch, Debian, Fedora CI

### DIFF
--- a/test/container/Dockerfile-alpine
+++ b/test/container/Dockerfile-alpine
@@ -40,5 +40,6 @@ RUN apk add --no-cache \
 
 # Packages for recent changes that are not yet released or packaged by dracut-tests
 RUN apk add --no-cache \
+    dnsmasq \
     networkmanager-cli \
     networkmanager-initrd-generator

--- a/test/container/Dockerfile-arch
+++ b/test/container/Dockerfile-arch
@@ -27,6 +27,7 @@ RUN pacman --noconfirm -Syu \
     cpio \
     dhcp \
     dmraid \
+    dnsmasq \
     dracut \
     elfutils \
     erofs-utils \

--- a/test/container/Dockerfile-azurelinux
+++ b/test/container/Dockerfile-azurelinux
@@ -18,6 +18,7 @@ RUN tdnf -y install --setopt=install_weak_deps=False \
     cifs-utils \
     cryptsetup \
     dhcpcd \
+    dnsmasq \
     e2fsprogs \
     fuse3 \
     gcc \

--- a/test/container/Dockerfile-debian
+++ b/test/container/Dockerfile-debian
@@ -42,6 +42,7 @@ RUN \
     cpio \
     cryptsetup \
     curl \
+    dnsmasq \
     docbook \
     docbook-xml \
     docbook-xsl \

--- a/test/container/Dockerfile-fedora
+++ b/test/container/Dockerfile-fedora
@@ -49,6 +49,7 @@ RUN dnf -y install --setopt=install_weak_deps=False \
     cryptsetup \
     crypto-policies-scripts \
     device-mapper-multipath \
+    dnsmasq \
     dracut-live \
     e2fsprogs \
     erofs-utils \

--- a/test/container/Dockerfile-gentoo
+++ b/test/container/Dockerfile-gentoo
@@ -47,6 +47,7 @@ emerge --quiet --deep --autounmask-continue=y --with-bdeps=n --noreplace \
     app-emulation/qemu \
     app-portage/gentoolkit \
     dev-ruby/asciidoctor \
+    net-dns/dnsmasq \
     sys-kernel/dracut \
     sys-kernel/gentoo-kernel-bin \
     sys-libs/libxcrypt \

--- a/test/container/Dockerfile-opensuse
+++ b/test/container/Dockerfile-opensuse
@@ -20,6 +20,7 @@ RUN zypper --non-interactive install --no-recommends \
     cryptsetup \
     dhcp-client \
     dhcp-server \
+    dnsmasq \
     distribution-gpg-keys \
     e2fsprogs \
     erofs-utils \

--- a/test/container/Dockerfile-void
+++ b/test/container/Dockerfile-void
@@ -30,6 +30,7 @@ RUN xbps-install -Syu xbps && xbps-install -yu \
     cryptsetup \
     dhclient \
     dhcp \
+    dnsmasq \
     e2fsprogs \
     edk2-ovmf \
     elfutils \


### PR DESCRIPTION
## Changes

The motivation to remove dhclient is to make sure that dracut networking does not need dhclient (when used with network-manager or systemd-networkd).

Add dnsmasq to prepare to change the test cases to use dnsmasq.

## Checklist
- [ ] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it

Fixes partially #1451 #686
