### PR TITLE
ci(alpine-busybox): alpine container with busybox 

### DIFF
--- a/.github/workflows/container.yml
+++ b/.github/workflows/container.yml
@@ -42,6 +42,7 @@ jobs:
                     - {dockerfile: 'Dockerfile-debian', tag: 'ubuntu:devel'}
                     - {dockerfile: 'Dockerfile-debian', tag: 'ubuntu:rolling'}
                     - {dockerfile: 'Dockerfile-alpine', tag: 'alpine:edge'}
+                    - {dockerfile: 'Dockerfile-alpine-busybox', tag: 'alpine-busybox:edge'}
                     - {dockerfile: 'Dockerfile-void', tag: 'void:latest'}
                 exclude:
                     - config: {tag: 'arch:latest'}

--- a/test/container/Dockerfile-alpine-busybox
+++ b/test/container/Dockerfile-alpine-busybox
@@ -1,0 +1,18 @@
+# Tiny container with busybox
+# GNU coreutils should not be installed
+
+FROM docker.io/alpine:edge
+
+RUN apk add --no-cache \
+    bash \
+    e2fsprogs \
+    eudev \
+    findmnt \
+    gcc \
+    grep \
+    kmod-dev \
+    linux-virt \
+    make \
+    musl-dev  \
+    musl-fts-dev \
+    qemu-system-$(uname -m)


### PR DESCRIPTION
## Changes

The `coreutils` binaries are not installed and only `busybox` binaries are available.

This container is meant to prevent regressions when running basic test with `busybox`.

## Checklist
- [ ] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it


