### PR TITLE
feat: remove inst_any

### DIFF
--- a/dracut.sh
+++ b/dracut.sh
@@ -1864,33 +1864,6 @@ build_ld_cache() {
     fi
 }
 
-# install any of listed files
-#
-# If first argument is '-d' and second some destination path, first accessible
-# source is installed into this path, otherwise it will installed in the same
-# path as source.  If none of listed files was installed, function return 1.
-# On first successful installation it returns with 0 status.
-#
-# Example:
-#
-# inst_any -d /bin/foo /bin/bar /bin/baz
-#
-# Lets assume that /bin/baz exists, so it will be installed as /bin/foo in
-# initramfs.
-inst_any() {
-    local to f
-
-    [[ $1 == '-d' ]] && to="$2" && shift 2
-
-    for f in "$@"; do
-        [[ -e $f ]] || continue
-        [[ $to ]] && inst "$f" "$to" && return 0
-        inst "$f" && return 0
-    done
-
-    return 1
-}
-
 # inst_libdir_dir <dir> [<dir>...]
 # Install a <dir> located on a lib directory to the initramfs image
 inst_libdir_dir() {


### PR DESCRIPTION
inst_any is not used. It is hard to maintain code that is not documented, not used and has no test coverage.

Introduced by 3378a54f15016c86e4c8c2ecafcaa45f0119fc00 - without using it, or documenting it or justifying it.

## Checklist
- [ ] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it

Fixes #
