### PR TITLE
ci: install xfsprogs in all containers

### DIFF
--- a/test/container/Dockerfile-arch
+++ b/test/container/Dockerfile-arch
@@ -60,5 +60,6 @@ RUN pacman --noconfirm -Syu \
     systemd-ukify \
     tgt \
     tpm2-tools \
+    xfsprogs \
     xorriso \
     && yes | pacman -Scc

--- a/test/container/Dockerfile-gentoo
+++ b/test/container/Dockerfile-gentoo
@@ -82,6 +82,7 @@ if [ "$OPTION" = "systemd" ] ; then \
     sys-fs/mdadm \
     sys-fs/multipath-tools \
     sys-fs/squashfs-tools \
+    sys-fs/xfsprogs \
     sys-libs/glibc ;\
 else \
     emerge --quiet --deep --autounmask-continue=y --with-bdeps=n --noreplace net-misc/networkmanager ;\

--- a/test/container/Dockerfile-opensuse
+++ b/test/container/Dockerfile-opensuse
@@ -56,6 +56,7 @@ RUN zypper --non-interactive install --no-recommends \
     tgt \
     tpm2.0-tools \
     util-linux-systemd \
+    xfsprogs \
     xorriso \
     zstd \
     && zypper --non-interactive dist-upgrade --no-recommends


### PR DESCRIPTION
## Changes

Install xfsprogs in all containers because it is needed for TEST-44-DRIVERS.

## Checklist
- [ ] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it

Fixes #
