### PR TITLE
ci: limit iscsi testing to Debian/Ubuntu

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -202,9 +202,7 @@ jobs:
                 network:
                     - network-manager
                 container:
-                    - arch:latest
                     - debian:latest
-                    - opensuse:latest
                     - ubuntu:devel
                 test:
                     - "70"


### PR DESCRIPTION
## Changes

Based on CI test tun observations iscsi tests seems to be more flaky on Arch and openSUSE. Remove these flaky test runs from the CI and keep Debian/Ubuntu, which seems to be more stable.

## Checklist
- [ ] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it

