### PR TITLE
fix(plymouth): drop depending on bash

### DIFF
--- a/modules.d/45plymouth/module-setup.sh
+++ b/modules.d/45plymouth/module-setup.sh
@@ -24,7 +24,7 @@ check() {
 
 # called by dracut
 depends() {
-    echo drm bash
+    echo drm
 }
 
 # called by dracut


### PR DESCRIPTION
## Changes

The only Bash script in the Plymouth module is
`plymouth-populate-initrd.sh` which is called by `module-setup.sh` and not included in the initrd. Therefore the Plymouth module does not require Bash.

Fixes: 3a04a139700 ("fix: add bash dependency when bash scripts are used in the module")

@jozzsi This reverts https://github.com/dracut-ng/dracut-ng/pull/925 partially.

## Checklist
- [ ] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it

Fixes #
