### PR TITLE
ci(alpine): simplify CI container after Alpine v3.23 release

### DIFF
--- a/test/container/Dockerfile-alpine
+++ b/test/container/Dockerfile-alpine
@@ -26,16 +26,7 @@ ARG DISTRIBUTION
 # Packages to pass the BASIC test
 # Use dracut-tests package to install dependencies for test suite
 RUN apk add --no-cache \
-    asciidoctor \
-    dracut-tests \
-    file \
-    gcc \
-    kmod \
-    kmod-dev \
-    linux-virt \
-    make \
-    musl-dev \
-    musl-fts-dev
+    dracut-tests
 
 # Packages for recent changes that are not yet released or packaged by dracut-tests
 RUN apk add --no-cache \


### PR DESCRIPTION
## Changes

The upstream dracut-tests package in Alpine v3.23 already installs dracut build dependencies, no need to repeat them here.

Simplify the package list of the dracut CI.

Alpine v3.23 stable has been released on 2025-12-03.

Follow-up to 353373e99b37ef30e9fc218a3766d379e6c1af5b .

## Checklist
- [ ] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it

