### PR TITLE
test: use truncate instead of dd if=/dev/zero

### DIFF
--- a/test/TEST-30-DMSQUASH/test.sh
+++ b/test/TEST-30-DMSQUASH/test.sh
@@ -106,7 +106,8 @@ test_setup() {
 2048,652688
 EOF
 
-    dd if=/dev/zero of="$TESTDIR"/ext4.img bs=512 count=652688 status=none
+    rm -f "$TESTDIR/ext4.img"
+    truncate -s "$((512 * 652688))" "$TESTDIR/ext4.img"
     mkfs.ext4 -q -L dracut -d "$TESTDIR"/rootfs/ "$TESTDIR"/ext4.img
     dd if="$TESTDIR"/ext4.img of="$TESTDIR"/root.img bs=512 seek=2048 conv=noerror,notrunc
 

--- a/test/test-functions
+++ b/test/test-functions
@@ -170,7 +170,8 @@ build_ext4_image() {
     # Add 8 MB for ext4 journal
     size="$((size + 8000000))"
 
-    dd if=/dev/zero of="$image" bs="$size" count=1 status=none
+    rm -f "$image"
+    truncate -s "$size" "$image"
     mkfs.ext4 -q -L "$label" -d "$source_dir" "$image"
 }
 
@@ -225,7 +226,8 @@ qemu_add_drive() {
             size=512
         fi
 
-        dd if=/dev/zero of="${file}" bs=1MiB count="${size}" status=none
+        rm -f "$file"
+        truncate -s "${size}M" "$file"
     fi
 
     eval "${2}"'+=(' \
@@ -238,7 +240,8 @@ qemu_add_drive() {
 }
 
 test_marker_reset() {
-    dd if=/dev/zero of="$TESTDIR"/marker.img bs=1MiB count=1 status=none
+    rm -f "$TESTDIR/marker.img"
+    truncate -s 1M "$TESTDIR/marker.img"
 }
 
 test_marker_check() {


### PR DESCRIPTION
## Changes

Use `truncate` to create sparse files.

## Checklist
- [ ] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it

Fixes #
