### PR TITLE
test: use UEFI for QEMU when available and support UEFI on ARM

### DIFF
--- a/test/TEST-12-UEFI/test.sh
+++ b/test/TEST-12-UEFI/test.sh
@@ -16,7 +16,8 @@ test_check() {
         return 1
     fi
 
-    if [[ -z "$(ovmf_code)" ]]; then
+    if ! "$testdir"/run-qemu --check-uefi; then
+        echo "No UEFI firmware (for QEMU) found" >&2
         return 1
     fi
 }
@@ -34,9 +35,7 @@ client_run() {
 
     test_marker_reset
     "$testdir"/run-qemu "${disk_args[@]}" -net none \
-        -drive file=fat:rw:"$TESTDIR"/ESP,format=vvfat,label=EFI \
-        -global driver=cfi.pflash01,property=secure,value=on \
-        -drive if=pflash,format=raw,unit=0,file="$(ovmf_code)",readonly=on
+        -drive file=fat:rw:"$TESTDIR"/ESP,format=vvfat,label=EFI
     test_marker_check
 }
 

--- a/test/run-qemu
+++ b/test/run-qemu
@@ -32,6 +32,25 @@ get_initrd() {
     done
 }
 
+# Search for the UEFI firmware file
+# Print UEFI firmware file on stdout on success.
+# Return 1 in case no UEFI firmware file was found.
+get_uefi_code() {
+    for path in \
+        "/usr/share/OVMF/OVMF_CODE.fd" \
+        "/usr/share/OVMF/OVMF_CODE_4M.fd" \
+        "/usr/share/edk2/x64/OVMF_CODE.fd" \
+        "/usr/share/edk2/x64/OVMF_CODE.4m.fd" \
+        "/usr/share/edk2-ovmf/OVMF_CODE.fd" \
+        "/usr/share/qemu/ovmf-x86_64-4m.bin"; do
+        if [[ -s $path ]]; then
+            echo -n "$path"
+            return 0
+        fi
+    done
+    return 1
+}
+
 quote_args() {
     local arg args=()
     for arg in "$@"; do
@@ -97,6 +116,11 @@ set_vmlinux_env() {
     exit 1
 }
 
+if test "${1-}" = "--check-uefi"; then
+    get_uefi_code > /dev/null
+    exit 0
+fi
+
 if test "${1-}" = "--supports"; then
     option="$2"
     "$BIN" -help | grep -q "^$option"
@@ -120,6 +144,11 @@ case "$ARCH" in
         console=hvc0
         ;;
 esac
+
+if uefi_code=$(get_uefi_code); then
+    ARGS+=(-drive "if=pflash,format=raw,readonly=on,unit=0,file=$uefi_code"
+        -global "driver=cfi.pflash01,property=secure,value=on")
+fi
 
 # Provide rng device sourcing the hosts /dev/urandom and other standard parameters
 ARGS+=(-smp 2 -m "${MEMORY-1024}" -nodefaults -vga none -display none -no-reboot -watchdog-action poweroff -device virtio-rng-pci)

--- a/test/run-qemu
+++ b/test/run-qemu
@@ -36,13 +36,26 @@ get_initrd() {
 # Print UEFI firmware file on stdout on success.
 # Return 1 in case no UEFI firmware file was found.
 get_uefi_code() {
-    for path in \
-        "/usr/share/OVMF/OVMF_CODE.fd" \
-        "/usr/share/OVMF/OVMF_CODE_4M.fd" \
-        "/usr/share/edk2/x64/OVMF_CODE.fd" \
-        "/usr/share/edk2/x64/OVMF_CODE.4m.fd" \
-        "/usr/share/edk2-ovmf/OVMF_CODE.fd" \
-        "/usr/share/qemu/ovmf-x86_64-4m.bin"; do
+    local paths=()
+    case "$ARCH" in
+        aarch64 | arm64)
+            paths=("/usr/share/AAVMF/AAVMF_CODE.no-secboot.fd")
+            ;;
+        amd64 | x86_64)
+            paths=(
+                "/usr/share/OVMF/OVMF_CODE.fd"
+                "/usr/share/OVMF/OVMF_CODE_4M.fd"
+                "/usr/share/edk2/x64/OVMF_CODE.fd"
+                "/usr/share/edk2/x64/OVMF_CODE.4m.fd"
+                "/usr/share/edk2-ovmf/OVMF_CODE.fd"
+                "/usr/share/qemu/ovmf-x86_64-4m.bin"
+            )
+            ;;
+        arm | armhf | armv7l)
+            paths=("/usr/share/AAVMF/AAVMF32_CODE.fd")
+            ;;
+    esac
+    for path in "${paths[@]}"; do
         if [[ -s $path ]]; then
             echo -n "$path"
             return 0
@@ -146,8 +159,7 @@ case "$ARCH" in
 esac
 
 if uefi_code=$(get_uefi_code); then
-    ARGS+=(-drive "if=pflash,format=raw,readonly=on,unit=0,file=$uefi_code"
-        -global "driver=cfi.pflash01,property=secure,value=on")
+    ARGS+=(-drive "if=pflash,format=raw,readonly=on,unit=0,file=$uefi_code")
 fi
 
 # Provide rng device sourcing the hosts /dev/urandom and other standard parameters

--- a/test/test-functions
+++ b/test/test-functions
@@ -112,18 +112,6 @@ wait_for_server_startup() {
     fi
 }
 
-ovmf_code() {
-    for path in \
-        "/usr/share/OVMF/OVMF_CODE.fd" \
-        "/usr/share/OVMF/OVMF_CODE_4M.fd" \
-        "/usr/share/edk2/x64/OVMF_CODE.fd" \
-        "/usr/share/edk2/x64/OVMF_CODE.4m.fd" \
-        "/usr/share/edk2-ovmf/OVMF_CODE.fd" \
-        "/usr/share/qemu/ovmf-x86_64-4m.bin"; do
-        [[ -s $path ]] && echo -n "$path" && return
-    done
-}
-
 command -v test_check &> /dev/null || test_check() {
     :
 }


### PR DESCRIPTION
## Changes

Move the `ovmf_code` function and related code to `run-qemu` and always use UEFI when available.

The OVMF firmware files are builds of EDK II for 64-bit x86 virtual machines. They do not work on other architectures.

So search for AAVMF files on ARM. Remove the `cfi.pflash01` driver setting because it does not work on Ubuntu arm64 and `readonly=on` is already set for the firmware file.

## Checklist
- [x] I have tested it locally
- [x] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it

Fixes: https://github.com/dracut-ng/dracut-ng/issues/1861
