### PR TITLE
ci: move mkosi testing into daily testsuite

### DIFF
--- a/.github/workflows/daily-mkosi-x64.yml
+++ b/.github/workflows/daily-mkosi-x64.yml
@@ -1,0 +1,37 @@
+---
+name: Daily Tests - mkosi (x64)
+
+on:  # yamllint disable-line rule:truthy
+    schedule:
+        - cron: '30 23 * * *'   # every day at 23:30 UTC
+
+    # Allows you to run this workflow manually from the Actions tab
+    workflow_dispatch:
+
+    pull_request:
+        paths:
+            - '.github/workflows/daily-mkosi-x64.yml'
+
+jobs:
+    mkosi:
+        name: ${{ matrix.config.test }}
+        runs-on: ubuntu-24.04
+        timeout-minutes: 30
+        concurrency:
+            group: daily-mkosi-${{ github.workflow }}-${{ github.ref }}-${{ matrix.container }}-${{ matrix.config.test }}
+            cancel-in-progress: true
+        strategy:
+            fail-fast: false
+            matrix:
+                container:
+                    - opensuse:latest
+                config:
+                    - {test: '41', deps: 'mkosi-initrd'}
+        container:
+            image: ghcr.io/dracut-ng/${{ matrix.container }}-amd
+            options: '--device=/dev/kvm --privileged'
+        steps:
+            - name: "Checkout Repository"
+              uses: actions/checkout@v6
+            - name: "TEST-${{ matrix.config.test }}"
+              run: TEST_CONTAINER_COMMAND="zypper --non-interactive install ${{ matrix.config.deps }}" ./test/test-container.sh "TEST-${{ matrix.config.test }}" ${{ matrix.config.test }}

--- a/test/container/Dockerfile-opensuse
+++ b/test/container/Dockerfile-opensuse
@@ -2,7 +2,6 @@
 # - arm64
 # - hostonly
 # - network-legacy
-# - mkosi-initrd
 # - hmaccalc (fido)
 # - rdma out of tree dracut module
 # - dbus-broker
@@ -37,7 +36,6 @@ RUN zypper --non-interactive install --no-recommends \
     lvm2 \
     make \
     mdadm \
-    mkosi-initrd \
     nbd \
     NetworkManager \
     nfs-kernel-server \


### PR DESCRIPTION
## Changes

`mkosi` is not default/native in any of the test containers and it does not seem to be stable. Move running `mkosi` reference into daily testing so that the dedicated GitHub Action can be just disabled without a PR.

## Checklist
- [ ] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it

