### PR TITLE
ci(test-root): ext4 driver for test root is coming from the test initrd

### DIFF
--- a/dracut.conf.d/test-root/test-root.conf
+++ b/dracut.conf.d/test-root/test-root.conf
@@ -7,6 +7,3 @@ early_microcode="no"
 hostonly="no"
 stdloglvl=2
 keep=yes
-
-# testsuite assumes the following drivers for convenience
-add_drivers+=" ext4 "


### PR DESCRIPTION
Partail revert of 6d1a898. The ext4 driver does not need to be forced (and is not needed) for the rootfs that the test case is booting into.

## Checklist
- [ ] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it

Fixes #
