### PR TITLE
ci: install more packages for gentoo:amd64-openrc

### DIFF
--- a/test/container/Dockerfile-gentoo
+++ b/test/container/Dockerfile-gentoo
@@ -42,39 +42,19 @@ RUN \
 # Dependencies to pass basic test
 RUN \
 emerge --quiet --deep --autounmask-continue=y --with-bdeps=n --noreplace \
+    app-alternatives/bc \
     app-alternatives/cpio \
     app-arch/cpio \
     app-emulation/qemu \
-    app-portage/gentoolkit \
-    dev-ruby/asciidoctor \
-    net-dns/dnsmasq \
-    sys-kernel/dracut \
-    sys-kernel/gentoo-kernel-bin \
-    sys-libs/libxcrypt \
-    virtual/libelf \
-    virtual/pkgconfig ;\
-# Dependencies for full testsuite \
-if [ "$OPTION" = "systemd" ] ; then \
-    emerge --quiet --deep --autounmask-continue=y --with-bdeps=n --noreplace \
-    app-alternatives/bc \
-    app-crypt/swtpm \
-    app-crypt/tpm2-tools \
     app-misc/jq \
+    app-portage/gentoolkit \
     dev-lang/perl \
-    dev-lang/rust-bin \
-    dev-libs/libfido2 \
     dev-libs/libxslt \
     dev-libs/openssl \
-    net-fs/nfs-utils \
-    net-misc/dhcp \
-    net-wireless/bluez \
-    sys-apps/systemd \
+    dev-ruby/asciidoctor \
+    net-dns/dnsmasq \
     sys-apps/nvme-cli \
-    sys-block/nbd \
-    sys-block/open-iscsi \
     sys-block/parted \
-    sys-block/tgt \
-    sys-boot/plymouth \
     sys-devel/bison \
     sys-devel/flex \
     sys-fs/btrfs-progs \
@@ -83,6 +63,26 @@ if [ "$OPTION" = "systemd" ] ; then \
     sys-fs/multipath-tools \
     sys-fs/squashfs-tools \
     sys-fs/xfsprogs \
+    sys-kernel/dracut \
+    sys-kernel/gentoo-kernel-bin \
+    sys-libs/libxcrypt \
+    virtual/libelf \
+    virtual/pkgconfig ;\
+# Dependencies for full testsuite \
+if [ "$OPTION" = "systemd" ] ; then \
+    emerge --quiet --deep --autounmask-continue=y --with-bdeps=n --noreplace \
+    app-crypt/swtpm \
+    app-crypt/tpm2-tools \
+    dev-lang/rust-bin \
+    dev-libs/libfido2 \
+    net-fs/nfs-utils \
+    net-misc/dhcp \
+    net-wireless/bluez \
+    sys-apps/systemd \
+    sys-block/nbd \
+    sys-block/open-iscsi \
+    sys-block/tgt \
+    sys-boot/plymouth \
     sys-libs/glibc ;\
 else \
     emerge --quiet --deep --autounmask-continue=y --with-bdeps=n --noreplace net-misc/networkmanager ;\


### PR DESCRIPTION
## Changes

Increase test coverage for gentoo:amd64-openrc by installing more dependencies into the test container.

This change should enable running btrfs dependent (e.g. USR-MOUNT) and squashfs dependent (e.g. DMSQUASH) tests.

## Checklist
- [ ] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it

Fixes #
