### PR TITLE
fix(dracut): move comment back to related dracut_args variable

### DIFF
--- a/dracut.sh
+++ b/dracut.sh
@@ -23,8 +23,6 @@
 # Please do not use functions from this file in your dracut module
 # Only use functions from dracut-functions.sh
 
-# store for logging
-
 unset BASH_ENV
 unset GZIP
 
@@ -34,6 +32,7 @@ if ((BASH_VERSINFO[0] < 4)); then
     exit 1
 fi
 
+# store for logging
 dracut_args=("$@")
 dracut_cmd=$(readlink -f "$0")
 readonly dracut_cmd


### PR DESCRIPTION
## Changes

Commit 58dad7025b01 added the comment "store for logging" next to the `dracut_args` variable. Move that comment back to this place.

## Checklist
- [ ] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it

Fixes #
