### PR TITLE
feat(systemd-coredump): save coredumps to journal

### DIFF
--- a/modules.d/11systemd-coredump/initrd.conf
+++ b/modules.d/11systemd-coredump/initrd.conf
@@ -1,0 +1,8 @@
+# This file is part of dracut systemd-coredump module.
+# SPDX-License-Identifier: GPL-2.0-or-later
+#
+# The default "Storage=external" (/var/lib/systemd/coredump/) is usually lost
+# after switching root, because /var is usually not mounted in the initrd.
+
+[Coredump]
+Storage=journal

--- a/modules.d/11systemd-coredump/module-setup.sh
+++ b/modules.d/11systemd-coredump/module-setup.sh
@@ -34,7 +34,8 @@ config() {
 # Install the required file(s) and directories for the module in the initramfs.
 install() {
 
-    inst_dir /var/lib/systemd/coredump
+    inst_simple "$moddir/initrd.conf" "$systemdutildir/coredump.conf.d/initrd.conf"
+
     inst_sysusers systemd-coredump.conf
 
     inst_multiple -o \


### PR DESCRIPTION
This is the current process to get the core dump file of a process that crashed in the initrd:

- Set `rd.break` in the kernel cmdline to enter the emergency shell.
- The core dump file should be located in /var/lib/systemd/coredump/, but /var is not persistent in the initrd, and /sysroot is mounted read-only. So, the user has to manually `mount -o remount,rw /sysroot` and then `cp /var/lib/systemd/coredump/* /sysroot/var/lib/systemd/coredump`.

To make this process much easier, store in the journal coredumps generated in the initrd.

## Checklist
- [X] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it