### PR TITLE
test: split "made it to the rootfs" from "Powering down."

### DIFF
--- a/test/TEST-60-NFS/client-init.sh
+++ b/test/TEST-60-NFS/client-init.sh
@@ -6,7 +6,7 @@
 export PATH=/usr/sbin:/usr/bin:/sbin:/bin
 exec > /dev/console 2>&1
 
-echo "made it to the rootfs!"
+echo "made it to the NFS client rootfs!"
 
 while read -r dev _ fstype opts rest || [ -n "$dev" ]; do
     [ "$fstype" != "nfs" ] && [ "$fstype" != "nfs4" ] && continue

--- a/test/TEST-60-NFS/server-init.sh
+++ b/test/TEST-60-NFS/server-init.sh
@@ -5,7 +5,7 @@ export PATH=/usr/sbin:/usr/bin:/sbin:/bin
 export TERM=linux
 export PS1='nfstest-server:\w\$ '
 : > /dev/watchdog
-echo "made it to the rootfs!"
+echo "made it to the NFS server rootfs!"
 echo server > /proc/sys/kernel/hostname
 
 wait_for_if_link() {

--- a/test/TEST-70-ISCSI/client-init.sh
+++ b/test/TEST-70-ISCSI/client-init.sh
@@ -3,7 +3,7 @@
 export PATH=/usr/sbin:/usr/bin:/sbin:/bin
 exec > /dev/console 2>&1
 
-echo "made it to the rootfs!"
+echo "made it to the iSCSI client rootfs!"
 while read -r dev _ fstype opts rest || [ -n "$dev" ]; do
     [ "$fstype" != "ext4" ] && continue
     echo "iscsi-OK $dev $fstype $opts" | dd oflag=direct,dsync of=/dev/disk/by-id/scsi-0QEMU_QEMU_HARDDISK_marker status=none

--- a/test/TEST-70-ISCSI/server-init.sh
+++ b/test/TEST-70-ISCSI/server-init.sh
@@ -4,7 +4,7 @@ set -x
 export PATH=/usr/sbin:/usr/bin:/sbin:/bin
 export TERM=linux
 export PS1='server:\w\$ '
-echo "made it to the rootfs!"
+echo "made it to the iSCSI server rootfs!"
 echo server > /proc/sys/kernel/hostname
 
 wait_for_if_link() {

--- a/test/TEST-71-ISCSI-MULTI/client-init.sh
+++ b/test/TEST-71-ISCSI-MULTI/client-init.sh
@@ -3,7 +3,7 @@
 export PATH=/usr/sbin:/usr/bin:/sbin:/bin
 exec > /dev/console 2>&1
 
-echo "made it to the rootfs!"
+echo "made it to the iSCSI multi client rootfs!"
 while read -r dev _ fstype opts rest || [ -n "$dev" ]; do
     [ "$fstype" != "ext4" ] && continue
     echo "iscsi-OK $dev $fstype $opts" | dd oflag=direct,dsync of=/dev/disk/by-id/scsi-0QEMU_QEMU_HARDDISK_marker status=none

--- a/test/TEST-71-ISCSI-MULTI/server-init.sh
+++ b/test/TEST-71-ISCSI-MULTI/server-init.sh
@@ -4,7 +4,7 @@ set -x
 export PATH=/usr/sbin:/usr/bin:/sbin:/bin
 export TERM=linux
 export PS1='server:\w\$ '
-echo "made it to the rootfs!"
+echo "made it to the iSCSI multi server rootfs!"
 echo server > /proc/sys/kernel/hostname
 
 wait_for_if_link() {

--- a/test/TEST-72-NBD/client-init.sh
+++ b/test/TEST-72-NBD/client-init.sh
@@ -3,7 +3,7 @@
 
 export PATH=/usr/sbin:/usr/bin:/sbin:/bin
 exec > /dev/console 2>&1
-echo "made it to the rootfs!"
+echo "made it to the NBD client rootfs!"
 
 while read -r dev fs fstype opts rest || [ -n "$dev" ]; do
     [ "$dev" = "rootfs" ] && continue

--- a/test/TEST-72-NBD/server-init.sh
+++ b/test/TEST-72-NBD/server-init.sh
@@ -4,7 +4,7 @@ set -x
 export PATH=/usr/sbin:/usr/bin:/sbin:/bin
 export TERM=linux
 export PS1='nbdtest-server:\w\$ '
-echo "made it to the rootfs!"
+echo "made it to the NBD server rootfs!"
 echo server > /proc/sys/kernel/hostname
 
 wait_for_if_link() {

--- a/test/modules.d/70test-root/test-init.sh
+++ b/test/modules.d/70test-root/test-init.sh
@@ -17,7 +17,7 @@ grep -q '^tmpfs /run tmpfs' /proc/self/mounts \
 : > /dev/watchdog
 
 exec > /dev/console 2>&1
-echo "made it to the rootfs!"
+echo "made it to the test rootfs!"
 
 if command -v systemctl > /dev/null 2>&1; then
     systemctl --failed --no-legend --no-pager >> /run/failed


### PR DESCRIPTION
## Changes

Since the test script does things between reaching the rootfs and powering down, split those messages.

To help debugging issues, name the different rootfs' differently (i.e. include the name of the test and whether it is the server or client part).

## Checklist
- [x] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it

Fixes #
