### PR TITLE
ci(openSUSE): container build fix

### DIFF
--- a/test/container/Dockerfile-opensuse
+++ b/test/container/Dockerfile-opensuse
@@ -46,7 +46,7 @@ RUN zypper --non-interactive install --no-recommends \
     pciutils \
     python3-pefile \
     qemu \
-    ruby3.4-rubygem-asciidoctor \
+    ruby4.0-rubygem-asciidoctor \
     squashfs \
     swtpm \
     systemd-boot \


### PR DESCRIPTION
## Changes

ruby3.4-rubygem-asciidoctor is now called ruby4.0-rubygem-asciidoctor.

## Checklist
- [ ] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it
