### PR TITLE
feat(dmsquash-live-autooverlay): support readlink from uutils

### DIFF
--- a/modules.d/70dmsquash-live-autooverlay/create-overlay.sh
+++ b/modules.d/70dmsquash-live-autooverlay/create-overlay.sh
@@ -51,7 +51,8 @@ gatherData() {
         info "Skipping overlay creation: unpartitioned or read-only media detected"
         exit 0
     fi
-    fullDriveSysfsPath=$(readlink -f "${rootDeviceSysfsPath}/..")
+    fullSysfsPath=$(readlink -f "${rootDeviceSysfsPath}")
+    fullDriveSysfsPath="${fullSysfsPath%/*}"
     blockDevice="/dev/${fullDriveSysfsPath##*/}"
     currentPartitionCount=$(grep --count -E "${blockDevice#/dev/}[0-9]+" /proc/partitions)
 


### PR DESCRIPTION
## Changes

The readlink command from GNU coreutils and the one from uutil coreutils behave differently in case the path contains symlinks and `..`. GNU readlink traverses symlinks first, but uutils resolves `..` first.

Example from Ubuntu 25.10 (questing):

```sh
$ gnureadlink -f /sys/class/block/nvme0n1p1/..
/sys/devices/pci0000:00/0000:00:01.0/0000:01:00.0/nvme/nvme0/nvme0n1
$ /usr/lib/cargo/bin/coreutils/readlink -f /sys/class/block/nvme0n1p1/..
/sys/class/block
```

Enforce the correct order by resolving the symlinks before `..`. That way the result does not rely on implementation specifics of different readlink implementations.

## Checklist
- [x] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it

Fixes #
