### PR TITLE
test: avoid kernel-install add-all

### DIFF
--- a/test/TEST-12-UEFI/test.sh
+++ b/test/TEST-12-UEFI/test.sh
@@ -56,11 +56,7 @@ test_setup() {
         "$TESTDIR"/tmp-initramfs.root
 
     KVERSION=$(determine_kernel_version "$TESTDIR"/tmp-initramfs.root)
-
-    # workaround for kernel-install for Debian
-    if ! [ -e /usr/lib/modules/"$KVERSION"/vmlinuz ]; then
-        ln -sf /boot/vmlinuz-"$KVERSION" /usr/lib/modules/"$KVERSION"/vmlinuz
-    fi
+    KIMAGE=$(determine_kernel_image "$KVERSION")
 
     mksquashfs "$TESTDIR"/dracut.*/initramfs/ "$TESTDIR"/squashfs.img -quiet -no-progress
 
@@ -90,7 +86,7 @@ test_setup() {
 
         # using kernell-install to invoke dracut
         mkdir -p "$BOOT_ROOT/$TOKEN/$KVERSION" "$BOOT_ROOT/loader/entries"
-        kernel-install add-all
+        kernel-install add "$KVERSION" "$KIMAGE"
 
         mv "$TESTDIR"/EFI/Linux/*.efi "$TESTDIR"/ESP/EFI/BOOT/BOOTX64.efi
 

--- a/test/TEST-43-KERNEL-INSTALL/test.sh
+++ b/test/TEST-43-KERNEL-INSTALL/test.sh
@@ -50,11 +50,7 @@ test_setup() {
         -f "$TESTDIR"/initramfs.root
 
     KVERSION=$(determine_kernel_version "$TESTDIR"/initramfs.root)
-
-    # workaround for kernel-install for Debian
-    if ! [ -e /usr/lib/modules/"$KVERSION"/vmlinuz ]; then
-        ln -sf /boot/vmlinuz-"$KVERSION" /usr/lib/modules/"$KVERSION"/vmlinuz
-    fi
+    KIMAGE=$(determine_kernel_image "$KVERSION")
 
     dd if=/dev/zero of="$TESTDIR"/root.img bs=200MiB count=1 status=none && sync "$TESTDIR"/root.img
     mkfs.ext4 -q -L dracut -d "$TESTDIR"/dracut.*/initramfs/ "$TESTDIR"/root.img && sync "$TESTDIR"/root.img
@@ -70,7 +66,7 @@ test_setup() {
 
     # using kernell-install to invoke dracut
     mkdir -p "$BOOT_ROOT/$TOKEN/$KVERSION" "$BOOT_ROOT/loader/entries" "$BOOT_ROOT/$TOKEN/0-rescue/loader/entries"
-    kernel-install add-all
+    kernel-install add "$KVERSION" "$KIMAGE"
 }
 
 # shellcheck disable=SC1090

--- a/test/test-functions
+++ b/test/test-functions
@@ -111,6 +111,27 @@ determine_kernel_version() {
     lsinitrd "$1" | grep modules.dep | head -1 | rev | cut -d'/' -f2 | rev
 }
 
+determine_kernel_image() {
+    local kversion="$1"
+    local paths=(
+        "/lib/modules/${kversion}/vmlinuz"
+        "/lib/modules/${kversion}/vmlinux"
+        "lib/modules/${kversion}/Image"
+        "/boot/vmlinuz-${kversion}"
+        "/boot/vmlinux-${kversion}"
+    )
+
+    for path in "${paths[@]}"; do
+        if [ -f "$path" ]; then
+            echo "$path"
+            return 0
+        fi
+    done
+
+    echo "Could not find a Linux kernel image for version '$kversion'!" >&2
+    exit 1
+}
+
 # terminal sequence to set color to a 'success' color (currently: green)
 function SETCOLOR_SUCCESS() { echo -en '\033[0;32m'; }
 # terminal sequence to set color to a 'failure' color (currently: red)


### PR DESCRIPTION
## Changes

The man page of `kernel-install` says about `add-all`: "This is the same as add, but invokes the operation iteratively for every installed kernel in /usr/lib/modules/. This operation is only supported on systems where the kernel image is installed in /usr/lib/modules/KERNEL-VERSION/vmlinuz."

Debian and Ubuntu do not ship the kernel images in `/usr/lib/modules/` and therefore `add-all` is not supported there.

Since the test cases already determine the kernel version, search for the kernel image and use `kernel-install add` instead of `add-all`.

## Checklist
- [ ] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it

Fixes #
