### PR TITLE
feat(dracut): drop unreachable code for dracutbasedir/initdir

### DIFF
--- a/dracut.sh
+++ b/dracut.sh
@@ -1477,22 +1477,6 @@ fi
 
 export LC_MESSAGES=C kernel
 
-if ! [[ ${dracutbasedir-} ]]; then
-    dracutbasedir=${BASH_SOURCE[0]%/*}
-    [[ $dracutbasedir == dracut-functions* ]] && dracutbasedir="."
-    [[ $dracutbasedir ]] || dracutbasedir="."
-    dracutbasedir="$(readlink -f "$dracutbasedir")"
-fi
-
-if ! [[ ${initdir-} ]]; then
-    dfatal "initdir not set"
-    exit 1
-fi
-
-if ! [[ -d $initdir ]]; then
-    mkdir -p "$initdir"
-fi
-
 srcmods="$(realpath -e "${dracutsysrootdir-}/lib/modules/$kernel")"
 
 [[ ${drivers_dir-} ]] && {


### PR DESCRIPTION
## Changes

`dracut.sh` sets the variables `dracutbasedir` and `initdir`. Then it creates the `initdir` directory. So checking those variables again can be dropped.

Follow-up: 4cb4917e1222 ("refactor: fold dracut-init.sh into dracut.sh")

## Checklist
- [ ] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it

Fixes #
