### PR TITLE
test(nbd): test-makeroot does not need network

### DIFF
--- a/test/TEST-72-NBD/test.sh
+++ b/test/TEST-72-NBD/test.sh
@@ -276,7 +276,6 @@ EOF
     # devices, volume groups, encrypted partitions, etc.
     "$DRACUT" -i "$TESTDIR"/overlay / \
         --add-confdir test-makeroot \
-        -a "$USE_NETWORK" \
         -i ./create-server-root.sh /lib/dracut/hooks/initqueue/01-create-server-root.sh \
         -f "$TESTDIR"/initramfs.makeroot
 


### PR DESCRIPTION
## Changes

The `test-makeroot` initrd does not need network.

## Checklist
- [x] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it

Fixes #
