### PR TITLE
test: drop including missing overlay in server initrd

### DIFF
--- a/test/TEST-71-ISCSI-MULTI/test.sh
+++ b/test/TEST-71-ISCSI-MULTI/test.sh
@@ -223,7 +223,7 @@ test_setup() {
         -i ./client-persistent-lan1.link /etc/systemd/network/01-persistent-lan1.link
 
     # Make server's dracut image
-    call_dracut -i "$TESTDIR"/overlay / \
+    call_dracut \
         --add-confdir test \
         -a "qemu-net $USE_NETWORK ${SERVER_DEBUG:+debug}" \
         -i "./server.link" "/etc/systemd/network/01-server.link" \

--- a/test/TEST-72-NBD/test.sh
+++ b/test/TEST-72-NBD/test.sh
@@ -321,7 +321,7 @@ test_setup() {
         -i "/tmp/crypttab" "/etc/crypttab" \
         -i "/tmp/key" "/etc/key"
 
-    call_dracut -N -i "$TESTDIR"/overlay / \
+    call_dracut -N \
         --add-confdir test \
         -a "qemu-net $USE_NETWORK ${SERVER_DEBUG:+debug}" \
         -i "./server.link" "/etc/systemd/network/01-server.link" \


### PR DESCRIPTION
## Changes

The tests 71 and 72 shows following warning when generating `initramfs.server`:

```
dracut[E]: /var/tmp/dracut-test.zfcBR5/overlay doesn't exist
```

There is no overlay directory for the server initrd. Commit c855fa1ee5c0f01da91bb7724c9dd2f4adb3b50e ("test(NFS): drop including missing overlay in server initrd") fixed it for test 60. So do the same for these tests.

## Checklist
- [ ] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it

Fixes #
