### PR TITLE
ci: update ubuntu:rolling images

### DIFF
--- a/.github/workflows/container-extra.yml
+++ b/.github/workflows/container-extra.yml
@@ -40,6 +40,7 @@ jobs:
                 config:
                     - {dockerfile: 'Dockerfile-debian', tag: 'debian:sid'}
                     - {dockerfile: 'Dockerfile-debian', tag: 'ubuntu:devel'}
+                    - {dockerfile: 'Dockerfile-debian', tag: 'ubuntu:rolling'}
                     - {dockerfile: 'Dockerfile-alpine', tag: 'alpine:edge'}
                     - {dockerfile: 'Dockerfile-gentoo', tag: 'gentoo:latest', option: 'systemd'}
                     - {dockerfile: 'Dockerfile-gentoo', tag: 'gentoo:amd64-openrc', option: 'amd64-openrc'}

--- a/.github/workflows/container.yml
+++ b/.github/workflows/container.yml
@@ -40,6 +40,7 @@ jobs:
                     - {dockerfile: 'Dockerfile-opensuse', tag: 'opensuse:latest'}
                     - {dockerfile: 'Dockerfile-arch', tag: 'arch:latest'}
                     - {dockerfile: 'Dockerfile-debian', tag: 'ubuntu:devel'}
+                    - {dockerfile: 'Dockerfile-debian', tag: 'ubuntu:rolling'}
                     - {dockerfile: 'Dockerfile-alpine', tag: 'alpine:latest'}
                     - {dockerfile: 'Dockerfile-void', tag: 'void:latest'}
                 exclude:

--- a/test/container/Dockerfile-debian
+++ b/test/container/Dockerfile-debian
@@ -25,7 +25,7 @@ RUN if [ "$DISTRIBUTION" != "debian:latest" ] ; then \
     ; fi
 
 # use GNU coreutils instead of uutil's coreutils until https://github.com/uutils/coreutils/issues/9057 and https://launchpad.net/bugs/2129037 are fixed
-RUN if [ "$DISTRIBUTION" = "ubuntu:devel" ]; then \
+RUN if [ "$DISTRIBUTION" = "ubuntu:devel" ] || [ "$DISTRIBUTION" = "ubuntu:rolling" ]; then \
     DEBIAN_FRONTEND=noninteractive apt-get install -y -qq --no-install-recommends -o Dpkg::Use-Pty=0 \
     coreutils-from-gnu coreutils-from-uutils- --allow-remove-essential; \
     fi


### PR DESCRIPTION
## Changes

The `ghcr.io/dracut-ng/ubuntu:rolling-amd` image is three month old and has not been updated.

Update the `ubuntu:rolling` images.

## Checklist
- [ ] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it

Fixes #
