### PR TITLE
ci: run network tests also on arm64

### DIFF
--- a/.github/workflows/integration-extra-arm64.yml
+++ b/.github/workflows/integration-extra-arm64.yml
@@ -98,3 +98,41 @@ jobs:
               uses: actions/checkout@v6
             - name: "${{ matrix.container }} TEST-${{ matrix.test }}"
               run: ./test/test-container.sh "TEST-${{ matrix.test }}" ${{ matrix.test }}
+    network-arm64:
+        name: ${{ matrix.test }} on ${{ matrix.container }} on arm64
+        runs-on: ubuntu-24.04-arm
+        timeout-minutes: 40
+        concurrency:
+            group: extra-network-arm64-${{ github.workflow }}-${{ github.ref }}-${{ matrix.container }}-${{ matrix.test }}
+            cancel-in-progress: true
+        strategy:
+            fail-fast: false
+            matrix:
+                network:
+                    - network-manager
+                container:
+                    - debian:latest
+                    - debian:sid
+                    - opensuse:latest
+                    - ubuntu:devel
+                    - ubuntu:rolling
+                test:
+                    - "60"
+                    - "70"
+                    - "71"
+                    - "72"
+                exclude:
+                    # https://github.com/dracut-ng/dracut-ng/issues/1815
+                    - container: ubuntu:devel
+                      test: "72"
+                    # https://github.com/dracut-ng/dracut-ng/issues/1815
+                    - container: ubuntu:rolling
+                      test: "72"
+        container:
+            image: ghcr.io/dracut-ng/${{ matrix.container }}-arm
+            options: '--privileged'
+        steps:
+            - name: "Checkout Repository"
+              uses: actions/checkout@v6
+            - name: "${{ matrix.container }} TEST-${{ matrix.test }}"
+              run: ./test/test-container.sh "TEST-${{ matrix.test }}" ${{ matrix.test }}


### PR DESCRIPTION
## Changes

Increase test coverage by also running the network tests on arm64. Since arm64 is slower than amd64 and test 60 already takes five minutes on amd64, double the timeout for arm64.

## Checklist
- [ ] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it

Fixes #
