### PR TITLE
test(NFS): enable tests when dhclient is not available

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -171,11 +171,11 @@ jobs:
             matrix:
                 container:
                     - arch:latest
-                    - debian:latest
                     - fedora:latest
-                    - gentoo:latest
                     - opensuse:latest
                     - ubuntu:devel
+                network:
+                    - network-manager
                 test:
                     - "60"
         container:

--- a/test/TEST-60-NFS/test.sh
+++ b/test/TEST-60-NFS/test.sh
@@ -227,7 +227,7 @@ test_run() {
 test_setup() {
     "$DRACUT" --tmpdir "$TESTDIR" \
         --add-confdir test-root \
-        -a "url-lib nfs" \
+        -a "$USE_NETWORK url-lib nfs" \
         -I "ip grep setsid" \
         -f "$TESTDIR"/initramfs.root || return 1
 


### PR DESCRIPTION
`$USE_NETWORK` dracut module needs to be added explicitly when networking is required.

Follow-up to 16b5e37 .

## Checklist
- [ ] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it

Fixes #
