### PR TITLE
fix(dracut): use the same systemd config as on the host

### DIFF
--- a/dracut.sh
+++ b/dracut.sh
@@ -2249,9 +2249,6 @@ if [[ $kernel_only != yes ]]; then
             mkdir -p "${initdir}"/etc/conf.d
             {
                 printf "%s\n" "systemdutildir=\"$systemdutildir\""
-                printf "%s\n" "systemdsystemunitdir=\"$systemdsystemunitdir\""
-                printf "%s\n" "systemdsystemconfdir=\"$systemdsystemconfdir\""
-                printf "%s\n" "systemdnetworkconfdir=\"$systemdnetworkconfdir\""
             } > "${initdir}"/etc/conf.d/systemd.conf
         fi
     fi


### PR DESCRIPTION
Dracut is very opinionated when it comes to configuring systemd in /etc/conf.d/system.conf.
    
Currently dracut allows setting systemdsystemunitdir differently from the host which likely a misconfiguration that leads to errors.
    
Remove systemdsystemunitdir and a few other variables from /etc/conf.d/system.conf and only keep systemdutildir, which is used to configure the patch for udevd.

## Checklist
- [ ] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it

Fixes #
