### PR TITLE
test: also use ukify in chroot

### DIFF
--- a/test/TEST-12-UEFI/test.sh
+++ b/test/TEST-12-UEFI/test.sh
@@ -44,6 +44,10 @@ test_run() {
     client_run "UEFI with UKI and squashfs root"
 }
 
+in_container_or_chroot() {
+    systemd-detect-virt -c &> /dev/null || systemd-detect-virt -r &> /dev/null
+}
+
 test_setup() {
     # Create what will eventually be our root filesystem
     "$DRACUT" --tmpdir "$TESTDIR" \
@@ -58,7 +62,7 @@ test_setup() {
     mkdir -p "$TESTDIR"/ESP/EFI/BOOT "$TESTDIR"/dracut.conf.d
 
     # This is the preferred way to build uki with dracut on a systemd based system
-    if command -v systemd-detect-virt &> /dev/null && systemd-detect-virt -c &> /dev/null \
+    if command -v systemd-detect-virt &> /dev/null && in_container_or_chroot \
         && command -v kernel-install &> /dev/null \
         && command -v systemctl &> /dev/null \
         && command -v ukify &> /dev/null; then


### PR DESCRIPTION
## Changes

The ukify tests want to run in an isolated environment to avoid modifying the host system. Allow running those tests in a chroot (like schroot).

## Checklist
- [x] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it

Fixes #
