### PR TITLE
feat(dracut): print $initrdname with --printconfig

### DIFF
--- a/dracut.sh
+++ b/dracut.sh
@@ -3039,6 +3039,7 @@ if [[ $printconfig ]]; then
         fscks \
         fw_dir \
         hostonly_cmdline \
+        initrdname \
         kernel_only \
         kmsgloglvl \
         libdirs \


### PR DESCRIPTION
kiwi will need this to properly get the name of the initrd output file.

See https://github.com/OSInside/kiwi/issues/2918
See also https://github.com/OSInside/kiwi/pull/2921#issuecomment-3646056757

## Checklist
- [X] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it
