### PR TITLE
fix(multipath): add udev rule 99-z-dm-mpath-late.rules

### DIFF
--- a/modules.d/70multipath/module-setup.sh
+++ b/modules.d/70multipath/module-setup.sh
@@ -165,5 +165,6 @@ EOF
     inst_rules 40-multipath.rules 56-multipath.rules \
         62-multipath.rules 65-multipath.rules \
         66-kpartx.rules 67-kpartx-compat.rules \
-        11-dm-mpath.rules 11-dm-parts.rules
+        11-dm-mpath.rules 11-dm-parts.rules \
+        99-z-dm-mpath-late.rules
 }


### PR DESCRIPTION
multipath-tools 0.9.8 added a new udev rules file that restores DM_UDEV_DISABLE_OTHER_RULES_FLAG before saving properties to the udev db [1]. This fixes a few corner cases that can arise with LVM2 < 2.03.24 if uevents occur for previously suspended devices. This rule will do nothing, unless DM_UDEV_DISABLE_OTHER_RULES_FLAG has been previously modified by 11-dm-mpath.rules.

While it's rather unlikely that this situation occurs during initrd processing, add the rule file if present, to make sure the multipath udev rule set is complete and consistent.

[1] https://github.com/opensvc/multipath-tools/commit/35640f26a4b820a2fb1e5a148d7cc0e2663ec6fa

This pull request changes...

## Changes

## Checklist
- [x] I have tested it locally
- [x] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it
