### PR TITLE
fix(systemd): only install systemd-coredump with systemd-coredump dracut module

### DIFF
--- a/modules.d/10systemd/module-setup.sh
+++ b/modules.d/10systemd/module-setup.sh
@@ -34,7 +34,6 @@ install() {
 
     inst_multiple -o \
         "$systemdutildir"/systemd \
-        "$systemdutildir"/systemd-coredump \
         "$systemdutildir"/systemd-cgroups-agent \
         "$systemdutildir"/systemd-executor \
         "$systemdutildir"/systemd-shutdown \


### PR DESCRIPTION
## Changes

systemd-coredump is not meant to be installed "by default" and expected to be an opt-in binary, which is achieved by adding systemd-coredump dracut module.

## Checklist
- [ ] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it

Fixes #
