### PR TITLE
fix(base): don't wait infinitely for a device with non-persistent name

### DIFF
--- a/modules.d/80base/module-setup.sh
+++ b/modules.d/80base/module-setup.sh
@@ -161,15 +161,7 @@ install() {
                 done
 
                 for _dev in "${user_devs[@]}"; do
-
-                    case "$_dev" in
-                        /dev/?*) wait_for_dev "$_dev" 0 ;;
-                        *) ;;
-                    esac
-
                     _pdev=$(get_persistent_dev "$_dev")
-                    [[ $_dev == "$_pdev" ]] && continue
-
                     case "$_pdev" in
                         /dev/?*) wait_for_dev "$_pdev" 0 ;;
                         *) ;;


### PR DESCRIPTION
Currently, dracut will wait finitely for a block device e.g. /dev/sda2
when users use "dracut --add-device /dev/sda2". However, /dev/sda2 is
not a persistant name and it can show as a different name and kdump can
fail [1] as dracut will wait forever for /dev/sda2.

Commit c79fc8fd0 ("fix(dracut): rework timeout for devices added
via --mount and --add-device") already sets infinite timeout for
the underlying persistent device. There is no need to also set infinite
timeout for non-persistent device name. Removing the redundant wait can
automatically resolve the case where a device name changes.

[1] https://github.com/rhkdump/kdump-utils/pull/121

Reported-by: Alex Burmashev <alexander.burmashev@oracle.com>
Reported-by: Harshvardhan Jha <harshvardhan.j.jha@oracle.com>
Fixes: c79fc8fd0 ("fix(dracut): rework timeout for devices added via --mount and --add-device")

## Checklist
- [x] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it