### PR TITLE
fix: line-buffer log output to /dev/kmsg

### DIFF
--- a/dracut-logger.sh
+++ b/dracut-logger.sh
@@ -436,8 +436,9 @@ _do_dlog_batch_kmsglog() {
     local kmsg_lvlc
     if ((lvl <= kmsgloglvl)); then
         kmsg_lvlc="$(_dlvl2syslvl "$lvl")" || return 1
-        awk -v lvlc="${kmsg_lvlc}" -v prefix="dracut[$$] " \
-            '{ if (NR==1) printf "<%s>", lvlc; print prefix $0 }' > /dev/kmsg
+        # /dev/kmsg is designed to only accept single lines at a time, so the
+        # output of awk has to be line-buffered.
+        awk -v prefix="<${kmsg_lvlc}>dracut[$$] " '{ print prefix $0; fflush() }' > /dev/kmsg
     else
         cat > /dev/null
     fi


### PR DESCRIPTION
/dev/kmsg is only designed to accept single lines at a time, and therefore has a relatively small message size limit. This means we need to line-buffer the output of awk (and prepend the message level prefix to each line rather than just the first).

(This was missed in local testing because it only becomes an issue for sufficiently large inputs. I tested this with larger inputs and it works properly with the line-buffering.)

Fixes #1803 properly—the previous PR fixed the immediate issue but still ran into problems because of the lack of line-buffering.