### PR TITLE
refactor: move defining inst_sysusers to dracut-functions.sh

### DIFF
--- a/dracut-functions.sh
+++ b/dracut-functions.sh
@@ -1304,6 +1304,15 @@ inst_rules() {
     done
 }
 
+# install sysusers files
+inst_sysusers() {
+    inst_multiple -o "$sysusers/$*" "$sysusers/acct-*-$*"
+
+    if [[ ${hostonly-} ]]; then
+        inst_multiple -H -o "$sysusersconfdir/$*" "$sysusers/acct-*-$*"
+    fi
+}
+
 # inst_libdir_dir <dir> [<dir>...]
 # Install a <dir> located on a lib directory to the initramfs image
 inst_libdir_dir() {

--- a/dracut.sh
+++ b/dracut.sh
@@ -1633,16 +1633,6 @@ build_ld_cache() {
     fi
 }
 
-# install sysusers files
-# shellcheck disable=SC2317,SC2329
-inst_sysusers() {
-    inst_multiple -o "$sysusers/$*" "$sysusers/acct-*-$*"
-
-    if [[ ${hostonly-} ]]; then
-        inst_multiple -H -o "$sysusersconfdir/$*" "$sysusers/acct-*-$*"
-    fi
-}
-
 module_functions=(
     check
     depends

--- a/man/dracut.modules.7.adoc
+++ b/man/dracut.modules.7.adoc
@@ -317,6 +317,11 @@ installs an executable/script <src> in the dracut hook <hookdir> with priority
 installs one or more udev rules. Non-existent udev rules are reported, but do
 not let dracut fail.
 
+==== inst_sysusers <sysuserconf>
+
+installs one sysuser config files. Non-existent sysuser config file
+is reported, but does not let dracut fail.
+
 ==== inst_libdir_dir <dir> [<dir>...]
 
 installs multiple directories (but not their content) located on a library


### PR DESCRIPTION
## Changes

`inst_sysusers` is a public interface to dracut modules, move it to `dracut-functions.sh`.

Document `inst_sysusers` in the man page as from now on it is a public interface.

## Checklist
- [ ] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it

