### PR TITLE
test: drop --auto=yes from mdadm call

### DIFF
--- a/test/TEST-20-STORAGE/create-root.sh
+++ b/test/TEST-20-STORAGE/create-root.sh
@@ -17,7 +17,7 @@ else
     # storage layers (if available)
     # mdadm (optional) --> crypt (optional) --> lvm --> TEST_FSTYPE (e.g. ext4)
     if ! grep -qF 'rd.md=0' /proc/cmdline && command -v mdadm > /dev/null; then
-        mdadm --create /dev/md0 --run --auto=yes --level=1 --metadata=0.90 --raid-devices=2 /dev/disk/by-id/scsi-0QEMU_QEMU_HARDDISK_disk[12]
+        mdadm --create /dev/md0 --run --level=1 --metadata=0.90 --raid-devices=2 /dev/disk/by-id/scsi-0QEMU_QEMU_HARDDISK_disk[12]
         # wait for the array to finish initializing, otherwise this sometimes fails randomly.
         mdadm -W /dev/md0 || :
     fi

--- a/test/TEST-26-ENC-RAID-LVM/create-root.sh
+++ b/test/TEST-26-ENC-RAID-LVM/create-root.sh
@@ -7,7 +7,7 @@ cryptsetup --pbkdf pbkdf2 -q luksFormat /dev/disk/by-id/scsi-0QEMU_QEMU_HARDDISK
 cryptsetup --pbkdf pbkdf2 -q luksFormat /dev/disk/by-id/scsi-0QEMU_QEMU_HARDDISK_disk2 /keyfile
 cryptsetup luksOpen /dev/disk/by-id/scsi-0QEMU_QEMU_HARDDISK_disk1 dracut_disk1 < /keyfile
 cryptsetup luksOpen /dev/disk/by-id/scsi-0QEMU_QEMU_HARDDISK_disk2 dracut_disk2 < /keyfile
-mdadm --create /dev/md0 --run --auto=yes --level=1 --metadata=0.90 --raid-devices=2 /dev/mapper/dracut_disk1 /dev/mapper/dracut_disk2
+mdadm --create /dev/md0 --run --level=1 --metadata=0.90 --raid-devices=2 /dev/mapper/dracut_disk1 /dev/mapper/dracut_disk2
 # wait for the array to finish initializing, otherwise this sometimes fails
 # randomly.
 mdadm -W /dev/md0

--- a/test/TEST-70-ISCSI/create-client-root.sh
+++ b/test/TEST-70-ISCSI/create-client-root.sh
@@ -8,7 +8,7 @@ mkdir -p /sysroot
 mount -t ext4 /dev/disk/by-id/scsi-0QEMU_QEMU_HARDDISK_singleroot /sysroot
 cp -a -t /sysroot /source/*
 umount /sysroot
-mdadm --create /dev/md0 --run --auto=yes --level=stripe --raid-devices=2 /dev/disk/by-id/scsi-0QEMU_QEMU_HARDDISK_raid0-1 /dev/disk/by-id/scsi-0QEMU_QEMU_HARDDISK_raid0-2
+mdadm --create /dev/md0 --run --level=stripe --raid-devices=2 /dev/disk/by-id/scsi-0QEMU_QEMU_HARDDISK_raid0-1 /dev/disk/by-id/scsi-0QEMU_QEMU_HARDDISK_raid0-2
 mdadm -W /dev/md0 || :
 lvm pvcreate -ff -y /dev/md0
 lvm vgcreate dracut /dev/md0

--- a/test/TEST-71-ISCSI-MULTI/create-client-root.sh
+++ b/test/TEST-71-ISCSI-MULTI/create-client-root.sh
@@ -8,7 +8,7 @@ mkdir -p /sysroot
 mount -t ext4 /dev/disk/by-id/scsi-0QEMU_QEMU_HARDDISK_singleroot /sysroot
 cp -a -t /sysroot /source/*
 umount /sysroot
-mdadm --create /dev/md0 --run --auto=yes --level=stripe --raid-devices=2 /dev/disk/by-id/scsi-0QEMU_QEMU_HARDDISK_raid0-1 /dev/disk/by-id/scsi-0QEMU_QEMU_HARDDISK_raid0-2
+mdadm --create /dev/md0 --run --level=stripe --raid-devices=2 /dev/disk/by-id/scsi-0QEMU_QEMU_HARDDISK_raid0-1 /dev/disk/by-id/scsi-0QEMU_QEMU_HARDDISK_raid0-2
 mdadm -W /dev/md0 || :
 lvm pvcreate -ff -y /dev/md0
 lvm vgcreate dracut /dev/md0


### PR DESCRIPTION
## Changes

mdadm 4.5 emits following warning:

```
mdadm: --auto is deprecated and will be removed in future releases.
```

So drop `--auto=yes` from the `mdadm --create` calls.

## Checklist
- [ ] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it

Fixes #
