### PR TITLE
ci(alpine): fix regression regarding make is not installed

### DIFF
--- a/test/container/Dockerfile-alpine
+++ b/test/container/Dockerfile-alpine
@@ -26,6 +26,7 @@ ARG DISTRIBUTION
 # Packages to pass the BASIC test
 # Use dracut-tests package to install dependencies for test suite
 RUN apk add --no-cache \
+    make \
     dracut-tests
 
 # Packages for recent changes that are not yet released or packaged by dracut-tests


### PR DESCRIPTION
## Changes

It turns out make it not a dependency for dracut-tests downstream. Add make dependency to continue upstream development.

Follow-up to 52606ca .

## Checklist
- [ ] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it


