### PR TITLE
fix(dracut): call cpio with more portable argument

### DIFF
--- a/dracut.sh
+++ b/dracut.sh
@@ -3121,7 +3121,7 @@ cpio_extract() {
     if [[ $CPIO == 3cpio ]]; then
         3cpio --extract "$file" -- "$@"
     else
-        cpio --extract --file "$file" --quiet -- "$@"
+        cpio -i -F "$file" --quiet -- "$@"
     fi
 }
 

--- a/lsinitrd.sh
+++ b/lsinitrd.sh
@@ -206,7 +206,7 @@ cpio_extract_to_stdout() {
     if [ "$CPIO" = 3cpio ]; then
         3cpio --extract --parts "$parts" --to-stdout "$image" -- "$@"
     else
-        $CAT "$image" 2> /dev/null | cpio --extract --quiet --to-stdout -- "$@"
+        $CAT "$image" 2> /dev/null | cpio -i --quiet --to-stdout -- "$@"
     fi
 }
 
@@ -215,7 +215,7 @@ cpio_list() {
     if [ "$CPIO" = 3cpio ]; then
         3cpio --list --parts "$parts" --verbose "$image" -- "$@"
     else
-        $CAT "$image" 2> /dev/null | cpio --extract --verbose --quiet --list -- "$@"
+        $CAT "$image" 2> /dev/null | cpio -i --verbose --quiet --list -- "$@"
     fi
 }
 


### PR DESCRIPTION
## Changes

`busybox` cpio does not support --extract or --file, but it does support -i and -F.

Overall `-i` and `-F` are more portable arguments for all cpio implementations.

## Checklist
- [ ] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it

Fixes #
