### PR TITLE
ci: increase release cadence from 3 to 2 month

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,8 +3,8 @@ name: Release
 
 on:  # yamllint disable-line rule:truthy
   schedule:
-    ## Schedule the job quarterly to run on Feb-1, May-1, Aug-1, and Nov-1
-    - cron: '0 0 1 FEB,MAY,AUG,NOV *'
+    ## Schedule the job every two months to run on the first of each even month
+    - cron: '0 0 1 FEB,APR,JUN,AUG,OCT,DEC *'
   workflow_dispatch:
     inputs:
       tag:


### PR DESCRIPTION
## Changes

The current release schedule of Dracut is time based every three months. The git main branch should be in a releasable state all the time. There are currently no point releases for Dracut. Distributions/users need to cherry-pick relevant fixes for their own or wait for the next release.

The release cadence for relevant other projects: The Linux kernel releases every 9-10 weeks normally. Systemd tries to have two releases per year.

Our development process allows to release early, release often. Increase the release cadence from three to two months. This way we make (rolling) distributions happy that are quick in introducing new upstream releases. Distributions that do not want to package Dracut updates every two months can simply skip some Dracut releases.

We could decide in the future to start releasing point releases with cherry-picked fixes.

@LaszloGombos and @Conan-Kudo what do you think?

## Checklist
- [ ] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it

Fixes: https://github.com/dracut-ng/dracut-ng/issues/1519
