### PR TITLE
test(NFS): include pidof command in server root fs

### DIFF
--- a/test/TEST-60-NFS/test.sh
+++ b/test/TEST-60-NFS/test.sh
@@ -238,7 +238,7 @@ test_setup() {
         --add-confdir test-root \
         -a "bash $USE_NETWORK nfs" \
         --add-drivers "nfsd sunrpc lockd" \
-        -I "exportfs rpc.nfsd rpc.mountd dhcpd" \
+        -I "exportfs pidof rpc.nfsd rpc.mountd dhcpd" \
         --install-optional "/etc/netconfig /etc/nsswitch.conf /etc/rpc /etc/protocols /etc/services /usr/etc/nsswitch.conf /usr/etc/rpc /usr/etc/protocols /usr/etc/services rpc.idmapd /etc/idmapd.conf" \
         -i "./dhcpd.conf" "/etc/dhcpd.conf" \
         -f "$TESTDIR"/initramfs.root


### PR DESCRIPTION
## Changes

The `server-init.sh` script calls `pidof rpc.idmapd` and therefore the `pidof` command is needed in the server root file system.

## Checklist
- [x] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it

Fixes #
