### PR TITLE
feat(IMA): Ability to halt system if IMA policy fails to load

### DIFF
--- a/modules.d/77integrity/ima-policy-load.sh
+++ b/modules.d/77integrity/ima-policy-load.sh
@@ -32,6 +32,9 @@ load_ima_policy() {
         info "Loading the provided IMA custom policy"
         printf '%s' "${IMAPOLICYPATH}" > "${IMASECDIR}"/policy \
             || cat "${IMAPOLICYPATH}" > "${IMASECDIR}"/policy
+    } || {
+        getargbool 0 "rd.ima.require_policy_file" \
+        && die "IMA policy required but not loaded"
     }
 
     return 0

--- a/modules.d/77integrity/ima-policy-load.sh
+++ b/modules.d/77integrity/ima-policy-load.sh
@@ -34,7 +34,7 @@ load_ima_policy() {
             || cat "${IMAPOLICYPATH}" > "${IMASECDIR}"/policy
     } || {
         getargbool 0 "rd.ima.require_policy_file" \
-        && die "IMA policy required but not loaded"
+            && die "IMA policy required but not loaded"
     }
 
     return 0

--- a/modules.d/77integrity/ima-policy-load.sh
+++ b/modules.d/77integrity/ima-policy-load.sh
@@ -28,6 +28,7 @@ load_ima_policy() {
     IMAPOLICYPATH="${NEWROOT}${IMAPOLICY}"
 
     # check the existence of the IMA policy file
+    # shellcheck disable=SC2015 
     [ -f "${IMAPOLICYPATH}" ] && {
         info "Loading the provided IMA custom policy"
         printf '%s' "${IMAPOLICYPATH}" > "${IMASECDIR}"/policy \

--- a/modules.d/77integrity/ima-policy-load.sh
+++ b/modules.d/77integrity/ima-policy-load.sh
@@ -28,7 +28,7 @@ load_ima_policy() {
     IMAPOLICYPATH="${NEWROOT}${IMAPOLICY}"
 
     # check the existence of the IMA policy file
-    # shellcheck disable=SC2015 
+    # shellcheck disable=SC2015
     [ -f "${IMAPOLICYPATH}" ] && {
         info "Loading the provided IMA custom policy"
         printf '%s' "${IMAPOLICYPATH}" > "${IMASECDIR}"/policy \


### PR DESCRIPTION
Add a new boolean cmdline option that, when set, will halt the system if the IMA policy file is not present or fails to load

When both `ima_policy=secure_boot` and `rd.ima.require_policy_file` are set, the system will halt if the required policy file is not also signed.

This option provides higher assurance that the system can boot into a trusted IMA state.

This pull request changes...

## Changes

## Checklist
- [x ] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it

Fixes #
