### PR TITLE
feat(dracut): allow hostonly mode if /sys /proc or /run is missing

### DIFF
--- a/dracut.sh
+++ b/dracut.sh
@@ -1362,12 +1362,12 @@ else
 fi
 
 if [[ ${hostonly-} ]]; then
-    for i in /sys /proc /run /dev; do
-        if ! findmnt --target "$i" &> /dev/null; then
-            dwarning "Turning off host-only mode: '$i' is not mounted!"
-            unset hostonly
-        fi
-    done
+    if ! findmnt --target "/dev" &> /dev/null; then
+        dwarning "Turning off host-only mode: /dev is not mounted!"
+        unset hostonly
+    elif ! findmnt --target "/sys" &> /dev/null; then
+        dwarning "Hostonly mode with no /sys mounted!"
+    fi
 fi
 
 case $hostonly_mode in


### PR DESCRIPTION
## Changes

Missing /sys, /proc, or /run no longer forces non-hostonly mode. Hostonly initramfs generation still requires /dev to be mounted and  continues to work in chroot environments where these filesystems may be absent.                                                                                                                                                                                                                            
                                                                                                                                                                                                                                      
If /sys is missing, dracut emits a warning but does not fall back to non-hostonly mode. Hostonly generation should not depend on /sys, /proc, or /run being mounted.

## Checklist
- [ ] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it

