### PR TITLE
feat: move DRACUT_VERSION from dracut-version.sh into dracut.sh

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,12 +1,11 @@
--include dracut-version.sh
 
 DRACUT_MAIN_VERSION ?= $(shell env GIT_CEILING_DIRECTORIES=$(CURDIR)/.. git describe --abbrev=0 --tags --always 2>/dev/null || :)
 ifeq ($(DRACUT_MAIN_VERSION),)
-DRACUT_MAIN_VERSION = $(DRACUT_VERSION)
+DRACUT_MAIN_VERSION := $(shell sed -n 's/^DRACUT_VERSION="\(.*\)"$$/\1/p' dracut.sh)
 endif
 DRACUT_FULL_VERSION ?= $(shell env GIT_CEILING_DIRECTORIES=$(CURDIR)/.. git describe --tags --always 2>/dev/null || :)
 ifeq ($(DRACUT_FULL_VERSION),)
-DRACUT_FULL_VERSION = $(DRACUT_VERSION)
+DRACUT_FULL_VERSION := $(shell sed -n 's/^DRACUT_VERSION="\(.*\)"$$/\1/p' dracut.sh)
 endif
 
 HAVE_SHELLCHECK ?= $(shell command -v shellcheck >/dev/null 2>&1 && echo yes)
@@ -191,14 +190,13 @@ install: all
 	mkdir -p $(DESTDIR)$(pkglibdir)/modules.d
 	mkdir -p $(DESTDIR)$(mandir)/man1 $(DESTDIR)$(mandir)/man5 $(DESTDIR)$(mandir)/man7 $(DESTDIR)$(mandir)/man8
 	install -m 0755 dracut.sh $(DESTDIR)$(bindir)/dracut
+	sed -i 's;^\(DRACUT_VERSION\)=".*"$$;\1="$(DRACUT_FULL_VERSION)";' $(DESTDIR)$(bindir)/dracut
 	install -m 0755 dracut-catimages.sh $(DESTDIR)$(bindir)/dracut-catimages
 	install -m 0755 lsinitrd.sh $(DESTDIR)$(bindir)/lsinitrd
 	install -m 0644 dracut.conf $(DESTDIR)$(sysconfdir)/dracut.conf
 	mkdir -p $(DESTDIR)$(sysconfdir)/dracut.conf.d
 	mkdir -p $(DESTDIR)$(pkglibdir)/dracut.conf.d
 	install -m 0755 dracut-functions.sh $(DESTDIR)$(pkglibdir)/dracut-functions.sh
-	install -m 0755 dracut-version.sh $(DESTDIR)$(pkglibdir)/dracut-version.sh
-	sed -i 's;^\(DRACUT_VERSION=\).*;\1$(DRACUT_FULL_VERSION);' $(DESTDIR)$(pkglibdir)/dracut-version.sh
 	ln -fs dracut-functions.sh $(DESTDIR)$(pkglibdir)/dracut-functions
 	install -m 0755 dracut-logger.sh $(DESTDIR)$(pkglibdir)/dracut-logger.sh
 	install -m 0755 dracut-initramfs-restore.sh $(DESTDIR)$(pkglibdir)/dracut-initramfs-restore

--- a/dracut-version.sh
+++ b/dracut-version.sh
@@ -1,3 +1,0 @@
-#!/bin/sh
-# shellcheck disable=SC2034
-DRACUT_VERSION=109

--- a/dracut.sh
+++ b/dracut.sh
@@ -23,6 +23,8 @@
 # Please do not use functions from this file in your dracut module
 # Only use functions from dracut-functions.sh
 
+DRACUT_VERSION="109"
+
 unset BASH_ENV
 unset GZIP
 
