### PR TITLE
test: print end of client tests even in failure case

### DIFF
--- a/test/TEST-11-USR-MOUNT/test.sh
+++ b/test/TEST-11-USR-MOUNT/test.sh
@@ -19,7 +19,7 @@ client_run() {
     shift
     local client_opts="$*"
 
-    echo "CLIENT TEST START: $test_name"
+    client_test_start "$test_name"
 
     declare -a disk_args=()
     declare -i disk_index=0
@@ -33,10 +33,10 @@ client_run() {
         -initrd "$TESTDIR"/initramfs.testing
 
     if ! test_marker_check; then
-        echo "CLIENT TEST END: $test_name [FAILED]"
+        client_test_end "FAILED"
         return 1
     fi
-    echo "CLIENT TEST END: $test_name [OK]"
+    client_test_end
 }
 
 test_run() {

--- a/test/TEST-12-UEFI/test.sh
+++ b/test/TEST-12-UEFI/test.sh
@@ -25,7 +25,7 @@ test_check() {
 client_run() {
     local test_name="$1"
 
-    echo "CLIENT TEST START: $test_name"
+    client_test_start "$test_name"
 
     declare -a disk_args=()
     # shellcheck disable=SC2034  # disk_index used in qemu_add_drive

--- a/test/TEST-20-STORAGE/test.sh
+++ b/test/TEST-20-STORAGE/test.sh
@@ -31,7 +31,7 @@ client_run() {
     shift
     local client_opts="$*"
 
-    echo "CLIENT TEST START: $test_name"
+    client_test_start "$test_name"
 
     declare -a disk_args=()
     declare -i disk_index=0
@@ -55,7 +55,7 @@ client_run() {
         -initrd "$TESTDIR"/initramfs.testing
     test_marker_check
 
-    echo "CLIENT TEST END: $test_name [OK]"
+    client_test_end
 }
 
 test_run() {

--- a/test/TEST-26-ENC-RAID-LVM/test.sh
+++ b/test/TEST-26-ENC-RAID-LVM/test.sh
@@ -23,7 +23,7 @@ test_check() {
 test_run() {
     LUKSARGS=$(cat "$TESTDIR"/luks.txt)
 
-    echo "CLIENT TEST START: $LUKSARGS"
+    client_test_start "$LUKSARGS"
 
     declare -a disk_args=()
     declare -i disk_index=0
@@ -37,17 +37,17 @@ test_run() {
         -append "$TEST_KERNEL_CMDLINE root=/dev/dracut/root ro rd.auto rootwait $LUKSARGS" \
         -initrd "$TESTDIR"/initramfs.testing
     test_marker_check
-    echo "CLIENT TEST END: [OK]"
+    client_test_end
 
     test_marker_reset
 
-    echo "CLIENT TEST START: Any LUKS"
+    client_test_start "Any LUKS"
     "$testdir"/run-qemu \
         "${disk_args[@]}" \
         -append "$TEST_KERNEL_CMDLINE root=/dev/dracut/root rd.auto" \
         -initrd "$TESTDIR"/initramfs.testing
     test_marker_check
-    echo "CLIENT TEST END: [OK]"
+    client_test_end
 
     return 0
 }

--- a/test/TEST-30-DMSQUASH/test.sh
+++ b/test/TEST-30-DMSQUASH/test.sh
@@ -21,7 +21,7 @@ client_run() {
     shift
     local client_opts="$*"
 
-    echo "CLIENT TEST START: $test_name"
+    client_test_start "$test_name"
 
     declare -a disk_args=()
     declare -i disk_index=0
@@ -37,10 +37,10 @@ client_run() {
         -initrd "$TESTDIR"/initramfs.testing
 
     if ! test_marker_check; then
-        echo "CLIENT TEST END: $test_name [FAILED]"
+        client_test_end "FAILED"
         return 1
     fi
-    echo "CLIENT TEST END: $test_name [OK]"
+    client_test_end
 }
 
 test_run() {

--- a/test/TEST-41-FULL-SYSTEMD/test.sh
+++ b/test/TEST-41-FULL-SYSTEMD/test.sh
@@ -22,7 +22,7 @@ client_run() {
     shift 2
     local client_opts="$*"
 
-    echo "CLIENT TEST START: $test_name"
+    client_test_start "$test_name"
 
     declare -a disk_args=()
     declare -i disk_index=0
@@ -38,10 +38,10 @@ client_run() {
         -initrd "$TESTDIR"/initramfs.testing
 
     if ! test_marker_check; then
-        echo "CLIENT TEST END: $test_name [FAILED]"
+        client_test_end "FAILED"
         return 1
     fi
-    echo "CLIENT TEST END: $test_name [OK]"
+    client_test_end
 }
 
 test_run() {

--- a/test/TEST-42-SYSTEMD-INITRD/test.sh
+++ b/test/TEST-42-SYSTEMD-INITRD/test.sh
@@ -15,7 +15,7 @@ client_run() {
     shift
     local client_opts="$*"
 
-    echo "CLIENT TEST START: $test_name"
+    client_test_start "$test_name"
 
     declare -a disk_args=()
     declare -i disk_index=0
@@ -29,10 +29,10 @@ client_run() {
         -initrd "$TESTDIR"/initramfs.testing
 
     if ! test_marker_check; then
-        echo "CLIENT TEST END: $test_name [FAILED]"
+        client_test_end "FAILED"
         return 1
     fi
-    echo "CLIENT TEST END: $test_name [OK]"
+    client_test_end
 }
 
 test_run() {

--- a/test/TEST-60-NFS/test.sh
+++ b/test/TEST-60-NFS/test.sh
@@ -54,7 +54,7 @@ client_test() {
     local check_opt="$5"
     local nfsinfo opts found expected
 
-    echo "CLIENT TEST START: $test_name"
+    client_test_start "$test_name"
 
     # Need this so kvm-qemu will boot (needs non-/dev/zero local disk)
     declare -a disk_args=()
@@ -71,7 +71,7 @@ client_test() {
         -initrd "$TESTDIR"/initramfs.testing
 
     if ! test_marker_check nfs-OK; then
-        echo "CLIENT TEST END: $test_name [FAILED - MISSING MARKER]"
+        client_test_end "FAILED - MISSING MARKER"
         return 1
     fi
 
@@ -81,7 +81,7 @@ client_test() {
     if [[ ${nfsinfo[0]%%:*} != "$server" ]]; then
         echo "CLIENT TEST INFO: got server: ${nfsinfo[0]%%:*}"
         echo "CLIENT TEST INFO: expected server: $server"
-        echo "CLIENT TEST END: $test_name [FAILED - WRONG SERVER]"
+        client_test_end "FAILED - WRONG SERVER"
         return 1
     fi
 
@@ -105,20 +105,20 @@ client_test() {
         echo "CLIENT TEST INFO: got options: ${nfsinfo[2]%%:*}"
         if [[ $expected -eq 0 ]]; then
             echo "CLIENT TEST INFO: did not expect: $check_opt"
-            echo "CLIENT TEST END: $test_name [FAILED - UNEXPECTED OPTION]"
+            client_test_end "FAILED - UNEXPECTED OPTION"
         else
             echo "CLIENT TEST INFO: missing: $check_opt"
-            echo "CLIENT TEST END: $test_name [FAILED - MISSING OPTION]"
+            client_test_end "FAILED - MISSING OPTION"
         fi
         return 1
     fi
 
     if ! test_marker_check nfsfetch-OK marker2.img; then
-        echo "CLIENT TEST END: $test_name [FAILED - NFS FETCH FAILED]"
+        client_test_end "FAILED - NFS FETCH FAILED"
         return 1
     fi
 
-    echo "CLIENT TEST END: $test_name [OK]"
+    client_test_end
     return 0
 }
 

--- a/test/TEST-70-ISCSI/test.sh
+++ b/test/TEST-70-ISCSI/test.sh
@@ -45,7 +45,7 @@ run_client() {
     local test_name=$1
     local acpitable_file=$2
     shift 2
-    echo "CLIENT TEST START: $test_name"
+    client_test_start "$test_name"
 
     declare -a disk_args=()
     declare -i disk_index=0
@@ -62,11 +62,11 @@ run_client() {
         -initrd "$TESTDIR"/initramfs.testing
 
     if ! test_marker_check iscsi-OK; then
-        echo "CLIENT TEST END: $test_name [FAILED - MISSING MARKER]"
+        client_test_end "FAILED - MISSING MARKER"
         return 1
     fi
 
-    echo "CLIENT TEST END: $test_name [OK]"
+    client_test_end
     return 0
 }
 

--- a/test/TEST-71-ISCSI-MULTI/test.sh
+++ b/test/TEST-71-ISCSI-MULTI/test.sh
@@ -43,7 +43,7 @@ run_server() {
 run_client() {
     local test_name=$1
     shift
-    echo "CLIENT TEST START: $test_name"
+    client_test_start "$test_name"
 
     declare -a disk_args=()
     declare -i disk_index=0
@@ -58,11 +58,11 @@ run_client() {
         -append "$TEST_KERNEL_CMDLINE rw rd.auto $*" \
         -initrd "$TESTDIR"/initramfs.testing
     if ! test_marker_check iscsi-OK; then
-        echo "CLIENT TEST END: $test_name [FAILED - BAD EXIT]"
+        client_test_end "FAILED - BAD EXIT"
         return 1
     fi
 
-    echo "CLIENT TEST END: $test_name [OK]"
+    client_test_end
     return 0
 }
 

--- a/test/TEST-72-NBD/test.sh
+++ b/test/TEST-72-NBD/test.sh
@@ -57,7 +57,7 @@ client_test() {
     local fsopt=${5-ro}
     local found opts nbdinfo
 
-    echo "CLIENT TEST START: $test_name"
+    client_test_start "$test_name"
 
     declare -a disk_args=()
     declare -i disk_index=0
@@ -72,7 +72,7 @@ client_test() {
         -initrd "$TESTDIR"/initramfs.testing
 
     if ! test_marker_check nbd-OK; then
-        echo "CLIENT TEST END: $test_name [FAILED - MISSING MARKER]"
+        client_test_end "FAILED - MISSING MARKER"
         return 1
     fi
 
@@ -80,7 +80,7 @@ client_test() {
     read -r -a nbdinfo < <(awk '{print $2, $3; exit}' "$TESTDIR"/marker.img)
 
     if [[ ${nbdinfo[0]} != "$fstype" ]]; then
-        echo "CLIENT TEST END: $test_name [FAILED - WRONG FS TYPE] \"${nbdinfo[0]}\" != \"$fstype\""
+        client_test_end "FAILED - WRONG FS TYPE: \"${nbdinfo[0]}\" != \"$fstype\""
         return 1
     fi
 
@@ -94,11 +94,11 @@ client_test() {
     done
 
     if [[ ! $found ]]; then
-        echo "CLIENT TEST END: $test_name [FAILED - BAD FS OPTS] \"${nbdinfo[1]}\" != \"$fsopt\""
+        client_test_end "FAILED - BAD FS OPTS: \"${nbdinfo[1]}\" != \"$fsopt\""
         return 1
     fi
 
-    echo "CLIENT TEST END: $test_name [OK]"
+    client_test_end
 }
 
 test_run() {

--- a/test/test-functions
+++ b/test/test-functions
@@ -84,6 +84,23 @@ call_dracut() {
     "$DRACUT" "$@"
 }
 
+# Log the start of a client test.
+client_test_start() {
+    local test_name="$1"
+    echo "CLIENT TEST START: $test_name"
+    echo "$test_name" > "$TESTDIR/client_test_name.txt"
+}
+
+# Log the end of a client test if one was started with client_test_start before.
+client_test_end() {
+    local status="${1-OK}"
+    local test_name
+    [[ -e "$TESTDIR/client_test_name.txt" ]] || return 0
+    test_name=$(cat "$TESTDIR/client_test_name.txt")
+    echo "CLIENT TEST END: $test_name [$status]"
+    rm "$TESTDIR/client_test_name.txt"
+}
+
 # Wait for the server QEMU has been started up.
 # It should print "Serving" in the server.log in that case.
 wait_for_server_startup() {

--- a/test/test-functions
+++ b/test/test-functions
@@ -272,9 +272,11 @@ test_marker_check() {
 print_test_result() {
     local ret=${1-1}
     if [ "$ret" -eq 0 ]; then
+        client_test_end
         rm -- test${TEST_RUN_ID:+-$TEST_RUN_ID}.log
         echo -e "TEST: $TEST_DESCRIPTION " "$COLOR_SUCCESS" "[OK]" "$COLOR_NORMAL"
     else
+        client_test_end "FAILED"
         echo -e "TEST: $TEST_DESCRIPTION " "$COLOR_FAILURE" "[FAILED]" "$COLOR_NORMAL"
         if [[ -f "$TESTDIR"/server.log ]]; then
             mv "$TESTDIR"/server.log ./server${TEST_RUN_ID:+-$TEST_RUN_ID}.log


### PR DESCRIPTION
## Changes

Introduce the functions `client_test_start` and `client_test_end` to unify the start and end of subtests.

If client tests started and failed with a command failing, the test will exit and the ERR trap will execute `print_test_result`. But the client test end will not be printed.

So call `client_test_end` in `print_test_result` to print a client test end result in case a client test was in progress.

## Checklist
- [x] I have tested it locally (success and failure case)
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it

Fixes #
