### PR TITLE
test: drop checking $?

### DIFF
--- a/test/TEST-60-NFS/test.sh
+++ b/test/TEST-60-NFS/test.sh
@@ -70,9 +70,8 @@ client_test() {
         -append "$TEST_KERNEL_CMDLINE $cmdline ro" \
         -initrd "$TESTDIR"/initramfs.testing
 
-    # shellcheck disable=SC2181
-    if [[ $? -ne 0 ]] || ! test_marker_check nfs-OK; then
-        echo "CLIENT TEST END: $test_name [FAILED - BAD EXIT]"
+    if ! test_marker_check nfs-OK; then
+        echo "CLIENT TEST END: $test_name [FAILED - MISSING MARKER]"
         return 1
     fi
 

--- a/test/TEST-70-ISCSI/test.sh
+++ b/test/TEST-70-ISCSI/test.sh
@@ -61,9 +61,8 @@ run_client() {
         -append "$TEST_KERNEL_CMDLINE $*" \
         -initrd "$TESTDIR"/initramfs.testing
 
-    # shellcheck disable=SC2181
-    if [[ $? -ne 0 ]] || ! test_marker_check iscsi-OK; then
-        echo "CLIENT TEST END: $test_name [FAILED - BAD EXIT]"
+    if ! test_marker_check iscsi-OK; then
+        echo "CLIENT TEST END: $test_name [FAILED - MISSING MARKER]"
         return 1
     fi
 

--- a/test/TEST-72-NBD/test.sh
+++ b/test/TEST-72-NBD/test.sh
@@ -71,9 +71,8 @@ client_test() {
         -append "$cmdline rd.auto ro" \
         -initrd "$TESTDIR"/initramfs.testing
 
-    # shellcheck disable=SC2181
-    if [[ $? -ne 0 ]] || ! test_marker_check nbd-OK; then
-        echo "CLIENT TEST END: $test_name [FAILED - BAD EXIT]"
+    if ! test_marker_check nbd-OK; then
+        echo "CLIENT TEST END: $test_name [FAILED - MISSING MARKER]"
         return 1
     fi
 


### PR DESCRIPTION
## Changes

The tests are run with `set -e`. So the test will exit in case of a failure and `$?` will always be `0`. So drop the check for `$?`.

## Checklist
- [ ] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it

Fixes #
