### PR TITLE
ci(alpine): install openRC and build-base

### DIFF
--- a/test/container/Dockerfile-alpine
+++ b/test/container/Dockerfile-alpine
@@ -23,13 +23,10 @@ FROM docker.io/${DISTRIBUTION}
 # export ARG
 ARG DISTRIBUTION
 
-# Packages to pass the BASIC test
 # Use dracut-tests package to install dependencies for test suite
 RUN apk add --no-cache \
-    make \
-    dracut-tests
-
-# Packages for recent changes that are not yet released or packaged by dracut-tests
-RUN apk add --no-cache \
+    alpine-base \
+    build-base \
     cargo \
-    dnsmasq
+    dnsmasq \
+    dracut-tests


### PR DESCRIPTION
alpine-base package is required to make the container bootable and have the openRC services available.

The alpine-base package is not installed by default in the alpine container (only the alpine-baselayout package is installed).

Instead of explicitly installing make, install build-base meta-package for future proofing.

## Checklist
- [ ] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it

Fixes #
