### PR TITLE
ci: use ubuntu:rolling instead of ubuntu:latest

### DIFF
--- a/.github/workflows/integration-extra-arm64.yml
+++ b/.github/workflows/integration-extra-arm64.yml
@@ -28,7 +28,7 @@ jobs:
                     - gentoo:latest
                     - opensuse:latest
                     - ubuntu:devel
-                    - ubuntu:latest
+                    - ubuntu:rolling
                     - void:latest
                 test:
                     - "10"
@@ -68,7 +68,7 @@ jobs:
                     - gentoo:latest
                     - opensuse:latest
                     - ubuntu:devel
-                    - ubuntu:latest
+                    - ubuntu:rolling
                 test:
                     - "40"
                     - "41"
@@ -78,14 +78,14 @@ jobs:
                     # mkosi test step fails
                     - container: opensuse:latest
                       test: "41"
-                    # fails to boot
-                    - container: ubuntu:latest
-                      test: "41"
                     # fails with key file '/run/credentials/@system/key' missing
                     - container: gentoo:latest
                       test: "41"
                     # /boot/vmlinuz-... is missing .efi suffix: https://launchpad.net/bugs/2133402
                     - container: ubuntu:devel
+                      test: "43"
+                    # /boot/vmlinuz-... is missing .efi suffix: https://launchpad.net/bugs/2133402
+                    - container: ubuntu:rolling
                       test: "43"
         container:
             image: ghcr.io/dracut-ng/${{ matrix.container }}-arm

--- a/.github/workflows/integration-extra-arm64.yml
+++ b/.github/workflows/integration-extra-arm64.yml
@@ -84,7 +84,7 @@ jobs:
                     # fails with key file '/run/credentials/@system/key' missing
                     - container: gentoo:latest
                       test: "41"
-                    # /boot/vmlinuz-... is missing .efi suffix
+                    # /boot/vmlinuz-... is missing .efi suffix: https://launchpad.net/bugs/2133402
                     - container: ubuntu:devel
                       test: "43"
         container:
@@ -95,4 +95,3 @@ jobs:
               uses: actions/checkout@v6
             - name: "${{ matrix.container }} TEST-${{ matrix.test }}"
               run: ./test/test-container.sh "TEST-${{ matrix.test }}" ${{ matrix.test }}
-


### PR DESCRIPTION
## Changes

`ubuntu:latest` points to the latest LTS version (currently 24.04) and `ubuntu:rolling` to the latest release (currently 25.10). Use `ubuntu:rolling` instead of `ubuntu:latest` consistently everywhere.

## Checklist
- [ ] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it

Fixes #
