### PR TITLE
ci: only pass TEST_FSTYPE to the CI container if it is set

### DIFF
--- a/test/test.sh
+++ b/test/test.sh
@@ -49,7 +49,7 @@ fi
 # clear previous test run
 TARGETS='clean all install check' "$PODMAN" run --rm -it \
     --device=/dev/kvm --privileged \
-    -e V -e TESTS -e TEST_RUN_ID -e TARGETS -e MAKEFLAGS -e TEST_DRACUT_ARGS -e TEST_FSTYPE \
+    -e V -e TESTS -e TEST_RUN_ID -e TARGETS -e MAKEFLAGS -e TEST_DRACUT_ARGS ${TEST_FSTYPE:+-e TEST_FSTYPE} \
     -v "$PWD"/:/z \
     "$CONTAINER" \
     /z/test/test-container.sh


### PR DESCRIPTION
Follow-up to 58007a0 to resolve the CI coverage regression where TEST_FSTYPE defaulted to ext4 in all test containers.

## Checklist
- [ ] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it

Fixes #
