### PR TITLE
ci: drop alpine:latest and run tests only on alpine:edge

### DIFF
--- a/.github/workflows/container-extra.yml
+++ b/.github/workflows/container-extra.yml
@@ -41,7 +41,6 @@ jobs:
                     - {dockerfile: 'Dockerfile-debian', tag: 'debian:sid'}
                     - {dockerfile: 'Dockerfile-debian', tag: 'ubuntu:devel'}
                     - {dockerfile: 'Dockerfile-debian', tag: 'ubuntu:rolling'}
-                    - {dockerfile: 'Dockerfile-alpine', tag: 'alpine:edge'}
                     - {dockerfile: 'Dockerfile-gentoo', tag: 'gentoo:latest', option: 'systemd'}
                     - {dockerfile: 'Dockerfile-gentoo', tag: 'gentoo:amd64-openrc', option: 'amd64-openrc'}
                     - {dockerfile: 'Dockerfile-fedora', tag: 'fedora:rawhide', registry: 'registry.fedoraproject.org'}

--- a/.github/workflows/container.yml
+++ b/.github/workflows/container.yml
@@ -41,7 +41,7 @@ jobs:
                     - {dockerfile: 'Dockerfile-arch', tag: 'arch:latest'}
                     - {dockerfile: 'Dockerfile-debian', tag: 'ubuntu:devel'}
                     - {dockerfile: 'Dockerfile-debian', tag: 'ubuntu:rolling'}
-                    - {dockerfile: 'Dockerfile-alpine', tag: 'alpine:latest'}
+                    - {dockerfile: 'Dockerfile-alpine', tag: 'alpine:edge'}
                     - {dockerfile: 'Dockerfile-void', tag: 'void:latest'}
                 exclude:
                     - config: {tag: 'arch:latest'}

--- a/.github/workflows/doc.yml
+++ b/.github/workflows/doc.yml
@@ -22,7 +22,7 @@ jobs:
             fail-fast: false
             matrix:
                 container:
-                    - alpine:latest
+                    - alpine:edge
                     - arch:latest
                     - debian:latest
                     - fedora:latest

--- a/.github/workflows/integration-extra.yml
+++ b/.github/workflows/integration-extra.yml
@@ -25,7 +25,6 @@ jobs:
             fail-fast: false
             matrix:
                 container:
-                    - alpine:latest
                     - alpine:edge
                     - arch:latest
                     - azurelinux:3.0

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -30,7 +30,7 @@ jobs:
             fail-fast: false
             matrix:
                 container:
-                    - alpine:latest
+                    - alpine:edge
                     - arch:latest
                     - debian:latest
                     - fedora:latest

--- a/.github/workflows/manualtest.yml
+++ b/.github/workflows/manualtest.yml
@@ -13,7 +13,6 @@ on:  # yamllint disable-line rule:truthy
                 default: 'all'
                 options:
                     - "all"
-                    - "alpine:latest"
                     - "alpine:edge"
                     - "azurelinux:3.0"
                     - "centos:latest"


### PR DESCRIPTION
## Changes

alpine:edge has been very stable CI environment for this project, so let's promote it to the main CI and at the same time let's retire alpine:latest.

The goal of this PR is to reduce time and computation on the CI without loosing significant test coverage.

## Checklist
- [ ] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it


