### PR TITLE
test: do not use dsync oflag for dd calls

### DIFF
--- a/test/TEST-11-USR-MOUNT/create-root.sh
+++ b/test/TEST-11-USR-MOUNT/create-root.sh
@@ -15,5 +15,6 @@ btrfs filesystem sync /root
 # read-only snapshot of /root
 btrfs subvolume snapshot -r /root /root/snapshot-root
 umount /root
-echo "dracut-root-block-created" | dd oflag=direct,dsync of=/dev/disk/by-id/scsi-0QEMU_QEMU_HARDDISK_marker status=none
+echo "dracut-root-block-created" | dd oflag=direct of=/dev/disk/by-id/scsi-0QEMU_QEMU_HARDDISK_marker status=none
+sync /dev/disk/by-id/scsi-0QEMU_QEMU_HARDDISK_marker
 poweroff -f

--- a/test/TEST-20-STORAGE/create-root.sh
+++ b/test/TEST-20-STORAGE/create-root.sh
@@ -84,7 +84,7 @@ fi
     echo "dracut-root-block-created"
     echo "MD_UUID=$MD_UUID"
     echo "ID_FS_UUID=$ID_FS_UUID"
-} | dd oflag=direct,dsync of=/dev/disk/by-id/scsi-0QEMU_QEMU_HARDDISK_marker status=none
+} | dd oflag=direct of=/dev/disk/by-id/scsi-0QEMU_QEMU_HARDDISK_marker status=none
 
 sync /dev/disk/by-id/scsi-0QEMU_QEMU_HARDDISK_marker
 poweroff -f

--- a/test/TEST-26-ENC-RAID-LVM/create-root.sh
+++ b/test/TEST-26-ENC-RAID-LVM/create-root.sh
@@ -32,6 +32,6 @@ cryptsetup luksClose /dev/mapper/dracut_disk2
     for i in /dev/disk/by-id/scsi-0QEMU_QEMU_HARDDISK_disk[12]; do
         udevadm info --query=property --name="$i" | grep -F 'ID_FS_UUID='
     done
-} | dd oflag=direct,dsync of=/dev/disk/by-id/scsi-0QEMU_QEMU_HARDDISK_marker status=none
+} | dd oflag=direct of=/dev/disk/by-id/scsi-0QEMU_QEMU_HARDDISK_marker status=none
 sync /dev/disk/by-id/scsi-0QEMU_QEMU_HARDDISK_marker
 poweroff -f

