### PR TITLE
fix(Makefile): correct filter condition for s390 specific modules

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -284,7 +284,7 @@ endif
 			rm -r $(DESTDIR)$(pkglibdir)/modules.d/[0-9][0-9]$${i}; \
 		done \
 	fi
-ifeq ($(ARCH),s390x)
+ifneq ($(ARCH),s390x)
 	for f in cio_ignore cms dasd dasd_mod dcssblk zfcp zipl znet; do \
 		rm -r $(DESTDIR)$(pkglibdir)/modules.d/[0-9][0-9]$${f}; \
 	done


### PR DESCRIPTION
## Changes

Commit fe6c47025516fe9705fa0fb621b381ce85d5127c ("feat(Makefile): filter out s390 specific dracut modules") want to exclude s390 specific dracut modules but got the condition inversed.

## Checklist
- [x] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it

Fixes #
