### PR TITLE
feat(systemd): install new dlopened libraries

### DIFF
--- a/modules.d/10systemd/module-setup.sh
+++ b/modules.d/10systemd/module-setup.sh
@@ -16,7 +16,7 @@ check() {
 
 # Config adjustments before installing anything.
 config() {
-    add_dlopen_features+=" libsystemd-shared-*.so:kmod "
+    add_dlopen_features+=" libsystemd-shared-*.so:audit,kmod,mount,seccomp,selinux "
 }
 
 installkernel() {

--- a/modules.d/11systemd-tmpfiles/module-setup.sh
+++ b/modules.d/11systemd-tmpfiles/module-setup.sh
@@ -11,6 +11,11 @@ check() {
     return 255
 }
 
+# Config adjustments before installing anything.
+config() {
+    add_dlopen_features+=" libsystemd-shared-*.so:acl "
+}
+
 # Install the required file(s) and directories for the module in the initramfs.
 install() {
     # Excluding "$tmpfilesdir/home.conf", sets up /home /srv

--- a/modules.d/11systemd-udevd/module-setup.sh
+++ b/modules.d/11systemd-udevd/module-setup.sh
@@ -14,6 +14,11 @@ check() {
     return 255
 }
 
+# Config adjustments before installing anything.
+config() {
+    add_dlopen_features+=" libsystemd-shared-*.so:blkid "
+}
+
 # Module dependency requirements.
 depends() {
     local deps


### PR DESCRIPTION
Preparation for systemd-v259. In chronological order:

- libaudit: https://github.com/systemd/systemd/commit/4d8c5c657ae0829f93944a00302e7ce700913e54
- ~~libpam: https://github.com/systemd/systemd/commit/882c9ce0402ec6e37201628a9a361500ff39b1ed~~
- libacl: https://github.com/systemd/systemd/commit/7c3a7f925f83bd05a49e8b1f09726cccc26977f7
- libblkid: https://github.com/systemd/systemd/commit/c349edfe49dc2c4b8a79e5d08ecf7c8e93c4c909
- libseccomp: https://github.com/systemd/systemd/commit/aaca6bd5d97258f29c1b8c991e8617c7272308e0
- libmount: https://github.com/systemd/systemd/commit/b3243f4beead231e27a4f017f53288a303177cb2
- libselinux: https://github.com/systemd/systemd/commit/83b6ef9b62765b11bc602eae906ff13a5464a638

## Checklist
- [X] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it
