### PR TITLE
fix(dracut): remove newlines from libdirs variable

### DIFF
--- a/dracut.sh
+++ b/dracut.sh
@@ -1571,8 +1571,10 @@ if ! [[ ${libdirs-} ]]; then
         [[ -d "${dracutsysrootdir-}/usr/lib" ]] && libdirs+=" /usr/lib"
     fi
 
-    libdirs+=" $(ldconfig_paths)"
+    # shellcheck disable=SC2046  # word splitting is wanted, libraries must not contain spaces
+    libdirs+="$(printf ' %s' $(ldconfig_paths))"
 
+    libdirs="${libdirs# }"
     export libdirs
 fi
 


### PR DESCRIPTION
## Changes

The `libdirs` variable might contain newlines:

```
$ dracut --printconfig
[...]
dracutconfig: libdirs= /lib64 /usr/lib64 /lib /usr/lib /usr/lib/x86_64-linux-gnu
/usr/lib/x86_64-linux-gnu/libfakeroot
```

This is confusing. Replace those newlines by spaces:

```
$ dracut --printconfig
[...]
dracutconfig: libdirs=/lib64 /usr/lib64 /lib /usr/lib /usr/lib/x86_64-linux-gnu /usr/lib/x86_64-linux-gnu/libfakeroot
```

## Checklist
- [x] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it

Fixes #
