### PR TITLE
ci: extend run-qemu function to pass test 82 on Void arm64 as well     

### DIFF
--- a/.github/workflows/integration-extra-arm64.yml
+++ b/.github/workflows/integration-extra-arm64.yml
@@ -42,10 +42,6 @@ jobs:
                     - "80"
                     - "81"
                     - "82"
-                exclude:
-                    # run-qemu: Could not find a Linux kernel version to test with!
-                    - container: void:latest
-                      test: "82"
         container:
             image: ghcr.io/dracut-ng/${{ matrix.container }}-arm
             options: '--device=/dev/kvm --privileged'

--- a/test/run-qemu
+++ b/test/run-qemu
@@ -105,7 +105,9 @@ set_vmlinux_env() {
     fi
 
     ! [ -f "${VMLINUZ-}" ] && VMLINUZ=$(find /boot/vmlinuz-* -type f 2> /dev/null | tail -1)
+    ! [ -f "${VMLINUZ-}" ] && VMLINUZ=$(find /boot/vmlinux-* -type f 2> /dev/null | tail -1)
     ! [ -f "${VMLINUZ-}" ] && VMLINUZ=$(find /lib/modules/ -type f -name vmlinuz 2> /dev/null | tail -1)
+    ! [ -f "${VMLINUZ-}" ] && VMLINUZ=$(find /lib/modules/ -type f -name vmlinux 2> /dev/null | tail -1)
     ! [ -f "${VMLINUZ-}" ] && VMLINUZ=$(find /lib/modules/ -type f -name Image 2> /dev/null | tail -1)
 
     if ! [ -f "$VMLINUZ" ]; then


### PR DESCRIPTION
## Changes

Extend the rules to find the kernel inside the Void container. Void on arm64 uses the `vmlinux` filename pattern.

## Checklist
- [ ] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it

Fixes #
