### PR TITLE
chore(doc): fix syntax

### DIFF
--- a/doc_site/modules/ROOT/pages/developer/hacking.adoc
+++ b/doc_site/modules/ROOT/pages/developer/hacking.adoc
@@ -149,6 +149,7 @@ Run test 10 with `rdma` package installed on `fedora` :: {empty}
 [,console]
 ----
 $ TESTS="10" TEST_CONTAINER_COMMAND="dnf -y install rdma" test/test.sh fedora
+----
 
 === On bare metal
 


### PR DESCRIPTION
Building documentation fails with the following error

```
/opt/hostedtoolcache/node/18.20.8/x64/bin/npx antora --attribute "mainversion=108" \
  --attribute "version=108-192-g8f076010" \
  antora-playbook.yml
[22:11:55.565] WARN (asciidoctor): unterminated listing block
    file: /home/runner/work/dracut-ng/dracut-ng/doc_site/modules/ROOT/pages/developer/hacking.adoc:187
    source: /home/runner/work/dracut-ng/dracut-ng (branch: main <worktree> | start path: doc_site)
make: *** [Makefile:173: doc_site] Error 1
Error: Process completed with exit code 2.
```

## Checklist
- [ ] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it

Fixes #
