### PR TITLE
fix(ci): allow each test to decide to use -a or -m

### DIFF
--- a/dracut.conf.d/test-root/test-root.conf
+++ b/dracut.conf.d/test-root/test-root.conf
@@ -1,4 +1,5 @@
-dracutmodules+=" test-root "
+# no initrd services for rootfs
+omit_dracutmodules=" systemd-initrd dracut-systemd "
 # do not compress, do not strip
 compress="cat"
 do_strip="no"

--- a/test/TEST-10-BASIC/test.sh
+++ b/test/TEST-10-BASIC/test.sh
@@ -24,6 +24,7 @@ test_setup() {
     # create root filesystem
     "$DRACUT" --tmpdir "$TESTDIR" \
         --add-confdir test-root \
+        -m test-root \
         -f "$TESTDIR"/initramfs.root
 
     dd if=/dev/zero of="$TESTDIR"/root.img bs=200MiB count=1 status=none && sync "$TESTDIR"/root.img

--- a/test/TEST-11-USR-MOUNT/test.sh
+++ b/test/TEST-11-USR-MOUNT/test.sh
@@ -51,6 +51,7 @@ test_setup() {
     # Create what will eventually be our root filesystem onto an overlay
     "$DRACUT" --tmpdir "$TESTDIR" \
         --add-confdir test-root \
+        -m test-root \
         --mount "/dev/disk/by-id/scsi-0QEMU_QEMU_HARDDISK_root /usr btrfs subvol=usr,rw" \
         -f "$TESTDIR"/initramfs.root
     mkdir -p "$TESTDIR"/overlay/source && mv "$TESTDIR"/dracut.*/initramfs/* "$TESTDIR"/overlay/source && rm -rf "$TESTDIR"/dracut.*

--- a/test/TEST-12-UEFI/test.sh
+++ b/test/TEST-12-UEFI/test.sh
@@ -48,6 +48,7 @@ test_setup() {
     # Create what will eventually be our root filesystem
     "$DRACUT" --tmpdir "$TESTDIR" \
         --add-confdir test-root \
+        -m test-root \
         "$TESTDIR"/tmp-initramfs.root
 
     KVERSION=$(determine_kernel_version "$TESTDIR"/tmp-initramfs.root)

--- a/test/TEST-13-SYSROOT/test.sh
+++ b/test/TEST-13-SYSROOT/test.sh
@@ -24,6 +24,7 @@ test_setup() {
     # create root filesystem
     "$DRACUT" --tmpdir "$TESTDIR" \
         --add-confdir test-root \
+        -m test-root \
         -f "$TESTDIR"/initramfs.root
 
     dd if=/dev/zero of="$TESTDIR"/root.img bs=200MiB count=1 status=none && sync "$TESTDIR"/root.img

--- a/test/TEST-20-STORAGE/test.sh
+++ b/test/TEST-20-STORAGE/test.sh
@@ -116,6 +116,7 @@ test_setup() {
     # Create what will eventually be our root filesystem onto an overlay
     "$DRACUT" --tmpdir "$TESTDIR" \
         --add-confdir test-root \
+        -m test-root \
         -f "$TESTDIR"/initramfs.root
     mkdir -p "$TESTDIR"/overlay/source && mv "$TESTDIR"/dracut.*/initramfs/* "$TESTDIR"/overlay/source && rm -rf "$TESTDIR"/dracut.*
 

--- a/test/TEST-26-ENC-RAID-LVM/test.sh
+++ b/test/TEST-26-ENC-RAID-LVM/test.sh
@@ -56,6 +56,7 @@ test_setup() {
     # Create what will eventually be our root filesystem onto an overlay
     "$DRACUT" --tmpdir "$TESTDIR" \
         --add-confdir test-root \
+        -m test-root \
         -f "$TESTDIR"/initramfs.root
     mkdir -p "$TESTDIR"/overlay/source && mv "$TESTDIR"/dracut.*/initramfs/* "$TESTDIR"/overlay/source && rm -rf "$TESTDIR"/dracut.*
 

--- a/test/TEST-30-DMSQUASH/test.sh
+++ b/test/TEST-30-DMSQUASH/test.sh
@@ -84,6 +84,7 @@ test_setup() {
     # Create what will eventually be our root filesystem onto an overlay
     "$DRACUT" --tmpdir "$TESTDIR" \
         --add-confdir test-root \
+        -m test-root \
         -i ./test-init.sh /sbin/init-persist \
         -f "$TESTDIR"/initramfs.root
     mkdir -p "$TESTDIR"/rootfs && mv "$TESTDIR"/dracut.*/initramfs/* "$TESTDIR"/rootfs && rm -rf "$TESTDIR"/dracut.*

--- a/test/TEST-40-SYSTEMD/test.sh
+++ b/test/TEST-40-SYSTEMD/test.sh
@@ -28,6 +28,7 @@ test_setup() {
     # Create what will eventually be our root filesystem onto an overlay
     "$DRACUT" --tmpdir "$TESTDIR" \
         --add-confdir test-root \
+        -m test-root \
         -f "$TESTDIR"/initramfs.root
     mkdir -p "$TESTDIR"/overlay/source && mv "$TESTDIR"/dracut.*/initramfs/* "$TESTDIR"/overlay/source && rm -rf "$TESTDIR"/dracut.*
 

--- a/test/TEST-41-FULL-SYSTEMD/test.sh
+++ b/test/TEST-41-FULL-SYSTEMD/test.sh
@@ -93,7 +93,7 @@ test_setup() {
     # Create what will eventually be our root filesystem onto an overlay
     "$DRACUT" --tmpdir "$TESTDIR" \
         --add-confdir test-root \
-        -a "$dracut_modules" \
+        -a "test-root $dracut_modules" \
         -f "$TESTDIR"/initramfs.root
 
     KVERSION=$(determine_kernel_version "$TESTDIR"/initramfs.root)

--- a/test/TEST-42-SYSTEMD-INITRD/test.sh
+++ b/test/TEST-42-SYSTEMD-INITRD/test.sh
@@ -44,6 +44,7 @@ test_setup() {
     # Create what will eventually be our root filesystem onto an overlay
     "$DRACUT" --tmpdir "$TESTDIR" \
         --add-confdir test-root \
+        -m test-root \
         -f "$TESTDIR"/initramfs.root
     mkdir -p "$TESTDIR"/overlay/source && mv "$TESTDIR"/dracut.*/initramfs/* "$TESTDIR"/overlay/source && rm -rf "$TESTDIR"/dracut.*
 

--- a/test/TEST-43-KERNEL-INSTALL/test.sh
+++ b/test/TEST-43-KERNEL-INSTALL/test.sh
@@ -42,6 +42,7 @@ test_setup() {
     # shellcheck disable=SC2153
     "$DRACUT" --tmpdir "$TESTDIR" \
         --add-confdir test-root \
+        -m test-root \
         -f "$TESTDIR"/initramfs.root
 
     KVERSION=$(determine_kernel_version "$TESTDIR"/initramfs.root)

--- a/test/TEST-50-NETWORK/test.sh
+++ b/test/TEST-50-NETWORK/test.sh
@@ -30,6 +30,7 @@ test_setup() {
         -I "ip" \
         -i "./assertion.sh" "/assertion.sh" \
         --add-confdir test-root \
+        -m test-root \
         -f "$TESTDIR"/initramfs.root "$KVERSION"
 
     dd if=/dev/zero of="$TESTDIR"/root.img bs=200MiB count=1 status=none && sync "$TESTDIR"/root.img

--- a/test/TEST-60-NFS/test.sh
+++ b/test/TEST-60-NFS/test.sh
@@ -227,6 +227,7 @@ test_run() {
 test_setup() {
     "$DRACUT" --tmpdir "$TESTDIR" \
         --add-confdir test-root \
+        -m test-root \
         -a "$USE_NETWORK url-lib nfs" \
         -I "ip grep setsid" \
         -f "$TESTDIR"/initramfs.root || return 1
@@ -236,6 +237,7 @@ test_setup() {
     # Create what will eventually be the server root filesystem onto an overlay
     "$DRACUT" --tmpdir "$TESTDIR"/server/overlay \
         --add-confdir test-root \
+        -m test-root \
         -a "bash $USE_NETWORK nfs" \
         --add-drivers "nfsd sunrpc lockd" \
         -I "exportfs pidof rpc.nfsd rpc.mountd dhcpd" \

--- a/test/TEST-70-ISCSI/test.sh
+++ b/test/TEST-70-ISCSI/test.sh
@@ -132,6 +132,7 @@ test_setup() {
     # Create what will eventually be the client root filesystem onto an overlay
     "$DRACUT" --tmpdir "$TESTDIR" \
         --add-confdir test-root \
+        -m test-root \
         -I "ip grep setsid" \
         -f "$TESTDIR"/initramfs.root
     mkdir -p "$TESTDIR"/overlay/source && mv "$TESTDIR"/dracut.*/initramfs/* "$TESTDIR"/overlay/source && rm -rf "$TESTDIR"/dracut.*
@@ -168,6 +169,7 @@ test_setup() {
     # Create what will eventually be the server root filesystem onto an overlay
     "$DRACUT" --tmpdir "$TESTDIR" \
         --add-confdir test-root \
+        -m test-root \
         -a "$USE_NETWORK" \
         -d "iscsi_tcp crc32c ipv6" \
         -I "modprobe chmod ip setsid pidof tgtd tgtadm /etc/passwd" \

--- a/test/TEST-71-ISCSI-MULTI/test.sh
+++ b/test/TEST-71-ISCSI-MULTI/test.sh
@@ -140,6 +140,7 @@ test_setup() {
     rm -rf -- "$TESTDIR"/overlay
     "$DRACUT" --keep --tmpdir "$TESTDIR" \
         --add-confdir test-root \
+        -m test-root \
         -I "ip grep setsid" \
         --no-hostonly \
         -f "$TESTDIR"/initramfs.root
@@ -176,6 +177,7 @@ test_setup() {
     rm -rf -- "$TESTDIR"/overlay
     "$DRACUT" --tmpdir "$TESTDIR" \
         --add-confdir test-root \
+        -m test-root \
         -a "$USE_NETWORK iscsi" \
         -d "iscsi_tcp crc32c ipv6 af_packet" \
         -I "ip grep sleep setsid chmod modprobe pidof tgtd tgtadm" \

--- a/test/TEST-72-NBD/test.sh
+++ b/test/TEST-72-NBD/test.sh
@@ -179,6 +179,7 @@ make_encrypted_root() {
     # Create what will eventually be our root filesystem onto an overlay
     "$DRACUT" --tmpdir "$TESTDIR" \
         --add-confdir test-root \
+        -m test-root \
         -I "ip grep" \
         --no-hostonly \
         -f "$TESTDIR"/initramfs.root
@@ -214,6 +215,7 @@ make_client_root() {
     rm -fr "$TESTDIR"/overlay
     "$DRACUT" --tmpdir "$TESTDIR" \
         --add-confdir test-root \
+        -m test-root \
         -I "ip" \
         --no-hostonly \
         -f "$TESTDIR"/initramfs.root
@@ -259,6 +261,7 @@ EOF
 
     "$DRACUT" --keep --tmpdir "$TESTDIR" \
         --add-confdir test-root \
+        -m test-root \
         -a "$USE_NETWORK" \
         -I "ip grep sleep nbd-server chmod modprobe pidof" \
         --install-optional "/etc/netconfig dhcpd /etc/group /etc/nsswitch.conf /etc/rpc /etc/protocols /etc/services /usr/etc/nsswitch.conf /usr/etc/rpc /usr/etc/protocols /usr/etc/services" \


### PR DESCRIPTION
## Changes

Forcing '-m' in the test-root config file would mean that an individual test case can no longer opt into using '-a'.

This can lead to a situation, where e.g. plymouth dracut module is included in the initramfs, but not in the rootfs, which could lead to test failure.

## Checklist
- [ ] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it

Fixes #
