### PR TITLE
ci: enable arm64 tests on Gentoo container

### DIFF
--- a/.github/workflows/integration-extra-arm64.yml
+++ b/.github/workflows/integration-extra-arm64.yml
@@ -25,6 +25,7 @@ jobs:
             matrix:
                 container:
                     - debian
+                    - gentoo
                     - opensuse
                     - ubuntu
                     - void
@@ -63,6 +64,7 @@ jobs:
             matrix:
                 container:
                     - debian
+                    - gentoo
                     - opensuse
                     - ubuntu
                 test:
@@ -76,6 +78,10 @@ jobs:
                       test: "41"
                     # fails to boot
                     - container: ubuntu
+                      test: "41"
+                exclude:
+                    # fails with key file '/run/credentials/@system/key' missing.
+                    - container: gentoo
                       test: "41"
         container:
             image: ghcr.io/dracut-ng/${{ matrix.container }}:latest-arm


### PR DESCRIPTION
## Changes

Gentoo container now supports arm64. Enable running tests on this CI container as well.

## Checklist
- [ ] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it

