### PR TITLE
fix(network-manager): hostname not set with old systemd service units

### DIFF
--- a/modules.d/35network-manager/nm-run.sh
+++ b/modules.d/35network-manager/nm-run.sh
@@ -13,10 +13,11 @@ if [ -z "${DRACUT_SYSTEMD-}" ]; then
             break
         done
     fi
+fi
 
-    if [ -s /run/NetworkManager/initrd/hostname ]; then
-        cat /run/NetworkManager/initrd/hostname > /proc/sys/kernel/hostname
-    fi
+if [ -e /usr/lib/systemd/system/nm-initrd.service ] \
+    && [ -s /run/NetworkManager/initrd/hostname ]; then
+    cat /run/NetworkManager/initrd/hostname > /proc/sys/kernel/hostname
 fi
 
 kf_get_string() {


### PR DESCRIPTION
Regression introduced in 83dffc58f606ad7ad47a32716ce240831d7f018f

## Checklist
- [X] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it

Fixes #1743