@@ -53,13 +55,6 @@ path_rel_to_abs() {
 }
 
 usage() {
-    [[ $sysroot_l ]] && dracutsysrootdir="$sysroot_l"
-    [[ $dracutbasedir ]] || dracutbasedir="${dracutsysrootdir-}"/usr/lib/dracut
-    if [[ -f $dracutbasedir/dracut-version.sh ]]; then
-        # shellcheck source=./dracut-version.sh
-        . "$dracutbasedir"/dracut-version.sh
-    fi
-
     #                                                   80x25 linebreak here ^
     cat << EOF
 Usage: $dracut_cmd [OPTION]... [<initramfs> [<kernel-version>]]
@@ -80,12 +75,6 @@ EOF
 }
 
 long_usage() {
-    [[ $dracutbasedir ]] || dracutbasedir="${dracutsysrootdir-}"/usr/lib/dracut
-    if [[ -f $dracutbasedir/dracut-version.sh ]]; then
-        # shellcheck source=./dracut-version.sh
-        . "$dracutbasedir"/dracut-version.sh
-    fi
-
     #                                                   80x25 linebreak here ^
     cat << EOF
 Usage: $dracut_cmd [OPTION]... [<initramfs> [<kernel-version>]]
@@ -321,11 +310,6 @@ EOF
 }
 
 long_version() {
-    [[ $dracutbasedir ]] || dracutbasedir="${dracutsysrootdir-}"/usr/lib/dracut
-    if [[ -f $dracutbasedir/dracut-version.sh ]]; then
-        # shellcheck source=./dracut-version.sh
-        . "$dracutbasedir"/dracut-version.sh
-    fi
     echo "dracut $DRACUT_VERSION"
 }
 
@@ -1467,11 +1451,6 @@ if [[ $print_cmdline ]]; then
     sysloglvl=0
     fileloglvl=0
     kmsgloglvl=0
-fi
-
-if [[ -f $dracutbasedir/dracut-version.sh ]]; then
-    # shellcheck source=./dracut-version.sh
-    . "$dracutbasedir"/dracut-version.sh
 fi
 
 export LC_MESSAGES=C kernel

--- a/tools/release.sh
+++ b/tools/release.sh
@@ -50,8 +50,8 @@ cat NEWS_header.md NEWS_header_new.md NEWS_body_new.md NEWS_body_with_conttribut
 # message for https://github.com/dracut-ng/dracut-ng/releases/tag
 cat -s NEWS_body_new.md CONTRIBUTORS.md > release.md
 
-# dracut-version.sh
-printf "#!/bin/sh\n# shellcheck disable=SC2034\nDRACUT_VERSION=%s\n" "$NEW_VERSION" > dracut-version.sh
+# update DRACUT_VERSION
+sed -i "s;^\(DRACUT_VERSION\)=\".*\"$;\1=\"$(DRACUT_FULL_VERSION)\";" dracut.sh
 
 if [ -z "$(git config --get user.name)" ]; then
     git config user.name "dracutng[bot]"
@@ -62,7 +62,7 @@ if [ -z "$(git config --get user.email)" ]; then
 fi
 
 # Check in AUTHORS and NEWS.md
-git commit -m "docs: update NEWS.md and AUTHORS for release $NEW_VERSION" NEWS.md AUTHORS dracut-version.sh
+git commit -m "docs: update NEWS.md and AUTHORS for release $NEW_VERSION" NEWS.md AUTHORS dracut.sh
 
 # git push can fail due to insufficient permissions
 if ! git push --force -u origin release; then
@@ -72,5 +72,5 @@ fi
 # tagging and release genaration is no longer automated
 # Once the created release commit is merged, create a (signed) release tag:
 #
-# . ./dracut-version.sh
+# DRACUT_VERSION=$(sed -n 's/^DRACUT_VERSION="\(.*\)"$/\1/p' dracut.sh)
 # git tag -s -m "Dracut $DRACUT_VERSION release" "$DRACUT_VERSION"


### PR DESCRIPTION
## Changes

`dracut-version.sh` is only sourced by `dracut.sh`. So move defining `DRACUT_VERSION` into `dracut.sh` and remove `dracut-version.sh`. This allows removing code for sourcing this file.

## Checklist
- [ ] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it

Fixes #
