### PR TITLE
docs: document rd.lunmask and rd.dcssblk

### DIFF
--- a/man/dracut.cmdline.7.adoc
+++ b/man/dracut.cmdline.7.adoc
@@ -1012,6 +1012,20 @@ See https://gitlab.com/virtio-fs/virtiofsd for more information.
 root=virtiofs:host rw
 --
 
+LUNMASK
+~~~~~~~
+Requires the dracut 'lunmask' module.
+
+**rd.lunmask=**....::
+    lunmask support.
+
+DCSSBLK
+~~~~~~~
+Requires the dracut 'dcssblk' module.
+
+**rd.dcssblk=**....::
+    dcssblk support (s390 only).
+
 DASD
 ~~~~
 Requires the dracut 'dasd' module.


### PR DESCRIPTION
## Changes

The documentation for `rd.lunmask` and `rd.dcssblk` are missing.

Add documentation for `rd.lunmask` and `rd.dcssblk`.

## Checklist
- [ ] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it


