### PR TITLE
ci: enable test 30 on ubuntu:rolling again

### DIFF
--- a/.github/workflows/integration-extra.yml
+++ b/.github/workflows/integration-extra.yml
@@ -52,9 +52,6 @@ jobs:
                     - "81"
                     - "82"
                 exclude:
-                    # https://github.com/dracut-ng/dracut-ng/issues/1590
-                    - container: ubuntu:rolling
-                      test: "30"
                     # btrfs kernel module is not available on CentOS Stream 10
                     - container: centos:latest
                       test: "11"


### PR DESCRIPTION
## Changes

The test 30 succeed again on `ubuntu:rolling`. The failure was probably due to uutil's coreutils in the image.

## Checklist
- [x] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it

Fixes: https://github.com/dracut-ng/dracut-ng/issues/1590
