### PR TITLE
fix(virtfs, virtiofs): dracut module should not delete rootfs files

### DIFF
--- a/modules.d/74virtfs/mount-virtfs.sh
+++ b/modules.d/74virtfs/mount-virtfs.sh
@@ -64,8 +64,6 @@ mount_root() {
     info "Remounting ${root#virtfs:} with -o ${rflags}"
     mount -t ${rootfs} -o "$rflags" "${root#virtfs:}" "$NEWROOT" 2>&1 | vinfo
 
-    [ -f "$NEWROOT"/forcefsck ] && rm -f -- "$NEWROOT"/forcefsck 2> /dev/null
-    [ -f "$NEWROOT"/.autofsck ] && rm -f -- "$NEWROOT"/.autofsck 2> /dev/null
 }
 
 if [ -n "$root" ] && [ -z "${root%%virtfs:*}" ]; then

--- a/modules.d/74virtiofs/mount-virtiofs.sh
+++ b/modules.d/74virtiofs/mount-virtiofs.sh
@@ -13,8 +13,5 @@ if [ "${fstype}" = "virtiofs" ] || [ "${root%%:*}" = "virtiofs" ]; then
     fi
 
     info "virtiofs: root fs mounted (options: '${rflags}')"
-
-    [ -f "$NEWROOT"/forcefsck ] && rm -f -- "$NEWROOT"/forcefsck 2> /dev/null
-    [ -f "$NEWROOT"/.autofsck ] && rm -f -- "$NEWROOT"/.autofsck 2> /dev/null
 fi
 :


### PR DESCRIPTION
Dracut built-in modules should not delete files from rootfs.

Follow-up to 8d2a6d2 .

## Checklist
- [ ] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it


