### PR TITLE
ci(debian): move workaround to the test case

### DIFF
--- a/test/TEST-12-UEFI/test.sh
+++ b/test/TEST-12-UEFI/test.sh
@@ -17,6 +17,11 @@ test_check() {
     fi
 
     [[ -n "$(ovmf_code)" ]]
+
+    if command -v systemd-detect-virt > /dev/null && ! systemd-detect-virt -c &> /dev/null; then
+        echo "This test assumes that it runs inside a CI container."
+        return 1
+    fi
 }
 
 client_run() {
@@ -49,6 +54,11 @@ test_setup() {
         "$TESTDIR"/tmp-initramfs.root
 
     KVERSION=$(determine_kernel_version "$TESTDIR"/tmp-initramfs.root)
+
+    # workaround for kernel-install for Debian
+    if ! [ -e /usr/lib/modules/"$KVERSION"/vmlinuz ]; then
+        ln -sf /boot/vmlinuz-"$KVERSION" /usr/lib/modules/"$KVERSION"/vmlinuz
+    fi
 
     mksquashfs "$TESTDIR"/dracut.*/initramfs/ "$TESTDIR"/squashfs.img -quiet -no-progress
 

--- a/test/TEST-43-KERNEL-INSTALL/test.sh
+++ b/test/TEST-43-KERNEL-INSTALL/test.sh
@@ -56,6 +56,11 @@ test_setup() {
 
     KVERSION=$(determine_kernel_version "$TESTDIR"/initramfs.root)
 
+    # workaround for kernel-install for Debian
+    if ! [ -e /usr/lib/modules/"$KVERSION"/vmlinuz ]; then
+        ln -sf /boot/vmlinuz-"$KVERSION" /usr/lib/modules/"$KVERSION"/vmlinuz
+    fi
+
     dd if=/dev/zero of="$TESTDIR"/root.img bs=200MiB count=1 status=none && sync "$TESTDIR"/root.img
     mkfs.ext4 -q -L dracut -d "$TESTDIR"/dracut.*/initramfs/ "$TESTDIR"/root.img && sync "$TESTDIR"/root.img
 


### PR DESCRIPTION
Including workaround in the test case itself will allow to pass it downstream.

These workarounds are still needed.

## Checklist
- [ ] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it

Fixes #
