### PR TITLE
chore: move net udev rules to net-lib dracut modules

### DIFF
--- a/modules.d/45net-lib/module-setup.sh
+++ b/modules.d/45net-lib/module-setup.sh
@@ -17,6 +17,12 @@ installkernel() {
 }
 
 install() {
+    inst_rules \
+        75-net-description.rules \
+        80-net-name-slot.rules \
+        80-net-setup-link.rules \
+        81-net-dhcp.rules
+
     inst_script "$moddir/netroot.sh" "/sbin/netroot"
     inst_simple "$moddir/net-lib.sh" "/lib/net-lib.sh"
     inst_hook pre-udev 50 "$moddir/ifname-genrules.sh"

--- a/modules.d/74udev-rules/module-setup.sh
+++ b/modules.d/74udev-rules/module-setup.sh
@@ -51,13 +51,9 @@ install() {
         70-uaccess.rules \
         71-seat.rules \
         73-seat-late.rules \
-        75-net-description.rules \
         75-probe_mtd.rules \
         78-sound-card.rules \
         80-drivers.rules \
-        80-net-name-slot.rules \
-        80-net-setup-link.rules \
-        81-net-dhcp.rules \
         95-udev-late.rules
 
     {


### PR DESCRIPTION
## Changes

The net-lib dracut module is designed to be always installed when networking is enabled in the generated initramfs.

Move networking related udev rules to net-lib dracut modules from the udev-rules dracut module.

The motivation behind this change is to increase modularity, stay consistent with other dracut modules and potentially increase performance when networking is not required in the initramfs.

## Checklist
- [ ] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it


