### PR TITLE
fix(base): set udev log level properly

### DIFF
--- a/modules.d/80base/init.sh
+++ b/modules.d/80base/init.sh
@@ -146,8 +146,11 @@ getargbool 0 rd.udev.log_level=info -d rd.udev.log-priority=info -d rd.udev.info
 getargbool 0 rd.udev.log_level=debug -d rd.udev.log-priority=debug -d rd.udev.debug -d -y rdudevdebug \
     && UDEV_LOG=debug
 
+mkdir -p /etc/udev
+echo "udev_log=${UDEV_LOG}" >> /etc/udev/udev.conf
+
 # start up udev and trigger cold plugs
-UDEV_LOG=$UDEV_LOG "$systemdutildir"/systemd-udevd --daemon --resolve-names=never
+"$systemdutildir"/systemd-udevd --daemon --resolve-names=never
 
 UDEV_QUEUE_EMPTY="udevadm settle --timeout=0"
 


### PR DESCRIPTION
since udev logging functionality was added in af67d62151 to dracut, in commit 25e773eeb4 in systemd, udev has since migrated from its own logging system to the logging system found in the rest of systemd, which uses a different environment variable for setting the log level.  this will allow for systems to truely be quiet during boot (i.e., before showing a splash or before the init system begins being loud)

hilariously, udev did the migration the day after dracut added support! if systems were kept up to date with live branches, that means the original change would have only worked for one day.

## Checklist
- [x] I have tested it locally
- [x] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it

Fixes af67d62151
