### PR TITLE
feat(dracut): add support for /run/initramfs/dracut.conf.d

### DIFF
--- a/dracut.sh
+++ b/dracut.sh
@@ -1033,7 +1033,7 @@ if [[ -f $conffile ]]; then
 fi
 
 # source our config dir
-for f in $(dropindirs_sort ".conf" "$confdir" ${add_confdir:+"$add_confdir"} "$dracutbasedir/dracut.conf.d"); do
+for f in $(dropindirs_sort ".conf" "$confdir" ${add_confdir:+"$add_confdir"} "$dracutbasedir/dracut.conf.d" "/run/initramfs/dracut.conf.d"); do
     check_conf_file "$f"
     # shellcheck disable=SC1090
     [[ -e $f ]] && . "$f"

--- a/man/dracut.conf.5.adoc
+++ b/man/dracut.conf.5.adoc
@@ -11,12 +11,14 @@ dracut.conf - configuration file(s) for dracut
 _/etc/dracut.conf_
 _/etc/dracut.conf.d/\*.conf_
 _/usr/lib/dracut/dracut.conf.d/*.conf_
+_/run/initramfs/dracut.conf.d/*.conf_
 
 == Description
 _dracut.conf_ is loaded during the initialization phase of dracut.
 
-_*.conf_ files are read from `/usr/lib/dracut/dracut.conf.d` and
-/etc/dracut.conf.d. Files with the same name in `/etc/dracut.conf.d` will replace
+_*.conf_ files are read from `/run/initramfs/dracut.conf.d`,
+`/usr/lib/dracut/dracut.conf.d` and `/etc/dracut.conf.d`.
+Files with the same name in `/etc/dracut.conf.d` will replace
 files in `/usr/lib/dracut/dracut.conf.d`.
 
 The files are then read in alphanumerical order and will override parameters


### PR DESCRIPTION
Allow dracut read configuration files from /run as well, in addition to /etc/ and /usr.

Modify test case to demonstrate use-case and provide test coverage.

## Checklist
- [ ] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it

Fixes #
