### PR TITLE
test: drop root=LABEL=dracut from TEST_KERNEL_CMDLINE

### DIFF
--- a/test/TEST-10-BASIC/test.sh
+++ b/test/TEST-10-BASIC/test.sh
@@ -14,7 +14,7 @@ test_run() {
 
     "$testdir"/run-qemu -nic none \
         "${disk_args[@]}" \
-        -append "$TEST_KERNEL_CMDLINE" \
+        -append "root=LABEL=dracut $TEST_KERNEL_CMDLINE" \
         -initrd "$TESTDIR"/initramfs.testing
 
     test_marker_check

--- a/test/TEST-11-USR-MOUNT/test.sh
+++ b/test/TEST-11-USR-MOUNT/test.sh
@@ -29,7 +29,7 @@ client_run() {
     test_marker_reset
     "$testdir"/run-qemu \
         "${disk_args[@]}" \
-        -append "$TEST_KERNEL_CMDLINE $client_opts" \
+        -append "root=LABEL=dracut $TEST_KERNEL_CMDLINE $client_opts" \
         -initrd "$TESTDIR"/initramfs.testing
 
     if ! test_marker_check; then

--- a/test/TEST-13-SYSROOT/test.sh
+++ b/test/TEST-13-SYSROOT/test.sh
@@ -14,7 +14,7 @@ test_run() {
 
     "$testdir"/run-qemu -nic none \
         "${disk_args[@]}" \
-        -append "$TEST_KERNEL_CMDLINE" \
+        -append "root=LABEL=dracut $TEST_KERNEL_CMDLINE" \
         -initrd "$TESTDIR"/initramfs.testing
 
     test_marker_check

--- a/test/TEST-20-STORAGE/test.sh
+++ b/test/TEST-20-STORAGE/test.sh
@@ -46,6 +46,8 @@ client_run() {
 
     if [ "$TEST_FSTYPE" = "zfs" ]; then
         TEST_KERNEL_CMDLINE+=" root=ZFS=dracut/root "
+    else
+        TEST_KERNEL_CMDLINE+=" root=LABEL=dracut "
     fi
 
     test_marker_reset

--- a/test/TEST-41-FULL-SYSTEMD/test.sh
+++ b/test/TEST-41-FULL-SYSTEMD/test.sh
@@ -34,7 +34,7 @@ client_run() {
     test_marker_reset
     "$testdir"/run-qemu \
         "${disk_args[@]}" ${smbios:+-smbios "${smbios}"} \
-        -append "$TEST_KERNEL_CMDLINE mount.usr=LABEL=dracutusr mount.usrflags=subvol=usr $client_opts ${DEBUGOUT-}" \
+        -append "root=LABEL=dracut $TEST_KERNEL_CMDLINE mount.usr=LABEL=dracutusr mount.usrflags=subvol=usr $client_opts ${DEBUGOUT-}" \
         -initrd "$TESTDIR"/initramfs.testing
 
     if ! test_marker_check; then

--- a/test/TEST-42-SYSTEMD-INITRD/test.sh
+++ b/test/TEST-42-SYSTEMD-INITRD/test.sh
@@ -25,7 +25,7 @@ client_run() {
     test_marker_reset
     "$testdir"/run-qemu \
         "${disk_args[@]}" \
-        -append "$TEST_KERNEL_CMDLINE $client_opts" \
+        -append "root=LABEL=dracut $TEST_KERNEL_CMDLINE $client_opts" \
         -initrd "$TESTDIR"/initramfs.testing
 
     if ! test_marker_check; then

--- a/test/TEST-43-KERNEL-INSTALL/test.sh
+++ b/test/TEST-43-KERNEL-INSTALL/test.sh
@@ -21,7 +21,7 @@ test_run() {
 
     "$testdir"/run-qemu \
         "${disk_args[@]}" \
-        -append "$TEST_KERNEL_CMDLINE" \
+        -append "root=LABEL=dracut $TEST_KERNEL_CMDLINE" \
         -initrd "$BOOT_ROOT/$TOKEN/$KVERSION"/initrd
 
     test_marker_check
@@ -31,7 +31,7 @@ test_run() {
     # rescue (non-hostonly) boot
     "$testdir"/run-qemu \
         "${disk_args[@]}" \
-        -append "$TEST_KERNEL_CMDLINE" \
+        -append "root=LABEL=dracut $TEST_KERNEL_CMDLINE" \
         -initrd "$BOOT_ROOT/$TOKEN"/0-rescue/initrd
 
     test_marker_check

--- a/test/TEST-44-DRIVERS/test.sh
+++ b/test/TEST-44-DRIVERS/test.sh
@@ -29,7 +29,7 @@ test_run() {
     # This test should fail if rd.driver.export is not passed at kernel command-line
     "$testdir"/run-qemu \
         "${disk_args[@]}" \
-        -append "$TEST_KERNEL_CMDLINE rd.driver.export" \
+        -append "root=LABEL=dracut $TEST_KERNEL_CMDLINE rd.driver.export" \
         -initrd "$TESTDIR"/initramfs.testing
 
     test_marker_check

--- a/test/TEST-50-NETWORK/test.sh
+++ b/test/TEST-50-NETWORK/test.sh
@@ -19,7 +19,7 @@ test_run() {
         -device "virtio-net-pci,netdev=lan0" \
         -netdev "user,id=lan0,net=10.0.2.0/24,dhcpstart=10.0.2.15" \
         "${disk_args[@]}" \
-        -append "$TEST_KERNEL_CMDLINE rd.neednet=1 net.ifnames=0" \
+        -append "root=LABEL=dracut $TEST_KERNEL_CMDLINE rd.neednet=1 net.ifnames=0" \
         -initrd "$TESTDIR"/initramfs.testing
 
     test_marker_check

--- a/test/test-functions
+++ b/test/test-functions
@@ -21,7 +21,7 @@ if [[ -f /etc/machine-id ]]; then
 fi
 [ -z "${TOKEN-}" ] && . /etc/os-release && TOKEN="$ID"
 
-TEST_KERNEL_CMDLINE+=" root=LABEL=dracut panic=1 oops=panic softlockup_panic=1 systemd.crash_reboot ${DEBUGFAIL-} "
+TEST_KERNEL_CMDLINE+=" panic=1 oops=panic softlockup_panic=1 systemd.crash_reboot ${DEBUGFAIL-} "
 
 if [[ ${V-} == "1" || ${V-} == "2" ]]; then
     TEST_KERNEL_CMDLINE+="systemd.journald.forward_to_console=1 "


### PR DESCRIPTION
## Changes

Several tests (for example the NFS or iSCSI tests) set the kernel cmdline `root=` and therefore overwrite `root=LABEL=dracut` set by `TEST_KERNEL_CMDLINE`.

Shorten the kernel cmdline and avoid confusion, drop `root=LABEL=dracut` and specify it only in tests that do not set `root=`.

## Checklist
- [ ] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it

Fixes #
