### PR TITLE
feat(fedora): turn on hostonly_cmdline by default

### DIFF
--- a/dracut.conf.d/fedora/01-dist.conf
+++ b/dracut.conf.d/fedora/01-dist.conf
@@ -13,6 +13,6 @@ sysloglvl=5
 install_optional_items+=" vi /usr/libexec/vi /etc/virc ps grep cat rm chroot "
 
 hostonly="yes"
-hostonly_cmdline="no"
+hostonly_cmdline="yes"
 early_microcode="yes"
 reproducible="yes"


### PR DESCRIPTION
## Changes

openSUSE, Debian/Ubuntu, Arch, Gentoo all have hostonly_cmdline enabled by default. Fedora should match the default of other distributions as there is no documented reason why hostonly_cmdline is turned off for Fedora users by default.

## Checklist
- [ ] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it

CC @dracut-ng/fedora-maint @pvalena @dtardon 
