### PR TITLE
ci: simplify GitHub Action job naming

### DIFF
--- a/.github/workflows/daily-iscsi-x64.yml
+++ b/.github/workflows/daily-iscsi-x64.yml
@@ -1,5 +1,5 @@
 ---
-name: Daily Tests - network-manager-iscsi (x64)
+name: Daily Tests - iscsi (x64)
 
 on:  # yamllint disable-line rule:truthy
     schedule:
@@ -10,21 +10,19 @@ on:  # yamllint disable-line rule:truthy
 
     pull_request:
         paths:
-            - '.github/workflows/daily-network-manager-iscsi-x64.yml'
+            - '.github/workflows/daily-iscsi-x64.yml'
 
 jobs:
-    network-manager-iscsi:
-        name: ${{ matrix.test }} on ${{ matrix.container }} ${{ matrix.network }} networking
+    iscsi:
+        name: ${{ matrix.test }} on ${{ matrix.container }}
         runs-on: ubuntu-24.04
         timeout-minutes: 20
         concurrency:
-            group: daily-network-manager-iscsi-${{ github.workflow }}-${{ github.ref }}-${{ matrix.container }}-${{ matrix.test }}-${{ matrix.network }}-amd
+            group: daily-iscsi-${{ github.workflow }}-${{ github.ref }}-${{ matrix.container }}-${{ matrix.test }}-amd
             cancel-in-progress: true
         strategy:
             fail-fast: false
             matrix:
-                network:
-                    - network-manager
                 container:
                     - debian:latest
                     - debian:sid
@@ -40,4 +38,4 @@ jobs:
             - name: "Checkout Repository"
               uses: actions/checkout@v6
             - name: "${{ matrix.container }} TEST-${{ matrix.test }}"
-              run: USE_NETWORK=${{ matrix.network }} ./test/test-container.sh "TEST-${{ matrix.test }}" ${{ matrix.test }}
+              run: ./test/test-container.sh "TEST-${{ matrix.test }}" ${{ matrix.test }}

--- a/.github/workflows/daily-iscsi-x64.yml
+++ b/.github/workflows/daily-iscsi-x64.yml
@@ -24,8 +24,6 @@ jobs:
             fail-fast: false
             matrix:
                 container:
-                    - debian:latest
-                    - debian:sid
                     - ubuntu:devel
                     - ubuntu:rolling
                 test:

--- a/.github/workflows/daily-network.yml
+++ b/.github/workflows/daily-network.yml
@@ -1,5 +1,5 @@
 ---
-name: Daily Tests - network-manager
+name: Daily Tests - network
 
 on:  # yamllint disable-line rule:truthy
     schedule:
@@ -10,15 +10,15 @@ on:  # yamllint disable-line rule:truthy
 
     pull_request:
         paths:
-            - '.github/workflows/daily-network-manager.yml'
+            - '.github/workflows/daily-network.yml'
 
 jobs:
-    network-manager:
+    network:
         name: ${{ matrix.test }} on ${{ matrix.container }} on ${{ matrix.architecture.tag }}
         runs-on: ${{ matrix.architecture.runner }}
         timeout-minutes: 40
         concurrency:
-            group: daily-network-manager-${{ github.workflow }}-${{ github.ref }}-${{ matrix.container }}-${{ matrix.test }}-${{ matrix.network }}-${{ matrix.architecture.tag }}
+            group: daily-network-${{ github.workflow }}-${{ github.ref }}-${{ matrix.container }}-${{ matrix.test }}-${{ matrix.architecture.tag }}
             cancel-in-progress: true
         strategy:
             fail-fast: false
@@ -26,8 +26,6 @@ jobs:
                 architecture:
                     - {runner: 'ubuntu-24.04', tag: 'amd'}
                     - {runner: 'ubuntu-24.04-arm', tag: 'arm'}
-                network:
-                    - network-manager
                 container:
                     - arch:latest
                     - debian:latest
@@ -63,4 +61,4 @@ jobs:
             - name: "Checkout Repository"
               uses: actions/checkout@v6
             - name: "${{ matrix.container }} TEST-${{ matrix.test }}"
-              run: USE_NETWORK=${{ matrix.network }} ./test/test-container.sh "TEST-${{ matrix.test }}" ${{ matrix.test }}
+              run: ./test/test-container.sh "TEST-${{ matrix.test }}" ${{ matrix.test }}


### PR DESCRIPTION
## Changes

network-manager dracut module is the default networking provider.

Remove forcing network-manager networking and simplify naming.

## Checklist
- [ ] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it

