### PR TITLE
ci(debian): install dracut-test into the CI container

### DIFF
--- a/test/container/Dockerfile-debian
+++ b/test/container/Dockerfile-debian
@@ -16,7 +16,7 @@ FROM docker.io/${DISTRIBUTION}
 ARG DISTRIBUTION
 
 # Install dracut as a linux-initramfs-tool provider so that the default initramfs-tool package does not get installed
-RUN apt-get update -y -qq && apt-get upgrade -y -qq && apt-get install -y -qq --install-recommends dracut dracut-network dracut-squash dracut-live
+RUN apt-get update -y -qq && apt-get upgrade -y -qq && apt-get install -y -qq --install-recommends dracut dracut-network dracut-squash dracut-live dracut-test
 
 # Install 3cpio where available
 RUN if [ "$DISTRIBUTION" != "debian:latest" ] ; then \


### PR DESCRIPTION
## Changes

Debian/Ubuntu maintains a downstream package for CI dependencies called dracut-test (similar to Alpine).

This package is a useful addition upstream as well to ensure that all CI dependencies are installed into the CI container.

## Checklist
- [ ] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it

CC @bdrung 