### PR TITLE
fix(dracut-systemd): use expected PS1 in the emergency shell

### DIFF
--- a/modules.d/77dracut-systemd/dracut-emergency.sh
+++ b/modules.d/77dracut-systemd/dracut-emergency.sh
@@ -31,7 +31,8 @@ if getargbool 1 rd.shell || getarg rd.break; then
         ) > /dev/"$_tty"
     done < /proc/consoles
     [ -f /etc/profile ] && . /etc/profile
-    [ -z "$PS1" ] && export PS1="$_name:\${PWD}# "
+    [ -z "$PS1" ] && PS1="$_rdshell_name:\${PWD}# "
+    export PS1
 
     if getargbool 0 SYSTEMD_SULOGIN_FORCE; then
         # allows passwordless logins if root account is locked.


### PR DESCRIPTION
Before starting `dracut-emergency.service`, the function `_emergency_shell()` writes `PS1` to `/etc/profile`. Then `/etc/profile` is sourced in `dracut-emergency.sh`, but `PS1` is not exported, so the current hook name is never displayed in the emergency shell. Also, the default name "dracut" is not printed either in the fallback `PS1`, because the variable `_name` is not set; it should be `_rdshell_name`.

## Checklist
- [X] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it