### PR TITLE
fix(dracut-rescue): add support for /run/initramfs/dracut.conf.d                                                                                                                                  

### DIFF
--- a/install.d/51-dracut-rescue.install
+++ b/install.d/51-dracut-rescue.install
@@ -110,7 +110,7 @@ case "$COMMAND" in
         fi
 
         # source our config dir
-        for f in $(dropindirs_sort ".conf" "/etc/dracut.conf.d" "/usr/lib/dracut/dracut.conf.d"); do
+        for f in $(dropindirs_sort ".conf" "/etc/dracut.conf.d" "/usr/lib/dracut/dracut.conf.d" "/run/initramfs/dracut.conf.d"); do
             if [[ -e $f ]]; then
                 # shellcheck disable=SC1090
                 . "$f"

--- a/test/TEST-43-KERNEL-INSTALL/test.sh
+++ b/test/TEST-43-KERNEL-INSTALL/test.sh
@@ -4,11 +4,6 @@ set -eu
 TEST_DESCRIPTION="kernel-install with root filesystem on ext4 filesystem"
 
 test_check() {
-    if command -v systemd-detect-virt > /dev/null && ! systemd-detect-virt -c &> /dev/null && ! systemd-detect-virt -r &> /dev/null; then
-        echo "This test assumes that it runs inside a chroot or CI container."
-        return 1
-    fi
-
     if ! command -v kernel-install > /dev/null; then
         echo "This test needs kernel-install to run."
         return 1
@@ -55,14 +50,14 @@ test_setup() {
     dd if=/dev/zero of="$TESTDIR"/root.img bs=200MiB count=1 status=none && sync "$TESTDIR"/root.img
     mkfs.ext4 -q -L dracut -d "$TESTDIR"/dracut.*/initramfs/ "$TESTDIR"/root.img && sync "$TESTDIR"/root.img
 
-    mkdir -p /run/kernel
+    mkdir -p /run/kernel /run/initramfs/dracut.conf.d
     echo 'initrd_generator=dracut' >> /run/kernel/install.conf
 
     # enable test dracut config
-    cp /usr/lib/dracut/dracut.conf.d/test/*.conf /usr/lib/dracut/dracut.conf.d/
+    cp "${basedir}"/dracut.conf.d/test/*.conf /run/initramfs/dracut.conf.d/
 
     # enable rescue boot config
-    cp /usr/lib/dracut/dracut.conf.d/rescue/*.conf /usr/lib/dracut/dracut.conf.d/
+    cp "${basedir}"/dracut.conf.d/rescue/*.conf /run/initramfs/dracut.conf.d/
 
     # using kernell-install to invoke dracut
     mkdir -p "$BOOT_ROOT/$TOKEN/$KVERSION" "$BOOT_ROOT/loader/entries" "$BOOT_ROOT/$TOKEN/0-rescue/loader/entries"


### PR DESCRIPTION
Allow dracut read configuration files from /run as well, in addition to /etc/ and /usr including the dracut-rescue kernel-install script.                                                                                                                                                                            
                                                                                                                                                                                                  
Modify test case to demonstrate use-case and provide test coverage.                                                                                                                                                                                         
                                                                                                                                                                                                  
Follow-up to 82cd3d3 . 

## Checklist
- [ ] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it

Fixes #
