### PR TITLE
fix(dm): add explicit rootfs-block dependency

### DIFF
--- a/modules.d/11systemd-cryptsetup/module-setup.sh
+++ b/modules.d/11systemd-cryptsetup/module-setup.sh
@@ -19,7 +19,7 @@ check() {
 # called by dracut
 depends() {
     local deps
-    deps="dm rootfs-block crypt systemd-ask-password"
+    deps="crypt systemd-ask-password"
     if [[ $hostonly && -f "${dracutsysrootdir-}"/etc/crypttab ]]; then
         if grep -q -e "fido2-device=" -e "fido2-cid=" "${dracutsysrootdir-}"/etc/crypttab; then
             deps+=" fido2"

--- a/modules.d/70crypt/module-setup.sh
+++ b/modules.d/70crypt/module-setup.sh
@@ -18,7 +18,7 @@ check() {
 
 # called by dracut
 depends() {
-    echo dm rootfs-block initqueue
+    echo dm initqueue
 }
 
 # called by dracut

--- a/modules.d/70dm/module-setup.sh
+++ b/modules.d/70dm/module-setup.sh
@@ -6,6 +6,11 @@ check() {
     return 255
 }
 
+depends() {
+    echo rootfs-block
+    return 0
+}
+
 # called by dracut
 installkernel() {
     hostonly=$(optional_hostonly) instmods '=drivers/md' dm_mod dm-cache dm-cache-mq dm-cache-cleaner

--- a/modules.d/70dmraid/module-setup.sh
+++ b/modules.d/70dmraid/module-setup.sh
@@ -31,7 +31,7 @@ check() {
 
 # called by dracut
 depends() {
-    echo dm rootfs-block
+    echo dm
     return 0
 }
 

--- a/modules.d/70dmsquash-live/module-setup.sh
+++ b/modules.d/70dmsquash-live/module-setup.sh
@@ -11,7 +11,7 @@ check() {
 depends() {
     # if dmsetup is not installed, then we cannot support fedora/red hat
     # style live images
-    echo dm rootfs-block img-lib overlayfs initqueue
+    echo dm img-lib overlayfs initqueue
     return 0
 }
 

--- a/modules.d/70lvm/module-setup.sh
+++ b/modules.d/70lvm/module-setup.sh
@@ -18,7 +18,7 @@ check() {
 # called by dracut
 depends() {
     # We depend on dm_mod being loaded
-    echo rootfs-block dm initqueue
+    echo dm initqueue
     return 0
 }
 


### PR DESCRIPTION
## Changes

Device mapper operates on local storage typically configured by the `rootfs-block` module.

This change tightens dependencies to ensure that including only the dm module via `dracut -m dm` produces a functional initramfs.

## Checklist
- [ ] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it

