### PR TITLE
ci: limit iscsi testing to Debian/Ubuntu on Daily testsuite

### DIFF
--- a/.github/workflows/integration-extra.yml
+++ b/.github/workflows/integration-extra.yml
@@ -163,6 +163,34 @@ jobs:
               uses: actions/checkout@v6
             - name: "${{ matrix.container }} TEST-${{ matrix.test }}"
               run: USE_NETWORK=${{ matrix.network }} ./test/test-container.sh "TEST-${{ matrix.test }}" ${{ matrix.test }}
+    network-manager-iscsi:
+        name: ${{ matrix.test }} on ${{ matrix.container }} ${{ matrix.network }} networking
+        runs-on: ubuntu-24.04
+        timeout-minutes: 20
+        concurrency:
+            group: extra-network-manager-iscsi-${{ github.workflow }}-${{ github.ref }}-${{ matrix.container }}-${{ matrix.test }}-${{ matrix.network }}
+            cancel-in-progress: true
+        strategy:
+            fail-fast: false
+            matrix:
+                network:
+                    - network-manager
+                container:
+                    - debian:latest
+                    - debian:sid
+                    - ubuntu:devel
+                    - ubuntu:rolling
+                test:
+                    - "70"
+                    - "71"
+        container:
+            image: ghcr.io/dracut-ng/${{ matrix.container }}-amd
+            options: '--device=/dev/kvm'
+        steps:
+            - name: "Checkout Repository"
+              uses: actions/checkout@v6
+            - name: "${{ matrix.container }} TEST-${{ matrix.test }}"
+              run: USE_NETWORK=${{ matrix.network }} ./test/test-container.sh "TEST-${{ matrix.test }}" ${{ matrix.test }}
     network-manager:
         name: ${{ matrix.test }} on ${{ matrix.container }} ${{ matrix.network }} networking
         runs-on: ubuntu-24.04
@@ -186,8 +214,6 @@ jobs:
                     - ubuntu:rolling
                 test:
                     - "60"
-                    - "70"
-                    - "71"
                     - "72"
                 exclude:
                     # https://github.com/dracut-ng/dracut-ng/issues/1815


### PR DESCRIPTION
## Changes

Based on CI test tun observations iscsi tests seems to be more flaky on Arch, Fedora and openSUSE. Remove these flaky test runs from the CI and keep Debian/Ubuntu, which seems to be more stable.

Follow-up to 79867b5.

## Checklist
- [ ] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it


