### PR TITLE
chore(deps): bump luizm/action-sh-checker from 0.9.0 to 0.10.0

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -18,6 +18,7 @@ switch_case_indent = true
 function_next_line = false
 binary_next_line   = true
 space_redirects    = true
+simplify           = true
 
 # Match config files, set indent to spaces with width of eight.
 [*.{c,h}]

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -17,9 +17,7 @@ jobs:
       - uses: actions/checkout@v6
 
       - name: shfmt
-        uses: luizm/action-sh-checker@v0.9.0
-        env:
-          SHFMT_OPTS: -s  # arguments to shfmt.
+        uses: luizm/action-sh-checker@v0.10.0
         with:
           # disable shellcheck in favor of differential-shellcheck
           sh_checker_shellcheck_disable: true

--- a/Makefile
+++ b/Makefile
@@ -110,7 +110,7 @@ indent-c:
 .PHONY: indent
 indent: indent-c
 ifeq ($(HAVE_SHFMT),yes)
-	shfmt --apply-ignore -w -s .
+	shfmt --apply-ignore -w .
 endif
 
 src/dracut-cpio/target/release/dracut-cpio: src/dracut-cpio/src/main.rs


### PR DESCRIPTION
## Changes

Bumps [luizm/action-sh-checker](https://github.com/luizm/action-sh-checker) from 0.9.0 to 0.10.0.
- [Release notes](https://github.com/luizm/action-sh-checker/releases)
- [Commits](luizm/action-sh-checker@v0.9.0...v0.10.0)

Removed the `-s` argument (stands for `--simplify`) as this argument now overrules `.editorconfig` and moved setting simplify to `.editorconfig`. 

For more info: https://github.com/mvdan/sh/releases/tag/v3.12.0

> --simplify and --minify are now formatting options, disabling the use of EditorConfig_

## Checklist
- [ ] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it
