### PR TITLE
fix(plymouth): check all library directories for Plymouth

### DIFF
--- a/modules.d/45plymouth/module-setup.sh
+++ b/modules.d/45plymouth/module-setup.sh
@@ -1,12 +1,9 @@
 #!/bin/bash
 
 pkglib_dir() {
-    local _dirs="/usr/lib/plymouth /usr/libexec/plymouth/"
-    local _arch=${DRACUT_ARCH:-$(uname -m)}
-    [ -n "$_arch" ] && _dirs+=" /usr/lib/$_arch/plymouth"
-    for _dir in $_dirs; do
-        if [ -x "${dracutsysrootdir-}$_dir"/plymouth-populate-initrd ]; then
-            echo "$_dir"
+    for _dir in /usr/libexec $libdirs; do
+        if [ -x "${dracutsysrootdir-}$_dir/plymouth/plymouth-populate-initrd" ]; then
+            echo "$_dir/plymouth"
             return
         fi
     done


### PR DESCRIPTION
## Changes

On amd64 `dpkg-architecture -qDEB_HOST_MULTIARCH` returns `x86_64-linux-gnu` but `uname -m` returns only `x86_64`. `/usr/lib/x86_64` does not exist on Debian/Ubuntu but `/usr/lib/x86_64-linux-gnu` exists.

Rely on `libdirs` to provide all possible library directories including the Debian multiarch directory `/usr/lib/x86_64-linux-gnu`.

Fixes: 1b374931126c ("fix(plymouth): do not depend on dpkg-architecture")

## Checklist
- [x] I have tested it locally
- [x] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it