### PR TITLE
test: determine rootfs size dynamically

### DIFF
--- a/test/test-functions
+++ b/test/test-functions
@@ -179,7 +179,12 @@ build_ext4_image() {
     local image="$2"
     local label="$3"
 
-    dd if=/dev/zero of="$image" bs=200MiB count=1 status=none
+    local size
+    size="$(du --summarize --block-size 1 "${source_dir}" | cut -f 1)"
+    # Add 8 MB for ext4 journal
+    size="$((size + 8000000))"
+
+    dd if=/dev/zero of="$image" bs="$size" count=1 status=none
     sync "$image"
     mkfs.ext4 -q -L "$label" -d "$source_dir" "$image"
     sync "$image"


### PR DESCRIPTION
## Changes

Do not hard-code the size of the rootfs, but determine the needed size dynamically. This will speed up the creation time for smaller content and prevent failures in case of bigger content.

## Checklist
- [x] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it

Fixes #
