### PR TITLE
fix(nfs): simplify DRACUT_CP arguments to increase portability

### DIFF
--- a/modules.d/74nfs/module-setup.sh
+++ b/modules.d/74nfs/module-setup.sh
@@ -120,13 +120,13 @@ install() {
 
     # use the same directory permissions as the host
     [[ -d "${dracutsysrootdir-}"/var/lib/nfs/statd ]] \
-        && $DRACUT_CP -L --preserve=ownership -t "$initdir"/var/lib/nfs "${dracutsysrootdir-}"/var/lib/nfs/statd \
+        && $DRACUT_CP -L -p -t "$initdir"/var/lib/nfs "${dracutsysrootdir-}"/var/lib/nfs/statd \
         && rm -rf "$initdir"/var/lib/nfs/statd/*
     [[ -d "${dracutsysrootdir-}"/var/lib/nfs/statd/sm ]] \
-        && $DRACUT_CP -L --preserve=ownership -t "$initdir"/var/lib/nfs/statd "${dracutsysrootdir-}"/var/lib/nfs/statd/sm \
+        && $DRACUT_CP -L -p -t "$initdir"/var/lib/nfs/statd "${dracutsysrootdir-}"/var/lib/nfs/statd/sm \
         && rm -rf "$initdir"/var/lib/nfs/statd/sm/*
     [[ -d "${dracutsysrootdir-}"/var/lib/nfs/sm ]] \
-        && $DRACUT_CP -L --preserve=ownership -t "$initdir"/var/lib/nfs "${dracutsysrootdir-}"/var/lib/nfs/sm \
+        && $DRACUT_CP -L -p -t "$initdir"/var/lib/nfs "${dracutsysrootdir-}"/var/lib/nfs/sm \
         && rm -rf "$initdir"/var/lib/nfs/sm/*
 
     # Rather than copy the passwd file in, just set a user for rpcbind


### PR DESCRIPTION
## Changes

`DRACUT_CP` defaults to preserving mode and timestamps already, which allows to just use `-p` argument here. 

`busybox` `cp` does not support `--preserve=`, but it does support `-p` argument.

Follow-up to 2f5a759f490.

## Checklist
- [ ] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it

