### PR TITLE
ci: install btrfs-progs in the CentOS container

### DIFF
--- a/test/container/Dockerfile-fedora
+++ b/test/container/Dockerfile-fedora
@@ -33,7 +33,6 @@ if [[ "${DISTRIBUTION}" =~ "centos:" ]]; then \
     dnf -y install epel-release; \
 else \
     dnf -y install --setopt=install_weak_deps=False \
-    btrfs-progs \
     dhcp-server \
     nbd \
     qemu \
@@ -45,6 +44,7 @@ RUN dnf -y install --setopt=install_weak_deps=False \
     asciidoctor \
     bash-completion \
     bluez \
+    btrfs-progs \
     cargo \
     cifs-utils \
     cryptsetup \


### PR DESCRIPTION
## Changes

Install btrfs-progs in the CentOS container because it is needed for TEST-11-USR-MOUNT.

## Checklist
- [ ] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it

