### PR TITLE
test: do not keep the initramfs.testing artefacts by default

### DIFF
--- a/test/TEST-13-SYSROOT/test.sh
+++ b/test/TEST-13-SYSROOT/test.sh
@@ -29,7 +29,7 @@ test_setup() {
     build_ext4_image "$TESTDIR"/dracut.*/initramfs/ "$TESTDIR"/root.img dracut
 
     ln -s / "$TESTDIR"/sysroot
-    test_dracut --hostonly --sysroot "$TESTDIR"/sysroot
+    test_dracut --keep --hostonly --sysroot "$TESTDIR"/sysroot
 
     if grep -q '^root:' /etc/shadow; then
         if ! grep -q '^root:' "$TESTDIR"/initrd/dracut.*/initramfs/etc/shadow; then

--- a/test/TEST-41-FULL-SYSTEMD/test.sh
+++ b/test/TEST-41-FULL-SYSTEMD/test.sh
@@ -131,7 +131,7 @@ test_setup() {
     grep -F -a -m 1 ID_FS_UUID "$TESTDIR"/marker.img > "$TESTDIR"/luks.uuid
 
     # force add all available dracut modules that are dependent on systemd
-    test_dracut \
+    test_dracut --keep \
         -a "dracut-systemd $dracut_modules" \
         --add-drivers "btrfs"
 

--- a/test/TEST-42-SYSTEMD-INITRD/test.sh
+++ b/test/TEST-42-SYSTEMD-INITRD/test.sh
@@ -82,7 +82,7 @@ test_setup() {
 
     # vanilla kernel-independent systemd-based minimal initrd without dracut specific customizations
     # since dracut-systemd is not included in the generated initrd, only systemd options are supported during boot
-    test_dracut --no-kernel \
+    test_dracut --keep --no-kernel \
         --omit "test systemd-sysctl systemd-modules-load" \
         -m "systemd-initrd base" \
         "$TESTDIR"/initramfs-systemd-initrd

--- a/test/test-functions
+++ b/test/test-functions
@@ -47,7 +47,7 @@ test_dracut() {
     fi
 
     # pick up configuration from $TESTDIR/dracut.conf.d when running the tests
-    TEST_DRACUT_ARGS+=" --confdir $TESTDIR/dracut.conf.d --add-confdir test --keep --tmpdir $TESTDIR/initrd"
+    TEST_DRACUT_ARGS+=" --confdir $TESTDIR/dracut.conf.d --add-confdir test --tmpdir $TESTDIR/initrd"
 
     # include $TESTDIR"/overlay if exists
     if [ -d "$TESTDIR"/overlay ]; then


### PR DESCRIPTION
## Changes

Calling dracut with `--keep` is not needed for initramfs.testing in most cases.

## Checklist
- [ ] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it

Fixes #
