### PR TITLE
Output additional CPIO information.

### DIFF
--- a/src/skipcpio/skipcpio.c
+++ b/src/skipcpio/skipcpio.c
@@ -80,6 +80,13 @@ int main(int argc, char **argv)
         int ret = EXIT_FAILURE;
         unsigned long filesize;
         unsigned long filename_length;
+        int debug_output = 0;
+
+        if (getenv("DEBUG_SKIPCPIO")) {
+                if (strcmp(getenv("DEBUG_SKIPCPIO"), "1") == 0) {
+                        debug_output = 1;
+                }
+        }
 
         if (argc != 2) {
                 fprintf(stderr, "Usage: %s <file>\n", argv[0]);
@@ -106,6 +113,9 @@ int main(int argc, char **argv)
 
         /* check, if this is a cpio archive */
         if (memcmp(buf.cpio.h.c_magic, CPIO_MAGIC, CPIO_MAGIC_LEN)) {
+                if (debug_output) {
+                        fprintf(stderr, "No CPIO header found.\n");
+                }
                 goto cat_rest;
         }
 
@@ -171,6 +181,9 @@ int main(int argc, char **argv)
                                 if (fseek(f, pos, SEEK_SET)) {
                                         pr_err("fseek\n");
                                         goto end;
+                                }
+                                if (debug_output) {
+                                        fprintf(stderr, "CPIO data and any trailing zeros end at position %ld.\n", (pos-1));
                                 }
                                 break;
                         }

--- a/test/TEST-81-SKIPCPIO/test.sh
+++ b/test/TEST-81-SKIPCPIO/test.sh
@@ -75,6 +75,29 @@ EOF
 11
 12
 EOF
+
+    DEBUG_SKIPCPIO=1 "$skipcpio_path"/skipcpio "$CPIO_TESTDIR/skipcpio_simple.cpio" \
+        > /dev/null 2> "$CPIO_TESTDIR/debug.log"
+    if [ ! -s "$CPIO_TESTDIR/debug.log" ]; then
+        echo "Debug log file is missing or empty."
+        return 1
+    fi
+    if ! grep -q "CPIO data and any trailing zeros end at position" "$CPIO_TESTDIR/debug.log"; then
+        echo "Expected debug message not found in log."
+        return 1
+    fi
+
+    truncate -s 1K "$CPIO_TESTDIR/empty.img"
+    DEBUG_SKIPCPIO=1 "$skipcpio_path"/skipcpio "$CPIO_TESTDIR/empty.img" > /dev/null \
+        2> "$CPIO_TESTDIR/debug.log"
+    if [ ! -s "$CPIO_TESTDIR/debug.log" ]; then
+        echo "Debug log file is missing or empty."
+        return 1
+    fi
+    if ! grep -q "No CPIO header found." "$CPIO_TESTDIR/debug.log"; then
+        echo "Expected debug message not found in log."
+        return 1
+    fi
 }
 
 test_run() {


### PR DESCRIPTION
This PR provides additional CPIO information to `skipcpio`, allowing users to better understand the composition of the split file.

## Changes
- skipcpio

## Checklist
- [x] I have tested it locally
- [x] I have reviewed and updated any documentation if relevant
- [x] I am providing new code and test(s) for it
