### PR TITLE
tests(FULL-SYSTEMD): remove dbus dependency

### DIFF
--- a/test/TEST-41-FULL-SYSTEMD/test.sh
+++ b/test/TEST-41-FULL-SYSTEMD/test.sh
@@ -73,13 +73,6 @@ test_setup() {
 
     local dracut_modules="resume systemd-udevd systemd-journald systemd-tmpfiles systemd-cryptsetup systemd-emergency systemd-ac-power systemd-coredump systemd-creds systemd-integritysetup systemd-ldconfig systemd-pstore systemd-repart systemd-sysext systemd-veritysetup systemd-hostnamed systemd-timedated"
 
-    # TODO - this workaround should not be needed and should be removed
-    if [ -f /usr/bin/dbus-broker ]; then
-        dracut_modules="$dracut_modules dbus-broker"
-    else
-        dracut_modules="$dracut_modules dbus-daemon"
-    fi
-
     if [ -f /usr/lib/systemd/systemd-networkd ] && [ -e "${PKGLIBDIR}/modules.d/00systemd-network-management/module-setup.sh" ]; then
         dracut_modules="$dracut_modules systemd-network-management"
     fi


### PR DESCRIPTION
Test FULL `systemd` without the `dbus` dracut module.

This is a follow-up to fdfa899.

## Checklist
- [ ] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it

Fixes #
