### PR TITLE
fix(plymouth): avoid warning if /etc/plymouth/plymouthd.conf is not present

### DIFF
--- a/modules.d/45plymouth/module-setup.sh
+++ b/modules.d/45plymouth/module-setup.sh
@@ -12,7 +12,9 @@ pkglib_dir() {
 read_setting_from_config() {
     local setting="$1"
     local config_file="$2"
-    sed -n "s/^${setting}= *\([^ ]\+\) */\1/p" "$config_file"
+    if [[ -f $config_file ]]; then
+        sed -n "s/^${setting}= *\([^ ]\+\) */\1/p" "$config_file"
+    fi
 }
 
 use_simpledrm() {


### PR DESCRIPTION
openSUSE does not install `/etc/plymouth/plymouthd.conf`, so plymouthd falls back to `/usr/share/plymouth/plymouthd.defaults`.

```
$ dracut -f
sed: can't read /etc/plymouth/plymouthd.conf: No such file or directory
```

Follow-up for 7f41458b9d8350d08b0057e050d98b7a25c3e640

## Checklist
- [X] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it
