### PR TITLE
ci: install 3cpio in the Arch and Fedora containers

### DIFF
--- a/test/container/Dockerfile-arch
+++ b/test/container/Dockerfile-arch
@@ -20,6 +20,7 @@ FROM docker.io/archlinux
 ENV TEST_FSTYPE=btrfs
 
 RUN pacman --noconfirm -Syu \
+    3cpio \
     asciidoctor \
     bluez \
     btrfs-progs \

--- a/test/container/Dockerfile-fedora
+++ b/test/container/Dockerfile-fedora
@@ -41,6 +41,7 @@ else \
 ; fi
 
 RUN dnf -y install --setopt=install_weak_deps=False \
+    3cpio \
     asciidoctor \
     bash-completion \
     bluez \


### PR DESCRIPTION
Install 3cpio in the Arch and Fedora containers to increase test coverage for 3cpio beyond just Debian based distributions.

## Checklist
- [ ] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it

Fixes #
