### PR TITLE
ci: use filesystems instead of drivers argument

### DIFF
--- a/dracut.conf.d/test-makeroot/test-makeroot.conf
+++ b/dracut.conf.d/test-makeroot/test-makeroot.conf
@@ -7,6 +7,7 @@ early_microcode="no"
 hostonly="no"
 stdloglvl=2
 mdadmconf="no"
+filesystems+=" ext4 "
 
 # testsuite assumes the following drivers for convenience
-add_drivers+=" ext4 sd_mod "
+add_drivers+=" sd_mod "

--- a/dracut.conf.d/test-root/test-root.conf
+++ b/dracut.conf.d/test-root/test-root.conf
@@ -7,6 +7,7 @@ early_microcode="no"
 hostonly="no"
 stdloglvl=2
 keep=yes
+filesystems+=" ext4 "
 
 # testsuite assumes the following drivers for convenience
-add_drivers+=" ext4 sd_mod "
+add_drivers+=" sd_mod "

--- a/dracut.conf.d/test/test.conf
+++ b/dracut.conf.d/test/test.conf
@@ -3,5 +3,7 @@ add_dracutmodules+=" qemu "
 # test the dlopen dependencies support
 add_dlopen_features+=" libsystemd-shared-*.so:fido2 "
 
+filesystems+=" ext4 "
+
 # testsuite assumes the following drivers for convenience
-add_drivers+=" ext4 sd_mod "
+add_drivers+=" sd_mod "

--- a/test/TEST-11-USR-MOUNT/test.sh
+++ b/test/TEST-11-USR-MOUNT/test.sh
@@ -82,7 +82,7 @@ test_setup() {
     fi
 
     test_dracut \
-        --add-drivers "btrfs"
+        --filesystems " btrfs "
 }
 
 # shellcheck disable=SC1090

--- a/test/TEST-42-SYSTEMD-INITRD/test.sh
+++ b/test/TEST-42-SYSTEMD-INITRD/test.sh
@@ -75,7 +75,8 @@ test_setup() {
         --no-compress \
         --kernel-only \
         -m "kernel-modules qemu" \
-        -d "ext4 sd_mod" \
+        --filesystems="ext4" \
+        -d "sd_mod" \
         -f "$TESTDIR"/initramfs-test
 
     # vanilla kernel-independent systemd-based minimal initrd without dracut specific customizations


### PR DESCRIPTION
To provide coverage for the `filesystems` dracut option and make the tests more readable, switch to `filesystems` where appropriate.

## Checklist
- [ ] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it

