### PR TITLE
test(NETWORK): do not set net.ifnames=0

### DIFF
--- a/test/TEST-50-NETWORK/assertion.sh
+++ b/test/TEST-50-NETWORK/assertion.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
-# Get the output of 'ip addr show eth0'
-ip_output=$(ip addr show eth0)
+# Get the output of 'ip addr show' and filter out lo interface
+ip_output=$(ip -o -4 addr show | grep -v ': lo')
 
 # Extract the line containing "inet"
 inet_line="${ip_output##*inet }"

--- a/test/TEST-50-NETWORK/test.sh
+++ b/test/TEST-50-NETWORK/test.sh
@@ -19,7 +19,7 @@ test_run() {
         -device "virtio-net-pci,netdev=lan0" \
         -netdev "user,id=lan0,net=10.0.2.0/24,dhcpstart=10.0.2.15" \
         "${disk_args[@]}" \
-        -append "root=LABEL=dracut $TEST_KERNEL_CMDLINE rd.neednet=1 net.ifnames=0" \
+        -append "root=LABEL=dracut $TEST_KERNEL_CMDLINE rd.neednet=1" \
         -initrd "$TESTDIR"/initramfs.testing
 
     test_marker_check


### PR DESCRIPTION
Increase test coverage by letting CI test containers to decide the value of `net.ifnames`.

Change the test expectation to handle both `net.ifnames=0` and `net.ifnames=1`.

## Checklist
- [ ] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it

