### PR TITLE
ci: enable daily-systemd on ubuntu:devel-arm

### DIFF
--- a/.github/workflows/daily-systemd.yml
+++ b/.github/workflows/daily-systemd.yml
@@ -65,10 +65,7 @@ jobs:
                     - container: centos:latest
                       test: "41"
                     # /boot/vmlinuz-... is missing .efi suffix: https://launchpad.net/bugs/2133402
-                    - container: ubuntu:devel
-                      architecture: {runner: 'ubuntu-24.04-arm', tag: 'arm'}
-                      test: "43"
-                    # /boot/vmlinuz-... is missing .efi suffix: https://launchpad.net/bugs/2133402
+                    # Ubuntu 25.10 is affected, will work with Ubuntu 26.04
                     - container: ubuntu:rolling
                       architecture: {runner: 'ubuntu-24.04-arm', tag: 'arm'}
                       test: "43"


### PR DESCRIPTION
## Changes

https://launchpad.net/bugs/2133402 has been fixed on the Ubuntu devel release. linux 6.19.0-3.3 contains the fixed stubble.

## Checklist
- [ ] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it

Fixes #
