### PR TITLE
feat: always preserve file ownership

### DIFF
--- a/dracut.sh
+++ b/dracut.sh
@@ -2701,9 +2701,9 @@ if ! dracut_module_included "squash-lib"; then
 fi
 
 if [[ $EUID == "0" ]] && ! [[ ${DRACUT_NO_XATTR-} ]]; then
-    export DRACUT_CP="cp --reflink=auto --preserve=mode,timestamps,xattr,links -dfr"
+    export DRACUT_CP="cp --reflink=auto --preserve=xattr -dfrp"
 else
-    export DRACUT_CP="cp --reflink=auto --preserve=mode,timestamps,links -dfr"
+    export DRACUT_CP="cp --reflink=auto -dfrp"
 fi
 
 if ! [[ $print_cmdline ]] && ! [[ $printconfig ]]; then

--- a/modules.d/74nfs/module-setup.sh
+++ b/modules.d/74nfs/module-setup.sh
@@ -120,13 +120,13 @@ install() {
 
     # use the same directory permissions as the host
     [[ -d "${dracutsysrootdir-}"/var/lib/nfs/statd ]] \
-        && $DRACUT_CP -L -p -t "$initdir"/var/lib/nfs "${dracutsysrootdir-}"/var/lib/nfs/statd \
+        && $DRACUT_CP -L -t "$initdir"/var/lib/nfs "${dracutsysrootdir-}"/var/lib/nfs/statd \
         && rm -rf "$initdir"/var/lib/nfs/statd/*
     [[ -d "${dracutsysrootdir-}"/var/lib/nfs/statd/sm ]] \
-        && $DRACUT_CP -L -p -t "$initdir"/var/lib/nfs/statd "${dracutsysrootdir-}"/var/lib/nfs/statd/sm \
+        && $DRACUT_CP -L -t "$initdir"/var/lib/nfs/statd "${dracutsysrootdir-}"/var/lib/nfs/statd/sm \
         && rm -rf "$initdir"/var/lib/nfs/statd/sm/*
     [[ -d "${dracutsysrootdir-}"/var/lib/nfs/sm ]] \
-        && $DRACUT_CP -L -p -t "$initdir"/var/lib/nfs "${dracutsysrootdir-}"/var/lib/nfs/sm \
+        && $DRACUT_CP -L -t "$initdir"/var/lib/nfs "${dracutsysrootdir-}"/var/lib/nfs/sm \
         && rm -rf "$initdir"/var/lib/nfs/sm/*
 
     # Rather than copy the passwd file in, just set a user for rpcbind

--- a/src/install/dracut-install.c
+++ b/src/install/dracut-install.c
@@ -437,10 +437,13 @@ static int cp(const char *src, const char *dst)
 
 normal_copy:
         pid = fork();
-        const char *preservation = (geteuid() == 0
-                                    && no_xattr == false) ? "--preserve=mode,xattr,timestamps,ownership" : "--preserve=mode,timestamps,ownership";
+        bool preservation = geteuid() == 0 && no_xattr == false;
+
         if (pid == 0) {
-                execlp("cp", "cp", "--reflink=auto", preservation, "-fL", src, dst, NULL);
+                if (preservation)
+                        execlp("cp", "cp", "--reflink=auto", "--preserve=xattr", "-fLp", src, dst, NULL);
+                else
+                        execlp("cp", "cp", "--reflink=auto", "-fLp", src, dst, NULL);
                 _exit(errno == ENOENT ? 127 : 126);
         }
 
@@ -451,8 +454,12 @@ normal_copy:
                 }
         }
         ret = WIFSIGNALED(ret) ? 128 + WTERMSIG(ret) : WEXITSTATUS(ret);
-        if (ret != 0)
-                log_error("ERROR: 'cp --reflink=auto %s -fL %s %s' failed with %d", preservation, src, dst, ret);
+        if (ret != 0) {
+                if (preservation)
+                        log_error("ERROR: 'cp --reflink=auto --preserve=xattr -fLp %s %s' failed with %d", src, dst, ret);
+                else
+                        log_error("ERROR: 'cp --reflink=auto -fLp %s %s' failed with %d", src, dst, ret);
+        }
         log_debug("cp ret = %d", ret);
         return ret;
 }


### PR DESCRIPTION
## Changes

Currently file ownership is almost always preserved, except when DRACUT_CP variable is used.

Make all file copying consistent and always preserve file ownership by passing `-p` to `cp`.

Follow-up to 9ef73b6ad .

## Checklist
- [ ] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it

