### PR TITLE
ci: allow the execution of arbitrary commands within the test container

### DIFF
--- a/doc_site/modules/ROOT/pages/developer/hacking.adoc
+++ b/doc_site/modules/ROOT/pages/developer/hacking.adoc
@@ -144,6 +144,12 @@ Run test 20 with `btrfs` omitting `systemd` dracut module on `debian` :: {empty}
 $ TESTS="20" TEST_FSTYPE=btrfs TEST_DRACUT_ARGS="--omit systemd" test/test.sh debian
 ----
 
+Run test 10 with `rdma` package installed on `fedora` :: {empty}
++
+[,console]
+----
+$ TESTS="10" TEST_CONTAINER_COMMAND="dnf -y install rdma" test/test.sh fedora
+
 === On bare metal
 
 For the testsuite to pass, you will have to install at least the software packages

--- a/test/test-container.sh
+++ b/test/test-container.sh
@@ -27,6 +27,9 @@ if [ "${V-}" = "2" ]; then set -x; fi
 # shellcheck disable=SC2086
 ./configure --enable-test ${CONFIGURE_ARG-}
 
+# allow the execution of arbitrary commands within the test container
+[[ -n ${TEST_CONTAINER_COMMAND-} ]] && eval "$TEST_CONTAINER_COMMAND"
+
 # treat warnings as error
 # shellcheck disable=SC2086
 CFLAGS="-Wextra -Werror" make TEST_RUN_ID="${TEST_RUN_ID:=${1-}}" TESTS="${TESTS:=${2-}}" V="${V:=1}" ${MAKEFLAGS-} ${TARGETS:=all install check}

--- a/test/test.sh
+++ b/test/test.sh
@@ -49,7 +49,7 @@ fi
 # clear previous test run
 TARGETS='clean all install check' "$PODMAN" run --rm -it \
     --device=/dev/kvm --privileged \
-    -e V -e TESTS -e TEST_RUN_ID -e TARGETS -e MAKEFLAGS -e TEST_DRACUT_ARGS ${TEST_FSTYPE:+-e TEST_FSTYPE} \
+    -e V -e TESTS -e TEST_RUN_ID -e TARGETS -e MAKEFLAGS -e TEST_DRACUT_ARGS ${TEST_FSTYPE:+-e TEST_FSTYPE} -e TEST_CONTAINER_COMMAND \
     -v "$PWD"/:/z \
     "$CONTAINER" \
     /z/test/test-container.sh


### PR DESCRIPTION
Evaluate the `TEST_CONTAINER_COMMAND` right before the test run inside the test container to facilitate additional testing that is not provided by the test CI containers by default.

## Checklist
- [x] I have tested it locally
- [x] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it

