### PR TITLE
ci(debian): install iscsiuio package into the test CI

### DIFF
--- a/test/container/Dockerfile-debian
+++ b/test/container/Dockerfile-debian
@@ -9,10 +9,6 @@
 # - dbus-daemon
 # - network: network-manager, systemd-networkd
 
-# Not installed
-# - iscsiuio (iscsiuio.socket missing, see https://bugs.debian.org/1056733)
-# - busybox-static
-
 ARG DISTRIBUTION=debian
 FROM docker.io/${DISTRIBUTION}
 
@@ -55,6 +51,7 @@ RUN \
     iputils-ping \
     iproute2 \
     isc-dhcp-server \
+    iscsiuio \
     jq \
     kbd \
     kmod \


### PR DESCRIPTION
The bug that was holding back installing `iscsiuio` is fixed. 

See https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=1056733

## Checklist
- [ ] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it

Fixes #
