### PR TITLE
test: poweroff with systemd if available

### DIFF
--- a/test/TEST-60-NFS/client-init.sh
+++ b/test/TEST-60-NFS/client-init.sh
@@ -45,4 +45,11 @@ fi
 sync /dev/disk/by-id/scsi-0QEMU_QEMU_HARDDISK_marker /dev/disk/by-id/scsi-0QEMU_QEMU_HARDDISK_marker2
 
 echo "Powering down."
-poweroff -f
+
+if [ -d /usr/lib/systemd/system ]; then
+    # graceful poweroff
+    systemctl poweroff
+else
+    # force immediate poweroff
+    poweroff -f
+fi

--- a/test/TEST-70-ISCSI/client-init.sh
+++ b/test/TEST-70-ISCSI/client-init.sh
@@ -13,4 +13,11 @@ done < /proc/mounts
 sync /dev/disk/by-id/scsi-0QEMU_QEMU_HARDDISK_marker
 
 echo "Powering down."
-poweroff -f
+
+if [ -d /usr/lib/systemd/system ]; then
+    # graceful poweroff
+    systemctl poweroff
+else
+    # force immediate poweroff
+    poweroff -f
+fi

--- a/test/TEST-71-ISCSI-MULTI/client-init.sh
+++ b/test/TEST-71-ISCSI-MULTI/client-init.sh
@@ -13,4 +13,11 @@ done < /proc/mounts
 sync /dev/disk/by-id/scsi-0QEMU_QEMU_HARDDISK_marker
 
 echo "Powering down."
-poweroff -f
+
+if [ -d /usr/lib/systemd/system ]; then
+    # graceful poweroff
+    systemctl poweroff
+else
+    # force immediate poweroff
+    poweroff -f
+fi

--- a/test/TEST-72-NBD/client-init.sh
+++ b/test/TEST-72-NBD/client-init.sh
@@ -18,4 +18,11 @@ mount -n -o remount,ro /
 sync /dev/disk/by-id/scsi-0QEMU_QEMU_HARDDISK_marker
 
 echo "Powering down."
-poweroff -f
+
+if [ -d /usr/lib/systemd/system ]; then
+    # graceful poweroff
+    systemctl poweroff
+else
+    # force immediate poweroff
+    poweroff -f
+fi


### PR DESCRIPTION
## Changes

Use the same poweroff code from `modules.d/70test-root/test-init.sh` in all test cases.

## Checklist
- [ ] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it

Fixes #
