### PR TITLE
fix(Makefile): improve support for shfmt v3.8.0+

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -110,7 +110,7 @@ indent-c:
 .PHONY: indent
 indent: indent-c
 ifeq ($(HAVE_SHFMT),yes)
-	shfmt -w -s .
+	shfmt --apply-ignore -w -s .
 endif
 
 src/dracut-cpio/target/release/dracut-cpio: src/dracut-cpio/src/main.rs


### PR DESCRIPTION
Add the --apply-ignore flag to respect ignore rules even when processing specific files by name or via stdin.

## Checklist
- [ ] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it

Fixes #1866
