### PR TITLE
fix(plymouth): do not install plymouth-set-default-theme into initrd

### DIFF
--- a/modules.d/45plymouth/module-setup.sh
+++ b/modules.d/45plymouth/module-setup.sh
@@ -67,7 +67,7 @@ install() {
 
     inst_multiple readlink
 
-    inst_multiple plymouthd plymouth plymouth-set-default-theme
+    inst_multiple plymouthd plymouth
 
     if ! dracut_module_included "systemd"; then
         inst_hook pre-trigger 10 "$moddir"/plymouth-pretrigger.sh


### PR DESCRIPTION
## Changes

The script `plymouth-set-default-theme` is not needed inside the initrd, because it is not called by anything. So skip installing it.

## Checklist
- [x] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it

Fixes #
