### PR TITLE
test(FULL-SYSTEMD): remove obsolete and incorrect check

### DIFF
--- a/test/TEST-41-FULL-SYSTEMD/test.sh
+++ b/test/TEST-41-FULL-SYSTEMD/test.sh
@@ -73,7 +73,7 @@ test_setup() {
 
     local dracut_modules="resume systemd-udevd systemd-journald systemd-tmpfiles systemd-cryptsetup systemd-emergency systemd-ac-power systemd-coredump systemd-creds systemd-integritysetup systemd-ldconfig systemd-pstore systemd-repart systemd-sysext systemd-veritysetup systemd-hostnamed systemd-timedated"
 
-    if [ -f /usr/lib/systemd/systemd-networkd ] && [ -e "${PKGLIBDIR}/modules.d/00systemd-network-management/module-setup.sh" ]; then
+    if [ -f /usr/lib/systemd/systemd-networkd ]; then
         dracut_modules="$dracut_modules systemd-network-management"
     fi
 


### PR DESCRIPTION
## Changes

`00systemd-network-management` has been renumbered and this additional check is not really needed any more.

Remove it.

## Checklist
- [ ] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it

Fixes #
