### PR TITLE
feat(install.d): skip if initrd_generator is unset

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -269,6 +269,8 @@ endif
 ifeq ($(enable_dracut_cpio),yes)
 	install -m 0755 dracut-cpio $(DESTDIR)$(pkglibdir)/dracut-cpio
 endif
+	mkdir -p $(DESTDIR)${prefix}/lib/kernel/install.conf.d
+	install -m 0644 install.conf.d/50-dracut.conf $(DESTDIR)${prefix}/lib/kernel/install.conf.d/50-dracut.conf
 	mkdir -p $(DESTDIR)${prefix}/lib/kernel/install.d
 	install -m 0755 install.d/50-dracut.install $(DESTDIR)${prefix}/lib/kernel/install.d/50-dracut.install
 	install -m 0755 install.d/51-dracut-rescue.install $(DESTDIR)${prefix}/lib/kernel/install.d/51-dracut-rescue.install

--- a/install.conf.d/50-dracut.conf
+++ b/install.conf.d/50-dracut.conf
@@ -1,0 +1,1 @@
+initrd_generator=dracut

--- a/install.d/50-dracut.install
+++ b/install.d/50-dracut.install
@@ -16,7 +16,7 @@ if [[ "$KERNEL_INSTALL_IMAGE_TYPE" = "uki" ]]; then
     exit 0
 fi
 
-if [[ "${KERNEL_INSTALL_INITRD_GENERATOR:-dracut}" = "dracut" ]]; then
+if [[ "${KERNEL_INSTALL_INITRD_GENERATOR-}" = "dracut" ]]; then
     # We are the initrd generator
     IMAGE="initrd"
     UEFI_OPTS="--no-uefi"

--- a/install.d/51-dracut-rescue.install
+++ b/install.d/51-dracut-rescue.install
@@ -20,7 +20,7 @@ fi
 if [[ "$KERNEL_INSTALL_UKI_GENERATOR" = "dracut" ]]; then
     # Rescue images currently not compatible with UKIs
     exit 0
-elif [[ "${KERNEL_INSTALL_INITRD_GENERATOR:-dracut}" != "dracut" ]]; then
+elif [[ "${KERNEL_INSTALL_INITRD_GENERATOR-}" != "dracut" ]]; then
     # We are not the initrd generator
     exit 0
 fi


### PR DESCRIPTION
## Changes

The Dracut 12-uefi and 43-kernel-install test cases fail on Debian/Ubuntu. dracut-core ships
`/usr/lib/kernel/install.d/50-dracut.install` which generates an initrd in `KERNEL_INSTALL_STAGING_AREA`.
`/usr/lib/kernel/install.d/55-initrd.install` (from the systemd package) then links to the initrd in /boot. This results in two initrd being included in the UKI and the content of later one overwrites the former one.

`/usr/lib/kernel/install.d/55-initrd.install` should only act if there is no initrd generator configured, but it needs to know when dracut is the initrd generator.

Be more explicit by changing the kernel-install hooks to only act if the initrd generator is set to dracut. But also ship a configuration snippet that sets the initrd generator to dracut.

Bug-Debian: https://bugs.debian.org/1117563

## Checklist
- [x] I have tested it locally in combination with https://salsa.debian.org/systemd-team/systemd/-/merge_requests/295
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it

Fixes #
