### PR TITLE
feat(network-manager): add systemd generator if available

### DIFF
--- a/modules.d/35network-manager/module-setup.sh
+++ b/modules.d/35network-manager/module-setup.sh
@@ -69,9 +69,15 @@ install() {
             inst_simple "$moddir/NetworkManager-wait-online-initrd-dracut.conf" \
                 "$systemdsystemunitdir/NetworkManager-wait-online-initrd.service.d/NetworkManager-wait-online-initrd-dracut.conf"
 
-            $SYSTEMCTL -q --root "$initdir" enable NetworkManager-initrd.service
+            # NetworkManager-1.56 provides a systemd generator to install initrd
+            # services, so they no longer have an "[Install]" section.
+            if [[ -e "$systemdutildir"/system-generators/nm-initrd-generator.sh ]]; then
+                inst "$systemdutildir"/system-generators/nm-initrd-generator.sh
+            else
+                $SYSTEMCTL -q --root "$initdir" enable NetworkManager-initrd.service
+            fi
         else
-            #TODO: remove custom systemd services when NetworkManager-1.54 is the minimum supported version
+            #TODO: remove custom systemd services when NetworkManager-1.56 is the minimum supported version
             inst_simple "$moddir"/nm-initrd.service "$systemdsystemunitdir"/nm-initrd.service
             inst_simple "$moddir"/nm-wait-online-initrd.service "$systemdsystemunitdir"/nm-wait-online-initrd.service
 


### PR DESCRIPTION
A systemd generator was added in [1] to fix an upstream issue [2]. It also brings the removal of the "[Install]" section from the upstream initrd services; it is used to mask the initrd services on the host, and to mask the host services and provide installation links of the initrd services in the initrd.

Additionally, increase the minimum NetworkManager version set to remove custom systemd services from dracut.

[1] https://gitlab.freedesktop.org/NetworkManager/NetworkManager/-/commit/636fb5ef24640856515584977174fa44a986e374
[2] https://gitlab.freedesktop.org/NetworkManager/NetworkManager/-/issues/1814

## Checklist
- [X] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it
