### PR TITLE
feat(no-xattr): no longer support no-xattr config

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -32,7 +32,6 @@ configs = \
 	hostonly/10-hostonly.conf \
 	ima/10-ima.conf \
 	no-network/10-no-network.conf \
-	no-xattr/10-no-xattr.conf \
 	rescue/10-rescue.conf \
 	$(NULL)
 

--- a/dracut.conf.d/no-xattr/10-no-xattr.conf
+++ b/dracut.conf.d/no-xattr/10-no-xattr.conf
@@ -1,2 +1,0 @@
-# disable xattr
-export DRACUT_NO_XATTR=1


### PR DESCRIPTION
## Changes

Starting with dracut release v110, `no-xattr` is the default config, so it is no longer desired to maintain a separate config file for `no-xattr`.

Follow-up to 941b18d .

## Checklist
- [ ] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it

