### PR TITLE
test(UEFI): change the order of execution to fix regression

### DIFF
--- a/test/TEST-12-UEFI/test.sh
+++ b/test/TEST-12-UEFI/test.sh
@@ -16,10 +16,12 @@ test_check() {
         return 1
     fi
 
-    [[ -n "$(ovmf_code)" ]]
-
     if command -v systemd-detect-virt > /dev/null && ! systemd-detect-virt -c &> /dev/null; then
         echo "This test assumes that it runs inside a CI container."
+        return 1
+    fi
+
+    if [[ -z "$(ovmf_code)" ]]; then
         return 1
     fi
 }


### PR DESCRIPTION
6ae7ac0 regressed testing on Alpine and Azure Linux as on those platforms the test is no longer skipped.

Make sure the test is skipped if stub is not available.

## Checklist
- [ ] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it

Fixes #
