### PR TITLE
ci(alpine): simplify CI container after Alpine v3.23 release

### DIFF
--- a/test/container/Dockerfile-alpine
+++ b/test/container/Dockerfile-alpine
@@ -40,6 +40,4 @@ RUN apk add --no-cache \
 # Packages for recent changes that are not yet released or packaged by dracut-tests
 RUN apk add --no-cache \
     cargo \
-    dnsmasq \
-    networkmanager-cli \
-    networkmanager-initrd-generator
+    dnsmasq


### PR DESCRIPTION
## Changes

The upstream dracut-tests package in Alpine v3.23 already installs `networkmanager-cli` and `networkmanager-initrd-generator`.

Simplify the package list of the dracut CI.

Alpine v3.23 stable has been released on 2025-12-03.

## Checklist
- [ ] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it

Fixes #
