### PR TITLE
test: explicitly create virtio-net-pci device

### DIFF
--- a/test/TEST-50-NETWORK/test.sh
+++ b/test/TEST-50-NETWORK/test.sh
@@ -16,7 +16,8 @@ test_run() {
     test_marker_reset
 
     "$testdir"/run-qemu \
-        -nic user,id=lan0,net=10.0.2.0/24,dhcpstart=10.0.2.15,model=virtio-net-pci \
+        -device "virtio-net-pci,netdev=lan0" \
+        -netdev "user,id=lan0,net=10.0.2.0/24,dhcpstart=10.0.2.15" \
         "${disk_args[@]}" \
         -append "$TEST_KERNEL_CMDLINE rd.neednet=1 net.ifnames=0" \
         -initrd "$TESTDIR"/initramfs.testing


### PR DESCRIPTION
## Changes

TEST-50-NETWORK fails on s390x:

```
run-qemu: /usr/bin/qemu-system-s390x '-cpu' 'max' '-smp' '2' '-m' '1024' '-nodefaults' '-vga' 'none' '-display' 'none' '-no-reboot' '-watchdog-action' 'poweroff' '-device' 'virtio-rng-pci' '-serial' 'stdio' '-kernel' '/boot/vmlinuz-6.17.0-5-generic' '-nic' 'user,id=lan0,net=10.0.2.0/24,dhcpstart=10.0.2.15,model=virtio-net-pci' '-device' 'virtio-scsi-pci,id=scsi0' '-drive' 'if=none,format=raw,file=/var/tmp/dracut-test.rTJZc1/marker.img,id=drive-data0' '-device' 'scsi-hd,bus=scsi0.0,drive=drive-data0,id=data0,serial=marker' '-device' 'virtio-scsi-pci,id=scsi1' '-drive' 'if=none,format=raw,file=/var/tmp/dracut-test.rTJZc1/root.img,id=drive-data1' '-device' 'scsi-hd,bus=scsi1.0,drive=drive-data1,id=data1,serial=root' '-append' ' root=LABEL=dracut panic=1 oops=panic softlockup_panic=1 systemd.crash_reboot   rd.neednet=1 net.ifnames=0' '-initrd' '/var/tmp/dracut-test.rTJZc1/initramfs.testing'
qemu-system-s390x: warning: netdev lan0 has no peer
qemu-system-s390x: warning: requested NIC (anonymous, model virtio-net-pci) was not created (not supported by this machine?)
[...]
Device "eth0" does not exist.
**************************FAILED**************************
ip addr show
1: lo: <LOOPBACK,UP,LOWER_UP> mtu 65536 qdisc noqueue state UNKNOWN group default qlen 1000
    link/loopback 00:00:00:00:00:00 brd 00:00:00:00:00:00
    inet 127.0.0.1/8 scope host lo
       valid_lft forever preferred_lft forever
    inet6 ::1/128 scope host noprefixroute
       valid_lft forever preferred_lft forever
**************************FAILED**************************
```

Explicitly define a `virtio-net-pci` device.

## Checklist
- [ ] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it

Fixes: https://github.com/dracut-ng/dracut-ng/issues/1800
