### PR TITLE
ci: re-enable running iscsi tests parallel

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -196,7 +196,6 @@ jobs:
             cancel-in-progress: true
         strategy:
             fail-fast: false
-            max-parallel: 1
             matrix:
                 network:
                     - network-manager


### PR DESCRIPTION
## Changes

iscsi tests have been stabilized (based on the CI runs in the last few days), let's try to open them back up and re-enable running iscsi tests parallel.

Reverts 9b63e4e .

## Checklist
- [ ] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it

