### PR TITLE
fix(dracut.sh): check that custom fw search patch exists before reading it

### DIFF
--- a/dracut.sh
+++ b/dracut.sh
@@ -1143,7 +1143,8 @@ drivers_dir="${drivers_dir%"${drivers_dir##*[!/]}"}"
 [[ $lvmconf_l ]] && lvmconf=$lvmconf_l
 [[ $dracutbasedir ]] || dracutbasedir="${dracutsysrootdir-}"/usr/lib/dracut
 [[ $fw_dir ]] || {
-    fw_path_para=$(< /sys/module/firmware_class/parameters/path)
+    [[ -e /sys/module/firmware_class/parameters/path ]] \
+        && fw_path_para=$(< /sys/module/firmware_class/parameters/path)
     fw_dir="${fw_path_para:+${dracutsysrootdir-}$fw_path_para:}${dracutsysrootdir-}/lib/firmware/updates/$kernel:${dracutsysrootdir-}/lib/firmware/updates:${dracutsysrootdir-}/lib/firmware/$kernel:${dracutsysrootdir-}/lib/firmware"
 }
 [[ $tmpdir_l ]] && tmpdir="$tmpdir_l"


### PR DESCRIPTION
It may not exist, for example, when using an image builder like kiwi:

```
[ DEBUG   ]: 07:58:22 | /usr/bin/dracut: line 1095: /sys/module/firmware_class/parameters/path: No such file or directory
```

## Checklist
- [ ] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it
