### PR TITLE
test(KERNEL-INSTALL): layout and uki_generator set must be set on Gentoo        

### DIFF
--- a/test/TEST-43-KERNEL-INSTALL/test.sh
+++ b/test/TEST-43-KERNEL-INSTALL/test.sh
@@ -50,7 +50,7 @@ test_setup() {
     build_ext4_image "$TESTDIR"/dracut.*/initramfs/ "$TESTDIR"/root.img dracut
 
     mkdir -p /run/kernel /run/initramfs/dracut.conf.d
-    echo 'initrd_generator=dracut' >> /run/kernel/install.conf
+    printf "layout=bls\ninitrd_generator=dracut\nuki_generator=none\n" >> /run/kernel/install.conf
 
     # enable test dracut config
     cp "${basedir}"/dracut.conf.d/test/*.conf /run/initramfs/dracut.conf.d/


### PR DESCRIPTION
## Changes

Set layout, initrd_generator, and uki_generator for kernel-install.

## Checklist
- [ ] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it

Fixes #2018
