### PR TITLE
ci: exclude TEST-41 on arch due to systemd v258 regression

### DIFF
--- a/.github/workflows/integration-extra.yml
+++ b/.github/workflows/integration-extra.yml
@@ -69,6 +69,9 @@ jobs:
                     # https://github.com/dracut-ng/dracut-ng/issues/1314
                     - container: azurelinux:3.0
                       test: "43"
+                    # https://github.com/dracut-ng/dracut-ng/issues/1677
+                    - container: arch:latest
+                      test: "41"
         container:
             image: ghcr.io/dracut-ng/${{ matrix.container }}-amd
             options: '--device=/dev/kvm --privileged'

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -121,6 +121,10 @@ jobs:
                     - "41"
                     - "42"
                     - "43"
+                exclude:
+                    # https://github.com/dracut-ng/dracut-ng/issues/1677
+                    - container: arch:latest
+                      test: "41"
         container:
             image: ghcr.io/dracut-ng/${{ matrix.container }}-amd
             options: '--device=/dev/kvm --privileged'


### PR DESCRIPTION
## Changes

Skip to keep the CI green for the ongoing development.

Based on the information available currently, this is likely a regression with systemd.    


## Checklist
- [ ] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it


