### PR TITLE
ci(debian): revert Debian workarounds

### DIFF
--- a/test/container/Dockerfile-debian
+++ b/test/container/Dockerfile-debian
@@ -102,8 +102,3 @@ RUN \
     && apt-get clean \
     && chmod a+r /boot/vmlinu*
 
-# workaround for kernel-install
-RUN \
-    KVERSION="$(cd /lib/modules && ls -1 | tail -1)" \
-    ; if ! [ -e /usr/lib/modules/"$KVERSION"/vmlinuz ]; then ln -sf /boot/vmlinuz /usr/lib/modules/"$KVERSION"/vmlinuz; fi  \
-    ; if ! [ -e /usr/lib/modules/"$KVERSION"/vmlinuz ]; then ln -sf /boot/vmlinuz-"$KVERSION" /usr/lib/modules/"$KVERSION"/vmlinuz; fi


### PR DESCRIPTION
Now, that the CI transitioned to Debian trixie release let's remove Debian workarounds for kernel-install.

This commit is a revert for 64d6da9f2 .


## Checklist
- [ ] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it

Fixes #
