### PR TITLE
chore: remove default --reflink=auto argument from cp calls

### DIFF
--- a/dracut.sh
+++ b/dracut.sh
@@ -1471,9 +1471,9 @@ fi
 export LC_MESSAGES=C kernel
 
 if [[ $EUID == "0" ]] && ! [[ ${DRACUT_NO_XATTR-} ]]; then
-    export DRACUT_CP="cp --reflink=auto --preserve=mode,timestamps,xattr,links -dfr"
+    export DRACUT_CP="cp --preserve=mode,timestamps,xattr,links -dfr"
 else
-    export DRACUT_CP="cp --reflink=auto --preserve=mode,timestamps,links -dfr"
+    export DRACUT_CP="cp --preserve=mode,timestamps,links -dfr"
 fi
 
 if ! [[ ${dracutbasedir-} ]]; then

--- a/install.d/50-dracut.install
+++ b/install.d/50-dracut.install
@@ -35,7 +35,7 @@ if [[ -f ${KERNEL_IMAGE%/*}/$IMAGE ]]; then
     # use this and don't generate a new one
     [[ $KERNEL_INSTALL_VERBOSE == 1 ]] && echo \
         "There is an $IMAGE image at the same place as the kernel, skipping generating a new one"
-    cp --reflink=auto "${KERNEL_IMAGE%/*}/$IMAGE" "$KERNEL_INSTALL_STAGING_AREA/$IMAGE" \
+    cp "${KERNEL_IMAGE%/*}/$IMAGE" "$KERNEL_INSTALL_STAGING_AREA/$IMAGE" \
         && chown root:root "$KERNEL_INSTALL_STAGING_AREA/$IMAGE" \
         && chmod 0600 "$KERNEL_INSTALL_STAGING_AREA/$IMAGE" \
         && exit 0

--- a/install.d/51-dracut-rescue.install
+++ b/install.d/51-dracut-rescue.install
@@ -125,7 +125,7 @@ case "$COMMAND" in
 
         [[ -d $BOOT_DIR_ABS ]] || mkdir -p "$BOOT_DIR_ABS"
 
-        if ! cp --reflink=auto "$KERNEL_IMAGE" "$BOOT_DIR_ABS/$KERNEL"; then
+        if ! cp "$KERNEL_IMAGE" "$BOOT_DIR_ABS/$KERNEL"; then
             echo "Can't copy '$KERNEL_IMAGE to '$BOOT_DIR_ABS/$KERNEL'!" >&2
         fi
 

--- a/src/install/dracut-install.c
+++ b/src/install/dracut-install.c
@@ -440,7 +440,7 @@ normal_copy:
         const char *preservation = (geteuid() == 0
                                     && no_xattr == false) ? "--preserve=mode,xattr,timestamps,ownership" : "--preserve=mode,timestamps,ownership";
         if (pid == 0) {
-                execlp("cp", "cp", "--reflink=auto", preservation, "-fL", src, dst, NULL);
+                execlp("cp", "cp", preservation, "-fL", src, dst, NULL);
                 _exit(errno == ENOENT ? 127 : 126);
         }
 
@@ -452,7 +452,7 @@ normal_copy:
         }
         ret = WIFSIGNALED(ret) ? 128 + WTERMSIG(ret) : WEXITSTATUS(ret);
         if (ret != 0)
-                log_error("ERROR: 'cp --reflink=auto %s -fL %s %s' failed with %d", preservation, src, dst, ret);
+                log_error("ERROR: 'cp %s -fL %s %s' failed with %d", preservation, src, dst, ret);
         log_debug("cp ret = %d", ret);
         return ret;
 }


### PR DESCRIPTION
## Changes

Adding argument processing for arguments that are the default anyways just adds to cognitive load of reading the code and a little bit of performance overhead.

`--reflink=auto` is the default. There is no need to re-specify it.

Also, busybox cp does not support `--reflink=auto`, so this change makes dracut more portable.

## Checklist
- [ ] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it


