### PR TITLE
fix(dracut): use grep -q/-s to silence output/error

### DIFF
--- a/dracut-init.sh
+++ b/dracut-init.sh
@@ -475,15 +475,15 @@ inst_rule_group_owner() {
 
     # shellcheck disable=SC2013
     for i in $(sed -nr 's/.*OWNER=?"([^ "]+).*/\1/p' "$1"); do
-        if ! grep -Eq "^$i:" "$initdir/etc/passwd" 2> /dev/null; then
-            grep -E "^$i:" "${dracutsysrootdir-}/etc/passwd" 2> /dev/null >> "$initdir/etc/passwd"
+        if ! grep -Eqs "^$i:" "$initdir/etc/passwd"; then
+            grep -Es "^$i:" "${dracutsysrootdir-}/etc/passwd" >> "$initdir/etc/passwd"
         fi
     done
 
     # shellcheck disable=SC2013
     for i in $(sed -nr 's/.*GROUP=?"([^ "]+).*/\1/p' "$1"); do
-        if ! grep -Eq "^$i:" "$initdir/etc/group" 2> /dev/null; then
-            grep -E "^$i:" "${dracutsysrootdir-}/etc/group" 2> /dev/null >> "$initdir/etc/group"
+        if ! grep -Eqs "^$i:" "$initdir/etc/group"; then
+            grep -Es "^$i:" "${dracutsysrootdir-}/etc/group" >> "$initdir/etc/group"
         fi
     done
 }

--- a/dracut-initramfs-restore.sh
+++ b/dracut-initramfs-restore.sh
@@ -99,7 +99,7 @@ elif [[ -f erofs-root.img ]]; then
     fi
 fi
 
-if grep -q -w selinux /sys/kernel/security/lsm 2> /dev/null \
+if grep -qs -w selinux /sys/kernel/security/lsm \
     && [ -e /etc/selinux/config ] && [ -x /usr/sbin/setfiles ]; then
     . /etc/selinux/config
     if [[ $SELINUX != "disabled" && -n $SELINUXTYPE ]]; then

