### PR TITLE
fix(network-manager): handle rd.neednet change in cmdline hook

### DIFF
--- a/modules.d/35network-manager/nm-config.sh
+++ b/modules.d/35network-manager/nm-config.sh
@@ -6,8 +6,10 @@ command -v getargbool > /dev/null || . /lib/dracut-lib.sh
     && nm_service_name="NetworkManager-initrd" \
     || nm_service_name="nm-initrd"
 
+nm_needs_generate_connections=
 if [ -n "$netroot" ] || [ -e /tmp/net.ifaces ]; then
     echo rd.neednet >> /etc/cmdline.d/20-neednet.conf
+    nm_needs_generate_connections=1
 fi
 
 if getargbool 0 rd.debug; then
@@ -36,7 +38,7 @@ EOF
     fi
 fi
 
-if [ "$nm_service_name" = "nm-initrd" ]; then
+if [ "$nm_service_name" = "nm-initrd" ] || [ "$nm_needs_generate_connections" ]; then
     command -v nm_generate_connections > /dev/null || . /lib/nm-lib.sh
     nm_generate_connections
 fi


### PR DESCRIPTION
When `rd.neednet` is set in /etc/cmdline.d by network-manager's cmdline hook (`${hookdir}/cmdline/99-nm-config.sh`), NetworkManager-config-initrd.service has already run and finished, so it's too late and needs to be restarted to parse cmdline options again, detect the new `rd.neednet` and generate network connections.

## Checklist
- [X] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it
