### PR TITLE
feat(debian): add additional dracut modules for more flexibility

### DIFF
--- a/dracut.conf.d/debian/01-debian.conf
+++ b/dracut.conf.d/debian/01-debian.conf
@@ -1,3 +1,6 @@
 # Debian/Ubuntu specific Dracut configuration
 i18n_vars="/etc/locale.conf:LANG /etc/default/console-setup:FONT,FONT_MAP,CONSOLE_MAP-FONT_UNIMAP /etc/default/keyboard:XKBLAYOUT-KEYMAP,XKBVARIANT-EXT_KEYMAPS"
 initrdname="initrd.img-${kernel}"
+
+# users can move installations from bare metal to VMs and the other way around
+add_dracutmodules+=" qemu "


### PR DESCRIPTION
On Debian the policy is for users users to allow move installations from bare metal to VMs and the other way around.   

## Checklist
- [ ] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it

Fixes #748

CC @bdrung @ArrayBolt3 @adrelanos @dracut-ng/debian-maint 