--- a/modules.d/10systemd/module-setup.sh
+++ b/modules.d/10systemd/module-setup.sh
@@ -118,18 +118,18 @@ install() {
 
     inst_multiple -o nologin
     {
-        grep '^adm:' "${dracutsysrootdir-}"/etc/passwd 2> /dev/null
+        grep -s '^adm:' "${dracutsysrootdir-}"/etc/passwd
         # we don't use systemd-networkd, but the user is in systemd.conf tmpfiles snippet
-        grep '^systemd-network:' "${dracutsysrootdir-}"/etc/passwd 2> /dev/null
+        grep -s '^systemd-network:' "${dracutsysrootdir-}"/etc/passwd
     } >> "$initdir/etc/passwd"
 
     {
-        grep '^wheel:' "${dracutsysrootdir-}"/etc/group 2> /dev/null
-        grep '^adm:' "${dracutsysrootdir-}"/etc/group 2> /dev/null
-        grep '^utmp:' "${dracutsysrootdir-}"/etc/group 2> /dev/null
-        grep '^root:' "${dracutsysrootdir-}"/etc/group 2> /dev/null
+        grep -s '^wheel:' "${dracutsysrootdir-}"/etc/group
+        grep -s '^adm:' "${dracutsysrootdir-}"/etc/group
+        grep -s '^utmp:' "${dracutsysrootdir-}"/etc/group
+        grep -s '^root:' "${dracutsysrootdir-}"/etc/group
         # we don't use systemd-networkd, but the user is in systemd.conf tmpfiles snippet
-        grep '^systemd-network:' "${dracutsysrootdir-}"/etc/group 2> /dev/null
+        grep -s '^systemd-network:' "${dracutsysrootdir-}"/etc/group
     } >> "$initdir/etc/group"
 
     local _systemdbinary="$systemdutildir"/systemd

--- a/modules.d/11systemd-ask-password/module-setup.sh
+++ b/modules.d/11systemd-ask-password/module-setup.sh
@@ -27,7 +27,7 @@ depends() {
         # - ramfb is not enough
         # Therefore, depend on the drm module if virtio_gpu is loaded on the system.
         if [[ ${DRACUT_ARCH:-$(uname -m)} == arm* || ${DRACUT_ARCH:-$(uname -m)} == aarch64 ]] \
-            && grep -r -q "virtio:d00000010v" /sys/bus/virtio/devices/*/modalias 2> /dev/null; then
+            && grep -r -qs "virtio:d00000010v" /sys/bus/virtio/devices/*/modalias; then
             echo drm
         fi
     fi

--- a/modules.d/35network-legacy/dhcp-multi.sh
+++ b/modules.d/35network-legacy/dhcp-multi.sh
@@ -22,7 +22,7 @@ do_dhclient() {
     _DHCPRETRY=$(getargnum 1 1 1000000000 rd.net.dhcp.retry=)
 
     if [ -n "$_timeout" ]; then
-        if ! (dhclient --help 2>&1 | grep -q -F -- '--timeout' 2> /dev/null); then
+        if ! (dhclient --help 2>&1 | grep -qs -F -- '--timeout'); then
             warn "rd.net.timeout.dhcp has no effect because dhclient does not implement the --timeout option"
             unset _timeout
         fi

--- a/modules.d/35network-legacy/ifup.sh
+++ b/modules.d/35network-legacy/ifup.sh
@@ -73,7 +73,7 @@ do_dhcp() {
     fi
 
     if [ -n "$_timeout" ]; then
-        if ! (dhclient --help 2>&1 | grep -q -F -- '--timeout' 2> /dev/null); then
+        if ! (dhclient --help 2>&1 | grep -qs -F -- '--timeout'); then
             warn "rd.net.timeout.dhcp has no effect because dhclient does not implement the --timeout option"
             unset _timeout
         fi

--- a/modules.d/35network-manager/nm-run.sh
+++ b/modules.d/35network-manager/nm-run.sh
@@ -57,7 +57,7 @@ dhcpopts_create() {
 for _i in /sys/class/net/*; do
     [ -d "$_i" ] || continue
     state="/run/NetworkManager/devices/$(cat "$_i"/ifindex)"
-    grep -q '^connection-uuid=' "$state" 2> /dev/null || continue
+    grep -qs '^connection-uuid=' "$state" || continue
     ifname="${_i##*/}"
     dhcpopts_create "$state" > /tmp/dhclient."$ifname".dhcpopts
     source_hook initqueue/online "$ifname"

--- a/modules.d/70bluetooth/module-setup.sh
+++ b/modules.d/70bluetooth/module-setup.sh
@@ -13,7 +13,7 @@ check() {
         #  * Keyboard (0x40)
         #  * Keyboard/pointing (0xC0)
         # and if Appearance is set to the value defined for keyboard (0x03C1)
-        [ -d "/sys/class/bluetooth" ] && grep -qiE -e 'Class=0x[0-9a-f]{3}5[4c]0' -e 'Appearance=0x03c1' /var/lib/bluetooth/*/*/info 2> /dev/null \
+        [ -d "/sys/class/bluetooth" ] && grep -qsiE -e 'Class=0x[0-9a-f]{3}5[4c]0' -e 'Appearance=0x03c1' /var/lib/bluetooth/*/*/info \
             && dwarn "If you need to use bluetooth, please include it explicitly."
     fi
 

--- a/modules.d/74debug/module-setup.sh
+++ b/modules.d/74debug/module-setup.sh
@@ -47,5 +47,5 @@ install() {
         tcpdump \
         vi
 
-    grep '^tcpdump:' "${dracutsysrootdir-}"/etc/passwd 2> /dev/null >> "$initdir/etc/passwd"
+    grep -s '^tcpdump:' "${dracutsysrootdir-}"/etc/passwd >> "$initdir/etc/passwd"
 }

--- a/modules.d/74fcoe/module-setup.sh
+++ b/modules.d/74fcoe/module-setup.sh
@@ -79,12 +79,12 @@ cmdline() {
             # DCB_REQUIRED in "/etc/fcoe/cfg-xxx" is expected to set to "no".
             #
             # Force "nodcb" if there's any DCB_REQUIRED="no"(child or vlan parent).
-            if grep -q '^[[:blank:]]*DCB_REQUIRED="no"' /etc/fcoe/cfg-"${i##*/}" &> /dev/null; then
+            if grep -qs '^[[:blank:]]*DCB_REQUIRED="no"' /etc/fcoe/cfg-"${i##*/}"; then
                 dcb="nodcb"
             fi
 
             if [ "$p" ]; then
-                if grep -q '^[[:blank:]]*DCB_REQUIRED="no"' /etc/fcoe/cfg-"${p}" &> /dev/null; then
+                if grep -qs '^[[:blank:]]*DCB_REQUIRED="no"' /etc/fcoe/cfg-"${p}"; then
                     dcb="nodcb"
                 fi
             fi

--- a/modules.d/74resume/module-setup.sh
+++ b/modules.d/74resume/module-setup.sh
@@ -14,7 +14,7 @@ check() {
     if [[ $hostonly ]] || [[ $mount_needs ]]; then
         # Resuming won't work if swap is on a netdevice
         swap_on_netdevice && return 255
-        if grep -rqE '(^| )resume=' /proc/cmdline /etc/cmdline /etc/cmdline.d /etc/kernel/cmdline /usr/lib/kernel/cmdline 2> /dev/null; then
+        if grep -rqsE '(^| )resume=' /proc/cmdline /etc/cmdline /etc/cmdline.d /etc/kernel/cmdline /usr/lib/kernel/cmdline; then
             # hibernation support requested on kernel command line
             return 0
         else

--- a/modules.d/74udev-rules/module-setup.sh
+++ b/modules.d/74udev-rules/module-setup.sh
@@ -62,8 +62,8 @@ install() {
 
     {
         for i in cdrom tape dialout floppy; do
-            if ! grep -q "^$i:" "$initdir"/etc/group 2> /dev/null; then
-                if ! grep "^$i:" "${dracutsysrootdir-}"/etc/group 2> /dev/null; then
+            if ! grep -qs "^$i:" "$initdir"/etc/group; then
+                if ! grep -s "^$i:" "${dracutsysrootdir-}"/etc/group; then
                     case $i in
                         cdrom) echo "$i:x:11:" ;;
                         dialout) echo "$i:x:18:" ;;

--- a/modules.d/77dracut-systemd/parse-root.sh
+++ b/modules.d/77dracut-systemd/parse-root.sh
@@ -26,7 +26,7 @@ if [ "$rootok" = "1" ]; then
         # after remote-fs-pre.target since the initqueue is ordered before it so
         # it will never actually show up (think Tang-pinned rootfs).
         cat > "$hookdir/initqueue/finished/devexists-${root_name}.sh" << EOF
-if ! grep -q After=remote-fs-pre.target /run/systemd/generator/systemd-cryptsetup@*.service 2>/dev/null; then
+if ! grep -qs After=remote-fs-pre.target /run/systemd/generator/systemd-cryptsetup@*.service; then
     [ -e "$root_dev" ]
 fi
 EOF

--- a/modules.d/80base/module-setup.sh
+++ b/modules.d/80base/module-setup.sh
@@ -66,11 +66,11 @@ install() {
     # add common users in /etc/passwd, it will be used by nfs/ssh currently
     # use password for hostonly images to facilitate secure sulogin in emergency console
     [[ $hostonly ]] && pwshadow='x'
-    grep '^root:' "$initdir/etc/passwd" > /dev/null 2>&1 || echo "root:$pwshadow:0:0::/root:/bin/sh" >> "$initdir/etc/passwd"
+    grep -qs '^root:' "$initdir/etc/passwd" || echo "root:$pwshadow:0:0::/root:/bin/sh" >> "$initdir/etc/passwd"
 
     if [[ $hostonly ]]; then
         # check if other dracut modules already created an entry for root in /etc/shadow
-        if grep -q '^root:' "$initdir/etc/shadow" > /dev/null 2>&1; then
+        if grep -qs '^root:' "$initdir/etc/shadow"; then
             grep -v '^root:' "$initdir/etc/shadow" > "$initdir/etc/shadow-"
             mv "$initdir/etc/shadow-" "$initdir/etc/shadow"
         fi


### PR DESCRIPTION
## Changes

There is no need to redirect output/error to /dev/null. Simply use -q/-s option provided by grep.

Note we should use avoid using "set -o pipefail lsinitrd PAHT_PATH_INITRAMFS | grep -q PATTERN". Because with set -o pipefail, a pipeline’s exit status becomes non-zero if any element of the pipeline fails and grep -q exits as soon as it sees a match.

## Checklist
- [ ] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it

Fixes #
