### PR TITLE
ci: expose /dev/kvm on arm64 as well

### DIFF
--- a/.github/workflows/integration-extra-arm64.yml
+++ b/.github/workflows/integration-extra-arm64.yml
@@ -48,7 +48,7 @@ jobs:
                       test: "82"
         container:
             image: ghcr.io/dracut-ng/${{ matrix.container }}-arm
-            options: '--privileged'
+            options: '--device=/dev/kvm --privileged'
         steps:
             - name: "Checkout Repository"
               uses: actions/checkout@v6
@@ -92,7 +92,7 @@ jobs:
                       test: "43"
         container:
             image: ghcr.io/dracut-ng/${{ matrix.container }}-arm
-            options: '--privileged'
+            options: '--device=/dev/kvm --privileged'
         steps:
             - name: "Checkout Repository"
               uses: actions/checkout@v6
@@ -130,7 +130,7 @@ jobs:
                       test: "72"
         container:
             image: ghcr.io/dracut-ng/${{ matrix.container }}-arm
-            options: '--privileged'
+            options: '--device=/dev/kvm --privileged'
         steps:
             - name: "Checkout Repository"
               uses: actions/checkout@v6

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -258,7 +258,7 @@ jobs:
                     - "10"
         container:
             image: ghcr.io/dracut-ng/${{ matrix.container }}-arm
-            options: '--privileged'
+            options: '--device=/dev/kvm --privileged'
         steps:
             - name: "Checkout Repository"
               uses: actions/checkout@v6


### PR DESCRIPTION
## Changes

Similar to amd64 expose `/dev/kvm` to the arm64 container for faster QEMU execution.

As of 2025-12-19 the arm64 runners do not provide nested virtualization. Nested virtualization is possible on AArch64 since Linux 6.16, so it should be possible to offer even without bare metal instances.

Similar to amd64 expose `/dev/kvm` to the arm64 container for faster QEMU execution once the runners provide nested virtualization.

## Checklist
- [ ] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it

Fixes #
