### PR TITLE
feat(pcsc): add openSUSE support

### DIFF
--- a/modules.d/73pcsc/module-setup.sh
+++ b/modules.d/73pcsc/module-setup.sh
@@ -30,6 +30,7 @@ install() {
 
     inst_multiple -o \
         pcscd \
+        /etc/pkcs11/modules/opensc.module \
         /usr/share/p11-kit/modules/opensc.module \
         /usr/share/p11-kit/modules/opensc-pkcs11.module
 


### PR DESCRIPTION
The openSUSE version of the opensc package installs the module configuration in `/etc/pkcs11/modules/opensc.module`

## Checklist
- [X] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it
