### PR TITLE
feat(dracut): print $uefi with --printconfig

### DIFF
--- a/dracut.sh
+++ b/dracut.sh
@@ -2672,6 +2672,7 @@ if [[ $printconfig ]]; then
         ro_mnt \
         squash_compress \
         sshkey \
+        uefi \
         use_fstab; do
         if [[ -n ${!v} ]]; then
             echo "dracutconfig: $v=${!v}"


### PR DESCRIPTION
## Changes

Allow the enviroment (e.g. package managers) to discover if uefi is enabled or not.

Similar to 71a713bb2 .

## Checklist
- [ ] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it
