### PR TITLE
ci(debian): install packages recommended by packaging

### DIFF
--- a/test/container/Dockerfile-debian
+++ b/test/container/Dockerfile-debian
@@ -23,7 +23,7 @@ ARG DISTRIBUTION
 ENV V=2
 
 # Install dracut as a linux-initramfs-tool provider so that the default initramfs-tool package does not get installed
-RUN apt-get update -y -qq && apt-get upgrade -y -qq && apt-get install -y -qq --no-install-recommends dracut
+RUN apt-get update -y -qq && apt-get upgrade -y -qq && apt-get install -y -qq --install-recommends dracut dracut-network dracut-squash dracut-live
 
 # Install 3cpio where available
 RUN if [ "$DISTRIBUTION" != "debian:latest" ] ; then \


### PR DESCRIPTION
## Changes

Install all package dependencies based on downstream packaging.

This commit ensures that we do not miss some dowsntream package dependencies here upstream.


## Checklist
- [ ] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it

Fixes #
