### PR TITLE
fix(dracut): --printconfig does not work without --force

### DIFF
--- a/dracut.sh
+++ b/dracut.sh
@@ -2541,7 +2541,7 @@ if [[ $no_kernel != yes ]] && ! [[ -d $srcmods ]]; then
     exit 1
 fi
 
-if ! [[ $print_cmdline ]]; then
+if ! [[ $print_cmdline ]] && ! [[ $printconfig ]]; then
     inst "$DRACUT_TESTBIN"
     if ! $DRACUT_INSTALL ${initdir:+-D "$initdir"} ${dracutsysrootdir:+-r "$dracutsysrootdir"} -R "$DRACUT_TESTBIN" &> /dev/null; then
         unset DRACUT_RESOLVE_LAZY
@@ -2706,7 +2706,7 @@ if [[ $no_kernel != yes ]] && [[ -d $srcmods ]]; then
     fi
 fi
 
-if [[ ! $print_cmdline ]]; then
+if ! [[ $print_cmdline ]] && ! [[ $printconfig ]]; then
     if [[ -f $outfile && ! $force ]]; then
         dfatal "Will not override existing initramfs ($outfile) without --force"
         exit 1


### PR DESCRIPTION
```
$ dracut --printconfig
dracut[F]: Will not override existing initramfs (/boot/initrd-6.17.0-2-default) without --force
```

Follow-up for 8e24c4bf06850da1bc89022081b7e793548d9b0b

## Checklist
- [X] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it