### PR TITLE
chore: reduce the scope of shellcheck exceptions

### DIFF
--- a/dracut.sh
+++ b/dracut.sh
@@ -1,7 +1,4 @@
 #!/bin/bash -p
-# temporarly disable some shellcheck warning to be able to preserve commit history
-# before additional commits.
-# shellcheck disable=SC2317,SC2329
 #
 # Generator script for a dracut initramfs
 
@@ -1544,6 +1541,7 @@ dracut_module_included() {
     [[ " $mods_to_load $modules_loaded " == *\ $*\ * ]]
 }
 
+# shellcheck disable=SC2317,SC2329
 dracut_no_switch_root() {
     : > "$initdir/lib/dracut/no-switch-root"
 }
@@ -1585,10 +1583,12 @@ inst_symlink() {
     fi
 }
 
+# shellcheck disable=SC2317,SC2329
 dracut_install() {
     inst_multiple "$@"
 }
 
+# shellcheck disable=SC2317,SC2329
 dracut_instmods() {
     local _ret _silent=0
     local i
@@ -1615,15 +1615,18 @@ dracut_instmods() {
 
 # this is not used within dracut itself, but external modules use it,
 # do not remove it!
+# shellcheck disable=SC2317,SC2329
 inst_library() {
     inst "$@"
 }
 
 # empty function for compatibility
+# shellcheck disable=SC2317,SC2329
 inst_fsck_help() {
     :
 }
 
+# shellcheck disable=SC2317,SC2329
 mark_hostonly() {
     for i in "$@"; do
         echo "$i" >> "$initdir/lib/dracut/hostonly-files"
@@ -1647,6 +1650,7 @@ build_ld_cache() {
 }
 
 # install sysusers files
+# shellcheck disable=SC2317,SC2329
 inst_sysusers() {
     inst_multiple -o "$sysusers/$*" "$sysusers/acct-*-$*"
 
@@ -1667,6 +1671,7 @@ module_functions=(
 # module_check <dracut module> [<forced>] [<module path>]
 # execute the check() function of module-setup.sh of <dracut module>
 # "check $hostonly" is called
+# shellcheck disable=SC2317,SC2329
 module_check() {
     local _moddir=$3
     local _ret
@@ -1693,6 +1698,7 @@ module_check() {
 # module_check_mount <dracut module> [<module path>]
 # execute the check() function of module-setup.sh of <dracut module>
 # "mount_needs=1 check 0" is called
+# shellcheck disable=SC2317,SC2329
 module_check_mount() {
     local _moddir=$2
     local _ret
@@ -1712,6 +1718,7 @@ module_check_mount() {
 
 # module_depends <dracut module> [<module path>]
 # execute the depends() function of module-setup.sh of <dracut module>
+# shellcheck disable=SC2317,SC2329
 module_depends() {
     local _moddir=$2
     local _ret
@@ -1729,6 +1736,7 @@ module_depends() {
 
 # module_cmdline <dracut module> [<module path>]
 # execute the cmdline() function of module-setup.sh of <dracut module>
+# shellcheck disable=SC2317,SC2329
 module_cmdline() {
     local _moddir=$2
     local _ret
@@ -1746,6 +1754,7 @@ module_cmdline() {
 
 # module_config <dracut module> [<module path>]
 # execute the config() function of module-setup.sh of <dracut module>
+# shellcheck disable=SC2317,SC2329
 module_config() {
     local _moddir=$2
     local _ret
@@ -1763,6 +1772,7 @@ module_config() {
 
 # module_install <dracut module> [<module path>]
 # execute the install() function of module-setup.sh of <dracut module>
+# shellcheck disable=SC2317,SC2329
 module_install() {
     local _moddir=$2
     local _ret
@@ -1780,6 +1790,7 @@ module_install() {
 
 # module_installkernel <dracut module> [<module path>]
 # execute the installkernel() function of module-setup.sh of <dracut module>
+# shellcheck disable=SC2317,SC2329
 module_installkernel() {
     local _moddir=$2
     local _ret
@@ -1798,6 +1809,7 @@ module_installkernel() {
 # check_mount <dracut module> [<use_as_dep>] [<module path>]
 # check_mount checks, if a dracut module is needed for the given
 # device and filesystem types in "${host_fs_types[@]}"
+# shellcheck disable=SC2317,SC2329
 check_mount() {
     local _mod=$1
     local _moddir=$3
@@ -1865,6 +1877,7 @@ check_mount() {
 # check if a dracut module is to be used in the initramfs process
 # if <use_as_dep> is set, then the process also keeps track
 # that the modules were checked for the dependency tracking process
+# shellcheck disable=SC2317,SC2329
 check_module() {
     local _mod=$1
     local _moddir=$3
@@ -2070,6 +2083,7 @@ else
     }
 fi
 
+# shellcheck disable=SC2317,SC2329
 is_qemu_virtualized() {
     # 0 if a virt environment was detected
     # 1 if a virt environment could not be detected


### PR DESCRIPTION
## Changes

The motivation behind this commit is to be able easily identify unused functions in dracut.sh going forward.

## Checklist
- [ ] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it


