### PR TITLE
fix(iscsi): only enable services if they are included

### DIFF
--- a/modules.d/74iscsi/module-setup.sh
+++ b/modules.d/74iscsi/module-setup.sh
@@ -224,7 +224,9 @@ install() {
             "${initdir}$systemdsystemunitdir/iscsid.service"
 
         for i in iscsid.socket iscsiuio.socket; do
-            $SYSTEMCTL -q --root "$initdir" enable "$i"
+            if [[ -e "${initdir}$systemdsystemunitdir/$i" ]]; then
+                $SYSTEMCTL -q --root "$initdir" enable "$i"
+            fi
         done
 
         mkdir -p "${initdir}/$systemdsystemunitdir/iscsid.service.d"


### PR DESCRIPTION
## Changes

On systems without iscsiuio installed, dracut emits this warning:

```
Failed to enable unit: Unit iscsiuio.socket does not exist
```

So check if the service is available before trying to enable it.

## Checklist
- [ ] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it

Fixes #
