### PR TITLE
feat(Makefile): filter out warpclock on S390(x) systems

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -288,6 +288,8 @@ ifneq ($(ARCH),s390x)
 	for f in cio_ignore cms dasd dasd_mod dcssblk zfcp zipl znet; do \
 		rm -r $(DESTDIR)$(pkglibdir)/modules.d/[0-9][0-9]$${f}; \
 	done
+else
+	rm -r $(DESTDIR)$(pkglibdir)/modules.d/[0-9][0-9]warpclock
 endif
 
 clean:


### PR DESCRIPTION
## Changes

hwclock does not exist on S390(x). So the module warpclock does not need to be installed on S390(x) systems.

## Checklist
- [ ] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it

Fixes #
