### PR TITLE
fix(man): avoid nesting italic in bold text

### DIFF
--- a/man/dracut.8.adoc
+++ b/man/dracut.8.adoc
@@ -382,7 +382,7 @@ provide a valid _/etc/fstab_.
 **-N, --no-hostonly**::
     Disable host-only mode.
 
-**--hostonly-mode _<mode>_**::
+**--hostonly-mode** _<mode>_::
     Specify the host-only mode to use. _<mode>_ could be one of "sloppy" or
     "strict".
     In "sloppy" host-only mode, extra drivers and modules will be installed, so
@@ -615,7 +615,7 @@ will not be able to boot. Equivalent to "--compress=zstd -15 -q -T0".
     Do not create an image in host-only mode, if no kernel driver is needed
 and no /etc/cmdline/*.conf will be generated into the initramfs.
 
-**--loginstall _<directory>_**::
+**--loginstall** _<directory>_::
     Log all files installed from the host to _<directory>_.
 
 **--uefi**::
@@ -634,21 +634,21 @@ and no /etc/cmdline/*.conf will be generated into the initramfs.
     Affects the default output filename of **--uefi** and will discard the
     <MACHINE_ID> part.
 
-**--uefi-stub _<file>_**::
+**--uefi-stub** _<file>_::
     Specifies the UEFI stub loader, which will load the attached kernel,
     initramfs and kernel command line and boots the kernel. The default is
     _$prefix/lib/systemd/boot/efi/linux<EFI-MACHINE-TYPE-NAME>.efi.stub_.
 
-**--uefi-splash-image _<file>_**::
+**--uefi-splash-image** _<file>_::
     Specifies the UEFI stub loader's splash image. Requires bitmap (**.bmp**)
     image format.
 
-**--kernel-image _<file>_**::
+**--kernel-image** _<file>_::
     Specifies the kernel image, which to include in the UEFI executable. The
     default is _/lib/modules/<KERNEL-VERSION>/vmlinuz_ or
     _/boot/vmlinuz-<KERNEL-VERSION>_.
 
-**--sbat <parameters>**::
+**--sbat** _<parameters>_::
     Specifies the SBAT parameters, which to include in the UEFI executable. By default
     the default SBAT string added is "sbat,1,SBAT Version,sbat,1,
     https://github.com/rhboot/shim/blob/main/SBAT.md".

--- a/man/dracut.cmdline.7.adoc
+++ b/man/dracut.cmdline.7.adoc
@@ -906,7 +906,7 @@ iscsistart -b --param node.session.timeo.replacement_timeout=30
 **rd.iscsi.testroute=0**:
     Turn off checking, if the route to the iSCSI target IP is possible before trying to login.
 
-**rd.iscsi.transport=__<transport_name>__**::
+**rd.iscsi.transport=**__<transport_name>__::
     Set the iSCSI transport name (see man:iscsiadm[8,external]). iSCSI offload
     transports like **bnx2i** don't need the network to be up in order to bring
     up iSCSI connections. This parameter indicates that network setup can be
@@ -1311,7 +1311,7 @@ filesystem specified within the +
 **root=**live:__<path to blockdevice>__ or **root=**live:__<url>__ device.
 
 The default *_pathspec_*, when *:auto* or
-no **:__<pathspec>__** is given, is `/<rd.live.dir>/overlay-<label>-<uuid>`,
+no **:**__<pathspec>__ is given, is `/<rd.live.dir>/overlay-<label>-<uuid>`,
 where _<label>_ and _<uuid>_ are the LABEL and UUID of the filesystem specified
 by the **root=**live:__<path|url>__ device.
 

--- a/man/dracut.cmdline.7.adoc
+++ b/man/dracut.cmdline.7.adoc
@@ -1118,7 +1118,7 @@ Dracut offers multiple options for live booted images:
 SquashFS (read-only) base filesystem image:::
 Note -- There are 3 separate overlay types available:
 - Device-mapper snapshots (the original offering),
-- Device-mapper thin provisioning snapshots (see *_rd.live.overlay.thin_*,
+- Device-mapper thin provisioning snapshots (see _rd.live.overlay.thin_,
 a later offering), and
 - OverlayFS based overlay mounts (a more recent offering).
 
@@ -1135,12 +1135,12 @@ leading to application failures.  The snapshot overlay device is marked
 'Overflow', and a difficult recovery is required to repair and enlarge the
 overlay offline.
 
-When *_rd.live.overlay=_* is not specified for persistent overlay storage, or
+When _rd.live.overlay=_ is not specified for persistent overlay storage, or
 the specified file is not found or writable, a Device-mapper snapshot based
 non-persistent or temporary overlay is automatically created as a sparse file
 in RAM of the initramfs.  This file will only consume content space as required
 blocks are allocated. This snapshot based overlay defaults to an apparent size
-of 32 GiB in RAM, and can be adjusted with the *_rd.live.overlay.size=_* kernel
+of 32 GiB in RAM, and can be adjusted with the _rd.live.overlay.size=_ kernel
 command line option.  This file is hidden (and appears deleted) when the boot
 process switches out of the initramfs to the main root filesystem but its loop
 device remains connected to the Device-mapper snapshot.
@@ -1152,8 +1152,8 @@ filesystem, which often provide only a small number of gigabytes of free space.
 This shortage could be remedied by building the root filesystem with more
 allocated free space, or the OverlayFS based overlay mount method can be used.
 
-When the *_rd.overlayfs_* option is specified or when
-*_rd.live.overlay=_* points to an appropriate directory with a sister at
+When the _rd.overlayfs_ option is specified or when
+_rd.live.overlay=_ points to an appropriate directory with a sister at
 `/../ovlwork`, then an OverlayFS based overlay mount is employed.  Such a
 persistent OverlayFS overlay can extend the available root filesystem storage
 up to the capacity of the LiveOS disk device.
@@ -1297,26 +1297,26 @@ when the image resides on, e.g., a DVD which needs to be ejected later on.
 Manage the usage of a persistent overlay.
 +
 --
-* *_<devspec>_* specifies the path to a device with a mountable filesystem.
-* *_<pathspec>_* is a path within the *_<devspec>_* filesystem to either
+* _<devspec>_ specifies the path to a device with a mountable filesystem.
+* _<pathspec>_ is a path within the _<devspec>_ filesystem to either
 ** a file (that is loop mounted for a Device-mapper overlay) or
 ** a directory (that is symbolically linked to `/run/overlayfs` for a OverlayFS
 mount overlay). (A required sister directory `/<pathspec>/../ovlwork` is
 automatically made.)
-* *_none_* (the word itself) specifies that no overlay will be used, such as
+* _none_ (the word itself) specifies that no overlay will be used, such as
 when an uncompressed, writable live root filesystem is available.
 
 The above method shall be used to persist the changes made to the root
 filesystem specified within the +
 **root=**live:__<path to blockdevice>__ or **root=**live:__<url>__ device.
 
-The default *_pathspec_*, when *:auto* or
+The default _pathspec_, when *:auto* or
 no **:**__<pathspec>__ is given, is `/<rd.live.dir>/overlay-<label>-<uuid>`,
 where _<label>_ and _<uuid>_ are the LABEL and UUID of the filesystem specified
 by the **root=**live:__<path|url>__ device.
 
 If a persistent overlay __is detected__ at the standard LiveOS path,
-and *_rd.overlayfs_* is not set to 1, the overlay type (either
+and _rd.overlayfs_ is not set to 1, the overlay type (either
 Device-mapper or OverlayFS) will be detected and it will be used.
 --
 +

--- a/man/dracut.modules.7.adoc
+++ b/man/dracut.modules.7.adoc
@@ -71,7 +71,7 @@ Now udev is started and the logging for udev is setup.
 === Hook: pre-trigger
 
 In this hook, you can set udev environment variables with **udevadm control
---property=KEY=_value_** or control the further execution of udev with
+--property=KEY=**__value__ or control the further execution of udev with
 udevadm.
 
 === Trigger Udev


### PR DESCRIPTION
## Changes

asciidoctor (on Ubuntu) does not format nested italic in bold text correctly. The following text will be in italic.

Since man pages do not use italic bold text, remove the nesting and pick either italic or bold.

## Checklist
- [x] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it

Fixes #
