### PR TITLE
fix: partial revert for hostonly sloppy mode

### DIFF
--- a/modules.d/11systemd-cryptsetup/module-setup.sh
+++ b/modules.d/11systemd-cryptsetup/module-setup.sh
@@ -6,7 +6,7 @@ check() {
     # if cryptsetup is not installed, then we cannot support encrypted devices.
     require_binaries "$systemdutildir"/systemd-cryptsetup || return 1
 
-    [[ $hostonly_mode == "strict" ]] || [[ $mount_needs ]] && {
+    [[ $hostonly ]] || [[ $mount_needs ]] && {
         for fs in "${host_fs_types[@]}"; do
             [[ $fs == "crypto_LUKS" ]] && return 0
         done

--- a/modules.d/70btrfs/module-setup.sh
+++ b/modules.d/70btrfs/module-setup.sh
@@ -6,7 +6,7 @@ check() {
     # no point in trying to support it in the initramfs.
     require_binaries btrfs || return 1
 
-    [[ $hostonly_mode == "strict" ]] || [[ $mount_needs ]] && {
+    [[ $hostonly ]] || [[ $mount_needs ]] && {
         for fs in "${host_fs_types[@]}"; do
             [[ $fs == "btrfs" ]] && return 0
         done

--- a/modules.d/70crypt/module-setup.sh
+++ b/modules.d/70crypt/module-setup.sh
@@ -6,7 +6,7 @@ check() {
     # if cryptsetup is not installed, then we cannot support encrypted devices.
     require_any_binary "$systemdutildir"/systemd-cryptsetup cryptsetup || return 1
 
-    [[ $hostonly_mode == "strict" ]] || [[ $mount_needs ]] && {
+    [[ $hostonly ]] || [[ $mount_needs ]] && {
         for fs in "${host_fs_types[@]}"; do
             [[ $fs == "crypto_LUKS" ]] && return 0
         done

--- a/modules.d/70dmraid/module-setup.sh
+++ b/modules.d/70dmraid/module-setup.sh
@@ -10,7 +10,7 @@ check() {
     require_binaries dmraid || return 1
     require_binaries kpartx || return 1
 
-    [[ $hostonly_mode == "strict" ]] || [[ $mount_needs ]] && {
+    [[ $hostonly ]] || [[ $mount_needs ]] && {
         for dev in "${!host_fs_types[@]}"; do
             [[ ${host_fs_types[$dev]} != *_raid_member ]] && continue
 

--- a/modules.d/70lvm/module-setup.sh
+++ b/modules.d/70lvm/module-setup.sh
@@ -5,7 +5,7 @@ check() {
     # No point trying to support lvm if the binaries are missing
     require_binaries lvm grep || return 1
 
-    [[ $hostonly_mode == "strict" ]] || [[ $mount_needs ]] && {
+    [[ $hostonly ]] || [[ $mount_needs ]] && {
         for fs in "${host_fs_types[@]}"; do
             [[ $fs == LVM*_member ]] && return 0
         done

--- a/modules.d/70mdraid/module-setup.sh
+++ b/modules.d/70mdraid/module-setup.sh
@@ -7,7 +7,7 @@ check() {
     # No mdadm?  No mdraid support.
     require_binaries mdadm expr || return 1
 
-    [[ $hostonly_mode == "strict" ]] || [[ $mount_needs ]] && {
+    [[ $hostonly ]] || [[ $mount_needs ]] && {
         for dev in "${!host_fs_types[@]}"; do
             [[ ${host_fs_types[$dev]} != *_raid_member ]] && continue
 

--- a/modules.d/70multipath/module-setup.sh
+++ b/modules.d/70multipath/module-setup.sh
@@ -25,7 +25,7 @@ check() {
     require_binaries multipath || return 1
     require_binaries kpartx || return 1
 
-    [[ $hostonly_mode == "strict" ]] || [[ $mount_needs ]] && {
+    [[ $hostonly ]] || [[ $mount_needs ]] && {
         for_each_host_dev_and_slaves is_mpath || return 255
     }
 

--- a/modules.d/70qemu-net/module-setup.sh
+++ b/modules.d/70qemu-net/module-setup.sh
@@ -4,7 +4,7 @@
 check() {
     is_qemu_virtualized && return 0
 
-    if [[ $hostonly_mode == "strict" ]] || [[ $mount_needs ]]; then
+    if [[ $hostonly ]] || [[ $mount_needs ]]; then
         return 255
     fi
 

--- a/modules.d/70qemu/module-setup.sh
+++ b/modules.d/70qemu/module-setup.sh
@@ -4,7 +4,7 @@
 check() {
     is_qemu_virtualized && return 0
 
-    if [[ $hostonly_mode == "strict" ]] || [[ $mount_needs ]]; then
+    if [[ $hostonly ]] || [[ $mount_needs ]]; then
         return 255
     fi
 

--- a/modules.d/74cifs/module-setup.sh
+++ b/modules.d/74cifs/module-setup.sh
@@ -5,7 +5,7 @@ check() {
     # If our prerequisites are not met, fail anyways.
     require_binaries mount.cifs || return 1
 
-    [[ $hostonly_mode == "strict" ]] || [[ $mount_needs ]] && {
+    [[ $hostonly ]] || [[ $mount_needs ]] && {
         for fs in "${host_fs_types[@]}"; do
             [[ $fs == "cifs" ]] && return 0
         done

--- a/modules.d/74fcoe-uefi/module-setup.sh
+++ b/modules.d/74fcoe-uefi/module-setup.sh
@@ -7,7 +7,7 @@ check() {
         block_is_fcoe "$1" || return 1
     }
 
-    [[ $hostonly_mode == "strict" ]] || [[ $mount_needs ]] && {
+    [[ $hostonly ]] || [[ $mount_needs ]] && {
         for_each_host_dev_and_slaves is_fcoe || return 255
         [ -d /sys/firmware/efi ] || return 255
     }

--- a/modules.d/74fcoe/module-setup.sh
+++ b/modules.d/74fcoe/module-setup.sh
@@ -7,7 +7,7 @@ check() {
         block_is_fcoe "$1" || return 1
     }
 
-    [[ $hostonly_mode == "strict" ]] || [[ $mount_needs ]] && {
+    [[ $hostonly ]] || [[ $mount_needs ]] && {
         for_each_host_dev_and_slaves is_fcoe || return 255
     }
 

--- a/modules.d/74hwdb/module-setup.sh
+++ b/modules.d/74hwdb/module-setup.sh
@@ -3,7 +3,7 @@
 # SPDX-License-Identifier: GPL-2.0-or-later
 
 check() {
-    if [[ $hostonly_mode == "strict" ]]; then
+    if [[ $hostonly ]]; then
         return 255
     fi
 

--- a/modules.d/74iscsi/module-setup.sh
+++ b/modules.d/74iscsi/module-setup.sh
@@ -6,9 +6,9 @@ check() {
     require_binaries iscsi-iname iscsiadm iscsid || return 1
     require_kernel_modules iscsi_tcp || return 1
 
-    # If hostonly strict was requested, fail the check if we are not actually
+    # If hostonly was requested, fail the check if we are not actually
     # booting from root.
-    [[ $hostonly_mode == "strict" ]] || [[ $mount_needs ]] && {
+    [[ $hostonly ]] || [[ $mount_needs ]] && {
         pushd . > /dev/null
         for_each_host_dev_and_slaves block_is_iscsi
         local _is_iscsi=$?

--- a/modules.d/74lunmask/module-setup.sh
+++ b/modules.d/74lunmask/module-setup.sh
@@ -45,7 +45,7 @@ cmdline() {
 
 # called by dracut
 check() {
-    [[ $hostonly_mode == "strict" ]] || [[ $mount_needs ]] && {
+    [[ $hostonly ]] || [[ $mount_needs ]] && {
         [ -w /sys/module/scsi_mod/parameters/scan ] || return 255
         read -r scan_type < /sys/module/scsi_mod/parameters/scan
         [ "$scan_type" = "manual" ] && return 0

--- a/modules.d/74nbd/module-setup.sh
+++ b/modules.d/74nbd/module-setup.sh
@@ -6,7 +6,7 @@ check() {
 
     # if an nbd device is not somewhere in the chain of devices root is
     # mounted on, fail the hostonly check.
-    [[ $hostonly_mode == "strict" ]] || [[ $mount_needs ]] && {
+    [[ $hostonly ]] || [[ $mount_needs ]] && {
         _rootdev=$(find_root_block_device)
         [[ -b /dev/block/$_rootdev ]] || return 1
         check_block_and_slaves block_is_nbd "$_rootdev" || return 255

--- a/modules.d/74nfs/module-setup.sh
+++ b/modules.d/74nfs/module-setup.sh
@@ -23,7 +23,7 @@ check() {
     require_any_binary rpcbind portmap || return 1
     require_binaries rpc.statd mount.nfs mount.nfs4 umount sed chmod chown || return 1
 
-    [[ $hostonly_mode == "strict" ]] || [[ $mount_needs ]] && {
+    [[ $hostonly ]] || [[ $mount_needs ]] && {
         [[ "$(get_nfs_type)" ]] && return 0
         return 255
     }

--- a/modules.d/74nvmf/module-setup.sh
+++ b/modules.d/74nvmf/module-setup.sh
@@ -42,7 +42,7 @@ check() {
         [[ $found ]]
     }
 
-    [[ $hostonly_mode == "strict" ]] || [[ $mount_needs ]] && {
+    [[ $hostonly ]] || [[ $mount_needs ]] && {
         [ -f /etc/nvme/hostnqn ] || return 255
         [ -f /etc/nvme/hostid ] || return 255
         pushd . > /dev/null

--- a/modules.d/74virtiofs/module-setup.sh
+++ b/modules.d/74virtiofs/module-setup.sh
@@ -2,7 +2,7 @@
 
 # called by dracut
 check() {
-    [[ $hostonly_mode == "strict" ]] || [[ $mount_needs ]] && {
+    [[ $hostonly ]] || [[ $mount_needs ]] && {
         is_qemu_virtualized && return 0
 
         for fs in "${host_fs_types[@]}"; do


### PR DESCRIPTION
This commit is a _partial_ revert of 8519dcd.

The goal of this commit is to have the same dracut modules included in both `sloppy` and in `strict` mode, but the dracut modules themselves might install more kernel modules depending on the `hostonly_mode` value.

Changes in other areas of the code (e.g. changes inside `installkernel`) were not reverted as they require more discussions and agreement by the community.

As an example the `crypt` dracut module could potentially copy more kernel modules into the generated initramfs in `sloppy` `hostonly_mode` mode than in `strict` `hostonly` mode.

## Checklist
- [ ] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it

CC @pvalena @AdamWill @lnykryn @Conan-Kudo

Related issue https://github.com/dracut-ng/dracut-ng/issues/748
