### PR TITLE
fix(systemd): add compatibility with systemd v258

### DIFF
--- a/modules.d/10systemd/module-setup.sh
+++ b/modules.d/10systemd/module-setup.sh
@@ -77,6 +77,10 @@ install() {
         "$systemdsystemunitdir"/paths.target \
         "$systemdsystemunitdir"/umount.target \
         "$systemdsystemunitdir"/sys-kernel-config.mount \
+        "$systemdsystemunitdir"/breakpoint-pre-basic.service \
+        "$systemdsystemunitdir"/breakpoint-pre-udev.service \
+        "$systemdsystemunitdir"/breakpoint-pre-mount.service \
+        "$systemdsystemunitdir"/breakpoint-pre-switch-root.service \
         "$systemdsystemunitdir"/systemd-halt.service \
         "$systemdsystemunitdir"/systemd-poweroff.service \
         "$systemdsystemunitdir"/systemd-reboot.service \


### PR DESCRIPTION
Add breakpoint units for the newly-introduced systemd.break= functionality.

Reference: systemd/systemd#35410

## Checklist
- [ ] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it

Fixes (partially): https://github.com/dracut-ng/dracut-ng/issues/1677
