### PR TITLE
fix(lsinitrd): drop --verbose from cpio --to-stdout call

### DIFF
--- a/lsinitrd.sh
+++ b/lsinitrd.sh
@@ -206,7 +206,7 @@ cpio_extract_to_stdout() {
     if [ "$CPIO" = 3cpio ]; then
         3cpio --extract --parts "$parts" --to-stdout "$image" -- "$@"
     else
-        $CAT "$image" 2> /dev/null | cpio --extract --verbose --quiet --to-stdout -- "$@" 2> /dev/null
+        $CAT "$image" 2> /dev/null | cpio --extract --quiet --to-stdout -- "$@"
     fi
 }
 


### PR DESCRIPTION
## Changes

Calling `cpio --extract` with `--verbose` will print the filenames to stderr, but this output is thrown away. Calling `cpio --extract --quiet` will not print anything on stderr (except for error messages).

So drop `--verbose` and then stderr does not need to be thrown away any more.

## Checklist
- [ ] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it

Fixes #
