### PR TITLE
test: support systemd in target rootfs

### DIFF
--- a/test/TEST-60-NFS/test.sh
+++ b/test/TEST-60-NFS/test.sh
@@ -250,7 +250,7 @@ test_setup() {
     export initdir=$TESTDIR/server/overlay/source
     mkdir -p "$initdir"/var/lib/{dhcpd,rpcbind} "$initdir"/var/lib/nfs/{v4recovery,rpc_pipefs}
     chmod 777 "$initdir"/var/lib/{dhcpd,rpcbind}
-    cp ./server-init.sh "$initdir"/sbin/init
+    inst_init ./server-init.sh "$initdir"
     cp ./exports "$initdir"/etc/exports
     cp ./dhcpd.conf "$initdir"/etc/dhcpd.conf
 
@@ -261,7 +261,7 @@ test_setup() {
     mv "$TESTDIR"/dracut.*/initramfs/* "$initdir"
     rm -rf "$TESTDIR"/dracut.*
     echo "TEST FETCH FILE" > "$initdir"/root/fetchfile
-    cp ./client-init.sh "$initdir"/sbin/init
+    inst_init ./client-init.sh "$initdir"
 
     # create an initramfs that will create the target root filesystem.
     # We do it this way so that we do not risk trashing the host mdraid

--- a/test/TEST-70-ISCSI/test.sh
+++ b/test/TEST-70-ISCSI/test.sh
@@ -139,7 +139,7 @@ test_setup() {
     rm -rf "$TESTDIR"/dracut.*
 
     mkdir -p -- "$TESTDIR"/overlay/source/var/lib/nfs/rpc_pipefs
-    cp ./client-init.sh "$TESTDIR"/overlay/source/sbin/init
+    inst_init ./client-init.sh "$TESTDIR"/overlay/source
 
     # create an initramfs that will create the target root filesystem.
     # We do it this way so that we do not risk trashing the host mdraid
@@ -181,7 +181,7 @@ test_setup() {
     rm -rf "$TESTDIR"/dracut.*
 
     mkdir -p "$TESTDIR"/overlay/source/var/lib/dhcpd
-    cp ./server-init.sh "$TESTDIR"/overlay/source/sbin/init
+    inst_init ./server-init.sh "$TESTDIR"/overlay/source
 
     # create an initramfs that will create the target root filesystem.
     # We do it this way so that we do not risk trashing the host mdraid

--- a/test/TEST-71-ISCSI-MULTI/test.sh
+++ b/test/TEST-71-ISCSI-MULTI/test.sh
@@ -147,7 +147,7 @@ test_setup() {
     mv "$TESTDIR"/dracut.*/initramfs/* "$TESTDIR"/overlay/source
     rm -rf "$TESTDIR"/dracut.*
     mkdir -p -- "$TESTDIR"/overlay/source/var/lib/nfs/rpc_pipefs
-    cp ./client-init.sh "$TESTDIR"/overlay/source/sbin/init
+    inst_init ./client-init.sh "$TESTDIR"/overlay/source
 
     # create an initramfs that will create the target root filesystem.
     # We do it this way so that we do not risk trashing the host mdraid
@@ -190,7 +190,7 @@ test_setup() {
     rm -rf "$TESTDIR"/dracut.*
 
     mkdir -p -- "$TESTDIR"/overlay/source/var/lib/dhcpd "$TESTDIR"/overlay/source/etc/iscsi
-    cp ./server-init.sh "$TESTDIR"/overlay/source/sbin/init
+    inst_init ./server-init.sh "$TESTDIR"/overlay/source
 
     # create an initramfs that will create the target root filesystem.
     # We do it this way so that we do not risk trashing the host mdraid

--- a/test/TEST-72-NBD/test.sh
+++ b/test/TEST-72-NBD/test.sh
@@ -185,7 +185,7 @@ make_encrypted_root() {
     mkdir -p "$TESTDIR"/overlay/source
     mv "$TESTDIR"/dracut.*/initramfs/* "$TESTDIR"/overlay/source
     rm -rf "$TESTDIR"/dracut.*
-    cp ./client-init.sh "$TESTDIR"/overlay/source/sbin/init
+    inst_init ./client-init.sh "$TESTDIR"/overlay/source
 
     # create an initramfs that will create the target root filesystem.
     # We do it this way so that we do not risk trashing the host mdraid
@@ -222,7 +222,7 @@ make_client_root() {
     mkdir -p "$TESTDIR"/overlay/source
     mv "$TESTDIR"/dracut.*/initramfs/* "$TESTDIR"/overlay/source
     rm -rf "$TESTDIR"/dracut.*
-    cp ./client-init.sh "$TESTDIR"/overlay/source/sbin/init
+    inst_init ./client-init.sh "$TESTDIR"/overlay/source
 
     # create an initramfs that will create the target root filesystem.
     # We do it this way so that we do not risk trashing the host mdraid
@@ -275,7 +275,7 @@ EOF
     rm -rf "$TESTDIR"/dracut.*
 
     mkdir -p -- "$TESTDIR"/overlay/source/var/lib/dhcpd "$TESTDIR"/overlay/source/etc/nbd-server
-    cp ./server-init.sh "$TESTDIR"/overlay/source/sbin/init
+    inst_init ./server-init.sh "$TESTDIR"/overlay/source
 
     # create an initramfs that will create the target root filesystem.
     # We do it this way so that we do not risk trashing the host mdraid

--- a/test/test-functions
+++ b/test/test-functions
@@ -146,6 +146,17 @@ COLOR_FAILURE='\033[0;31m'
 COLOR_WARNING='\033[0;33m'
 COLOR_NORMAL='\033[0;39m'
 
+# override the init script from the test-root dracut module (see module-setup.sh)
+inst_init() {
+    local init_script="$1"
+    local rootdir="$2"
+    if [ -e "$rootdir/sbin/test-init" ]; then
+        cp "$init_script" "$rootdir/sbin/test-init"
+    else
+        cp "$init_script" "$rootdir/sbin/init"
+    fi
+}
+
 # generate qemu arguments for named raw disks
 #
 # qemu_add_drive <index> <args> <filename> <id-name> [<bootindex>]


### PR DESCRIPTION
## Changes

The test-root module installs `test-init.sh` in `/sbin/test-init` and adds `testsuite.service` if systemd is used. When systemd is used in the target client/server rootfs, the systemd in the initrd hands over the control to the systemd in the rootfs. Then `testsuite.service` executes `test-init.sh` instead of the wanted client/server init scripts.

Add the helper function `inst_init` to override the init script from the test-root dracut module.

This is one step in the direction to make these tests work on Debian/Ubuntu.

## Checklist
- [x] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it

Fixes #
