### PR TITLE
test(KERNEL-INSTALL): remove checking for systemd version 255 or later

### DIFF
--- a/test/TEST-43-KERNEL-INSTALL/test.sh
+++ b/test/TEST-43-KERNEL-INSTALL/test.sh
@@ -13,11 +13,6 @@ test_check() {
         echo "This test needs kernel-install to run."
         return 1
     fi
-
-    if [[ $(kernel-install --version | grep -oP '(?<=systemd )\d+') -lt 255 ]]; then
-        echo "This test requires support for kernel-install add-all (v255)"
-        return 1
-    fi
 }
 
 test_run() {


### PR DESCRIPTION
systemd version 255 or later is already the minimal supported systemd version, so there is no longer a need to maintain this additional check and additional complexity.

See also 27d9a96 .

## Checklist
- [ ] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it

Fixes #
