### PR TITLE
chore: ignore dracut-cpio build artifacts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,10 +6,12 @@
 /.buildpath
 /.project
 /Makefile.inc
+/dracut-cpio
 /dracut-install
 /dracut-util
 /dracut.conf.d/*.conf
 /dracut.pc
+/src/dracut-cpio/target/
 /src/install/dracut-install
 /src/skipcpio/skipcpio
 /src/util/util


### PR DESCRIPTION
This pull request adds dracut-cpio Rust build artifacts to `.gitignore` to prevent them from being accidentally committed.

## Changes

- Add `src/dracut-cpio/target/` (Rust build directory)
- Add `dracut-cpio` (compiled binary symlink)

## Checklist
- [x] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it