### PR TITLE
test(SYSTEMD): run with --no-hostonly-cmdline

### DIFF
--- a/test/TEST-40-SYSTEMD/test.sh
+++ b/test/TEST-40-SYSTEMD/test.sh
@@ -61,6 +61,7 @@ test_setup() {
     #make sure --omit-drivers does not filter out drivers using regexp to test for an earlier regression (assuming there is no one letter linux kernel module needed to run the test)
 
     test_dracut \
+        --no-hostonly-cmdline \
         --omit "fido2 initqueue" \
         --omit-drivers 'a b c d e f g h i j k l m n o p q r s t u v w x y z' \
         -I systemd-analyze \


### PR DESCRIPTION
This test aims to run without the `initqueue` module, but the `base` module depends on it if `$hostonly_cmdline == "yes"` [1]. Although the test ends successfully, the log shows some errors because `dracut-lib.sh` is not present if the `base` module cannot be installed:

```
dracut[E]: Module 'base' depends on module 'initqueue', which can't be installed
...
/usr/bin/dracut-cmdline-ask: line 3: /lib/dracut-lib.sh: No such file or directory
[    2.108191] dracut-cmdline[254]: /usr/bin/dracut-cmdline: line 6: /lib/dracut-lib.sh: No such file or directory
[    2.129548] dracut-pre-udev[259]: /usr/bin/dracut-pre-udev: line 6: /lib/dracut-lib.sh: No such file or directory
...
[    3.176822] dracut-pre-pivot[368]: /usr/bin/dracut-pre-pivot: line 7: /lib/dracut-lib.sh: No such file or directory
...
All OK
```

[1] https://github.com/dracut-ng/dracut-ng/blob/bf29f4b79aee9771800dffe78857014970be117e/modules.d/80base/module-setup.sh#L8-L12

## Checklist
- [X] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it