### PR TITLE
chore: upgrade shellcheck

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -54,12 +54,14 @@ jobs:
         needs: basic
         name: syncheck
         runs-on: ubuntu-24.04
+        container:
+            image: ubuntu:devel
         steps:
             - name: "Checkout Repository"
               uses: actions/checkout@v6
             - run: |
-                  sudo apt-get update
-                  sudo apt-get -y install shellcheck shfmt
+                  apt-get update
+                  apt-get -y install shellcheck shfmt make
                   make syncheck
 
     extended:


### PR DESCRIPTION
Switch CI to a newer version of Ubuntu to get a newer version of shellcheck.

## Checklist
- [ ] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it

