### PR TITLE
test(NFS): do not ignore failures in test_nfsv3

### DIFF
--- a/test/TEST-60-NFS/test.sh
+++ b/test/TEST-60-NFS/test.sh
@@ -211,17 +211,13 @@ test_run() {
         return 1
     fi
 
-    test_nfsv3 \
-        && test_nfsv4
-
-    ret=$?
+    test_nfsv3
+    test_nfsv4
 
     if [[ -s $TESTDIR/server.pid ]]; then
         kill -TERM "$(cat "$TESTDIR"/server.pid)"
         rm -f -- "$TESTDIR"/server.pid
     fi
-
-    return $ret
 }
 
 test_setup() {


### PR DESCRIPTION
## Changes

After `set -e` is called, the shell will exit immediately if a simple command exits with a non-zero status, but the shell will not exit if the command is part of a `&&` list.

So calling `test_nfsv3 && test_nfsv4` will not exit on failures in `test_nfsv3`. Call those functions separately and rely on `set -e`.

## Checklist
- [x] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it

Fixes #
