### PR TITLE
test(USR-MOUNT): add a test step to mount read-only btrfs snapshot

### DIFF
--- a/test/TEST-11-USR-MOUNT/create-root.sh
+++ b/test/TEST-11-USR-MOUNT/create-root.sh
@@ -12,6 +12,8 @@ btrfs subvolume create /root/usr
 cp -a -t /root /source/*
 mkdir -p /root/run
 btrfs filesystem sync /root
+# read-only snapshot of /root
+btrfs subvolume snapshot -r /root /root/snapshot-root
 umount /root
 echo "dracut-root-block-created" | dd oflag=direct,dsync of=/dev/disk/by-id/scsi-0QEMU_QEMU_HARDDISK_marker status=none
 poweroff -f

--- a/test/TEST-11-USR-MOUNT/test.sh
+++ b/test/TEST-11-USR-MOUNT/test.sh
@@ -44,6 +44,7 @@ test_run() {
     client_run "readonly root and writeable /usr" "ro"
     client_run "writeable root and /usr" "rw"
     client_run "readonly root and /usr" "ro rd.fstab=0"
+    client_run "readonly root snapshot" "rd.fstab=0 subvol=snapshot-root"
 }
 
 test_setup() {


### PR DESCRIPTION
Add a step to create a read-only btrfs snapshot and mount it.

## Checklist
- [ ] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it

Fixes #
