### PR TITLE
ci: verify marker images consistently

### DIFF
--- a/test/TEST-20-STORAGE/test.sh
+++ b/test/TEST-20-STORAGE/test.sh
@@ -157,7 +157,7 @@ test_setup() {
     if [ -n "$HAVE_CRYPT" ] && [ -n "$HAVE_RAID" ]; then
         test_makeroot "raid-crypt" "raid-crypt" " "
 
-        eval "$(grep -F --binary-files=text -m 1 MD_UUID "$TESTDIR"/marker.img)"
+        eval "$(grep -F -a -m 1 MD_UUID "$TESTDIR"/marker.img)"
         echo "$MD_UUID" > "$TESTDIR"/mduuid
 
         eval "$(grep -F -a -m 1 ID_FS_UUID "$TESTDIR"/marker.img)"

--- a/test/TEST-26-ENC-RAID-LVM/test.sh
+++ b/test/TEST-26-ENC-RAID-LVM/test.sh
@@ -84,7 +84,7 @@ test_setup() {
         -append "root=/dev/fakeroot quiet" \
         -initrd "$TESTDIR"/initramfs.makeroot
     test_marker_check dracut-root-block-created
-    cryptoUUIDS=$(grep -F --binary-files=text -m 3 ID_FS_UUID "$TESTDIR"/marker.img)
+    cryptoUUIDS=$(grep -F -a -m 3 ID_FS_UUID "$TESTDIR"/marker.img)
     for uuid in $cryptoUUIDS; do
         eval "$uuid"
         printf ' rd.luks.uuid=luks-%s ' "$ID_FS_UUID"

--- a/test/TEST-30-DMSQUASH/test.sh
+++ b/test/TEST-30-DMSQUASH/test.sh
@@ -74,7 +74,7 @@ test_run() {
 
         # Verify that the string "dracut-autooverlay-success" occurs in the second partition in the image file.
         dd if="$TESTDIR"/root.img bs=1MiB status=none \
-            | grep -U --binary-files=binary -F -m 1 -q dracut-autooverlay-success
+            | grep -F -a -m 1 -q dracut-autooverlay-success
     )
 
     return 0

--- a/test/test-functions
+++ b/test/test-functions
@@ -265,7 +265,7 @@ test_marker_check() {
     local marker=${1:-dracut-root-block-success}
     local file=${2:-marker.img}
 
-    grep -U --binary-files=binary -F -m 1 -q "$marker" "$TESTDIR/$file"
+    grep -F -a -m 1 -q "$marker" "$TESTDIR/$file"
     return $?
 }
 


### PR DESCRIPTION
## Changes

Use `grep -F -a` to check marker images after test runs.

This affects test evaluation only and does not modify dracut core logic.

## Checklist
- [ ] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it

