### PR TITLE
chore: remove support for 64-device-mapper.rules

### DIFF
--- a/modules.d/70dm/module-setup.sh
+++ b/modules.d/70dm/module-setup.sh
@@ -19,9 +19,6 @@ install() {
     inst_multiple dmsetup
 
     inst_rules 10-dm.rules 13-dm-disk.rules 95-dm-notify.rules
-    # Gentoo ebuild for LVM2 prior to 2.02.63-r1 doesn't install above rules
-    # files, but provides the one below:
-    inst_rules 64-device-mapper.rules
     # debian udev rules
     inst_rules 60-persistent-storage-dm.rules 55-dm.rules
 

--- a/modules.d/70lvm/module-setup.sh
+++ b/modules.d/70lvm/module-setup.sh
@@ -80,9 +80,6 @@ install() {
 
     inst_rules 11-dm-lvm.rules
 
-    # Gentoo ebuild for LVM2 prior to 2.02.63-r1 doesn't install above rules
-    # files, but provides the one below:
-    inst_rules 64-device-mapper.rules
     # debian udev rules
     inst_rules 56-lvm.rules 60-persistent-storage-lvm.rules
 


### PR DESCRIPTION
## Changes

`64-device-mapper.rules` use to be a Gentoo specific file, which is now obsolete even on Gentoo.

Reverts 5d72984.

## Checklist
- [ ] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it

CC @Nowa-Ammerlaan 