--- a/test/TEST-40-SYSTEMD/create-root.sh
+++ b/test/TEST-40-SYSTEMD/create-root.sh
@@ -9,5 +9,6 @@ mount -t ext4 /dev/disk/by-id/scsi-0QEMU_QEMU_HARDDISK_root /root
 cp -a -t /root /source/*
 mkdir -p /root/run
 umount /root
-echo "dracut-root-block-created" | dd oflag=direct,dsync of=/dev/disk/by-id/scsi-0QEMU_QEMU_HARDDISK_marker status=none
+echo "dracut-root-block-created" | dd oflag=direct of=/dev/disk/by-id/scsi-0QEMU_QEMU_HARDDISK_marker status=none
+sync /dev/disk/by-id/scsi-0QEMU_QEMU_HARDDISK_marker
 poweroff -f

--- a/test/TEST-41-FULL-SYSTEMD/create-root.sh
+++ b/test/TEST-41-FULL-SYSTEMD/create-root.sh
@@ -37,5 +37,6 @@ eval "$(udevadm info --query=property --name=/dev/disk/by-id/scsi-0QEMU_QEMU_HAR
 {
     echo "dracut-root-block-created"
     echo "ID_FS_UUID=$ID_FS_UUID"
-} | dd oflag=direct,dsync of=/dev/disk/by-id/scsi-0QEMU_QEMU_HARDDISK_marker status=none
+} | dd oflag=direct of=/dev/disk/by-id/scsi-0QEMU_QEMU_HARDDISK_marker status=none
+sync /dev/disk/by-id/scsi-0QEMU_QEMU_HARDDISK_marker
 poweroff -f

--- a/test/TEST-42-SYSTEMD-INITRD/create-root.sh
+++ b/test/TEST-42-SYSTEMD-INITRD/create-root.sh
@@ -9,5 +9,6 @@ mount -t ext4 /dev/disk/by-id/scsi-0QEMU_QEMU_HARDDISK_root /root
 cp -a -t /root /source/*
 mkdir -p /root/run
 umount /root
-echo "dracut-root-block-created" | dd oflag=direct,dsync of=/dev/disk/by-id/scsi-0QEMU_QEMU_HARDDISK_marker status=none
+echo "dracut-root-block-created" | dd oflag=direct of=/dev/disk/by-id/scsi-0QEMU_QEMU_HARDDISK_marker status=none
+sync /dev/disk/by-id/scsi-0QEMU_QEMU_HARDDISK_marker
 poweroff -f

--- a/test/TEST-44-DRIVERS/create-root.sh
+++ b/test/TEST-44-DRIVERS/create-root.sh
@@ -10,5 +10,6 @@ cp -a -t /root /source/*
 mkdir -p /root/run
 umount /root
 mkfs.xfs -q /dev/disk/by-id/scsi-0QEMU_QEMU_HARDDISK_mnt
-echo "dracut-root-block-created" | dd oflag=direct,dsync of=/dev/disk/by-id/scsi-0QEMU_QEMU_HARDDISK_marker status=none
+echo "dracut-root-block-created" | dd oflag=direct of=/dev/disk/by-id/scsi-0QEMU_QEMU_HARDDISK_marker status=none
+sync /dev/disk/by-id/scsi-0QEMU_QEMU_HARDDISK_marker
 poweroff -f

--- a/test/TEST-60-NFS/client-init.sh
+++ b/test/TEST-60-NFS/client-init.sh
@@ -10,14 +10,14 @@ echo "made it to the NFS client rootfs!"
 
 while read -r dev _ fstype opts rest || [ -n "$dev" ]; do
     [ "$fstype" != "nfs" ] && [ "$fstype" != "nfs4" ] && continue
-    echo "nfs-OK $dev $fstype $opts" | dd oflag=direct,dsync of=/dev/disk/by-id/scsi-0QEMU_QEMU_HARDDISK_marker status=none
+    echo "nfs-OK $dev $fstype $opts" | dd oflag=direct of=/dev/disk/by-id/scsi-0QEMU_QEMU_HARDDISK_marker status=none
     break
 done < /proc/mounts
 
 # fail the test of rd.live.overlay did not worked as expected
 if grep -qF 'rd.live.overlay' /proc/cmdline; then
     if ! strstr "$(cat /proc/mounts)" LiveOS_rootfs; then
-        echo "nfs-FAIL" | dd oflag=direct,dsync of=/dev/disk/by-id/scsi-0QEMU_QEMU_HARDDISK_marker status=none
+        echo "nfs-FAIL" | dd oflag=direct of=/dev/disk/by-id/scsi-0QEMU_QEMU_HARDDISK_marker status=none
     fi
 fi
 
@@ -33,11 +33,11 @@ if [ "$fstype" = "nfs" ] || [ "$fstype" = "nfs4" ]; then
     echo test:nfs_fetch_url nfs::"${serverip}":"${path}"/root/fetchfile
     if nfs_fetch_url nfs::"${serverip}":"${path}"/root/fetchfile /run/nfsfetch.out; then
         echo nfsfetch-OK
-        echo "nfsfetch-OK" | dd oflag=direct,dsync of=/dev/disk/by-id/scsi-0QEMU_QEMU_HARDDISK_marker2 status=none
+        echo "nfsfetch-OK" | dd oflag=direct of=/dev/disk/by-id/scsi-0QEMU_QEMU_HARDDISK_marker2 status=none
     fi
 else
     echo nfsfetch-BYPASS fstype="${fstype}"
-    echo "nfsfetch-OK" | dd oflag=direct,dsync of=/dev/disk/by-id/scsi-0QEMU_QEMU_HARDDISK_marker2 status=none
+    echo "nfsfetch-OK" | dd oflag=direct of=/dev/disk/by-id/scsi-0QEMU_QEMU_HARDDISK_marker2 status=none
 fi
 
 : > /dev/watchdog

--- a/test/TEST-60-NFS/create-root.sh
+++ b/test/TEST-60-NFS/create-root.sh
@@ -18,6 +18,6 @@ mount -t ext4 /dev/disk/by-id/scsi-0QEMU_QEMU_HARDDISK_root /root
 cp -a -t /root /source/*
 mkdir -p /root/run
 umount /root
-echo "dracut-root-block-created" | dd oflag=direct,dsync of=/dev/disk/by-id/scsi-0QEMU_QEMU_HARDDISK_marker status=none
+echo "dracut-root-block-created" | dd oflag=direct of=/dev/disk/by-id/scsi-0QEMU_QEMU_HARDDISK_marker status=none
 sync /dev/disk/by-id/scsi-0QEMU_QEMU_HARDDISK_marker
 poweroff -f

--- a/test/TEST-70-ISCSI/client-init.sh
+++ b/test/TEST-70-ISCSI/client-init.sh
@@ -6,7 +6,7 @@ exec > /dev/console 2>&1
 echo "made it to the iSCSI client rootfs!"
 while read -r dev _ fstype opts rest || [ -n "$dev" ]; do
     [ "$fstype" != "ext4" ] && continue
-    echo "iscsi-OK $dev $fstype $opts" | dd oflag=direct,dsync of=/dev/disk/by-id/scsi-0QEMU_QEMU_HARDDISK_marker status=none
+    echo "iscsi-OK $dev $fstype $opts" | dd oflag=direct of=/dev/disk/by-id/scsi-0QEMU_QEMU_HARDDISK_marker status=none
     break
 done < /proc/mounts
 

--- a/test/TEST-70-ISCSI/create-client-root.sh
+++ b/test/TEST-70-ISCSI/create-client-root.sh
@@ -19,6 +19,6 @@ mount -t ext4 /dev/dracut/root /sysroot
 cp -a -t /sysroot /source/*
 umount /sysroot
 lvm lvchange -a n /dev/dracut/root
-echo "dracut-root-block-created" | dd oflag=direct,dsync of=/dev/disk/by-id/scsi-0QEMU_QEMU_HARDDISK_marker status=none
+echo "dracut-root-block-created" | dd oflag=direct of=/dev/disk/by-id/scsi-0QEMU_QEMU_HARDDISK_marker status=none
 sync /dev/disk/by-id/scsi-0QEMU_QEMU_HARDDISK_marker
 poweroff -f

--- a/test/TEST-70-ISCSI/create-server-root.sh
+++ b/test/TEST-70-ISCSI/create-server-root.sh
@@ -7,5 +7,6 @@ mount -t ext4 /dev/disk/by-id/scsi-0QEMU_QEMU_HARDDISK_root /root
 cp -a -t /root /source/*
 mkdir -p /root/run
 umount /root
-echo "dracut-root-block-created" | dd oflag=direct,dsync of=/dev/disk/by-id/scsi-0QEMU_QEMU_HARDDISK_marker status=none
+echo "dracut-root-block-created" | dd oflag=direct of=/dev/disk/by-id/scsi-0QEMU_QEMU_HARDDISK_marker status=none
+sync /dev/disk/by-id/scsi-0QEMU_QEMU_HARDDISK_marker
 poweroff -f

--- a/test/TEST-71-ISCSI-MULTI/client-init.sh
+++ b/test/TEST-71-ISCSI-MULTI/client-init.sh
@@ -6,7 +6,7 @@ exec > /dev/console 2>&1
 echo "made it to the iSCSI multi client rootfs!"
 while read -r dev _ fstype opts rest || [ -n "$dev" ]; do
     [ "$fstype" != "ext4" ] && continue
-    echo "iscsi-OK $dev $fstype $opts" | dd oflag=direct,dsync of=/dev/disk/by-id/scsi-0QEMU_QEMU_HARDDISK_marker status=none
+    echo "iscsi-OK $dev $fstype $opts" | dd oflag=direct of=/dev/disk/by-id/scsi-0QEMU_QEMU_HARDDISK_marker status=none
     break
 done < /proc/mounts
 

--- a/test/TEST-71-ISCSI-MULTI/create-client-root.sh
+++ b/test/TEST-71-ISCSI-MULTI/create-client-root.sh
@@ -19,6 +19,6 @@ mount -t ext4 /dev/dracut/root /sysroot
 cp -a -t /sysroot /source/*
 umount /sysroot
 lvm lvchange -a n /dev/dracut/root
-echo "dracut-root-block-created" | dd oflag=direct,dsync of=/dev/disk/by-id/scsi-0QEMU_QEMU_HARDDISK_marker status=none
+echo "dracut-root-block-created" | dd oflag=direct of=/dev/disk/by-id/scsi-0QEMU_QEMU_HARDDISK_marker status=none
 sync /dev/disk/by-id/scsi-0QEMU_QEMU_HARDDISK_marker
 poweroff -f

--- a/test/TEST-71-ISCSI-MULTI/create-server-root.sh
+++ b/test/TEST-71-ISCSI-MULTI/create-server-root.sh
@@ -7,5 +7,6 @@ mount -t ext4 /dev/disk/by-id/scsi-0QEMU_QEMU_HARDDISK_root /root
 cp -a -t /root /source/*
 mkdir -p /root/run
 umount /root
-echo "dracut-root-block-created" | dd oflag=direct,dsync of=/dev/disk/by-id/scsi-0QEMU_QEMU_HARDDISK_marker status=none
+echo "dracut-root-block-created" | dd oflag=direct of=/dev/disk/by-id/scsi-0QEMU_QEMU_HARDDISK_marker status=none
+sync /dev/disk/by-id/scsi-0QEMU_QEMU_HARDDISK_marker
 poweroff -f

--- a/test/TEST-72-NBD/client-init.sh
+++ b/test/TEST-72-NBD/client-init.sh
@@ -8,7 +8,7 @@ echo "made it to the NBD client rootfs!"
 while read -r dev fs fstype opts rest || [ -n "$dev" ]; do
     [ "$dev" = "rootfs" ] && continue
     [ "$fs" != "/" ] && continue
-    echo "nbd-OK $fstype $opts" | dd oflag=direct,dsync of=/dev/disk/by-id/scsi-0QEMU_QEMU_HARDDISK_marker status=none
+    echo "nbd-OK $fstype $opts" | dd oflag=direct of=/dev/disk/by-id/scsi-0QEMU_QEMU_HARDDISK_marker status=none
     echo "nbd-OK $fstype $opts"
     break
 done < /proc/mounts

--- a/test/TEST-72-NBD/create-client-root.sh
+++ b/test/TEST-72-NBD/create-client-root.sh
@@ -12,5 +12,6 @@ umount /root
 {
     echo "dracut-root-block-created"
     echo "ID_FS_UUID=$ID_FS_UUID"
-} | dd oflag=direct,dsync of=/dev/disk/by-id/scsi-0QEMU_QEMU_HARDDISK_marker status=none
+} | dd oflag=direct of=/dev/disk/by-id/scsi-0QEMU_QEMU_HARDDISK_marker status=none
+sync /dev/disk/by-id/scsi-0QEMU_QEMU_HARDDISK_marker
 poweroff -f

--- a/test/TEST-72-NBD/create-encrypted-root.sh
+++ b/test/TEST-72-NBD/create-encrypted-root.sh
@@ -27,6 +27,6 @@ eval "$(udevadm info --query=property --name=/dev/disk/by-id/scsi-0QEMU_QEMU_HAR
 {
     echo "dracut-root-block-created"
     echo "ID_FS_UUID=$ID_FS_UUID"
-} | dd oflag=direct,dsync of=/dev/disk/by-id/scsi-0QEMU_QEMU_HARDDISK_marker status=none
+} | dd oflag=direct of=/dev/disk/by-id/scsi-0QEMU_QEMU_HARDDISK_marker status=none
 sync /dev/disk/by-id/scsi-0QEMU_QEMU_HARDDISK_marker
 poweroff -f

--- a/test/TEST-72-NBD/create-server-root.sh
+++ b/test/TEST-72-NBD/create-server-root.sh
@@ -12,6 +12,6 @@ umount /root
 {
     echo "dracut-root-block-created"
     echo "ID_FS_UUID=$ID_FS_UUID"
-} | dd oflag=direct,dsync of=/dev/disk/by-id/scsi-0QEMU_QEMU_HARDDISK_marker status=none
+} | dd oflag=direct of=/dev/disk/by-id/scsi-0QEMU_QEMU_HARDDISK_marker status=none
 sync /dev/disk/by-id/scsi-0QEMU_QEMU_HARDDISK_marker
 poweroff -f

--- a/test/modules.d/70test-root/test-init.sh
+++ b/test/modules.d/70test-root/test-init.sh
@@ -33,7 +33,8 @@ if [ -s /run/failed ]; then
     cat /run/failed
     echo "**************************FAILED**************************"
 else
-    echo "dracut-root-block-success" | dd oflag=direct,dsync status=none of=/dev/disk/by-id/scsi-0QEMU_QEMU_HARDDISK_marker
+    echo "dracut-root-block-success" | dd oflag=direct status=none of=/dev/disk/by-id/scsi-0QEMU_QEMU_HARDDISK_marker
+    sync /dev/disk/by-id/scsi-0QEMU_QEMU_HARDDISK_marker
     echo "All OK"
 fi
 


### PR DESCRIPTION
## Changes

`dsync` `oflag` is not supported by all dd implementation. As an example `busybox` does not support `dsync`.

## Checklist
- [ ] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it

Fixes #
