### PR TITLE
test: exit with code 77 if test is skipped

### DIFF
--- a/test/test-functions
+++ b/test/test-functions
@@ -298,7 +298,7 @@ while (($# > 0)); do
                     cat test${TEST_RUN_ID:+-$TEST_RUN_ID}.log
                 fi
                 echo -e "TEST: $TEST_DESCRIPTION " "$COLOR_WARNING" "[SKIPPED]" "$COLOR_NORMAL"
-                exit 0
+                exit 77
             else
                 echo -e "TEST: $TEST_DESCRIPTION " "$COLOR_SUCCESS" "[STARTED]" "$COLOR_NORMAL"
             fi


### PR DESCRIPTION
## Changes

Exiting tests that are skipped with exit code 0 will hide that the test environment probably miss some tools. That can reduce the test coverage without anybody noting it.

Therefore exit tests that are skipped with exit code 77. In case tests are intentionally expected to be skipped, an environment variable could be introduce to exit with code 0 again.

## Checklist
- [ ] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it

Fixes #
