### PR TITLE
fix(dracut): ignore failing find_binary dracut-install

### DIFF
--- a/dracut.sh
+++ b/dracut.sh
@@ -1532,7 +1532,7 @@ PKG_CONFIG=${PKG_CONFIG:-pkg-config}
 . "$dracutbasedir"/dracut-functions.sh
 
 if ! [[ "${DRACUT_INSTALL-}" ]]; then
-    DRACUT_INSTALL=$(find_binary dracut-install)
+    DRACUT_INSTALL=$(find_binary dracut-install || true)
 fi
 
 if ! [[ $DRACUT_INSTALL ]] && [[ -x $dracutbasedir/dracut-install ]]; then


### PR DESCRIPTION
## Changes

The call `find_binary dracut-install` might fail. Ignore this failure, because a proper error message will be printed later in the code.

## Checklist
- [ ] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it

Fixes #
