### PR TITLE
feat(dracut): always check DRACUT_INSTALL being executable

### DIFF
--- a/dracut.sh
+++ b/dracut.sh
@@ -1541,19 +1541,15 @@ elif ! [[ $DRACUT_INSTALL ]] && [[ -x $dracutbasedir/src/install/dracut-install 
     DRACUT_INSTALL=$dracutbasedir/src/install/dracut-install
 fi
 
-# Test if dracut-install is a standalone executable with no options.
-# E.g. DRACUT_INSTALL may be set externally as:
+# Test if the configured dracut-install command exists.
+# Catch DRACUT_INSTALL being unset/empty.
+# The variable DRACUT_INSTALL may be set externally as:
 # DRACUT_INSTALL="valgrind dracut-install"
 # or
 # DRACUT_INSTALL="dracut-install --debug"
-# in which case the string cannot be tested for being executable.
-DRINSTALLPARTS=0
-for i in $DRACUT_INSTALL; do
-    DRINSTALLPARTS=$((DRINSTALLPARTS + 1))
-done
-
-if [[ $DRINSTALLPARTS == 1 ]] && ! command -v "$DRACUT_INSTALL" > /dev/null 2>&1; then
-    dfatal "dracut-install not found!"
+# in that case check if the first parameter (e.g. valgrind) is executable.
+if ! command -v "${DRACUT_INSTALL%% *}" > /dev/null 2>&1; then
+    dfatal "${DRACUT_INSTALL:-dracut-install} not found!"
     exit 10
 fi
 


### PR DESCRIPTION
## Changes

If `DRACUT_INSTALL` is set externally (to `valgrind dracut-install` for example), dracut will skip the check for the dracut-install command.

Better check the first parameter in `DRACUT_INSTALL` being executable (e.g. check `valgrind` being present when `DRACUT_INSTALL` is set to `valgrind dracut-install`).

## Checklist
- [ ] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it

Fixes #
