### PR TITLE
fix(dracut): add support for kernel name Image

### DIFF
--- a/dracut.sh
+++ b/dracut.sh
@@ -1710,7 +1710,8 @@ if [[ ! $print_cmdline ]]; then
 
         if ! [[ $kernel_image ]]; then
             for kernel_image in "${dracutsysrootdir-}/lib/modules/$kernel/vmlinuz" "${dracutsysrootdir-}/boot/vmlinuz-$kernel" \
-                "${dracutsysrootdir-}/lib/modules/$kernel/vmlinux" "${dracutsysrootdir-}/boot/vmlinux-$kernel"; do
+                "${dracutsysrootdir-}/lib/modules/$kernel/vmlinux" "${dracutsysrootdir-}/boot/vmlinux-$kernel" \
+                "${dracutsysrootdir-}/lib/modules/$kernel/Image"; do
                 [[ -s $kernel_image ]] || continue
                 break
             done

--- a/test/run-qemu
+++ b/test/run-qemu
@@ -15,6 +15,10 @@ set_vmlinux_env() {
         fi
 
         if ! [ -f "$VMLINUZ" ]; then
+            VMLINUZ="/lib/modules/${KVERSION}/Image"
+        fi
+
+        if ! [ -f "$VMLINUZ" ]; then
             [[ -f /etc/machine-id ]] && read -r MACHINE_ID < /etc/machine-id
 
             if [[ ${MACHINE_ID-} ]] && { [[ -d /boot/${MACHINE_ID} ]] || [[ -L /boot/${MACHINE_ID} ]]; }; then
@@ -33,6 +37,7 @@ set_vmlinux_env() {
 
     ! [ -f "${VMLINUZ-}" ] && VMLINUZ=$(find /boot/vmlinuz-* -type f 2> /dev/null | tail -1)
     ! [ -f "${VMLINUZ-}" ] && VMLINUZ=$(find /lib/modules/ -type f -name vmlinuz 2> /dev/null | tail -1)
+    ! [ -f "${VMLINUZ-}" ] && VMLINUZ=$(find /lib/modules/ -type f -name Image 2> /dev/null | tail -1)
 
     if ! [ -f "$VMLINUZ" ]; then
         echo "Could not find a Linux kernel version to test with!" >&2


### PR DESCRIPTION
On some architectures (arm64) the name of the kernel file is usually Image. Add support for it instead of working around it.

## Checklist
- [ ] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it

Fixes #
