### PR TITLE
ci(fedora): install diffutils

### DIFF
--- a/test/container/Dockerfile-fedora
+++ b/test/container/Dockerfile-fedora
@@ -49,6 +49,7 @@ RUN dnf -y install --setopt=install_weak_deps=False \
     cryptsetup \
     crypto-policies-scripts \
     device-mapper-multipath \
+    diffutils \
     dnsmasq \
     dracut-live \
     e2fsprogs \


### PR DESCRIPTION
## Changes

The test 81 needs the `diff` command which is provided by the diffutils package on Fedora. Otherwise the test 81 is skipped on Fedora.

## Checklist
- [ ] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it

Fixes #
