### PR TITLE
ci(alpine-busybox): GNU grep is no longer required

### DIFF
--- a/test/container/Dockerfile-alpine-busybox
+++ b/test/container/Dockerfile-alpine-busybox
@@ -1,5 +1,5 @@
 # Tiny container with busybox
-# GNU coreutils should not be installed
+# GNU coreutils and GNU grep should not be installed
 
 FROM docker.io/alpine:edge
 
@@ -9,7 +9,6 @@ RUN apk add --no-cache \
     eudev \
     findmnt \
     gcc \
-    grep \
     kmod-dev \
     linux-virt \
     make \


### PR DESCRIPTION
## Changes

busybox grep is supports all the required functionality and command line arguments to pass dracut's basic test.

Follow-up to 2de5129 .

## Checklist
- [ ] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it

