### PR TITLE
ci: install cargo in the Alpine container

### DIFF
--- a/test/container/Dockerfile-alpine
+++ b/test/container/Dockerfile-alpine
@@ -10,7 +10,6 @@
 # - network: networkmanager
 
 # Not installed
-# - cargo (to increase coverage)
 # - dash (to increase coverage)
 # - ntfs-3g (not enabled with linux-virt)
 # - erofs-utils (not enabled with linux-virt)
@@ -40,6 +39,7 @@ RUN apk add --no-cache \
 
 # Packages for recent changes that are not yet released or packaged by dracut-tests
 RUN apk add --no-cache \
+    cargo \
     dnsmasq \
     networkmanager-cli \
     networkmanager-initrd-generator


### PR DESCRIPTION
## Changes

Install cargo in the Alpine container because it is needed for TEST-82-DRACUT-CPIO.

## Checklist
- [ ] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it

Fixes #
