### PR TITLE
feat: rename rd.live.overlay.overlayfs to rd.overlayfs

### DIFF
--- a/man/dracut.cmdline.7.adoc
+++ b/man/dracut.cmdline.7.adoc
@@ -1086,6 +1086,29 @@ rd.znet=qeth,0.0.0600,0.0.0601,0.0.0602,layer2=1,portname=foo
 rd.znet=ctc,0.0.0600,0.0.0601,protocol=bar
 --
 
+OverlayFS
+~~~~~~~~~
+Requires the dracut 'overlayfs' module.
+
+**rd.overlayfs=**1::
+Enables the use of the *OverlayFS* kernel module, if available, to provide a
+copy-on-write union directory for the root filesystem.  OverlayFS overlays are
+directories of the files that have changed on the read-only base (lower)
+filesystem.  The root filesystem is provided through a special overlay type
+mount that merges at least two directories, designated the lower and the upper.
+If an OverlayFS upper directory is not present on the boot device, a tmpfs
+directory will be created at `/run/overlayfs` to provide temporary storage.
+Persistent storage can be provided on vfat or msdos formatted devices by
+supplying the OverlayFS upper directory within an embedded filesystem that
+supports the creation of trusted.* extended attributes and provides a valid
+d_type in readdir responses, such as with btrfs, ext4, f2fs, & xfs.  On
+non-vfat-formatted devices, a persistent OverlayFS overlay can extend the
+available root filesystem storage up to the capacity of the LiveOS disk device.
++
+The **rd.overlayfs.readonly** option, which allows a persistent overlayfs to
+be mounted read-only through a higher level transient overlay directory, has
+been implemented through the multiple lower layers feature of OverlayFS.
+
 Booting live images
 ~~~~~~~~~~~~~~~~~~~
 Requires the dracut 'dmsquash-live' module.
@@ -1129,7 +1152,7 @@ filesystem, which often provide only a small number of gigabytes of free space.
 This shortage could be remedied by building the root filesystem with more
 allocated free space, or the OverlayFS based overlay mount method can be used.
 
-When the *_rd.live.overlay.overlayfs_* option is specified or when
+When the *_rd.overlayfs_* option is specified or when
 *_rd.live.overlay=_* points to an appropriate directory with a sister at
 `/../ovlwork`, then an OverlayFS based overlay mount is employed.  Such a
 persistent OverlayFS overlay can extend the available root filesystem storage
@@ -1293,7 +1316,7 @@ where _<label>_ and _<uuid>_ are the LABEL and UUID of the filesystem specified
 by the **root=**live:__<path|url>__ device.
 
 If a persistent overlay __is detected__ at the standard LiveOS path,
