### PR TITLE
ci: run extra network-manager tests on Ubuntu

### DIFF
--- a/.github/workflows/integration-extra.yml
+++ b/.github/workflows/integration-extra.yml
@@ -182,11 +182,20 @@ jobs:
                     - fedora:latest
                     - fedora:rawhide
                     - opensuse:latest
+                    - ubuntu:devel
+                    - ubuntu:rolling
                 test:
                     - "60"
                     - "70"
                     - "71"
                     - "72"
+                exclude:
+                    # https://github.com/dracut-ng/dracut-ng/issues/1815
+                    - container: ubuntu:devel
+                      test: "72"
+                    # https://github.com/dracut-ng/dracut-ng/issues/1815
+                    - container: ubuntu:rolling
+                      test: "72"
         container:
             image: ghcr.io/dracut-ng/${{ matrix.container }}-amd
             options: '--device=/dev/kvm'


### PR DESCRIPTION
## Changes

Increase the test coverage and run the `network-manager` tests in `integration-extra.yml` on `ubuntu:devel` and `ubuntu:rolling`.

## Checklist
- [ ] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it

Fixes #
