### PR TITLE
fix(dracut): avoid calling dwarning before dracut-logger is sourced

### DIFF
--- a/dracut.sh
+++ b/dracut.sh
@@ -1204,6 +1204,13 @@ drivers_dir="${drivers_dir%"${drivers_dir##*[!/]}"}"
 [[ $sbat_l ]] && sbat="$sbat_l"
 [[ $machine_id_l ]] && machine_id="$machine_id_l"
 
+# initialize logging if not yet initialized
+if ! command -v dinfo > /dev/null; then
+    # shellcheck source=./dracut-logger.sh
+    . "$dracutbasedir"/dracut-logger.sh
+    dlog_init
+fi
+
 if ! [[ $outfile ]]; then
     if [[ $machine_id != "no" ]]; then
         if [[ -d "${dracutsysrootdir-}"/efi/Default ]] \


### PR DESCRIPTION
Follow-up for 8d9887b

## Checklist
- [ ] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it

Fixes https://bugs.debian.org/1124479
