### PR TITLE
fix(dracut-init): do not set DRACUT_KERNEL_MODALIASES for --no-kernel

### DIFF
--- a/dracut-init.sh
+++ b/dracut-init.sh
@@ -217,7 +217,7 @@ dracut_module_path() {
     return 1
 }
 
-if [[ ${hostonly-} == "-h" ]]; then
+if [[ ${hostonly-} == "-h" ]] && [[ $no_kernel != yes ]]; then
     if ! [[ $DRACUT_KERNEL_MODALIASES ]] || ! [[ -f $DRACUT_KERNEL_MODALIASES ]]; then
         export DRACUT_KERNEL_MODALIASES="${DRACUT_TMPDIR}/modaliases"
         $DRACUT_INSTALL ${dracutsysrootdir:+-r "$dracutsysrootdir"} ${srcmods:+--kerneldir "$srcmods"} --modalias > "$DRACUT_KERNEL_MODALIASES"


### PR DESCRIPTION
## Changes

When dracut is invoked with `--no-kernel`, do not set `DRACUT_KERNEL_MODALIASES` to avoid using kmod.

## Checklist
- [ ] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it

Fixes #691 
