### PR TITLE
test(sysroot): run with --no-hostonly-cmdline

### DIFF
--- a/test/TEST-13-SYSROOT/test.sh
+++ b/test/TEST-13-SYSROOT/test.sh
@@ -29,7 +29,7 @@ test_setup() {
     build_ext4_image "$TESTDIR"/dracut.*/initramfs/ "$TESTDIR"/root.img dracut
 
     ln -s / "$TESTDIR"/sysroot
-    test_dracut --keep --hostonly --sysroot "$TESTDIR"/sysroot
+    test_dracut --keep --hostonly --no-hostonly-cmdline --sysroot "$TESTDIR"/sysroot
 
     if grep -q '^root:' /etc/shadow; then
         if ! grep -q '^root:' "$TESTDIR"/initrd/dracut.*/initramfs/etc/shadow; then


### PR DESCRIPTION
## Changes

TEST-13-SYSROOT fails in a Ubuntu VM. This is the `lsblk -f` output in the VM:

```
 NAME    FSTYPE FSVER LABEL           UUID                                 FSAVAIL FSUSE% MOUNTPOINTS
 fd0
 sr0
 vda
 ├─vda1  ext4   1.0   cloudimg-rootfs 606e50c2-c444-4c6c-86a1-a6e16ff87015     19G    12% /
 ├─vda13 ext4   1.0   BOOT            30a0e670-dd1c-4d4f-8489-02af8f2f9a18  844.4M     8% /boot
 ├─vda14
 └─vda15 vfat   FAT32 UEFI            5150-4E06                              98.1M     6% /boot/efi
```

TEST-13-SYSROOT calls dracut with `--hostonly` which leads to `hostonly_cmdline` default to `yes`. This leads to the code path for "save host_devs which we need bring up" in `modules.d/80base/module-setup.sh` being executed. In this VM case the variables are:

```
host_devs: /dev/vda1 /dev/vda13 /dev/vda15
user_devs:
root_devs: /dev/vda1
```

The code in `modules.d/80base/module-setup.sh` creates systemd units for `/dev/vda13` and `/dev/vda15` which can be seen in the initrd file:

```
lrwxrwxrwx   1 root     root           78 Nov 24 13:35 etc/systemd/system/initrd.target.wants/dev-disk-by\x2duuid-30a0e670\x2ddd1c\x2d4d4f\x2d8489\x2d02af8f2f9a18.device -> ../dev-disk-by\x2duuid-30a0e670\x2ddd1c\x2d4d4f\x2d8489\x2d02af8f2f9a18.device
lrwxrwxrwx   1 root     root           42 Nov 24 13:35 etc/systemd/system/initrd.target.wants/dev-disk-by\x2duuid-5150\x2d4E06.device -> ../dev-disk-by\x2duuid-5150\x2d4E06.device
```

These two units hang forever in TEST-13-SYSROOT.

So run TEST-13-SYSROOT with `--no-hostonly-cmdline`.

## Checklist
- [ ] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it

Fixes: https://github.com/dracut-ng/dracut-ng/issues/1871
