### PR TITLE
fix(iscsi): drop ExecStartPre startup-checks.sh from iscsid.service

### DIFF
--- a/modules.d/74iscsi/module-setup.sh
+++ b/modules.d/74iscsi/module-setup.sh
@@ -220,9 +220,8 @@ install() {
             "$systemdsystemunitdir"/iscsiuio.socket \
             "$systemdsystemunitdir"/sockets.target.wants/iscsid.socket \
             "$systemdsystemunitdir"/sockets.target.wants/iscsiuio.socket
-        if grep -q '^ExecStartPre=/usr/lib/open-iscsi/startup-checks.sh$' "${dracutsysrootdir-}$systemdsystemunitdir/iscsid.service"; then
-            inst_simple /usr/lib/open-iscsi/startup-checks.sh
-        fi
+        sed -i '/ExecStartPre=\/usr\/lib\/open-iscsi\/startup-checks.sh/d' \
+            "${dracutsysrootdir-}$systemdsystemunitdir/iscsid.service"
 
         for i in \
             iscsid.socket \


### PR DESCRIPTION
## Changes

`/usr/lib/open-iscsi/startup-checks.sh` checks that `/etc/iscsi/iscsid.conf` and `/etc/iscsi/initiatorname.iscsi` are present. This is not the case for initrds built without hostonly.

So just drop `/usr/lib/open-iscsi/startup-checks.sh` from `iscsid.service` and rely on dracut to generate a working environment for iscsid.

This is one step to make the iscsi tests work on Debian/Ubuntu.

## Checklist
- [x] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it

Fixes #
