### PR TITLE
feat(dracut): print the computed configuration and exit

### DIFF
--- a/dracut.sh
+++ b/dracut.sh
@@ -276,6 +276,7 @@ Creates initial ramdisk images for preloading modules
                          build.
   --keep                Keep the temporary initramfs for debugging purposes.
   --printsize           Print out the module install size.
+  --printconfig         Print the computed configuration and exit.
   --sshkey [SSHKEY]     Add SSH key to initramfs (use with ssh-client module).
   --logfile [FILE]      Logfile to use (overrides configuration setting).
   --reproducible        Create reproducible images.
@@ -467,6 +468,7 @@ rearrange_params() {
             --long show-modules \
             --long keep \
             --long printsize \
+            --long printconfig \
             --long regenerate-all \
             --long parallel \
             --long noimageifnotneeded \
@@ -881,6 +883,7 @@ while :; do
             ;;
         --keep) keep="yes" ;;
         --printsize) printsize="yes" ;;
+        --printconfig) printconfig="yes" ;;
         --regenerate-all) regenerate_all_l="yes" ;;
         -p | --parallel) parallel_l="yes" ;;
         --noimageifnotneeded) noimageifnotneeded="yes" ;;
@@ -1964,6 +1967,42 @@ export initdir dracutbasedir \
     prefix filesystems drivers \
     hostonly_cmdline loginstall \
     squashdir squash_compress
+
+if [[ $printconfig ]]; then
+    for v in add_dracutmodules \
+        add_fstab \
+        debug \
+        dracutmodules \
+        drivers \
+        fileloglvl \
+        filesystems \
+        force_add_dracutmodules \
+        fscks \
+        fw_dir \
+        hostonly_cmdline \
+        kernel_only \
+        kmsgloglvl \
+        libdirs \
+        logfile \
+        loginstall \
+        lvmconf \
+        mdadmconf \
+        no_kernel \
+        nofscks \
+        omit_dracutmodules \
+        omit_drivers \
+        prefix \
+        ro_mnt \
+        squash_compress \
+        sshkey \
+        use_fstab; do
+        if [[ -n ${!v} ]]; then
+            echo "dracutconfig: $v=${!v}"
+        fi
+    done
+
+    exit 0
+fi
 
 mods_to_load=""
 # check all our modules to see if they should be sourced.

--- a/man/dracut.8.adoc
+++ b/man/dracut.8.adoc
@@ -578,6 +578,9 @@ will not be able to boot. Equivalent to "--compress=zstd -15 -q -T0".
 **--keep**::
     Keep the initramfs temporary directory for debugging purposes.
 
+**--printconfig**::
+    Print the computed configuration and exit.
+
 **--printsize**::
     Print out the module install size.
 

--- a/shell-completion/bash/dracut
+++ b/shell-completion/bash/dracut
@@ -37,7 +37,7 @@ _dracut() {
             --enhanced-cpio --rebuild --aggressive-strip --hostonly-cmdline
             --no-hostonly-cmdline --no-hostonly-default-device --nofscks
             --hostonly-i18n --no-hostonly-i18n --lzo --lz4 --no-reproducible
-            --no-uefi --no-machineid --version --parallel
+            --no-uefi --no-machineid --version --parallel --printconfig
             '
         [ARG]='-a -m -o -d -I -k -c -L -r -i
             --kver --add --force-add --add-drivers --force-drivers


### PR DESCRIPTION
Dracut is able to inspect the host and auto-determine the best configuration and compine the computed configurtion with the distribution and user configuration.

Since dracut does not have a dry-run option, there is no good option for an external tool to determine if a dracut invocaton will result in creating initramfs in hostonly or non-hostonly mode.

Add a command line option that is meant to just compute the current dracut configuration, print it out and exit.

## Checklist
- [ ] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it

