### PR TITLE
refactor: change TimeoutSec=0 to TimeoutSec=infinity

### DIFF
--- a/modules.d/70dmsquash-live/checkisomd5@.service
+++ b/modules.d/70dmsquash-live/checkisomd5@.service
@@ -10,5 +10,5 @@ ExecStart=/usr/bin/checkisomd5 --verbose %f
 StandardInput=tty-force
 StandardOutput=inherit
 StandardError=inherit
-TimeoutSec=0
+TimeoutSec=infinity
 SuccessExitStatus=2

--- a/modules.d/77dracut-systemd/rootfs-generator.sh
+++ b/modules.d/77dracut-systemd/rootfs-generator.sh
@@ -8,7 +8,7 @@ generator_wait_for_dev() {
 
     _name=$(dev_unit_name "$1")
     _timeout=$(getarg rd.timeout)
-    _timeout=${_timeout:-0}
+    _timeout=${_timeout:-infinity}
 
     if ! [ -L "$GENERATOR_DIR"/initrd.target.wants/"${_name}".device ]; then
         [ -d "$GENERATOR_DIR"/initrd.target.wants ] || mkdir -p "$GENERATOR_DIR"/initrd.target.wants

--- a/modules.d/80base/dracut-dev-lib.sh
+++ b/modules.d/80base/dracut-dev-lib.sh
@@ -69,7 +69,7 @@ set_systemd_timeout_for_dev() {
         _timeout=$(getarg rd.timeout)
     fi
 
-    _timeout=${_timeout:-0}
+    _timeout=${_timeout:-infinity}
 
     _name=$(dev_unit_name "$1")
     if ! [ -L "${PREFIX-}/etc/systemd/system/initrd.target.wants/${_name}.device" ]; then

--- a/modules.d/80base/module-setup.sh
+++ b/modules.d/80base/module-setup.sh
@@ -155,7 +155,7 @@ install() {
                     _pdev=$(get_persistent_dev "$_dev")
 
                     case "$_pdev" in
-                        /dev/?*) wait_for_dev "$_pdev" 0 ;;
+                        /dev/?*) wait_for_dev "$_pdev" "infinity" ;;
                         *) ;;
                     esac
                 done
@@ -163,7 +163,7 @@ install() {
                 for _dev in "${user_devs[@]}"; do
 
                     case "$_dev" in
-                        /dev/?*) wait_for_dev "$_dev" 0 ;;
+                        /dev/?*) wait_for_dev "$_dev" "infinity" ;;
                         *) ;;
                     esac
 
@@ -171,7 +171,7 @@ install() {
                     [[ $_dev == "$_pdev" ]] && continue
 
                     case "$_pdev" in
-                        /dev/?*) wait_for_dev "$_pdev" 0 ;;
+                        /dev/?*) wait_for_dev "$_pdev" "infinity" ;;
                         *) ;;
                     esac
                 done


### PR DESCRIPTION
The officially documented way to turn off the timeouts in systemd is setting them to infinity, 0 is kept as historic compat support.

See https://github.com/systemd/systemd/commit/a9b837aa34a2d0bff1687427c66bed3b74cf0fed

Spotted after reviewing #1844, this PR should be rebased after that is merged.

## Checklist
- [X] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it
