### PR TITLE
feat: source dracut-logger.sh from dracut-functions.sh

### DIFF
--- a/dracut-functions.sh
+++ b/dracut-functions.sh
@@ -1203,3 +1203,9 @@ inst_hook() {
     inst_simple "$3" "$hook"
     chmod u+x "$initdir/$hook"
 }
+
+if ! is_func dinfo > /dev/null 2>&1; then
+    # shellcheck source=./dracut-logger.sh
+    . "${BASH_SOURCE[0]%/*}/dracut-logger.sh"
+    dlog_init
+fi

--- a/dracut.sh
+++ b/dracut.sh
@@ -1476,12 +1476,6 @@ else
     export DRACUT_CP="cp --reflink=auto --sparse=auto --preserve=mode,timestamps,links -dfr"
 fi
 
-# is_func <command>
-# Check whether $1 is a function.
-is_func() {
-    [[ "$(type -t "$1")" == "function" ]]
-}
-
 if ! [[ ${dracutbasedir-} ]]; then
     dracutbasedir=${BASH_SOURCE[0]%/*}
     [[ $dracutbasedir == dracut-functions* ]] && dracutbasedir="."
@@ -1489,11 +1483,8 @@ if ! [[ ${dracutbasedir-} ]]; then
     dracutbasedir="$(readlink -f "$dracutbasedir")"
 fi
 
-if ! is_func dinfo > /dev/null 2>&1; then
-    # shellcheck source=./dracut-logger.sh
-    . "$dracutbasedir/dracut-logger.sh"
-    dlog_init
-fi
+# shellcheck source=./dracut-functions.sh
+. "$dracutbasedir"/dracut-functions.sh
 
 if ! [[ ${initdir-} ]]; then
     dfatal "initdir not set"
@@ -1527,9 +1518,6 @@ export srcmods
 DRACUT_TESTBIN=${DRACUT_TESTBIN:-/bin/sh}
 DRACUT_LDCONFIG=${DRACUT_LDCONFIG:-ldconfig}
 PKG_CONFIG=${PKG_CONFIG:-pkg-config}
-
-# shellcheck source=./dracut-functions.sh
-. "$dracutbasedir"/dracut-functions.sh
 
 if ! [[ "${DRACUT_INSTALL-}" ]]; then
     DRACUT_INSTALL=$(find_binary dracut-install)


### PR DESCRIPTION
## Changes

Some functions in `dracut-functions.sh` use logger functions defined in `dracut-logger.sh`, for example `inst_hook` might call `dfatal`.

So move the inclusion of `dracut-logger.sh` into `dracut-functions.sh` to make `dracut-functions.sh` useable on its own.

Move including `dracut-functions.sh` further up in `dracut.sh` because the logger function `dfatal` is needed afterwards.

## Checklist
- [ ] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it

Fixes #
