### PR TITLE
test(SKIPCPIO): support 3cpio

### DIFF
--- a/test/TEST-81-SKIPCPIO/test.sh
+++ b/test/TEST-81-SKIPCPIO/test.sh
@@ -10,6 +10,11 @@ test_check() {
     (command -v cpio && command -v find && command -v diff) &> /dev/null
 }
 
+cpio_list_first() {
+    local file="$1"
+    cpio --extract --quiet --list < "$file"
+}
+
 skipcpio_simple() {
     mkdir -p "$CPIO_TESTDIR/skipcpio_simple/first_archive"
     pushd "$CPIO_TESTDIR/skipcpio_simple/first_archive"
@@ -32,7 +37,7 @@ skipcpio_simple() {
         | cpio -o --null -H newc >> "$CPIO_TESTDIR/skipcpio_simple.cpio"
     popd
 
-    cpio -i --list < "$CPIO_TESTDIR/skipcpio_simple.cpio" \
+    cpio_list_first "$CPIO_TESTDIR/skipcpio_simple.cpio" \
         > "$CPIO_TESTDIR/skipcpio_simple.list"
     cat << EOF | diff - "$CPIO_TESTDIR/skipcpio_simple.list"
 .
@@ -47,7 +52,8 @@ EOF
         skipcpio_path="${PKGLIBDIR}"
     fi
     "$skipcpio_path"/skipcpio "$CPIO_TESTDIR/skipcpio_simple.cpio" \
-        | cpio -i --list > "$CPIO_TESTDIR/skipcpio_simple.list"
+        > "$CPIO_TESTDIR/skipped.cpio"
+    cpio_list_first "$CPIO_TESTDIR/skipped.cpio" > "$CPIO_TESTDIR/skipcpio_simple.list"
     cat << EOF | diff - "$CPIO_TESTDIR/skipcpio_simple.list"
 .
 10

--- a/test/TEST-81-SKIPCPIO/test.sh
+++ b/test/TEST-81-SKIPCPIO/test.sh
@@ -7,16 +7,29 @@ set -eu
 TEST_DESCRIPTION="test skipcpio"
 
 test_check() {
-    (command -v cpio && command -v find && command -v diff) &> /dev/null
+    if ! command -v 3cpio &> /dev/null && ! command -v cpio &> /dev/null; then
+        echo "Neither 3cpio nor cpio are available."
+        return 1
+    fi
+
+    (command -v find && command -v diff) &> /dev/null
 }
 
 cpio_create() {
-    find . -print0 | sort -z | cpio -o --null -H newc
+    if command -v 3cpio &> /dev/null; then
+        find . | sort | 3cpio --create
+    else
+        find . -print0 | sort -z | cpio -o --null -H newc
+    fi
 }
 
 cpio_list_first() {
     local file="$1"
-    cpio --extract --quiet --list < "$file"
+    if command -v 3cpio &> /dev/null; then
+        3cpio --list --parts 1 "$file"
+    else
+        cpio --extract --quiet --list < "$file"
+    fi
 }
 
 skipcpio_simple() {

--- a/test/TEST-81-SKIPCPIO/test.sh
+++ b/test/TEST-81-SKIPCPIO/test.sh
@@ -10,6 +10,10 @@ test_check() {
     (command -v cpio && command -v find && command -v diff) &> /dev/null
 }
 
+cpio_create() {
+    find . -print0 | sort -z | cpio -o --null -H newc
+}
+
 cpio_list_first() {
     local file="$1"
     cpio --extract --quiet --list < "$file"
@@ -22,8 +26,7 @@ skipcpio_simple() {
     for ((i = 0; i < 3; i++)); do
         echo "first archive file $i" >> ./"$i"
     done
-    find . -print0 | sort -z \
-        | cpio -o --null -H newc > "$CPIO_TESTDIR/skipcpio_simple.cpio"
+    cpio_create > "$CPIO_TESTDIR/skipcpio_simple.cpio"
     popd
 
     mkdir -p "$CPIO_TESTDIR/skipcpio_simple/second_archive"
@@ -33,8 +36,7 @@ skipcpio_simple() {
         echo "second archive file $i" >> ./"$i"
     done
 
-    find . -print0 | sort -z \
-        | cpio -o --null -H newc >> "$CPIO_TESTDIR/skipcpio_simple.cpio"
+    cpio_create >> "$CPIO_TESTDIR/skipcpio_simple.cpio"
     popd
 
     cpio_list_first "$CPIO_TESTDIR/skipcpio_simple.cpio" \


### PR DESCRIPTION
## Changes

Support using 3cpio in the skipcpio test to allow not having `cpio` installed.

## Checklist
- [ ] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it

Fixes #
