### PR TITLE
fix(doc): correct spelling mistake of recommended

### DIFF
--- a/man/dracut.8.adoc
+++ b/man/dracut.8.adoc
@@ -786,7 +786,7 @@ _/etc/cmdline_::
     /etc/cmdline.d/*.conf.
 
 _/etc/cmdline.d/*.conf_::
-    Can contain additional command line options. It is recomended to use an
+    Can contain additional command line options. It is recommended to use an
     ordering schema for these conf files in the range of 50-59.
     Dracut generated conf files are placed in the 10-49 and 60-99 ordering range.
 


### PR DESCRIPTION
## Changes

Correct spelling mistake of `recommended`.

## Checklist
- [ ] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it

Fixes #
