### PR TITLE
refactor: move defining require_X functions to dracut-functions.sh

### DIFF
--- a/dracut.sh
+++ b/dracut.sh
@@ -1540,60 +1540,6 @@ if ! [[ ${libdirs-} ]]; then
     export libdirs
 fi
 
-# helper function for check() in module-setup.sh
-# to check for required installed binaries
-# issues a standardized warning message
-require_binaries() {
-    local _module_name="${moddir##*/}"
-    local _ret=0
-
-    for cmd in "$@"; do
-        if ! find_binary "$cmd" &> /dev/null; then
-            ddebug "Module '${_module_name#[0-9][0-9]}' will not be installed, because command '$cmd' could not be found!"
-            ((_ret++))
-        fi
-    done
-    return "$_ret"
-}
-
-require_any_binary() {
-    local _module_name="${moddir##*/}"
-    local _ret=1
-
-    for cmd in "$@"; do
-        if find_binary "$cmd" &> /dev/null; then
-            _ret=0
-            break
-        fi
-    done
-
-    if ((_ret != 0)); then
-        dinfo "$_module_name: Could not find any command of '$*'!"
-        return 1
-    fi
-
-    return 0
-}
-
-# helper function for check() in module-setup.sh
-# to check for required kernel modules
-# issues a standardized warning message
-require_kernel_modules() {
-    local _module_name="${moddir##*/}"
-    local _ret=0
-
-    # Ignore kernel module requirement for no-kernel build
-    [[ $no_kernel == yes ]] && return 0
-
-    for mod in "$@"; do
-        if ! check_kernel_module "$mod" &> /dev/null; then
-            dinfo "Module '${_module_name#[0-9][0-9]}' will not be installed, because kernel module '$mod' is not available!"
-            ((_ret++))
-        fi
-    done
-    return "$_ret"
-}
-
 dracut_module_included() {
     [[ " $mods_to_load $modules_loaded " == *\ $*\ * ]]
 }

--- a/man/dracut.modules.7.adoc
+++ b/man/dracut.modules.7.adoc
@@ -369,6 +369,24 @@ dracut module.
 This function is maintained only to provide compatibility for modules aimed at older
 dracut releases.
 
+==== require_binaries
+
+Helper function for check() in module-setup.sh to check for required installed binaries.
+All of the binaries listed in the arguments of this function should exists in the host.
+Issues a standardized warning message.
+
+==== require_any_binary
+
+Helper function for check() in module-setup.sh to check for required installed binaries.
+At least one of the binaries listed in the arguments of this function should exists in
+the host.
+Issues a standardized warning message.
+
+==== require_kernel_modules
+
+Helper function for check() in module-setup.sh to check for required kernel modules.
+Issues a standardized warning message.
+
 === Initramfs Functions
 
 FIXME


### PR DESCRIPTION
## Changes

`require_X` are public interfaces to dracut modules, move them to `dracut-functions.sh`.

Add documentation for these public functions to make it clear that it is expected to be used in out-of-tree dracut modules as well.

## Checklist
- [ ] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it

