### PR TITLE
ci(debian): add bsdextrautils package for rev

### DIFF
--- a/test/container/Dockerfile-debian
+++ b/test/container/Dockerfile-debian
@@ -31,6 +31,7 @@ RUN \
     DEBIAN_FRONTEND=noninteractive apt-get install -y -qq --no-install-recommends -o Dpkg::Use-Pty=0 \
     asciidoctor \
     bluez \
+    bsdextrautils \
     btrfs-progs \
     ca-certificates \
     cargo \


### PR DESCRIPTION
The rev binary is now provided by bsdextrautils package on debian:sid.


## Checklist
- [ ] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it

Fixes #1727
