### PR TITLE
ci: add test 44 (drivers) to integration extra

### DIFF
--- a/.github/workflows/integration-extra-arm64.yml
+++ b/.github/workflows/integration-extra-arm64.yml
@@ -74,6 +74,7 @@ jobs:
                     - "41"
                     - "42"
                     - "43"
+                    - "44"
                 exclude:
                     # mkosi test step fails
                     - container: opensuse:latest

--- a/.github/workflows/integration-extra.yml
+++ b/.github/workflows/integration-extra.yml
@@ -121,6 +121,7 @@ jobs:
                     - "41"
                     - "42"
                     - "43"
+                    - "44"
                 exclude:
                     # https://github.com/dracut-ng/dracut-ng/issues/1677
                     - container: arch:latest


### PR DESCRIPTION
## Changes

The test 44 (drivers) is only run in the integration workflow. Add test 44 (drivers) to integration extra to run this test in all containers.

Fixes: 21096b7e0e85 ("feat(kernel-modules-export): make kernel modules from initramfs available")

## Checklist
- [ ] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it

Fixes #
