### PR TITLE
fix(debian): no need to change permissions

### DIFF
--- a/test/container/Dockerfile-debian
+++ b/test/container/Dockerfile-debian
@@ -99,6 +99,4 @@ RUN \
     tpm2-tools \
     xorriso \
     zstd \
-    && apt-get clean \
-    && chmod a+r /boot/vmlinu*
-
+    && apt-get clean


### PR DESCRIPTION
CI runs as root, no need to customize the Debian container.

Fixes the following error

```
chmod: cannot operate on dangling symlink '/boot/vmlinuz'
chmod: cannot operate on dangling symlink '/boot/vmlinuz.old'
```

## Checklist
- [ ] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it

Fixes #
