### PR TITLE
ci: use GNU coreutils instead of uutil's coreutils

### DIFF
--- a/test/container/Dockerfile-debian
+++ b/test/container/Dockerfile-debian
@@ -24,6 +24,12 @@ RUN if [ "$DISTRIBUTION" != "debian:latest" ] ; then \
     3cpio \
     ; fi
 
+# use GNU coreutils instead of uutil's coreutils until https://github.com/uutils/coreutils/issues/9057 and https://launchpad.net/bugs/2129037 are fixed
+RUN if [ "$DISTRIBUTION" = "ubuntu:devel" ]; then \
+    DEBIAN_FRONTEND=noninteractive apt-get install -y -qq --no-install-recommends -o Dpkg::Use-Pty=0 \
+    coreutils-from-gnu coreutils-from-uutils- --allow-remove-essential; \
+    fi
+
 RUN \
     DEBIAN_FRONTEND=noninteractive apt-get install -y -qq --no-install-recommends -o Dpkg::Use-Pty=0 \
     asciidoctor \


### PR DESCRIPTION
## Changes

Tests start to fail on Ubuntu resolute due to rust-coreutils 0.3.0:

```
dd: IO error: Invalid input
```

Use GNU coreutils instead of uutil's coreutils until https://github.com/uutils/coreutils/issues/9057 and https://launchpad.net/bugs/2129037 are fixed.

## Checklist
- [ ] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it

Fixes #