-and *_rd.live.overlay.overlayfs_* is not set to 1, the overlay type (either
+and *_rd.overlayfs_* is not set to 1, the overlay type (either
 Device-mapper or OverlayFS) will be detected and it will be used.
 --
 +
@@ -1339,28 +1362,6 @@ The advantage of thin snapshots is that they support discards, and will free
 blocks that are not claimed by the filesystem. In this use case, this means
 that memory is given back to the kernel when the filesystem does not claim it
 anymore.
-
-**rd.live.overlay.overlayfs=**1::
-Enables the use of the *OverlayFS* kernel module, if available, to provide a
-copy-on-write union directory for the root filesystem.  OverlayFS overlays are
-directories of the files that have changed on the read-only base (lower)
-filesystem.  The root filesystem is provided through a special overlay type
-mount that merges at least two directories, designated the lower and the upper.
-If an OverlayFS upper directory is not present on the boot device, a tmpfs
-directory will be created at `/run/overlayfs` to provide temporary storage.
-Persistent storage can be provided on vfat or msdos formatted devices by
-supplying the OverlayFS upper directory within an embedded filesystem that
-supports the creation of trusted.* extended attributes and provides a valid
-d_type in readdir responses, such as with btrfs, ext4, f2fs, & xfs.  On
-non-vfat-formatted devices, a persistent OverlayFS overlay can extend the
-available root filesystem storage up to the capacity of the LiveOS disk device.
-Requires the dracut 'overlayfs' module.
-+
-The **rd.live.overlay.readonly** option, which allows a persistent overlayfs to
-be mounted read-only through a higher level transient overlay directory, has
-been implemented through the multiple lower layers feature of OverlayFS.
-Requires the dracut 'overlayfs' module.
-
 
 ZIPL
 ~~~~
@@ -1507,6 +1508,10 @@ UNIMAP:: vconsole.font.unimap
 UNICODE:: vconsole.unicode
 
 EXT_KEYMAP:: vconsole.keymap.ext
+
+rd.live.overlay.overlayfs:: rd.overlayfs
+
+rd.live.overlay.readonly:: rd.overlayfs.readonly
 
 Configuration in the Initramfs
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/modules.d/70dmsquash-live/dmsquash-generator.sh
+++ b/modules.d/70dmsquash-live/dmsquash-generator.sh
@@ -45,8 +45,8 @@ GENERATOR_DIR="$2"
 [ -z "$GENERATOR_DIR" ] && exit 1
 [ -d "$GENERATOR_DIR" ] || mkdir -p "$GENERATOR_DIR"
 
-getargbool 0 rd.live.overlay.readonly && readonly_overlay="--readonly" || readonly_overlay=""
-getargbool 0 rd.live.overlay.overlayfs && overlayfs="yes"
+getargbool 0 rd.overlayfs.readonly -d rd.live.overlayfs.readonly && readonly_overlay="--readonly" || readonly_overlay=""
+getargbool 0 rd.overlayfs -d rd.live.overlay.overlayfs && overlayfs="yes"
 [ -e /xor_overlayfs ] && xor_overlayfs="yes"
 [ -e /xor_readonly ] && xor_readonly="--readonly"
 ROOTFLAGS="$(getarg rootflags)"

--- a/modules.d/70dmsquash-live/dmsquash-live-root.sh
+++ b/modules.d/70dmsquash-live/dmsquash-live-root.sh
@@ -24,7 +24,7 @@ squash_image=$(getarg rd.live.squashimg)
 
 getargbool 0 rd.live.ram && live_ram="yes"
 getargbool 0 rd.live.overlay.reset && reset_overlay="yes"
-getargbool 0 rd.live.overlay.readonly && readonly_overlay="--readonly" || readonly_overlay=""
+getargbool 0 rd.overlayfs.readonly -d rd.live.overlay.readonly && readonly_overlay="--readonly" || readonly_overlay=""
 getargbool 0 rd.live.overlay.nouserconfirmprompt && overlay_no_user_confirm_prompt="--noprompt" || overlay_no_user_confirm_prompt=""
 overlay=$(getarg rd.live.overlay)
 getargbool 0 rd.writable.fsimg && writable_fsimg="yes"
@@ -32,7 +32,7 @@ overlay_size=$(getarg rd.live.overlay.size=)
 [ -z "$overlay_size" ] && overlay_size=32768
 
 getargbool 0 rd.live.overlay.thin && thin_snapshot="yes"
-getargbool 0 rd.live.overlay.overlayfs && overlayfs="yes"
+getargbool 0 rd.overlayfs -d rd.live.overlay.overlayfs && overlayfs="yes"
 
 # Take a path to a disk label and return the parent disk if it is a partition
 # Otherwise returns the original path
@@ -416,7 +416,7 @@ fi
 ROOTFLAGS="$(getarg rootflags)"
 
 if [ "$overlayfs" = required ]; then
-    echo "rd.live.overlay.overlayfs=1" > /etc/cmdline.d/20-dmsquash-need-overlay.conf
+    echo "rd.overlayfs=1" > /etc/cmdline.d/20-dmsquash-need-overlay.conf
 fi
 
 if [ -n "$overlayfs" ]; then

--- a/modules.d/70livenet/livenet-generator.sh
+++ b/modules.d/70livenet/livenet-generator.sh
@@ -49,8 +49,8 @@ GENERATOR_DIR="$2"
 
 [ -d "$GENERATOR_DIR" ] || mkdir -p "$GENERATOR_DIR"
 
-getargbool 0 rd.live.overlay.readonly && readonly_overlay="--readonly" || readonly_overlay=""
-getargbool 0 rd.live.overlay.overlayfs && overlayfs="yes"
+getargbool 0 rd.overlayfs.readonly -d rd.live.overlay.readonly && readonly_overlay="--readonly" || readonly_overlay=""
+getargbool 0 rd.overlayfs -d rd.live.overlayfs.readonly && overlayfs="yes"
 [ -e /xor_overlayfs ] && xor_overlayfs="yes"
 [ -e /xor_readonly ] && xor_readonly="--readonly"
 ROOTFLAGS="$(getarg rootflags)"

--- a/modules.d/70overlayfs/mount-overlayfs.sh
+++ b/modules.d/70overlayfs/mount-overlayfs.sh
@@ -2,8 +2,8 @@
 
 command -v getarg > /dev/null || . /lib/dracut-lib.sh
 
-getargbool 0 rd.live.overlay.overlayfs && overlayfs="yes"
-getargbool 0 rd.live.overlay.readonly && readonly_overlay="--readonly" || readonly_overlay=""
+getargbool 0 rd.overlayfs -d rd.live.overlay.overlayfs && overlayfs="yes"
+getargbool 0 rd.overlayfs.readonly -d rd.live.overlayfs.readonly && readonly_overlay="--readonly" || readonly_overlay=""
 
 if [ -n "$overlayfs" ]; then
     if [ -n "$readonly_overlay" ] && [ -h /run/overlayfs-r ]; then

--- a/modules.d/70overlayfs/prepare-overlayfs.sh
+++ b/modules.d/70overlayfs/prepare-overlayfs.sh
@@ -2,7 +2,7 @@
 
 command -v getarg > /dev/null || . /lib/dracut-lib.sh
 
-getargbool 0 rd.live.overlay.overlayfs && overlayfs="yes"
+getargbool 0 rd.overlayfs -d rd.live.overlay.overlayfs && overlayfs="yes"
 getargbool 0 rd.live.overlay.reset && reset_overlay="yes"
 
 if [ -n "$overlayfs" ]; then

--- a/test/TEST-30-DMSQUASH/test.sh
+++ b/test/TEST-30-DMSQUASH/test.sh
@@ -33,7 +33,7 @@ client_run() {
     test_marker_reset
     "$testdir"/run-qemu \
         "${disk_args[@]}" \
-        -append "$TEST_KERNEL_CMDLINE rd.live.overlay.overlayfs=1 root=live:/dev/disk/by-label/dracut $client_opts" \
+        -append "$TEST_KERNEL_CMDLINE rd.overlayfs=1 root=live:/dev/disk/by-label/dracut $client_opts" \
         -initrd "$TESTDIR"/initramfs.testing
 
     if ! test_marker_check; then

--- a/test/TEST-60-NFS/test.sh
+++ b/test/TEST-60-NFS/test.sh
@@ -192,10 +192,10 @@ test_nfsv4() {
         "root=dhcp" 192.168.50.3 wsize=4096
 
     client_test "NFSv4 Overlayfs root=nfs4:..." 52:54:00:12:34:84 \
-        "root=nfs4:192.168.50.1:/client rd.live.overlay.overlayfs=1 " 192.168.50.1 -wsize=4096
+        "root=nfs4:192.168.50.1:/client rd.overlayfs=1 " 192.168.50.1 -wsize=4096
 
     client_test "NFSv4 Live Overlayfs root=nfs4:..." 52:54:00:12:34:84 \
-        "root=nfs4:192.168.50.1:/client rd.live.image rd.live.overlay.overlayfs=1" 192.168.50.1 -wsize=4096
+        "root=nfs4:192.168.50.1:/client rd.live.image rd.overlayfs=1" 192.168.50.1 -wsize=4096
 
     return 0
 }


### PR DESCRIPTION
## Changes

The overlayfs dracut module can be used without the dmsquash-live dracut module. This change improves on naming of command line options with better namespace scoping.
    
Move overlayfs documentation out of the live images section.

Follow-up to 40dd5c90e.

## Checklist
- [ ] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it

