### PR TITLE
ci(arm64): create a separate job for systemd tests

### DIFF
--- a/.github/workflows/integration-extra-arm64.yml
+++ b/.github/workflows/integration-extra-arm64.yml
@@ -32,7 +32,6 @@ jobs:
                     - "10"
                     - "13"
                     - "30"
-                    - "43"
                     - "50"
                     - "80"
                     - "81"
@@ -44,3 +43,28 @@ jobs:
               uses: actions/checkout@v6
             - name: "${{ matrix.container }} TEST-${{ matrix.test }}"
               run: ./test/test-container.sh "TEST-${{ matrix.test }}" ${{ matrix.test }}
+    systemd-arm64:
+        name: ${{ matrix.test }} on ${{ matrix.container }} on arm64
+        runs-on: ubuntu-24.04-arm
+        timeout-minutes: 20
+        concurrency:
+            group: extra-systemd-arm64-${{ github.workflow }}-${{ github.ref }}-${{ matrix.container }}-${{ matrix.test }}
+            cancel-in-progress: true
+        strategy:
+            fail-fast: false
+            matrix:
+                container:
+                    - debian
+                    - opensuse
+                    - ubuntu
+                test:
+                    - "43"
+        container:
+            image: ghcr.io/dracut-ng/${{ matrix.container }}:latest-arm
+            options: '--privileged'
+        steps:
+            - name: "Checkout Repository"
+              uses: actions/checkout@v6
+            - name: "${{ matrix.container }} TEST-${{ matrix.test }}"
+              run: ./test/test-container.sh "TEST-${{ matrix.test }}" ${{ matrix.test }}
+


### PR DESCRIPTION
## Changes

Do not attempt to run systemd tests on non-systemd enabled environment.

Follow-up to fb15792.

## Checklist
- [ ] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it
