### PR TITLE
test(UEFI): no longer needs to run inside a container

### DIFF
--- a/test/TEST-12-UEFI/test.sh
+++ b/test/TEST-12-UEFI/test.sh
@@ -58,8 +58,7 @@ test_setup() {
     mkdir -p "$TESTDIR"/ESP/EFI/BOOT "$TESTDIR"/dracut.conf.d
 
     # This is the preferred way to build uki with dracut on a systemd based system
-    if command -v systemd-detect-virt &> /dev/null && systemd-detect-virt -c &> /dev/null \
-        && command -v kernel-install &> /dev/null \
+    if command -v kernel-install &> /dev/null \
         && command -v systemctl &> /dev/null \
         && command -v ukify &> /dev/null; then
 


### PR DESCRIPTION
Commit 82cd3d3 allows changing the dracut configuration using the
/run/initramfs/dracut.conf.d directory without modifying the
/etc or /usr directories.

This new dracut feature allows running this test on bare metal.

Remove the check for running inside a container that was left
in this test inadvertently.

## Checklist
- [ ] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it

