### PR TITLE
ci: split install dependencies step from test run step

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -59,10 +59,9 @@ jobs:
         steps:
             - name: "Checkout Repository"
               uses: actions/checkout@v6
-            - run: |
-                  apt-get update
-                  apt-get -y install shellcheck shfmt make
-                  make syncheck
+            - name: Install dependencies
+              run: apt-get update && apt-get -y install make shellcheck shfmt
+            - run: make syncheck
 
     extended:
         needs: basic


### PR DESCRIPTION
## Changes

To ease looking at the test results, split the step that installs the dependencies step from the step that runs the actual test (in this case `make syncheck`).

## Checklist
- [ ] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it

Fixes #
