### PR TITLE
feat: allow booting from compressed ostree filesystems with dmsquash-live

### DIFF
--- a/modules.d/70dmsquash-live/dmsquash-live-root.sh
+++ b/modules.d/70dmsquash-live/dmsquash-live-root.sh
@@ -344,7 +344,7 @@ if [ -e "$SQUASHED" ]; then
         elif [ -f /run/initramfs/squashfs/LiveOS/ext3fs.img ]; then
             FSIMG="/run/initramfs/squashfs/LiveOS/ext3fs.img"
         fi
-    elif [ -d /run/initramfs/squashfs/usr ]; then
+    elif [ -d /run/initramfs/squashfs/usr ] || [ -d /run/initramfs/squashfs/ostree ]; then
         FSIMG=$SQUASHED
         if [ -z "$overlayfs" ] && [ -n "${DRACUT_SYSTEMD-}" ]; then
             reloadsysrootmountunit=":>/xor_overlayfs;"


### PR DESCRIPTION
When combined with the ostree module it is possible to boot from a compressed ostree filesystem, but the root of this has /ostree not /usr so it fails.

Related: HMS-8933

## Changes
Adds a test for /ostree next to the check for /usr in dmsquash-live-root

## Checklist
- [X] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it

Fixes #
