### PR TITLE
chore: remove default argument to cp

### DIFF
--- a/dracut.sh
+++ b/dracut.sh
@@ -1471,9 +1471,9 @@ fi
 export LC_MESSAGES=C kernel
 
 if [[ $EUID == "0" ]] && ! [[ ${DRACUT_NO_XATTR-} ]]; then
-    export DRACUT_CP="cp --reflink=auto --sparse=auto --preserve=mode,timestamps,xattr,links -dfr"
+    export DRACUT_CP="cp --reflink=auto --preserve=mode,timestamps,xattr,links -dfr"
 else
-    export DRACUT_CP="cp --reflink=auto --sparse=auto --preserve=mode,timestamps,links -dfr"
+    export DRACUT_CP="cp --reflink=auto --preserve=mode,timestamps,links -dfr"
 fi
 
 if ! [[ ${dracutbasedir-} ]]; then

--- a/src/install/dracut-install.c
+++ b/src/install/dracut-install.c
@@ -440,7 +440,7 @@ normal_copy:
         const char *preservation = (geteuid() == 0
                                     && no_xattr == false) ? "--preserve=mode,xattr,timestamps,ownership" : "--preserve=mode,timestamps,ownership";
         if (pid == 0) {
-                execlp("cp", "cp", "--reflink=auto", "--sparse=auto", preservation, "-fL", src, dst, NULL);
+                execlp("cp", "cp", "--reflink=auto", preservation, "-fL", src, dst, NULL);
                 _exit(errno == ENOENT ? 127 : 126);
         }
 
@@ -452,7 +452,7 @@ normal_copy:
         }
         ret = WIFSIGNALED(ret) ? 128 + WTERMSIG(ret) : WEXITSTATUS(ret);
         if (ret != 0)
-                log_error("ERROR: 'cp --reflink=auto --sparse=auto %s -fL %s %s' failed with %d", preservation, src, dst, ret);
+                log_error("ERROR: 'cp --reflink=auto %s -fL %s %s' failed with %d", preservation, src, dst, ret);
         log_debug("cp ret = %d", ret);
         return ret;
 }


### PR DESCRIPTION
Adding argument processing for arguments that are the default anyways just adds to cognitive load of reading the code and a little bit of performance overhead.

`--sparse=auto` is the default. There is no need to re-specify it.

## Checklist
- [ ] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it
