### PR TITLE
feat(plymouth): do not check plymouth-populate-initrd for "nash"

### DIFF
--- a/modules.d/45plymouth/module-setup.sh
+++ b/modules.d/45plymouth/module-setup.sh
@@ -54,8 +54,7 @@ depends() {
 # called by dracut
 install() {
     PKGLIBDIR=$(pkglib_dir)
-    if grep -q nash "${dracutsysrootdir-}${PKGLIBDIR}"/plymouth-populate-initrd \
-        || [ ! -x "${dracutsysrootdir-}${PKGLIBDIR}"/plymouth-populate-initrd ]; then
+    if [ ! -x "${dracutsysrootdir-}${PKGLIBDIR}"/plymouth-populate-initrd ]; then
         # shellcheck disable=SC1090
         . "$moddir"/plymouth-populate-initrd.sh
     else


### PR DESCRIPTION
## Changes

Commit f9749f368f1e ("plymouth: use /usr/libexec/plymouth/plymouth-populate-initrd if possible") checked `plymouth-populate-initrd` not not contain `nash` in 2009. The current Plymouth version does not contain this string and there were no reason given for this check.

Drop checking `plymouth-populate-initrd` for not containing `nash`.

## Checklist
- [ ] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it

Fixes #
