### PR TITLE
fix(dracut-systemd): install grep if initqueue is used

### DIFF
--- a/modules.d/77dracut-systemd/module-setup.sh
+++ b/modules.d/77dracut-systemd/module-setup.sh
@@ -51,6 +51,10 @@ install() {
     inst_script "$moddir/rootfs-generator.sh" "$systemdutildir"/system-generators/dracut-rootfs-generator
 
     inst_hook cmdline 00 "$moddir/parse-root.sh"
+    if dracut_module_included initqueue; then
+        # parse-root.sh injects grep call into initqueue/finished/devexists-${root_name}.sh
+        inst grep
+    fi
 
     for i in \
         dracut-cmdline.service \


### PR DESCRIPTION
## Changes

TEST-13-SYSROOT emits this error on Ubuntu:

```
dracut-initqueue[248]: /usr/bin/dracut-initqueue: 1: /lib/dracut/hooks/initqueue/finished/devexists-\x2fdev\x2fdisk\x2fby-label\x2fdracut.sh: grep: not found
```

`parse-root.sh` injects a grep call into
`$hookdir/initqueue/finished/devexists-${root_name}.sh`. Therefore the `grep` command needs to be installed if initqueue is used.

## Checklist
- [ ] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it

Fixes #
