### PR TITLE
chore: call inst_multiple instead of the dracut_install wrapper

### DIFF
--- a/dracut.sh
+++ b/dracut.sh
@@ -1911,7 +1911,7 @@ inst_rule_programs() {
             }
         fi
 
-        [[ $_bin ]] && dracut_install "$_bin"
+        [[ $_bin ]] && inst_multiple "$_bin"
     done
 }
 

--- a/modules.d/77integrity/module-setup.sh
+++ b/modules.d/77integrity/module-setup.sh
@@ -13,7 +13,7 @@ depends() {
 
 # called by dracut
 install() {
-    dracut_install evmctl keyctl
+    inst_multiple evmctl keyctl
     inst_hook pre-pivot 61 "$moddir/evm-enable.sh"
     inst_hook pre-pivot 61 "$moddir/ima-keys-load.sh"
     inst_hook pre-pivot 62 "$moddir/ima-policy-load.sh"


### PR DESCRIPTION
## Changes

`dracut_install` is no longer preferred. In almost all call sites `inst_multiple` is called directly instead of the `dracut_install` wrapper.

Call `inst_multiple` directly for better readability, consistency and possibly slightly faster perf.

## Checklist
- [ ] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it

Fixes #
