### PR TITLE
fix(dmsquash-live): install required stat binary

### DIFF
--- a/modules.d/70dmsquash-live/module-setup.sh
+++ b/modules.d/70dmsquash-live/module-setup.sh
@@ -22,7 +22,7 @@ installkernel() {
 
 # called by dracut
 install() {
-    inst_multiple umount dmsetup blkid dd losetup blockdev find rmdir grep
+    inst_multiple umount dmsetup blkid dd losetup blockdev find rmdir grep stat
     inst_multiple -o checkisomd5
     inst_hook cmdline 30 "$moddir/parse-dmsquash-live.sh"
     inst_hook cmdline 31 "$moddir/parse-iso-scan.sh"


### PR DESCRIPTION
Follow-up for 52351cfa049a9594d539e6a5337d591e8039ab80

## Checklist
- [ ] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it

Fixes #1780
