### PR TITLE
fix(qemu-net): in hostonly mode, only install if network is needed

### DIFF
--- a/modules.d/70kernel-network-modules/module-setup.sh
+++ b/modules.d/70kernel-network-modules/module-setup.sh
@@ -6,6 +6,12 @@ check() {
 }
 
 # called by dracut
+depends() {
+    is_qemu_virtualized && echo qemu-net
+    return 0
+}
+
+# called by dracut
 installkernel() {
     # Include wired net drivers, excluding wireless
     local _arch=${DRACUT_ARCH:-$(uname -m)}

--- a/modules.d/70qemu-net/module-setup.sh
+++ b/modules.d/70qemu-net/module-setup.sh
@@ -2,8 +2,6 @@
 
 # called by dracut
 check() {
-    is_qemu_virtualized && return 0
-
     if [[ $hostonly ]] || [[ $mount_needs ]]; then
         return 255
     fi


### PR DESCRIPTION
Commit 5698258d3022dd73045e2ffb279c799a70c3fef9 ("90qemu-net: in hostonly mode, only install if network is needed") added the feature of installing qemu network drivers in hostonly mode only if network is needed in the initrd, that is, if any network dracut modules are installed.

But, commit 2ecdda2d28f165d26cbdb82c9fe3a2f7bab71c52 ("fix(kernel-network-modules): if running inside vm, include qemu-net") moved the logic from the `network` dracut module to `kernel-network-modules`, and a few hours after, commit bb7425b8102f46928327bc762f653b2660643c34 ("fix(qemu-net): align check logic between qemu modules") removed the initial feature, with the only explanation that the check logic between the qemu modules needed to be aligned to fix some unknown problems.

So now `qemu-net` is always installed in hostonly mode, even if the initrd does not contain any network dracut modules because it does not need network.

Since b2c72e100db036e5eaaa2522b6d51351ac9834f9 ("fix(dracut-init): do not detect virt environment in non-hostonly mode") was merged on top of the commit bb7425b8102f46928327bc762f653b2660643c34 that needs to be reverted, let's implement back the missing feature using the current state, making `kernel-network-modules` install `qemu-net` in hostonly mode.

## Checklist
- [X] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it
