### PR TITLE
ci(debian): add util-linux-extra package for wdctl

### DIFF
--- a/test/container/Dockerfile-debian
+++ b/test/container/Dockerfile-debian
@@ -95,6 +95,7 @@ RUN \
     tgt \
     thin-provisioning-tools \
     tpm2-tools \
+    util-linux-extra \
     xorriso \
     zstd \
     && apt-get clean


### PR DESCRIPTION
The wdctl binary is now provided by util-linux-extra package on debian:sid.


## Checklist
- [ ] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it

Fixes #1727
