### PR TITLE
fix(systemd-pcrphase): revert changes related to inclusion and dependencies

### DIFF
--- a/modules.d/11systemd-pcrphase/module-setup.sh
+++ b/modules.d/11systemd-pcrphase/module-setup.sh
@@ -11,24 +11,14 @@ check() {
         return 1
     fi
 
-    return 0
+    # Return 255 to only include the module, if another module requires it.
+    return 255
 }
 
 # Module dependency requirements.
 depends() {
     # This module has external dependency on other module(s).
-
-    local deps
-    deps="systemd"
-
-    # optional dependencies
-    module="tpm2-tss"
-    module_check $module > /dev/null 2>&1
-    if [[ $? == 255 ]]; then
-        deps+=" $module"
-    fi
-    echo "$deps"
-
+    echo systemd tpm2-tss
     # Return 0 to include the dependent module(s) in the initramfs.
     return 0
 }


### PR DESCRIPTION
systemd-pcrextend is used to extend a TPM2 PCR with a boot phase. Specifically,
this dracut module installs systemd-pcrphase-initrd.service to extend PCR 11 in
UKIs (as per `ConditionSecurity=measured-uki`, see man systemd.unit(5)). The
problem with always installing this module in hostonly mode is that it pulls
tpm2-tss as an "optional" dependency only if tpm2-tools is installed in the
system, which often is done by default. That increases the size of the initrd by
~5 MB.

So systemd-pcrphase is used only if two conditions happen at the same time:
- The initrd is within an UKI.
- And that UKI is measured in a TPM2 PCR.

This is a very specific use case, so this module should not be always included
in the initrd.

Furthermore, allowing the dracut tpm2-tss module as an optional dependency is
incorrect; this module does not work without a TPM2 device or without all the
TPM2 elements added to the initrd by tpm2-tss.

Reverts ea6a47ede7d9c5b268bd51aac3808d8b3979a962
Reverts a2193b71f7be75f719eec29faacae36ab25e9147
Reverts 96d153fe927987ce31a1f876b7eeea6fe9cee06a
Reverts c5cbdaf3050f46c446fe736032ae872376f6d365

## Checklist
- [X] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it

