### PR TITLE
fix(dracut): source dracut-functions.sh before calling dwarning

### DIFF
--- a/dracut.sh
+++ b/dracut.sh
@@ -1204,6 +1204,9 @@ drivers_dir="${drivers_dir%"${drivers_dir##*[!/]}"}"
 [[ $sbat_l ]] && sbat="$sbat_l"
 [[ $machine_id_l ]] && machine_id="$machine_id_l"
 
+# shellcheck source=./dracut-functions.sh
+. "$dracutbasedir"/dracut-functions.sh
+
 if ! [[ $outfile ]]; then
     if [[ $machine_id != "no" ]]; then
         if [[ -d "${dracutsysrootdir-}"/efi/Default ]] \
@@ -1486,9 +1489,6 @@ if ! [[ ${dracutbasedir-} ]]; then
     [[ $dracutbasedir ]] || dracutbasedir="."
     dracutbasedir="$(readlink -f "$dracutbasedir")"
 fi
-
-# shellcheck source=./dracut-functions.sh
-. "$dracutbasedir"/dracut-functions.sh
 
 if ! [[ ${initdir-} ]]; then
     dfatal "initdir not set"


### PR DESCRIPTION
## Changes

`dracut-functions.sh` sources `dracut-logger.sh` which defines the `dwarning` function. `dracut.sh` might call `dwarning` before `dracut-functions.sh` is sourced.

`dracut-functions.sh` calls `find_binary` and `dlog_init` when sourced. `find_binary` needs `dracutsysrootdir` set and `dlog_init` needs `stdloglvl`, `sysloglvl`, `kmsgloglvl`, `maxloglvl`, `fileloglvl`, `logfile`. Move sourcing `dracut-functions.sh` as early as possible, but after setting those variables.

Follow-up for 8d9887b

## Checklist
- [ ] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it

Fixes: https://bugs.debian.org/1124479
