### PR TITLE
ci(alpine): remove support

### DIFF
--- a/.github/workflows/doc.yml
+++ b/.github/workflows/doc.yml
@@ -22,7 +22,6 @@ jobs:
             fail-fast: false
             matrix:
                 container:
-                    - alpine:latest
                     - arch:latest
                     - debian:latest
                     - fedora:latest

--- a/.github/workflows/integration-extra.yml
+++ b/.github/workflows/integration-extra.yml
@@ -25,8 +25,6 @@ jobs:
             fail-fast: false
             matrix:
                 container:
-                    - alpine:latest
-                    - alpine:edge
                     - arch:latest
                     - azurelinux:3.0
                     - debian:latest

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -30,7 +30,6 @@ jobs:
             fail-fast: false
             matrix:
                 container:
-                    - alpine:latest
                     - arch:latest
                     - debian:latest
                     - fedora:latest

--- a/.github/workflows/manualtest.yml
+++ b/.github/workflows/manualtest.yml
@@ -13,8 +13,6 @@ on:  # yamllint disable-line rule:truthy
                 default: 'all'
                 options:
                     - "all"
-                    - "alpine:latest"
-                    - "alpine:edge"
                     - "azurelinux:3.0"
                     - "centos:latest"
                     - "fedora:latest"


### PR DESCRIPTION
## Changes

Core maintainer(s) [1] decided that busybox and Alpine support is no longer welcomed upstream.

Removing Alpine support from the CI as I have no plans to maintain it anymore.

[1]: https://github.com/dracut-ng/dracut-ng/pull/1975#issuecomment-3680434811

## Checklist
- [ ] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it

