### PR TITLE
ci: create a separate job for systemd tests

### DIFF
--- a/.github/workflows/integration-extra.yml
+++ b/.github/workflows/integration-extra.yml
@@ -59,6 +59,25 @@ jobs:
                     # https://github.com/dracut-ng/dracut-ng/issues/1590
                     - container: ubuntu:rolling
                       test: "30"
+                    # intentionally skipped
+                    - container: centos:stream10-development
+                      test: "11"
+                    - container: alpine:latest
+                      test: "12"
+                    - container: alpine:edge
+                      test: "12"
+                    - container: azurelinux:3.0
+                      test: "12"
+                    - container: centos:stream10-development
+                      test: "12"
+                    - container: gentoo:amd64-openrc
+                      test: "12"
+                    - container: alpine:latest
+                      test: "82"
+                    - container: alpine:edge
+                      test: "82"
+                    - container: gentoo:amd64-openrc
+                      test: "82"
         container:
             image: ghcr.io/dracut-ng/${{ matrix.container }}-amd
             options: '--device=/dev/kvm --privileged'
@@ -98,6 +117,9 @@ jobs:
                 exclude:
                     # https://github.com/dracut-ng/dracut-ng/issues/1677
                     - container: arch:latest
+                      test: "41"
+                    # intentionally skipped
+                    - container: centos:stream10-development
                       test: "41"
         container:
             image: ghcr.io/dracut-ng/${{ matrix.container }}-amd
@@ -151,7 +173,6 @@ jobs:
                     - debian:sid
                     - fedora:latest
                     - fedora:rawhide
-                    - gentoo:amd64-openrc
                     - opensuse:latest
                 test:
                     - "60"

--- a/.github/workflows/integration-extra.yml
+++ b/.github/workflows/integration-extra.yml
@@ -48,24 +48,54 @@ jobs:
                     - "20"
                     - "26"
                     - "30"
-                    - "40"
-                    - "41"
-                    - "42"
-                    - "43"
                     - "50"
                     - "80"
                     - "81"
                     - "82"
                 exclude:
-                    # https://github.com/dracut-ng/dracut-ng/issues/1224
-                    - container: gentoo:amd64-openrc
-                      test: "43"
                     # https://github.com/dracut-ng/dracut-ng/issues/1407
                     - container: debian:sid
                       test: "12"
                     # https://github.com/dracut-ng/dracut-ng/issues/1590
                     - container: ubuntu:rolling
                       test: "30"
+        container:
+            image: ghcr.io/dracut-ng/${{ matrix.container }}-amd
+            options: '--device=/dev/kvm --privileged'
+        steps:
+            - name: "Checkout Repository"
+              uses: actions/checkout@v6
+            - name: "${{ matrix.container }} TEST-${{ matrix.test }}"
+              run: ./test/test-container.sh "TEST-${{ matrix.test }}" ${{ matrix.test }}
+    systemd:
+        # run this test on all containers
+        name: ${{ matrix.test }} on ${{ matrix.container }}
+        runs-on: ubuntu-24.04
+        timeout-minutes: 20
+        concurrency:
+            group: extra-basic-${{ github.workflow }}-${{ github.ref }}-${{ matrix.container }}-${{ matrix.test }}
+            cancel-in-progress: true
+        strategy:
+            fail-fast: false
+            matrix:
+                container:
+                    - arch:latest
+                    - azurelinux:3.0
+                    - debian:latest
+                    - debian:sid
+                    - fedora:latest
+                    - fedora:rawhide
+                    - centos:stream10-development
+                    - gentoo:latest
+                    - opensuse:latest
+                    - ubuntu:devel
+                    - ubuntu:rolling
+                test:
+                    - "40"
+                    - "41"
+                    - "42"
+                    - "43"
+                exclude:
                     # https://github.com/dracut-ng/dracut-ng/issues/1677
                     - container: arch:latest
                       test: "41"


### PR DESCRIPTION
## Changes

Do not attempt to run systemd tests on non-systemd enabled environment.

The motivation of this commit is to not run tests on the CI that would be skipped. This saves some CI resources and enables to get back to restore green CI, now that skipped tests are reported as failures after f120814.
    
This PR does not change code coverage. This is simply a different and more efficient way to skip tests on the CI.

## Checklist
- [ ] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it

Fixes #1886
