### PR TITLE
test: run QEMU with a timeout unless daemonized

### DIFF
--- a/test/run-qemu
+++ b/test/run-qemu
@@ -194,5 +194,11 @@ if [[ -n $initrd ]]; then
     add_to_append "console=${console:-ttyS0},115200"
 fi
 
+if ! [[ $* == *-daemonize* ]] && timeout --help 2> /dev/null | grep -q -- --foreground; then
+    # Run QEMU with a timeout (defaut: 10min) unless daemonized
+    ARGS=(--foreground "${QEMU_TIMEOUT-600}" "$BIN" "${ARGS[@]}")
+    BIN=timeout
+fi
+
 echo "${0##*/}: $BIN $(quote_args "${ARGS[@]}")"
 exec "$BIN" "${ARGS[@]}"


### PR DESCRIPTION
## Changes

Dracut tests might hang. The Dracut CI sets a timeout to kill those hanging tests, but downstream might not configure something similar.

Run QEMU with a timeout (unless daemonized) to avoid hanging tests forever.

The slowest tests executions that I have seen on Debian/Ubuntu:

* 33:44 for test 11 (5 client tests) on Ubuntu resolute on armhf
* 101:58 for test 60 (19 client tests) on Debian unstable on ppc64el
* 19:58 for test 70 (3 client tests) on Ubuntu resolute on arm64
* 22:35 for test 71 (4 client tests) on Ubuntu resolute on arm64
* 52:48 for test 72 (8 client tests) Debian unstable on ppc64el

These slow tests take between 5:22 and 6:45 for each client tests on average (ignoring the setup cost). So set the timeout to 10 minutes as default.

## Checklist
- [ ] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it

Fixes: https://bugs.debian.org/1121884