### PR TITLE
fix(network): handle network selection properly

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -174,8 +174,6 @@ jobs:
                     - fedora:latest
                     - opensuse:latest
                     - ubuntu:devel
-                network:
-                    - network-manager
                 test:
                     - "60"
         container:
@@ -198,6 +196,7 @@ jobs:
             fail-fast: false
             matrix:
                 container:
+                    - arch:latest
                     - opensuse:latest
                 test:
                     - "70"

--- a/modules.d/40network/module-setup.sh
+++ b/modules.d/40network/module-setup.sh
@@ -19,7 +19,7 @@ depends() {
     for module in network-manager systemd-networkd connman; do
         # install the first viable module, unless there omitted
         module_check $module > /dev/null 2>&1
-        if [[ $? == 255 ]] && ! [[ " $omit_dracutmodules " == *\ $module\ * ]] && check_module "$module"; then
+        if [[ $? == 255 ]] && ! [[ " $omit_dracutmodules " == *\ $module\ * ]]; then
             echo "$module"
             return 0
         fi


### PR DESCRIPTION
Prefer network-manager over network-legacy for all of CI.

Earlier each test CI container included `dhclient`, which meant that each CI container supported network-legacy.                                                                                                                                             
                                                                                                                                                                                                  
4ce57a5ad exposed a bug in the network selection as  network-manager was not selected even when available.  

This change is fixes the following issues on the CI:
- selects network-manager over network-legacy on Void
- selects network-manager or systemd-networkd if network-legacy is not installed
    
Revert c81c955 and follow-up to 4ce57a5ad.

Adjust the CI to test with default networking instead of forcing `network-manager` to test for this condition.

## Checklist
- [ ] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it

