### PR TITLE
test(run-qemu): use hvc0 console on s390x

### DIFF
--- a/test/run-qemu
+++ b/test/run-qemu
@@ -156,6 +156,9 @@ case "$ARCH" in
         ARGS+=(-M "cap-ccf-assist=off,cap-cfpc=broken,cap-ibs=broken,cap-sbbc=broken")
         console=hvc0
         ;;
+    s390x)
+        console=hvc0
+        ;;
 esac
 
 if uefi_code=$(get_uefi_code); then


### PR DESCRIPTION
## Changes

The test `TEST-41-FULL-SYSTEMD` fails (hangs) on s390x:

```
CLIENT TEST START: readonly root
run-qemu: /usr/bin/qemu-system-s390x -cpu max -smp 2 -m 1024 -nodefaults -vga none -display none -no-reboot -watchdog-action poweroff -device virtio-rng-pci -serial stdio -device virtio-scsi-pci,id=scsi0 -drive if=none,format=raw,file=/var/tmp/dracut-test.LX2MPr/marker.img,id=drive-data0 -device scsi-hd,bus=scsi0.0,drive=drive-data0,id=data0,serial=marker -device virtio-scsi-pci,id=scsi1 -drive if=none,format=raw,file=/var/tmp/dracut-test.LX2MPr/root.btrfs,id=drive-data1 -device scsi-hd,bus=scsi1.0,drive=drive-data1,id=data1,serial=root -device virtio-scsi-pci,id=scsi2 -drive if=none,format=raw,file=/var/tmp/dracut-test.LX2MPr/root_crypt.btrfs,id=drive-data2 -device scsi-hd,bus=scsi2.0,drive=drive-data2,id=data2,serial=root_crypt -device virtio-scsi-pci,id=scsi3 -drive if=none,format=raw,file=/var/tmp/dracut-test.LX2MPr/usr.btrfs,id=drive-data3 -device scsi-hd,bus=scsi3.0,drive=drive-data3,id=data3,serial=usr -append 'console=ttyS0,115200 root=LABEL=dracut panic=1 oops=panic softlockup_panic=1 systemd.crash_reboot   mount.usr=LABEL=dracutusr mount.usrflags=subvol=usr ro systemd.mask=systemd-sysusers systemd.mask=systemd-timesyncd systemd.mask=systemd-resolved ' -initrd /var/tmp/dracut-test.LX2MPr/initramfs.testing -kernel /boot/vmlinuz-6.16.12+deb14+1-s390x
[...]
[  OK  ] Reached target initrd-switch-root.target - Switch Root.
[...]
[  104.913552] systemd[1]: Starting testsuite.service - Testsuite service...
         Starting testsuite.service - Testsuite service...
[  105.245935] (test-init)[1028]: testsuite.service: Failed to set up standard input: No such file or directory
[  105.249516] (test-init)[1028]: testsuite.service: Failed at step STDIN spawning /sbin/test-init: No such file or directory
[  105.289084] systemd[1]: testsuite.service: Main process exited, code=exited, status=208/STDIN
[  105.305982] systemd[1]: testsuite.service: Failed with result 'exit-code'.
[FAILED] Failed to start testsuite.service - Testsuite service.
[  105.365771] systemd[1]: Failed to start testsuite.service - Testsuite service.
```

Replacing the default console `ttyS0` by the virtual console `hvc0` makes the test succeed.

## Checklist
- [x] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it

Bug-Debian: https://bugs.debian.org/1120955
Fixes: https://github.com/dracut-ng/dracut-ng/issues/1873

