### PR TITLE
fix(dracut): avoid calling dwarning before dracut-logger is sourced

### DIFF
--- a/dracut.sh
+++ b/dracut.sh
@@ -1362,7 +1362,7 @@ fi
 if [[ ${hostonly-} ]]; then
     for i in /sys /proc /run /dev; do
         if ! findmnt --target "$i" &> /dev/null; then
-            dwarning "Turning off host-only mode: '$i' is not mounted!"
+            printf "%s\n" "dracut[W]: Turning off host-only mode: '$i' is not mounted!" >&2
             unset hostonly
         fi
     done


### PR DESCRIPTION
Follow-up for 8d9887bd773936cf3e42798dd26d70edd4213d4d

## Checklist
- [X] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it

Fixes: https://bugs.debian.org/1124479
