### PR TITLE
fix(iscsi): modify iscsid.service in initrd instead of host

### DIFF
--- a/modules.d/74iscsi/module-setup.sh
+++ b/modules.d/74iscsi/module-setup.sh
@@ -221,7 +221,7 @@ install() {
             "$systemdsystemunitdir"/sockets.target.wants/iscsid.socket \
             "$systemdsystemunitdir"/sockets.target.wants/iscsiuio.socket
         sed -i '/ExecStartPre=\/usr\/lib\/open-iscsi\/startup-checks.sh/d' \
-            "${dracutsysrootdir-}$systemdsystemunitdir/iscsid.service"
+            "${initdir}$systemdsystemunitdir/iscsid.service"
 
         for i in \
             iscsid.socket \


### PR DESCRIPTION
## Changes

Commit b2287bb7c4544d841b3d5b0510ce765753d990af ("fix(iscsi): drop ExecStartPre startup-checks.sh from iscsid.service") incorrectly modifies `iscsid.service` on the host instead of the service that was copied into the initrd.

Corretly modify `iscsid.service` in initrd instead of on the host.

## Checklist
- [x] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it

Fixes #
