### PR TITLE
test: replace rev command by sed

### DIFF
--- a/test/container/Dockerfile-debian
+++ b/test/container/Dockerfile-debian
@@ -34,7 +34,6 @@ RUN \
     DEBIAN_FRONTEND=noninteractive apt-get install -y -qq --no-install-recommends -o Dpkg::Use-Pty=0 \
     asciidoctor \
     bluez \
-    bsdextrautils \
     btrfs-progs \
     ca-certificates \
     cargo \

--- a/test/run-qemu
+++ b/test/run-qemu
@@ -138,7 +138,7 @@ ARGS+=("$@")
 # only set -kernel if -initrd is specified
 initrd=$(get_initrd "${ARGS[@]}")
 if [[ -n $initrd ]]; then
-    KVERSION=$(lsinitrd "$initrd" | grep modules.dep | head -1 | rev | cut -d'/' -f2 | rev)
+    KVERSION=$(lsinitrd "$initrd" | grep modules.dep | head -1 | sed 's;.*/\([^/]\+\)/modules.dep;\1;')
     set_vmlinux_env
     ARGS+=(-kernel "$VMLINUZ")
     add_to_append "console=${console:-ttyS0},115200"

--- a/test/test-functions
+++ b/test/test-functions
@@ -129,7 +129,7 @@ command -v test_cleanup &> /dev/null || test_cleanup() {
 }
 
 determine_kernel_version() {
-    lsinitrd "$1" | grep modules.dep | head -1 | rev | cut -d'/' -f2 | rev
+    lsinitrd "$1" | grep modules.dep | head -1 | sed 's;.*/\([^/]\+\)/modules.dep;\1;'
 }
 
 determine_kernel_image() {


### PR DESCRIPTION
## Changes

On Debian-based systems, the `rev` command is shipped by the bsdextrautils package. Replace the `rev` command by `sed` which is an essential command and does not need additional packages.

## Checklist
- [ ] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it

Fixes #
