### PR TITLE
chore(Makefile): use cp -a consistently

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -217,7 +217,7 @@ install: all
 		install -m 0644 dracut.conf.d/$$i/* $(DESTDIR)$(pkglibdir)/dracut.conf.d/ ;\
 	done
 ifeq ($(enable_test),yes)
-	cp -arx test $(DESTDIR)$(pkglibdir)
+	cp -a test $(DESTDIR)$(pkglibdir)
 	for conf in $(test_configs); do \
 		install -D -m 0644 "dracut.conf.d/$$conf" "$(DESTDIR)$(pkglibdir)/dracut.conf.d/$$conf"; \
 	done


### PR DESCRIPTION
## Changes

`cp -a` is used in all call sites except one. Update the outlier to use the -a flag for consistency.

Follow-up to a0d12aa7d .

## Checklist
- [ ] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it

