### PR TITLE
test: allow running UEFI and kernel-install tests in chroot

### DIFF
--- a/test/TEST-12-UEFI/test.sh
+++ b/test/TEST-12-UEFI/test.sh
@@ -16,8 +16,8 @@ test_check() {
         return 1
     fi
 
-    if command -v systemd-detect-virt > /dev/null && ! systemd-detect-virt -c &> /dev/null; then
-        echo "This test assumes that it runs inside a CI container."
+    if command -v systemd-detect-virt > /dev/null && ! systemd-detect-virt -c &> /dev/null && ! systemd-detect-virt -r &> /dev/null; then
+        echo "This test assumes that it runs inside a chroot or CI container."
         return 1
     fi
 

--- a/test/TEST-43-KERNEL-INSTALL/test.sh
+++ b/test/TEST-43-KERNEL-INSTALL/test.sh
@@ -4,8 +4,8 @@ set -eu
 TEST_DESCRIPTION="kernel-install with root filesystem on ext4 filesystem"
 
 test_check() {
-    if command -v systemd-detect-virt > /dev/null && ! systemd-detect-virt -c &> /dev/null; then
-        echo "This test assumes that it runs inside a CI container."
+    if command -v systemd-detect-virt > /dev/null && ! systemd-detect-virt -c &> /dev/null && ! systemd-detect-virt -r &> /dev/null; then
+        echo "This test assumes that it runs inside a chroot or CI container."
         return 1
     fi
 


### PR DESCRIPTION
## Changes

The UEFI and kernel-install tests want to run in an isolated environment to avoid modifying the host system. Allow running those tests in a chroot (like schroot).

## Checklist
- [ ] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it

Fixes #
