### PR TITLE
refactor(test): introduce build_ext4_image function

### DIFF
--- a/test/TEST-10-BASIC/test.sh
+++ b/test/TEST-10-BASIC/test.sh
@@ -26,10 +26,7 @@ test_setup() {
         --add-confdir test-root \
         -f "$TESTDIR"/initramfs.root
 
-    dd if=/dev/zero of="$TESTDIR"/root.img bs=200MiB count=1 status=none
-    sync "$TESTDIR"/root.img
-    mkfs.ext4 -q -L dracut -d "$TESTDIR"/dracut.*/initramfs/ "$TESTDIR"/root.img
-    sync "$TESTDIR"/root.img
+    build_ext4_image "$TESTDIR"/dracut.*/initramfs/ "$TESTDIR"/root.img dracut
 
     test_dracut
 }

--- a/test/TEST-13-SYSROOT/test.sh
+++ b/test/TEST-13-SYSROOT/test.sh
@@ -26,10 +26,7 @@ test_setup() {
         --add-confdir test-root \
         -f "$TESTDIR"/initramfs.root
 
-    dd if=/dev/zero of="$TESTDIR"/root.img bs=200MiB count=1 status=none
-    sync "$TESTDIR"/root.img
-    mkfs.ext4 -q -L dracut -d "$TESTDIR"/dracut.*/initramfs/ "$TESTDIR"/root.img
-    sync "$TESTDIR"/root.img
+    build_ext4_image "$TESTDIR"/dracut.*/initramfs/ "$TESTDIR"/root.img dracut
 
     ln -s / "$TESTDIR"/sysroot
     test_dracut --hostonly --sysroot "$TESTDIR"/sysroot

--- a/test/TEST-43-KERNEL-INSTALL/test.sh
+++ b/test/TEST-43-KERNEL-INSTALL/test.sh
@@ -47,10 +47,7 @@ test_setup() {
     KVERSION=$(determine_kernel_version "$TESTDIR"/initramfs.root)
     KIMAGE=$(determine_kernel_image "$KVERSION")
 
-    dd if=/dev/zero of="$TESTDIR"/root.img bs=200MiB count=1 status=none
-    sync "$TESTDIR"/root.img
-    mkfs.ext4 -q -L dracut -d "$TESTDIR"/dracut.*/initramfs/ "$TESTDIR"/root.img
-    sync "$TESTDIR"/root.img
+    build_ext4_image "$TESTDIR"/dracut.*/initramfs/ "$TESTDIR"/root.img dracut
 
     mkdir -p /run/kernel /run/initramfs/dracut.conf.d
     echo 'initrd_generator=dracut' >> /run/kernel/install.conf

--- a/test/TEST-50-NETWORK/test.sh
+++ b/test/TEST-50-NETWORK/test.sh
@@ -32,10 +32,7 @@ test_setup() {
         --add-confdir test-root \
         -f "$TESTDIR"/initramfs.root "$KVERSION"
 
-    dd if=/dev/zero of="$TESTDIR"/root.img bs=200MiB count=1 status=none
-    sync "$TESTDIR"/root.img
-    mkfs.ext4 -q -L dracut -d "$TESTDIR"/dracut.*/initramfs/ "$TESTDIR"/root.img
-    sync "$TESTDIR"/root.img
+    build_ext4_image "$TESTDIR"/dracut.*/initramfs/ "$TESTDIR"/root.img dracut
 
     test_dracut --add-drivers "virtio_net" --add "qemu-net $USE_NETWORK"
 }

--- a/test/test-functions
+++ b/test/test-functions
@@ -151,6 +151,18 @@ COLOR_FAILURE='\033[0;31m'
 COLOR_WARNING='\033[0;33m'
 COLOR_NORMAL='\033[0;39m'
 
+# build an ext4 image from the given directory
+build_ext4_image() {
+    local source_dir="$1"
+    local image="$2"
+    local label="$3"
+
+    dd if=/dev/zero of="$image" bs=200MiB count=1 status=none
+    sync "$image"
+    mkfs.ext4 -q -L "$label" -d "$source_dir" "$image"
+    sync "$image"
+}
+
 # override the init script from the test-root dracut module (see module-setup.sh)
 inst_init() {
     local init_script="$1"


### PR DESCRIPTION
## Changes

Building an ext4 rootfs image from a directory is done in multiple test cases. Move those code into a single `build_ext4_image` helper function to reduce code duplication.

## Checklist
- [ ] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it

Fixes #
