### PR TITLE
fix(nvmf): do not install hostonly configuration in generic initramfs

### DIFF
--- a/modules.d/74nvmf/module-setup.sh
+++ b/modules.d/74nvmf/module-setup.sh
@@ -160,8 +160,8 @@ install() {
 
     inst_multiple nvme jq
     inst_hook cmdline 92 "$moddir/parse-nvmf-boot-connections.sh"
-    inst_simple "/etc/nvme/discovery.conf"
-    inst_simple "/etc/nvme/config.json"
+    inst_simple -H "/etc/nvme/discovery.conf"
+    inst_simple -H "/etc/nvme/config.json"
     inst_rules /usr/lib/udev/rules.d/71-nvmf-iopolicy-netapp.rules
     inst_rules "$moddir/95-nvmf-initqueue.rules"
 }


### PR DESCRIPTION
/etc/nvme/discovery.conf and /etc/nvme/config.json are meant to configure each host - only install them in hostonly initramfs.

## Checklist
- [ ] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it

Fixes #
