### PR TITLE
ci(debian): add xfsprogs

### DIFF
--- a/test/container/Dockerfile-debian
+++ b/test/container/Dockerfile-debian
@@ -96,6 +96,7 @@ RUN \
     thin-provisioning-tools \
     tpm2-tools \
     util-linux-extra \
+    xfsprogs \
     xorriso \
     zstd \
     && apt-get clean


### PR DESCRIPTION
## Changes

Add xfsprogs to the test container so that successful test run can be demonstrated as part of an upcoming test case development.


## Checklist
- [ ] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it

Fixes #
