### PR TITLE
ci: update centos from stream10-development to latest

### DIFF
--- a/.github/workflows/container-extra.yml
+++ b/.github/workflows/container-extra.yml
@@ -44,7 +44,7 @@ jobs:
                     - {dockerfile: 'Dockerfile-gentoo', tag: 'gentoo:latest', option: 'systemd'}
                     - {dockerfile: 'Dockerfile-gentoo', tag: 'gentoo:amd64-openrc', option: 'amd64-openrc'}
                     - {dockerfile: 'Dockerfile-fedora', tag: 'fedora:rawhide', registry: 'registry.fedoraproject.org'}
-                    - {dockerfile: 'Dockerfile-fedora', tag: 'centos:stream10-development', registry: 'quay.io/centos'}
+                    - {dockerfile: 'Dockerfile-fedora', tag: 'centos:latest', registry: 'quay.io/centos'}
                     - {dockerfile: 'Dockerfile-azurelinux', tag: 'azurelinux:3.0', registry: 'mcr.microsoft.com'}
                 exclude:
                    - config: {tag: 'arch:latest'}

--- a/.github/workflows/integration-extra.yml
+++ b/.github/workflows/integration-extra.yml
@@ -33,7 +33,7 @@ jobs:
                     - debian:sid
                     - fedora:latest
                     - fedora:rawhide
-                    - centos:stream10-development
+                    - centos:latest
                     - gentoo:latest
                     - gentoo:amd64-openrc
                     - opensuse:latest
@@ -55,8 +55,8 @@ jobs:
                     # https://github.com/dracut-ng/dracut-ng/issues/1590
                     - container: ubuntu:rolling
                       test: "30"
-                    # btrfs kernel module is not available
-                    - container: centos:stream10-development
+                    # btrfs kernel module is not available on CentOS Stream 10
+                    - container: centos:latest
                       test: "11"
         container:
             image: ghcr.io/dracut-ng/${{ matrix.container }}-amd
@@ -114,7 +114,7 @@ jobs:
                     - debian:sid
                     - fedora:latest
                     - fedora:rawhide
-                    - centos:stream10-development
+                    - centos:latest
                     - gentoo:latest
                     - opensuse:latest
                     - ubuntu:devel
@@ -129,7 +129,7 @@ jobs:
                     - container: arch:latest
                       test: "41"
                     # intentionally skipped
-                    - container: centos:stream10-development
+                    - container: centos:latest
                       test: "41"
         container:
             image: ghcr.io/dracut-ng/${{ matrix.container }}-amd

--- a/.github/workflows/manualtest.yml
+++ b/.github/workflows/manualtest.yml
@@ -16,7 +16,7 @@ on:  # yamllint disable-line rule:truthy
                     - "alpine:latest"
                     - "alpine:edge"
                     - "azurelinux:3.0"
-                    - "centos:stream10-development"
+                    - "centos:latest"
                     - "fedora:latest"
                     - "fedora:rawhide"
                     - "arch:latest"


### PR DESCRIPTION
## Changes

The last container build for `centos:stream10-development` is from 2024-11-07. CentOS Stream 10 was released on 2024-12-12.

So update the CentOS container from `stream10-development` to `latest` which is currently CentOS Stream 10.

See also https://quay.io/repository/centos/centos?tab=tags

## Checklist
- [ ] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it

Fixes #
