### PR TITLE
ci: daily busybox tests

### DIFF
--- a/.github/workflows/daily-busybox-x64.yml
+++ b/.github/workflows/daily-busybox-x64.yml
@@ -1,0 +1,43 @@
+---
+name: Daily Tests - busybox (x64)
+
+on:  # yamllint disable-line rule:truthy
+    schedule:
+        - cron: '30 23 * * *'   # every day at 23:30 UTC
+
+    # Allows you to run this workflow manually from the Actions tab
+    workflow_dispatch:
+
+    pull_request:
+        paths:
+            - '.github/workflows/daily-busybox-x64.yml'
+
+jobs:
+    busybox:
+        name: ${{ matrix.config.test }}
+        runs-on: ubuntu-24.04
+        timeout-minutes: 20
+        concurrency:
+            group: daily-busybox-${{ github.workflow }}-${{ github.ref }}-${{ matrix.container }}-${{ matrix.config.test }}
+            cancel-in-progress: true
+        strategy:
+            fail-fast: false
+            matrix:
+                container:
+                    - alpine-busybox:edge
+                config:
+                    - {test: '10', deps: ''}
+                    - {test: '11', deps: 'btrfs-progs'}
+                    - {test: '13', deps: ''}
+                    - {test: '20', deps: 'lvm2 device-mapper'}
+                    - {test: '26', deps: 'cryptsetup mdadm device-mapper lvm2 partx sed'}
+                    - {test: '50', deps: 'networkmanager-initrd-generator networkmanager'}
+                    - {test: '81', deps: ''}
+        container:
+            image: ghcr.io/dracut-ng/${{ matrix.container }}-amd
+            options: '--device=/dev/kvm --privileged'
+        steps:
+            - name: "Checkout Repository"
+              uses: actions/checkout@v6
+            - name: "TEST-${{ matrix.config.test }}"
+              run: TEST_CONTAINER_COMMAND="apk add ${{ matrix.config.deps }}" ./test/test-container.sh "TEST-${{ matrix.config.test }}" ${{ matrix.config.test }}

--- a/.github/workflows/daily-busybox-x64.yml
+++ b/.github/workflows/daily-busybox-x64.yml
@@ -33,6 +33,7 @@ jobs:
                     - {test: '26', deps: 'cryptsetup mdadm device-mapper lvm2 partx sed'}
                     - {test: '30', deps: 'squashfs-tools sfdisk device-mapper grep parted'}
                     - {test: '50', deps: 'networkmanager-initrd-generator networkmanager'}
+                    - {test: '80', deps: ''}
                     - {test: '81', deps: ''}
         container:
             image: ghcr.io/dracut-ng/${{ matrix.container }}-amd

--- a/.github/workflows/daily-busybox-x64.yml
+++ b/.github/workflows/daily-busybox-x64.yml
@@ -31,6 +31,7 @@ jobs:
                     - {test: '13', deps: ''}
                     - {test: '20', deps: 'lvm2 device-mapper'}
                     - {test: '26', deps: 'cryptsetup mdadm device-mapper lvm2 partx sed'}
+                    - {test: '30', deps: 'squashfs-tools sfdisk device-mapper grep parted'}
                     - {test: '50', deps: 'networkmanager-initrd-generator networkmanager'}
                     - {test: '81', deps: ''}
         container:

--- a/test/TEST-30-DMSQUASH/test.sh
+++ b/test/TEST-30-DMSQUASH/test.sh
@@ -73,7 +73,7 @@ test_run() {
         set +o pipefail
 
         # Verify that the string "dracut-autooverlay-success" occurs in the second partition in the image file.
-        dd if="$TESTDIR"/root.img bs=1MiB status=none \
+        dd if="$TESTDIR"/root.img bs=1M status=none \
             | grep -F -a -m 1 -q dracut-autooverlay-success
     )
 

--- a/test/TEST-80-GETARG/test.sh
+++ b/test/TEST-80-GETARG/test.sh
@@ -15,10 +15,10 @@ test_check() {
 }
 
 test_setup() {
-    ln -sfnr "$PKGLIBDIR"/dracut-util "$TESTDIR"/dracut-getarg
-    ln -sfnr "$PKGLIBDIR"/dracut-util "$TESTDIR"/dracut-getargs
-    ln -sfnr "$PKGLIBDIR"/modules.d/[0-9][0-9]base/dracut-lib.sh "$TESTDIR"/dracut-lib.sh
-    ln -sfnr "$PKGLIBDIR"/modules.d/[0-9][0-9]base/dracut-dev-lib.sh "$TESTDIR"/dracut-dev-lib.sh
+    ln -sfn "$PKGLIBDIR"/dracut-util "$TESTDIR"/dracut-getarg
+    ln -sfn "$PKGLIBDIR"/dracut-util "$TESTDIR"/dracut-getargs
+    ln -sfn "$PKGLIBDIR"/modules.d/[0-9][0-9]base/dracut-lib.sh "$TESTDIR"/dracut-lib.sh
+    ln -sfn "$PKGLIBDIR"/modules.d/[0-9][0-9]base/dracut-dev-lib.sh "$TESTDIR"/dracut-dev-lib.sh
     return 0
 }
 

--- a/test/test-container.sh
+++ b/test/test-container.sh
@@ -8,6 +8,9 @@ if command -v systemd-detect-virt > /dev/null && ! systemd-detect-virt -c &> /de
     exit 1
 fi
 
+# allow the execution of arbitrary commands within the test container
+[[ -n ${TEST_CONTAINER_COMMAND-} ]] && eval "$TEST_CONTAINER_COMMAND"
+
 set -eu
 if [ "${V-}" = "2" ]; then set -x; fi
 
@@ -26,9 +29,6 @@ if [ "${V-}" = "2" ]; then set -x; fi
 
 # shellcheck disable=SC2086
 ./configure --enable-test ${CONFIGURE_ARG-}
-
-# allow the execution of arbitrary commands within the test container
-[[ -n ${TEST_CONTAINER_COMMAND-} ]] && eval "$TEST_CONTAINER_COMMAND"
 
 # treat warnings as error
 # shellcheck disable=SC2086


### PR DESCRIPTION
## Changes

- Add a GitHub action to run and pass as many of the existing tests as possible without installing coreutils.
- run TEST_CONTAINER_COMMAND before configure runs
- make test 30, 80 compatible with busybox

## Checklist
- [ ] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it

