### PR TITLE
ci(opensuse): remove workaround for a sym link

### DIFF
--- a/test/container/Dockerfile-opensuse
+++ b/test/container/Dockerfile-opensuse
@@ -59,8 +59,3 @@ RUN zypper --non-interactive install --no-recommends \
     xorriso \
     zstd \
     && zypper --non-interactive dist-upgrade --no-recommends
-
-# workaround for openSUSE on arm64
-RUN \
-    KVERSION="$(cd /lib/modules && ls -1 | tail -1)" \
-    && if [ "$(arch)"="aarch64" ] && [ -e /usr/lib/modules/"$KVERSION"/Image ]; then ln -sf /usr/lib/modules/"$KVERSION"/Image /usr/lib/modules/"$KVERSION"/vmlinuz; fi


### PR DESCRIPTION
The sym link to the kernel Image workaround is no longer needed for arm64, as df93355 is landed.

## Checklist
- [ ] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it


