### PR TITLE
feat(systemd-sysusers): remove sysusers.d configuration from the initrd

### DIFF
--- a/modules.d/78systemd-sysusers/module-setup.sh
+++ b/modules.d/78systemd-sysusers/module-setup.sh
@@ -24,6 +24,10 @@ install() {
         systemd-sysusers --root="$initdir" 2>&1 >&3 | grep -v "^Creating " >&2
     } 3>&1
 
+    # remove sysusers.d configuration from the initrd
+    rm -rf "${initdir}${sysusers}"
+    [[ $hostonly ]] && rm -rf "${initdir}${sysusersconfdir}"
+
     # systemd-sysusers does not set any permission
     # set read and write permission for the current user
     [[ -f "$initdir/etc/gshadow" ]] && chmod u+rw "$initdir/etc/gshadow"


### PR DESCRIPTION
Commit f3dacc013d90bd2c0bbfa04f5f9b167b65298440 removed the systemd-sysusers machinery from the initrd, so these configuration files now are useless at boot.

## Checklist
- [X] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it