### PR TITLE
fix(systemd-networkd): correct path of 99-default.network on hostonly=no

### DIFF
--- a/modules.d/11systemd-networkd/module-setup.sh
+++ b/modules.d/11systemd-networkd/module-setup.sh
@@ -63,7 +63,7 @@ install() {
         "$systemdsystemunitdir"/systemd-networkd-wait-online.service.d/99-dracut.conf
 
     inst_simple "$moddir"/99-default.network \
-        "$systemdnetworkconfdir"/zzzz-dracut-default.network
+        "$systemdnetwork"/zzzz-dracut-default.network
 
     inst_hook cmdline 99 "$moddir"/networkd-config.sh
     inst_hook initqueue/settled 99 "$moddir"/networkd-run.sh


### PR DESCRIPTION
## Changes

Commit 2991f74ab46389947ce8f96b87a7abdc1862cbb6 ("chore(dracut): enforce that /etc is only used in hostonly mode") does not set `systemdnetworkconfdir` any more on `hostonly=no`. This causes the systemd-network module to install `99-default.network` to `/zzzz-dracut-default.network` on generic builds and therefore loosing this network config.

Install `99-default.network` to the system path in `/usr` instead.

## Checklist
- [x] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it

Fixes #
