### PR TITLE
ci: revert installing btrfs-progs in the CentOS container

### DIFF
--- a/test/container/Dockerfile-fedora
+++ b/test/container/Dockerfile-fedora
@@ -27,12 +27,14 @@ ARG DISTRIBUTION
 # prefer running tests with xfs
 ENV TEST_FSTYPE=xfs
 
+# btrfs kernel module is not available on CentOS
 RUN \
 if [[ "${DISTRIBUTION}" =~ "centos:" ]]; then \
     dnf config-manager --set-enabled crb; \
     dnf -y install epel-release; \
 else \
     dnf -y install --setopt=install_weak_deps=False \
+    btrfs-progs \
     dhcp-server \
     nbd \
     qemu \
@@ -44,7 +46,6 @@ RUN dnf -y install --setopt=install_weak_deps=False \
     asciidoctor \
     bash-completion \
     bluez \
-    btrfs-progs \
     cargo \
     cifs-utils \
     cryptsetup \


### PR DESCRIPTION
## Changes

Revert 29917ea and leave a comment that CentOS kernel does not include btrfs kernel module.

## Checklist
- [ ] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it

