### PR TITLE
fix(plymouth): do not require plymouth-set-default-theme

### DIFF
--- a/modules.d/45plymouth/module-setup.sh
+++ b/modules.d/45plymouth/module-setup.sh
@@ -17,7 +17,7 @@ check() {
     [[ "$mount_needs" ]] && return 1
     [[ $(pkglib_dir) ]] || return 1
 
-    require_binaries plymouthd plymouth plymouth-set-default-theme || return 1
+    require_binaries plymouthd plymouth || return 1
 
     return 0
 }
@@ -43,7 +43,7 @@ install() {
 
     inst_multiple readlink
 
-    inst_multiple plymouthd plymouth plymouth-set-default-theme
+    inst_multiple plymouthd plymouth
 
     if ! dracut_module_included "systemd"; then
         inst_hook pre-trigger 10 "$moddir"/plymouth-pretrigger.sh

--- a/modules.d/45plymouth/plymouth-populate-initrd.sh
+++ b/modules.d/45plymouth/plymouth-populate-initrd.sh
@@ -1,7 +1,25 @@
 #!/bin/bash
 
+read_setting_from_config() {
+    local setting="$1"
+    local config_file="$2"
+    sed -n "s/^${setting}= *\([^ ]\+\) */\1/p" "$config_file"
+}
+
+get_plymouth_theme() {
+    local config theme
+    for config in "${dracutsysrootdir-}/etc/plymouth/plymouthd.conf" "${dracutsysrootdir-}/usr/share/plymouth/plymouthd.defaults"; do
+        theme=$(read_setting_from_config Theme "$config")
+        if [[ -n $theme ]]; then
+            echo "$theme"
+            return
+        fi
+    done
+    echo spinner
+}
+
 PLYMOUTH_LOGO_FILE="/usr/share/pixmaps/system-logo-white.png"
-PLYMOUTH_THEME=$(plymouth-set-default-theme)
+PLYMOUTH_THEME=$(get_plymouth_theme)
 
 inst_multiple plymouthd plymouth
 


### PR DESCRIPTION
## Changes

Debian and Ubuntu do not ship `plymouth-set-default-theme` but rely on the Debian alternatives system to set the default theme.

So drop relying on `plymouth-set-default-theme` and determine the default theme by reading the configuration files.

## Checklist
- [x] I have tested it locally
- [x] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it

Fixes #
