### PR TITLE
fix(nfs): do not execute logic in nfs hooks if netroot is not nfs

### DIFF
--- a/modules.d/74nfs/nfs-start-rpc.sh
+++ b/modules.d/74nfs/nfs-start-rpc.sh
@@ -1,24 +1,32 @@
 #!/bin/sh
 
-if load_fstype sunrpc rpc_pipefs; then
-    [ ! -d /var/lib/nfs/rpc_pipefs/nfs ] \
-        && mount -t rpc_pipefs rpc_pipefs /var/lib/nfs/rpc_pipefs
+command -v load_fstype > /dev/null || . /lib/dracut-lib.sh
+command -v nfsroot_to_var > /dev/null || . /lib/nfs-lib.sh
 
-    # Start rpcbind
-    # FIXME occasionally saw 'rpcbind: fork failed: No such device' -- why?
-    command -v portmap > /dev/null && [ -z "$(pidof portmap)" ] && portmap
-    if command -v rpcbind > /dev/null && [ -z "$(pidof rpcbind)" ]; then
-        . /lib/nfs-lib.sh
-        mkdir -p /run/rpcbind
-        chown "$(get_rpc_user):" /run/rpcbind
-        rpcbind
-    fi
-
-    # Start rpc.statd as mount won't let us use locks on a NFSv4
-    # filesystem without talking to it. NFSv4 does locks internally,
-    # rpc.lockd isn't needed
-    command -v rpc.statd > /dev/null && [ -z "$(pidof rpc.statd)" ] && rpc.statd
-    command -v rpc.idmapd > /dev/null && [ -z "$(pidof rpc.idmapd)" ] && rpc.idmapd
-else
+if ! load_fstype sunrpc rpc_pipefs; then
     warn 'Kernel module "sunrpc" not in the initramfs, or support for filesystem "rpc_pipefs" missing!'
+    return 0
 fi
+
+[ -n "$netroot" ] || return 0
+nfsroot_to_var "$netroot"
+str_starts "$nfs" "nfs" || return 0
+
+[ ! -d /var/lib/nfs/rpc_pipefs/nfs ] \
+    && mount -t rpc_pipefs rpc_pipefs /var/lib/nfs/rpc_pipefs
+
+# Start rpcbind
+# FIXME occasionally saw 'rpcbind: fork failed: No such device' -- why?
+command -v portmap > /dev/null && [ -z "$(pidof portmap)" ] && portmap
+if command -v rpcbind > /dev/null && [ -z "$(pidof rpcbind)" ]; then
+    . /lib/nfs-lib.sh
+    mkdir -p /run/rpcbind
+    chown "$(get_rpc_user):" /run/rpcbind
+    rpcbind
+fi
+
+# Start rpc.statd as mount won't let us use locks on a NFSv4
+# filesystem without talking to it. NFSv4 does locks internally,
+# rpc.lockd isn't needed
+command -v rpc.statd > /dev/null && [ -z "$(pidof rpc.statd)" ] && rpc.statd
+command -v rpc.idmapd > /dev/null && [ -z "$(pidof rpc.idmapd)" ] && rpc.idmapd

--- a/modules.d/74nfs/nfsroot-cleanup.sh
+++ b/modules.d/74nfs/nfsroot-cleanup.sh
@@ -1,6 +1,11 @@
 #!/bin/sh
 
 command -v incol2 > /dev/null || . /lib/dracut-lib.sh
+command -v nfsroot_to_var > /dev/null || . /lib/nfs-lib.sh
+
+[ -n "$netroot" ] || return 0
+nfsroot_to_var "$netroot"
+str_starts "$nfs" "nfs" || return 0
 
 [ -f /tmp/nfs.rpc_pipefs_path ] && read -r rpcpipefspath < /tmp/nfs.rpc_pipefs_path
 [ -z "$rpcpipefspath" ] && rpcpipefspath=var/lib/nfs/rpc_pipefs


### PR DESCRIPTION
If the nfs module is present in the initrd, it always perform some operations (mount/umount rpc_pipefs, exec/kill rpcbind, rpc.statd and rpc.idmapd), even in initrds not specifically created for nfsroot (e.g., in non-hostonly mode).

This can create a conflict with some VMware tools that use the rpc_pipefs filesystem and can run in the initrd.

## Checklist
- [X] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it