### PR TITLE
feat(overlayfs): create overlayfs only if rootfs is read-only

### DIFF
--- a/modules.d/70overlayfs/mount-overlayfs.sh
+++ b/modules.d/70overlayfs/mount-overlayfs.sh
@@ -4,8 +4,26 @@ command -v getarg > /dev/null || . /lib/dracut-lib.sh
 
 getargbool 0 rd.live.overlay.overlayfs && overlayfs="yes"
 getargbool 0 rd.live.overlay.readonly && readonly_overlay="--readonly" || readonly_overlay=""
+getargbool 0 rd.overlay.auto && auto_overlay="yes" && overlayfs="yes"
 
 if [ -n "$overlayfs" ]; then
+    OPT=
+    FS=
+
+    boot_dev=$(findmnt --mountpoint "$NEWROOT" -o OPTIONS,FSTYPE -n)
+
+    while IFS= read -r OPT FS; do
+        printf '%s\n' "Processing: $OPT $FS"
+    done < "$boot_dev"
+
+    if [ -n "$auto_overlay" ] && [ "$FS" = "btrfs" ] && [ "$(btrfs property get "${NEWROOT}" ro)" = "ro=true" ]; then
+        return 0
+    fi
+
+    if [ -n "$auto_overlay" ] && [ "$OPT" = "rw" ]; then
+        return 0
+    fi
+
     if [ -n "$readonly_overlay" ] && [ -h /run/overlayfs-r ]; then
         ovlfs=lowerdir=/run/overlayfs-r:/run/rootfsbase
     else

--- a/test/TEST-11-USR-MOUNT/test.sh
+++ b/test/TEST-11-USR-MOUNT/test.sh
@@ -29,7 +29,7 @@ client_run() {
     test_marker_reset
     "$testdir"/run-qemu \
         "${disk_args[@]}" \
-        -append "$TEST_KERNEL_CMDLINE $client_opts" \
+        -append "$TEST_KERNEL_CMDLINE $client_opts rd.overlay.auto" \
         -initrd "$TESTDIR"/initramfs.testing
 
     if ! test_marker_check; then
@@ -82,6 +82,7 @@ test_setup() {
     fi
 
     test_dracut \
+        -a overlayfs \
         --add-drivers "btrfs"
 }
 


### PR DESCRIPTION
Check if rootfs is mounted read-only (regalrdless of the reason) and create an in-memory non-persistent overlayfs automatically.

## Checklist
- [ ] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it

Fixes #
