### PR TITLE
feat(Makefile): do not install network-legacy by default

### DIFF
--- a/.github/workflows/integration-extra.yml
+++ b/.github/workflows/integration-extra.yml
@@ -163,7 +163,7 @@ jobs:
             - name: "Checkout Repository"
               uses: actions/checkout@v5
             - name: "${{ matrix.container }} TEST-${{ matrix.test }}"
-              run: USE_NETWORK=${{ matrix.network }} ./test/test-container.sh "TEST-${{ matrix.test }}" ${{ matrix.test }}
+              run: USE_NETWORK=${{ matrix.network }} CONFIGURE_ARG='--enable-network-legacy' ./test/test-container.sh "TEST-${{ matrix.test }}" ${{ matrix.test }}
     omitsystemd:
         # run this test on all containers
         name: ${{ matrix.test }} on ${{ matrix.container }} with no systemd

--- a/Makefile
+++ b/Makefile
@@ -275,6 +275,9 @@ endif
 	install -m 0644 shell-completion/bash/lsinitrd $(DESTDIR)${bashcompletiondir}/lsinitrd
 	mkdir -p $(DESTDIR)${pkgconfigdatadir}
 	install -m 0644 dracut.pc $(DESTDIR)${pkgconfigdatadir}/dracut.pc
+ifneq ($(enable_network_legacy),yes)
+	rm -r $(DESTDIR)$(pkglibdir)/modules.d/[0-9][0-9]network-legacy
+endif
 	if ! [ -n "$(systemdsystemunitdir)" ]; then \
 		rm -rf $(DESTDIR)$(pkglibdir)/test/TEST-[0-9][0-9]-*SYSTEMD* ;\
 		rm -rf $(DESTDIR)$(pkglibdir)/modules.d/*systemd* $(DESTDIR)$(mandir)/*.service.* ; \

--- a/configure
+++ b/configure
@@ -82,6 +82,7 @@ while (($# > 0)); do
         --enable-dracut-cpio) enable_dracut_cpio=yes ;;
         --disable-dracut-cpio) enable_dracut_cpio=no ;;
         --enable-test) enable_test=yes ;;
+        --enable-network-legacy) enable_network_legacy=yes ;;
         --configprofile) read_arg configprofile "$@" || shift ;;
         --disable-asciidoctor) disable_asciidoctor=yes ;;
         *) echo "Ignoring unknown option '$1'" ;;
@@ -209,6 +210,7 @@ mandir ?= ${mandir:-${prefix}/share/man}
 disable_asciidoctor ?= ${disable_asciidoctor:-no}
 enable_documentation ?= ${enable_documentation:-yes}
 enable_test ?= ${enable_test:-no}
+enable_network_legacy ?= ${enable_network_legacy:-no}
 enable_dracut_cpio ?= ${enable_dracut_cpio}
 bindir ?= ${bindir:-${prefix}/bin}
 KMOD_CFLAGS ?= $(${PKG_CONFIG} --cflags " libkmod >= 23 ") ${KMOD_CFLAGS_EXTRA}


### PR DESCRIPTION
## Changes

This commit is the next step in the multi year effort to discourage the usage or network-legacy dracut module.

This commit changes the default build/packaging so that distributions wish to continue using network-legacy would  
have to explicitly opt in to it in the packaging step.

## Checklist
- [ ] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it

