### PR TITLE
test: show all server logs until the "Serving" line

### DIFF
--- a/test/test-functions
+++ b/test/test-functions
@@ -88,6 +88,7 @@ wait_for_server_startup() {
 
     if [ "${V-}" -ge 1 ]; then
         tail -n "+$((printed_lines + 1))" "$TESTDIR"/server.log
+        echo "Server has been start up."
     fi
 }
 


### PR DESCRIPTION
## Changes

The function `wait_for_server_startup` will search för `Serving` in the server log for the indication that the server started correctly. It will print the logs every second until `Serving` is found, but it will not print the `Serving` line.

Print the remaining log lines after `Serving` has been found.

## Checklist
- [x] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it

Fixes #
