### PR TITLE
ci: also run arm64 integration tests on debian:sid

### DIFF
--- a/.github/workflows/integration-extra-arm64.yml
+++ b/.github/workflows/integration-extra-arm64.yml
@@ -25,6 +25,7 @@ jobs:
             matrix:
                 container:
                     - debian:latest
+                    - debian:sid
                     - gentoo:latest
                     - opensuse:latest
                     - ubuntu:devel
@@ -65,6 +66,7 @@ jobs:
             matrix:
                 container:
                     - debian:latest
+                    - debian:sid
                     - gentoo:latest
                     - opensuse:latest
                     - ubuntu:devel


### PR DESCRIPTION
## Changes

Increase the test coverage and run the arm64 integration tests on `debian:sid` (in addition to `debian:latest`).

## Checklist
- [ ] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it

Fixes #
