### PR TITLE
test: drop do_hardlink=no from test-makeroot and test-root

### DIFF
--- a/dracut.conf.d/test-makeroot/test-makeroot.conf
+++ b/dracut.conf.d/test-makeroot/test-makeroot.conf
@@ -2,7 +2,6 @@ dracutmodules+=" test-makeroot "
 # do not compress, do not strip
 compress="cat"
 do_strip="no"
-do_hardlink="no"
 early_microcode="no"
 hostonly="no"
 stdloglvl=2

--- a/dracut.conf.d/test-root/test-root.conf
+++ b/dracut.conf.d/test-root/test-root.conf
@@ -2,7 +2,6 @@ dracutmodules+=" test-root "
 # do not compress, do not strip
 compress="cat"
 do_strip="no"
-do_hardlink="no"
 early_microcode="no"
 hostonly="no"
 stdloglvl=2


### PR DESCRIPTION
## Changes

TEST-60-NFS fails booting `initramfs.makeroot` on Ubuntu resolute:

```
[    2.147915] Kernel panic - not syncing: System is deadlocked on memory
```

The virtual machine has only 1 GB memory. The `initramfs.makeroot` is 601 MB in size. Over half of that size can be explained by using rust coreutils in combination with `do_hardlink=no`:

```
$ 3cpio -tv initramfs.makeroot
[...]
-rwxr-xr-x   1 root     root     10828088 Sep 24 15:36 usr/lib/cargo/bin/coreutils/cat
-rwxr-xr-x   1 root     root     10828088 Sep 24 15:36 usr/lib/cargo/bin/coreutils/ln
-rwxr-xr-x   1 root     root     10828088 Sep 24 15:36 usr/lib/cargo/bin/coreutils/ls
-rwxr-xr-x   1 root     root     10828088 Sep 24 15:36 usr/lib/cargo/bin/coreutils/mkdir
-rwxr-xr-x   1 root     root     10828088 Sep 24 15:36 usr/lib/cargo/bin/coreutils/mkfifo
-rwxr-xr-x   1 root     root     10828088 Sep 24 15:36 usr/lib/cargo/bin/coreutils/mknod
-rwxr-xr-x   1 root     root     10828088 Sep 24 15:36 usr/lib/cargo/bin/coreutils/readlink
-rwxr-xr-x   1 root     root     10828088 Sep 24 15:36 usr/lib/cargo/bin/coreutils/sleep
-rwxr-xr-x   1 root     root     10828088 Sep 24 15:36 usr/lib/cargo/bin/coreutils/sync
-rwxr-xr-x   1 root     root     10828088 Sep 24 15:36 usr/lib/cargo/bin/coreutils/tr
-rwxr-xr-x   1 root     root     10828088 Sep 24 15:36 usr/lib/cargo/bin/coreutils/uname
```

The coreutils binary is 10 MB in size and duplicated 11 times plus the same for `source` and `source/nfs/client`. Resulting in 357 MB.

Using `do_hardlink=yes` will reduce the initrd size from 601 MB to 123 MB. So drop `do_hardlink=no` from the `test-makeroot` and `test-root` configuration files.

## Checklist
- [x] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it

Fixes #
