### PR TITLE
test: drop calling "dmesg -c" from server rootfs script

### DIFF
--- a/test/TEST-70-ISCSI/server-init.sh
+++ b/test/TEST-70-ISCSI/server-init.sh
@@ -79,9 +79,7 @@ tgtadm --lld iscsi --mode target --op bind --tid 3 -I 192.168.50.101
 echo "Serving iSCSI"
 while pidof tgtd > /dev/null; do
     : > /dev/watchdog
-    dmesg -c
     sleep 1
 done
-dmesg -c
 mount -n -o remount,ro /
 poweroff -f

--- a/test/TEST-71-ISCSI-MULTI/server-init.sh
+++ b/test/TEST-71-ISCSI-MULTI/server-init.sh
@@ -79,9 +79,7 @@ tgtadm --lld iscsi --mode target --op bind --tid 3 -I 192.168.50.101
 echo "Serving iSCSI"
 while pidof tgtd > /dev/null; do
     : > /dev/watchdog
-    dmesg -c
     sleep 1
 done
-dmesg -c
 mount -n -o remount,ro /
 poweroff -f


### PR DESCRIPTION
## Changes

In verbose mode (V=1), the tests already print the kernel messages. Calling `dmesg -c` only duplicates the output and makes it harder to read.

## Checklist
- [x] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it

Fixes #
