### PR TITLE
fix(dracut): use the correct systemd environment directory

### DIFF
--- a/dracut.sh
+++ b/dracut.sh
@@ -2274,13 +2274,13 @@ if [[ $kernel_only != yes ]]; then
 
     if [[ ${dracutsysrootdir-}$systemdutildir ]]; then
         if [[ -d ${initdir}/$systemdutildir ]]; then
-            mkdir -p "${initdir}"/etc/conf.d
+            mkdir -p "${initdir}/$environment"
             {
                 printf "%s\n" "systemdutildir=\"$systemdutildir\""
                 printf "%s\n" "systemdsystemunitdir=\"$systemdsystemunitdir\""
                 printf "%s\n" "systemdsystemconfdir=\"$systemdsystemconfdir\""
                 printf "%s\n" "systemdnetworkconfdir=\"$systemdnetworkconfdir\""
-            } > "${initdir}"/etc/conf.d/systemd.conf
+            } > "${initdir}/$environment"/systemd.conf
         fi
     fi
 


### PR DESCRIPTION
Use the directory configued by the environment variable to store the systemd configuration insteadd of hardcoded path (which does not seem to be documented by systemd).

## Checklist
- [ ] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it

Fixes #
