### PR TITLE
ci(alpine): add seabios package

### DIFF
--- a/test/container/Dockerfile-alpine
+++ b/test/container/Dockerfile-alpine
@@ -19,10 +19,12 @@
 # - kernel-install is not available
 
 ARG DISTRIBUTION=alpine
+ARG PLATFORM=linux/amd64
 FROM docker.io/${DISTRIBUTION}
 
 # export ARG
 ARG DISTRIBUTION
+ARG PLATFORM
 
 # Packages to pass the BASIC test
 # Use dracut-tests package to install dependencies for test suite
@@ -43,3 +45,9 @@ RUN apk add --no-cache \
     dnsmasq \
     networkmanager-cli \
     networkmanager-initrd-generator
+
+RUN \
+if [ "${PLATFORM}" = "linux/amd64" ]; then \
+    apk add --no-cache \
+        seabios \
+; fi


### PR DESCRIPTION
## Changes

seabios no longer gets installed in the alpine container which leads to the following error.

```
run-qemu: /usr/bin/qemu-system-x86_64 ...

qemu: could not load PC BIOS 'bios-256k.bin'
```

To resolve the error, make sure seabios is installed.


## Checklist
- [ ] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it

Fixes #
