### PR TITLE
ci(debian): drop V=2

### DIFF
--- a/test/container/Dockerfile-debian
+++ b/test/container/Dockerfile-debian
@@ -15,9 +15,6 @@ FROM docker.io/${DISTRIBUTION}
 # export ARG
 ARG DISTRIBUTION
 
-# prefer running tests in verbose mode
-ENV V=2
-
 # Install dracut as a linux-initramfs-tool provider so that the default initramfs-tool package does not get installed
 RUN apt-get update -y -qq && apt-get upgrade -y -qq && apt-get install -y -qq --install-recommends dracut dracut-network dracut-squash dracut-live
 


### PR DESCRIPTION
## Changes

Running the tests in verbose mode `V=2` prints too much information and makes debugging harder (to find the actual useful information).

## Checklist
- [ ] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it

Fixes #
