### PR TITLE
test: fix MACAddressPolicy from keep to none

### DIFF
--- a/test/TEST-60-NFS/client.link
+++ b/test/TEST-60-NFS/client.link
@@ -3,4 +3,4 @@ OriginalName=*
 
 [Link]
 NamePolicy=keep kernel database onboard slot path
-MACAddressPolicy=keep
+MACAddressPolicy=none

--- a/test/TEST-60-NFS/server.link
+++ b/test/TEST-60-NFS/server.link
@@ -3,4 +3,4 @@ OriginalName=*
 
 [Link]
 NamePolicy=mac
-MACAddressPolicy=keep
+MACAddressPolicy=none

--- a/test/TEST-70-ISCSI/server.link
+++ b/test/TEST-70-ISCSI/server.link
@@ -3,4 +3,4 @@ OriginalName=*
 
 [Link]
 NamePolicy=mac
-MACAddressPolicy=keep
+MACAddressPolicy=none

--- a/test/TEST-71-ISCSI-MULTI/server.link
+++ b/test/TEST-71-ISCSI-MULTI/server.link
@@ -3,4 +3,4 @@ OriginalName=*
 
 [Link]
 NamePolicy=mac
-MACAddressPolicy=keep
+MACAddressPolicy=none

--- a/test/TEST-72-NBD/client.link
+++ b/test/TEST-72-NBD/client.link
@@ -3,4 +3,4 @@ OriginalName=*
 
 [Link]
 NamePolicy=keep kernel database onboard slot path
-MACAddressPolicy=keep
+MACAddressPolicy=none

--- a/test/TEST-72-NBD/server.link
+++ b/test/TEST-72-NBD/server.link
@@ -3,4 +3,4 @@ OriginalName=*
 
 [Link]
 NamePolicy=mac
-MACAddressPolicy=keep
+MACAddressPolicy=none


### PR DESCRIPTION
## Changes

The `MACAddressPolicy` can be only set to `persistent`, `random`, or `none` (see systemd.link man page). There is no policy `keep`.

So correct `MACAddressPolicy` to `none`.

Fixes: f3f081e5420f ("TEST-{20,50,60,70): set MACAddressPolicy=keep")

## Checklist
- [ ] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it
