### PR TITLE
test: drop sync calls on host

### DIFF
--- a/test/TEST-30-DMSQUASH/test.sh
+++ b/test/TEST-30-DMSQUASH/test.sh
@@ -106,12 +106,9 @@ test_setup() {
 2048,652688
 EOF
 
-    sync "$TESTDIR"/root.img
     dd if=/dev/zero of="$TESTDIR"/ext4.img bs=512 count=652688 status=none
-    sync "$TESTDIR"/ext4.img
     mkfs.ext4 -q -L dracut -d "$TESTDIR"/rootfs/ "$TESTDIR"/ext4.img
-    sync "$TESTDIR"/ext4.img
-    dd if="$TESTDIR"/ext4.img of="$TESTDIR"/root.img bs=512 seek=2048 conv=noerror,sync,notrunc
+    dd if="$TESTDIR"/ext4.img of="$TESTDIR"/root.img bs=512 seek=2048 conv=noerror,notrunc
 
     # erofs drive
     qemu_add_drive disk_index disk_args "$TESTDIR"/root_erofs.img root_erofs 1
@@ -129,7 +126,6 @@ EOF
         mkdir "$TESTDIR"/iso
         xorriso -as mkisofs -output "$TESTDIR"/iso/linux.iso "$TESTDIR"/live/ -volid "ISO" -iso-level 3
         mkfs.ext4 -q -L dracut_iso -d "$TESTDIR"/iso/ "$TESTDIR"/root_iso.img
-        sync "$TESTDIR"/root_iso.img
     fi
 
     local dracut_modules="dmsquash-live-autooverlay convertfs pollcdrom kernel-modules kernel-modules-extra qemu qemu-net"

--- a/test/test-functions
+++ b/test/test-functions
@@ -171,9 +171,7 @@ build_ext4_image() {
     size="$((size + 8000000))"
 
     dd if=/dev/zero of="$image" bs="$size" count=1 status=none
-    sync "$image"
     mkfs.ext4 -q -L "$label" -d "$source_dir" "$image"
-    sync "$image"
 }
 
 # override the init script from the test-root dracut module (see module-setup.sh)
@@ -228,7 +226,6 @@ qemu_add_drive() {
         fi
 
         dd if=/dev/zero of="${file}" bs=1MiB count="${size}" status=none
-        sync "${file}"
     fi
 
     eval "${2}"'+=(' \
@@ -242,7 +239,6 @@ qemu_add_drive() {
 
 test_marker_reset() {
     dd if=/dev/zero of="$TESTDIR"/marker.img bs=1MiB count=1 status=none
-    sync "$TESTDIR"/marker.img
 }
 
 test_marker_check() {


### PR DESCRIPTION
## Changes

Synchronizing cached writes to persistent storage is not needed for the test host. So drop those sync calls for faster test execution.

Keep only the sync calls in the scripts that are executed in a virtual machine (like `create-root.sh` and `client-init.sh`).

@jozzsi @LaszloGombos 

## Checklist
- [x] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it

Fixes #
