### PR TITLE
fix(dracut): ignore shellcheck SC2329 in addition to SC2317

### DIFF
--- a/dracut.sh
+++ b/dracut.sh
@@ -1,7 +1,7 @@
 #!/bin/bash -p
 # temporarly disable some shellcheck warning to be able to preserve commit history
 # before additional commits.
-# shellcheck disable=SC2317
+# shellcheck disable=SC2317,SC2329
 #
 # Generator script for a dracut initramfs
 


### PR DESCRIPTION
## Changes

Shellcheck <= 0.10 complains about SC2317 (info): Command appears to be unreachable. Check usage (or ignore if invoked indirectly). Shellcheck 0.11 changes this complaint to SC2329 (info): This function is never invoked. Check usage (or ignored if invoked indirectly).

So ignore shellcheck SC2329 in addition to SC2317 to make both shellcheck versions happy.

## Checklist
- [x] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it

Fixes #
