### PR TITLE
ci(debian): make sure ip command is available

### DIFF
--- a/test/container/Dockerfile-debian
+++ b/test/container/Dockerfile-debian
@@ -53,6 +53,7 @@ RUN \
     gpg \
     iputils-arping \
     iputils-ping \
+    iproute2 \
     isc-dhcp-server \
     jq \
     kbd \


### PR DESCRIPTION
`ip` command is required for networking. On Ubuntu `ip` command is already installed but on debian this requires and explicit installation of the `iproute2` package.

## Checklist
- [ ] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it

Fixes #
