### PR TITLE
fix(functions): do not use path escapes for non-paths

### DIFF
--- a/modules.d/80base/dracut-dev-lib.sh
+++ b/modules.d/80base/dracut-dev-lib.sh
@@ -26,7 +26,10 @@ dev_unit_name() {
     local dev="$1"
 
     if command -v systemd-escape > /dev/null; then
-        systemd-escape -p -- "$dev"
+        case $dev in
+            */*) systemd-escape -p -- "$dev" ;;
+            *) systemd-escape -- "$dev" ;;
+        esac
         return $?
     fi
 


### PR DESCRIPTION
Function dev_unit_name unconditionally calls `systemd-escape -p` on the device argument, even if that is a non-path, for example, a LUKS UUID. `systemd-escape -p` writes a warning for non-paths, so just use plain `systemd-escape` for these.

## Checklist
- [X] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it

## Background

My `/etc/crypttab` looks like this:

```
# target        source device                               key file    options
nvme0n1p3_crypt UUID=XXXXXXXX-XXXX-XXXX-XXXX-XXXXXXXXXXXX   none        luks,fido2-device=auto,token-timeout=5,x-initrd.attach
```

Because of the UUID-based device specification, every boot `systemd-escape` moans like this:

```
Nov 22 19:59:56 host01 systemd[1]: Starting dracut-cmdline.service - dracut cmdline hook...
[...]
Nov 22 19:59:56 host01 dracut-cmdline[379]: dracut-109-1
Nov 22 19:59:56 host01 dracut-cmdline[379]: Using kernel command line parameters:  rd.luks.uuid=luks-XXXXXXXX-XXXX-XXXX-XXXX-XXXXXXXXXXXX rd.lvm.lv=vghost01/root root=/dev/mapper/vghost01-root rootfstype=ext4 rootflags=rw,relatime,errors=remount-ro   BOOT_IMAGE=/vmlinuz-6.16.12+deb14+1-amd64 root=/dev/mapper/vghost01-root ro rd.retry=30 rd.shell mem_sleep_default=deep systemd.restore_state=0 i8042.unlock=1 video=efifb:off fbcon=font:TER16x32 vt.global_cursor_default=0 quiet loglevel=3
Nov 22 19:59:56 host01 systemd-modules-load[356]: Inserted module 'msr'
Nov 22 19:59:56 host01 systemd-modules-load[356]: Inserted module 'parport_pc'
Nov 22 19:59:56 host01 systemd[1]: Started systemd-journald.service - Journal Service.
Nov 22 19:59:56 host01 systemd[1]: Starting systemd-tmpfiles-setup.service - Create System Files and Directories...
Nov 22 19:59:56 host01 systemd[1]: Finished systemd-tmpfiles-setup.service - Create System Files and Directories.
                       vvvvvvvvvvvvvvvvvvv
Nov 22 19:59:56 host01 systemd-escape[477]: Input 'luks-XXXXXXXX-XXXX-XXXX-XXXX-XXXXXXXXXXXX' is not an absolute file system path, escaping is likely not going to be reversible.
                       ^^^^^^^^^^^^^^^^^^^
Nov 22 19:59:56 host01 systemd[1]: Finished dracut-cmdline.service - dracut cmdline hook.
```

I chose pattern `*/*` to detect non-paths as a compromise: It is simple yet should match all kind of UUIDs.