### PR TITLE
fix(multipath): always forcefully load multipath modules

### DIFF
--- a/modules.d/70multipath/module-setup.sh
+++ b/modules.d/70multipath/module-setup.sh
@@ -42,9 +42,7 @@ depends() {
 # called by dracut
 cmdline() {
     for m in scsi_dh_alua scsi_dh_emc scsi_dh_rdac dm_multipath; do
-        if grep -m 1 -q "$m" /proc/modules; then
-            printf 'rd.driver.pre=%s ' "$m"
-        fi
+        printf 'rd.driver.pre=%s ' "$m"
     done
 }
 


### PR DESCRIPTION
## Changes

cmdline() function gets called both in hostonly and non-hostonly mode. Make sure that non-hostonly mode is handled properly, so that cmdline does not get added.

## Checklist
- [ ] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it

CC @mwilck 