### PR TITLE
fix(systemd): make dbus optional dependency

### DIFF
--- a/modules.d/11systemd-hostnamed/module-setup.sh
+++ b/modules.d/11systemd-hostnamed/module-setup.sh
@@ -20,7 +20,7 @@ check() {
 depends() {
 
     # This module has external dependency on other module(s).
-    echo dbus systemd-sysusers
+    echo systemd-sysusers
     # Return 0 to include the dependent module(s) in the initramfs.
     return 0
 

--- a/modules.d/11systemd-portabled/module-setup.sh
+++ b/modules.d/11systemd-portabled/module-setup.sh
@@ -19,8 +19,6 @@ check() {
 # Module dependency requirements.
 depends() {
 
-    # This module has external dependency on other module(s).
-    echo dbus
     # Return 0 to include the dependent module(s) in the initramfs.
     return 0
 

--- a/modules.d/11systemd-resolved/module-setup.sh
+++ b/modules.d/11systemd-resolved/module-setup.sh
@@ -20,7 +20,7 @@ check() {
 depends() {
 
     # This module has external dependency on other module(s).
-    echo dbus systemd-sysusers
+    echo systemd-sysusers
     # Return 0 to include the dependent module(s) in the initramfs.
     return 0
 

--- a/modules.d/11systemd-timedated/module-setup.sh
+++ b/modules.d/11systemd-timedated/module-setup.sh
@@ -19,8 +19,6 @@ check() {
 # Module dependency requirements.
 depends() {
 
-    # This module has external dependency on other module(s).
-    echo dbus
     # Return 0 to include the dependent module(s) in the initramfs.
     return 0
 

--- a/modules.d/11systemd-timesyncd/module-setup.sh
+++ b/modules.d/11systemd-timesyncd/module-setup.sh
@@ -20,7 +20,7 @@ check() {
 depends() {
 
     # This module has external dependency on other module(s).
-    echo dbus systemd-sysusers systemd-timedated
+    echo systemd-sysusers systemd-timedated
     # Return 0 to include the dependent module(s) in the initramfs.
     return 0
 


### PR DESCRIPTION
## Changes

Remove `dbus` as a mandatory dependency for the following dracut modules
 - systemd-hostnamed
 - systemd-portabled
 - systemd-resolved
 - systemd-timedated
 - systemd-timesyncd

Users and distributions can still include dbus dracut module in the initramfs as before, but now dbus dracut module is required to be explicitly added in the dracut configuration.

The motivation of this change is to allow users and distributions to exclude dbus from the initramfs.

Related
 - https://github.com/dracut-ng/dracut-ng/issues/1677#issuecomment-3309938622
 - https://github.com/dracut-ng/dracut-ng/issues/60

## Checklist
- [ ] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it

Fixes #
