### PR TITLE
feat(pcsc): add Debian/Ubuntu support

### DIFF
--- a/modules.d/73pcsc/module-setup.sh
+++ b/modules.d/73pcsc/module-setup.sh
@@ -30,7 +30,8 @@ install() {
 
     inst_multiple -o \
         pcscd \
-        /usr/share/p11-kit/modules/opensc.module
+        /usr/share/p11-kit/modules/opensc.module \
+        /usr/share/p11-kit/modules/opensc-pkcs11.module
 
     # Enable systemd type unit(s)
     for i in \
@@ -51,6 +52,7 @@ install() {
         {"tls/$_arch/",tls/,"$_arch/",}"pcsc/drivers/ifd-ccid.bundle/Contents/Info.plist" \
         {"tls/$_arch/",tls/,"$_arch/",}"pcsc/drivers/ifd-ccid.bundle/Contents/Linux/libccid.so" \
         {"tls/$_arch/",tls/,"$_arch/",}"pcsc/drivers/serial/libccidtwin.so" \
+        {"tls/$_arch/",tls/,"$_arch/",}"libeac.so*" \
         {"tls/$_arch/",tls/,"$_arch/",}"libpcsclite.so.*" \
         {"tls/$_arch/",tls/,"$_arch/",}"libpcsclite_real.so.*"
 
@@ -58,6 +60,7 @@ install() {
     if [[ $hostonly ]]; then
         inst_multiple -H -o \
             /etc/opensc.conf \
+            /etc/opensc/opensc.conf \
             "/etc/reader.conf.d/*"
     fi
 


### PR DESCRIPTION
## Changes

On Debian/Ubuntu, the filename is `opensc-pkcs11.module` instead of `opensc.module`.

On Debian/Ubuntu, missing `libeac.so` libraries for OpenSC.

On Debian/Ubuntu the OpenSC configuration path is `/etc/opensc/opensc.conf` .

## Checklist
- [ ] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it

Fixes #1794
