### PR TITLE
fix(Makefile): correct path for man pages for service files

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -277,7 +277,7 @@ endif
 	install -m 0644 dracut.pc $(DESTDIR)${pkgconfigdatadir}/dracut.pc
 	if ! [ -n "$(systemdsystemunitdir)" ]; then \
 		rm -rf $(DESTDIR)$(pkglibdir)/test/TEST-[0-9][0-9]-*SYSTEMD* ;\
-		rm -rf $(DESTDIR)$(pkglibdir)/modules.d/*systemd* $(DESTDIR)$(mandir)/*.service.* ; \
+		rm -rf $(DESTDIR)$(pkglibdir)/modules.d/*systemd* $(DESTDIR)$(mandir)/man8/*.service.* ; \
 		for i in bluetooth connman dbus* fido2 lvmmerge lvmthinpool-monitor memstrack pcsc pkcs11 rngd squash* tpm2-tss; do \
 			rm -r $(DESTDIR)$(pkglibdir)/modules.d/[0-9][0-9]$${i}; \
 		done \


### PR DESCRIPTION
## Changes

The man pages for service files are installed to the man8 directory, so delete them from there.

## Checklist
- [ ] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it

Fixes #
