### PR TITLE
test(NFS): drop including missing overlay in server initrd

### DIFF
--- a/test/TEST-60-NFS/test.sh
+++ b/test/TEST-60-NFS/test.sh
@@ -289,7 +289,7 @@ test_setup() {
         -a "watchdog dmsquash-live qemu-net ${USE_NETWORK}"
 
     # Make server's dracut image
-    "$DRACUT" -i "$TESTDIR"/overlay / \
+    "$DRACUT" \
         -a "bash qemu-net $USE_NETWORK ${SERVER_DEBUG:+debug}" \
         --include ./server.link /etc/systemd/network/01-server.link \
         --include ./wait-if-server.sh /lib/dracut/hooks/pre-mount/99-wait-if-server.sh \


### PR DESCRIPTION
## Changes

The NFS test shows following warning when generating `initramfs.server`:

```
dracut[E]: /var/tmp/dracut-test.26n7FD/overlay doesn't exist
```

There is no overlay directory for the server initrd.

## Checklist
- [ ] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it

Fixes #
