### PR TITLE
feat(dracut-systemd): preserve the content of /var/lib/systemd

### DIFF
--- a/modules.d/77dracut-systemd/dracut-tmpfiles.conf
+++ b/modules.d/77dracut-systemd/dracut-tmpfiles.conf
@@ -1,3 +1,5 @@
 d /run/initramfs     0755 root root -
 d /run/initramfs/log 0755 root root -
+d /run/initramfs/systemd 0755 root root -
 L /var/log           -    -    -    - ../run/initramfs/log
+L /var/lib/systemd   -    -    -    - ../../run/initramfs/systemd


### PR DESCRIPTION
## Changes

Persist the content of /var/lib/systemd in memory during initramfs execution by linking it to /run/initramfs/systemd .

One of the motivation of this PR is to preserved coredumps when systemd-coredump dracut module is included in the initramfs.

In general, this approach would requires less customization of systemd configuration for dracut.

This PR is alternative (in a sense that it solves the same issue in a different way) to https://github.com/dracut-ng/dracut-ng/pull/1850 . 

Note that `coredumpctl` has command line argument for look for coredump file in an alternative directory.

CC @Conan-Kudo @aafeijoo-suse

## Checklist
- [ ] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it


