### PR TITLE
fix(Makefile): exclude hidden directories from shellcheck part 2

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -323,7 +323,7 @@ ifeq ($(HAVE_SHELLCHECK),yes)
 ifeq ($(HAVE_SHFMT),yes)
 	shellcheck $$(shfmt -f *)
 else
-	find . -name '*.sh' -print0 | xargs -0 shellcheck
+	find * -name '*.sh' -print0 | xargs -0 shellcheck
 endif
 endif
 


### PR DESCRIPTION
## Changes

`find .` also searches in hidden directories (like `.git` or `.pc`). The `.pc` is used on Debian for patch tracking and should not be searched for files.

So ignore the top-level hidden directories from shellcheck. See also commit 7a65d1a1f372 ("fix(Makefile): exclude hidden directories from shellcheck").

## Checklist
- [ ] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it

Fixes #
