### PR TITLE
fix(test-functions ): use absolute path

### DIFF
--- a/test/test-functions
+++ b/test/test-functions
@@ -116,7 +116,7 @@ determine_kernel_image() {
     local paths=(
         "/lib/modules/${kversion}/vmlinuz"
         "/lib/modules/${kversion}/vmlinux"
-        "lib/modules/${kversion}/Image"
+        "/lib/modules/${kversion}/Image"
         "/boot/vmlinuz-${kversion}"
         "/boot/vmlinux-${kversion}"
     )


### PR DESCRIPTION
This commit resolves recent ci regression caused by 0e88ccc.

## Checklist
- [ ] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it

Fixes #1672
