### PR TITLE
fix(dbus, network-manager): make generic mode host independent

### DIFF
--- a/modules.d/16dbus-broker/module-setup.sh
+++ b/modules.d/16dbus-broker/module-setup.sh
@@ -34,12 +34,6 @@ install() {
     inst_dir "$dbussession"
     inst_dir "$dbussystem"
     inst_dir "$dbussystemservices"
-    inst_dir "$dbusconfdir"
-    inst_dir "$dbusinterfacesconfdir"
-    inst_dir "$dbusservicesconfdir"
-    inst_dir "$dbussessionconfdir"
-    inst_dir "$dbussystemconfdir"
-    inst_dir "$dbussystemservicesconfdir"
 
     inst_sysusers dbus.conf
 
@@ -47,7 +41,6 @@ install() {
         "$dbus"/session.conf \
         "$dbus"/system.conf \
         "$dbussystem"/org.freedesktop.systemd1.conf \
-        "$dbusservicesconfdir"/org.freedesktop.systemd1.service \
         "$dbussystemservices"/org.freedesktop.systemd1.service \
         "$systemdcatalog"/dbus-broker.catalog \
         "$systemdcatalog"/dbus-broker-launch.catalog \
@@ -72,6 +65,12 @@ install() {
 
     # Install the hosts local user configurations if enabled.
     if [[ $hostonly ]]; then
+        inst_dir "$dbusconfdir"
+        inst_dir "$dbusinterfacesconfdir"
+        inst_dir "$dbusservicesconfdir"
+        inst_dir "$dbussessionconfdir"
+        inst_dir "$dbussystemconfdir"
+        inst_dir "$dbussystemservicesconfdir"
         inst_multiple -H -o \
             "$dbusconfdir"/session.conf \
             "$dbusconfdir"/system.conf \
@@ -79,6 +78,7 @@ install() {
             "$systemdsystemconfdir"/dbus.socket.d/*.conf \
             "$systemdsystemconfdir"/dbus-broker.service \
             "$systemdsystemconfdir"/dbus-broker.service.d/*.conf \
+            "$dbusservicesconfdir"/org.freedesktop.systemd1.service \
             "$systemdsystemconfdir"/sockets.target.wants/dbus.socket
     fi
 

--- a/modules.d/16dbus-daemon/module-setup.sh
+++ b/modules.d/16dbus-daemon/module-setup.sh
@@ -38,17 +38,10 @@ install() {
     inst_dir "$dbussession"
     inst_dir "$dbussystem"
     inst_dir "$dbussystemservices"
-    inst_dir "$dbusconfdir"
-    inst_dir "$dbusinterfacesconfdir"
-    inst_dir "$dbusservicesconfdir"
-    inst_dir "$dbussessionconfdir"
-    inst_dir "$dbussystemconfdir"
-    inst_dir "$dbussystemservicesconfdir"
 
     inst_multiple -o \
         "$dbus"/system.conf \
         "$dbussystem"/org.freedesktop.systemd1.conf \
-        "$dbusservicesconfdir"/org.freedesktop.systemd1.service \
         "$dbussystemservices"/org.freedesktop.systemd1.service \
         "$systemdsystemunitdir"/dbus.service \
         "$systemdsystemunitdir"/dbus.socket \
@@ -78,8 +71,15 @@ install() {
 
     # Install the hosts local user configurations if enabled.
     if [[ $hostonly ]]; then
+        inst_dir "$dbusconfdir"
+        inst_dir "$dbusinterfacesconfdir"
+        inst_dir "$dbusservicesconfdir"
+        inst_dir "$dbussessionconfdir"
+        inst_dir "$dbussystemconfdir"
+        inst_dir "$dbussystemservicesconfdir"
         inst_multiple -H -o \
             "$dbusconfdir"/system.conf \
+            "$dbusservicesconfdir"/org.freedesktop.systemd1.service \
             "$systemdsystemconfdir"/dbus.socket \
             "$systemdsystemconfdir"/dbus.socket.d/*.conf \
             "$systemdsystemconfdir"/dbus.service \

--- a/modules.d/35network-manager/module-setup.sh
+++ b/modules.d/35network-manager/module-setup.sh
@@ -44,8 +44,12 @@ install() {
 
         # teaming support under systemd+dbus
         inst_multiple -o \
-            "$dbussystem"/teamd.conf \
-            "$dbussystemconfdir"/teamd.conf
+            "$dbussystem"/teamd.conf
+
+        if [[ $hostonly ]]; then
+            inst_multiple -H -o \
+                "$dbussystemconfdir"/teamd.conf
+        fi
 
         # Install a configuration snippet to prevent the automatic creation of
         # "Wired connection #" DHCP connections for Ethernet interfaces


### PR DESCRIPTION
Files under /etc on the host are considered host specific. Do not include them in the generic initramfs.

As an example `$dbussystemconfdir/teamd.conf` points to `/etc/dbus-1/system.d/teamd.conf` - which should be only included in hostonly initramfs.

## Checklist
- [ ] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it

Fixes #
