### PR TITLE
fix(iscsi): do not include /etc/iscsi/iscsid.conf in generic mode

### DIFF
--- a/modules.d/74iscsi/module-setup.sh
+++ b/modules.d/74iscsi/module-setup.sh
@@ -192,8 +192,8 @@ install() {
     inst_multiple umount iscsi-iname iscsiadm iscsid
     inst_binary sort
 
-    inst_simple /etc/iscsi/iscsid.conf
     if [[ $hostonly ]]; then
+        inst_simple /etc/iscsi/iscsid.conf
         inst_simple /etc/iscsi/initiatorname.iscsi
     fi
 


### PR DESCRIPTION
Files under /etc on the host are considered host specific. Do not include them in the generic initramfs.

## Checklist
- [ ] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it

Fixes #
