### PR TITLE
feat: rename rd.live.overlay to rd.overlay

### DIFF
--- a/man/dracut.cmdline.7.adoc
+++ b/man/dracut.cmdline.7.adoc
@@ -1135,7 +1135,7 @@ leading to application failures.  The snapshot overlay device is marked
 'Overflow', and a difficult recovery is required to repair and enlarge the
 overlay offline.
 
-When _rd.live.overlay=_ is not specified for persistent overlay storage, or
+When _rd.overlay=_ is not specified for persistent overlay storage, or
 the specified file is not found or writable, a Device-mapper snapshot based
 non-persistent or temporary overlay is automatically created as a sparse file
 in RAM of the initramfs.  This file will only consume content space as required
@@ -1153,7 +1153,7 @@ This shortage could be remedied by building the root filesystem with more
 allocated free space, or the OverlayFS based overlay mount method can be used.
 
 When the _rd.overlayfs_ option is specified or when
-_rd.live.overlay=_ points to an appropriate directory with a sister at
+_rd.overlay=_ points to an appropriate directory with a sister at
 `/../ovlwork`, then an OverlayFS based overlay mount is employed.  Such a
 persistent OverlayFS overlay can extend the available root filesystem storage
 up to the capacity of the LiveOS disk device.
@@ -1216,7 +1216,7 @@ is involved during boot.
 root filesystem is copied during boot to `/run/initramfs/rootfs.img` in the
 `/run` tmpfs.
 +
-- If **rd.live.overlay=none** is provided as a kernel command line option,
+- If **rd.overlay=none** is provided as a kernel command line option,
 a writable, linear Device-mapper target is created on boot with no overlay.
 
 Writable filesystem image:::
@@ -1306,8 +1306,8 @@ By default, this is __squashfs.img__.
 Copy the complete image to RAM and use this for booting. This is useful
 when the image resides on, e.g., a DVD which needs to be ejected later on.
 
-**rd.live.overlay={**__<devspec>__[:__{<pathspec>|auto}__]|__none__}::
-Manage the usage of a persistent overlay.
+**rd.overlay={**__<devspec>__[:__{<pathspec>|auto}__]|__none__}::
+Manage the usage of a persistent overlay for live images.
 +
 --
 * _<devspec>_ specifies the path to a device with a mountable filesystem.
@@ -1336,8 +1336,8 @@ Device-mapper or OverlayFS) will be detected and it will be used.
 [listing]
 .Examples
 --
-rd.live.overlay=/dev/sdb1:/persistent-overlay.img
-rd.live.overlay=UUID=99440c1f-8daa-41bf-b965-b7240a8996f4
+rd.overlay=/dev/sdb1:/persistent-overlay.img
+rd.overlay=UUID=99440c1f-8daa-41bf-b965-b7240a8996f4
 --
 
 **rd.live.overlay.cowfs=**__[btrfs|ext4|xfs]__::
@@ -1365,7 +1365,7 @@ Suppresses the 'Using temporary overlay' blocking prompt that asks for a
 user confirmation before proceeding to boot. This allows the boot process
 to continue to completion without user interation.
 
-**rd.live.overlay.reset=**1::
+**rd.overlay.reset=**1::
 Specifies that a persistent overlay should be reset on boot.  All previous root
 filesystem changes are vacated by this action.
 
@@ -1525,6 +1525,10 @@ EXT_KEYMAP:: vconsole.keymap.ext
 rd.live.overlay.overlayfs:: rd.overlayfs
 
 rd.live.overlay.readonly:: rd.overlayfs.readonly
+
+rd.live.overlay:: rd.overlay
+
+rd.live.overlay.reset:: rd.overlay.reset
 
 Configuration in the Initramfs
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/man/dracut.usage.adoc
+++ b/man/dracut.usage.adoc
@@ -253,23 +253,23 @@ inside the initramfs to _/etc/cmdline.d/50-mycmdline.conf_.
 
 [,console]
 ----
-# mkdir -p rd.live.overlay/etc/cmdline.d
-# mkdir -p rd.live.overlay/etc/conf.d
-# echo "ip=dhcp" >> rd.live.overlay/etc/cmdline.d/50-mycmdline.conf
-# echo export FOO=testtest >> rd.live.overlay/etc/conf.d/testvar.conf
-# echo export BAR=testtest >> rd.live.overlay/etc/conf.d/testvar.conf
-# tree rd.live.overlay/
-rd.live.overlay/
+# mkdir -p rd.overlay/etc/cmdline.d
+# mkdir -p rd.overlay/etc/conf.d
+# echo "ip=dhcp" >> rd.overlay/etc/cmdline.d/50-mycmdline.conf
+# echo export FOO=testtest >> rd.overlay/etc/conf.d/testvar.conf
+# echo export BAR=testtest >> rd.overlay/etc/conf.d/testvar.conf
+# tree rd.overlay/
+rd.overlay/
 `-- etc
     |-- cmdline.d
     |   `-- 50-mycmdline.conf
     `-- conf.d
         `-- testvar.conf
 
-# dracut --include rd.live.overlay / initramfs-rd.live.overlay.img
+# dracut --include rd.overlay / initramfs-rd.overlay.img
 ----
 
-This will put the contents of the rd.live.overlay directory into the root of the
+This will put the contents of the rd.overlay directory into the root of the
 initramfs image.
 
 The --install option let you specify several files, which will get installed in

--- a/modules.d/70dmsquash-live-autooverlay/create-overlay.sh
+++ b/modules.d/70dmsquash-live-autooverlay/create-overlay.sh
@@ -9,13 +9,13 @@ if getargbool 0 rd.live.debug; then
 fi
 
 gatherData() {
-    overlay=$(getarg rd.live.overlay)
+    overlay=$(getarg rd.overlay -d rd.live.overlay)
     if [ -z "$overlay" ]; then
-        info "Skipping overlay creation: kernel command line parameter 'rd.live.overlay' is not set"
+        info "Skipping overlay creation: kernel command line parameter 'rd.overlay' is not set"
         exit 0
     fi
     if ! str_starts "${overlay}" LABEL=; then
-        die "Overlay creation failed: the partition must be set by LABEL in the 'rd.live.overlay' kernel parameter"
+        die "Overlay creation failed: the partition must be set by LABEL in the 'rd.overlay' kernel parameter"
     fi
 
     overlayLabel=${overlay#LABEL=}

--- a/modules.d/70dmsquash-live/dmsquash-live-root.sh
+++ b/modules.d/70dmsquash-live/dmsquash-live-root.sh
@@ -23,10 +23,10 @@ squash_image=$(getarg rd.live.squashimg)
 [ -z "$squash_image" ] && squash_image="squashfs.img"
 
 getargbool 0 rd.live.ram && live_ram="yes"
-getargbool 0 rd.live.overlay.reset && reset_overlay="yes"
+getargbool 0 rd.overlay.reset -d rd.live.overlay.reset && reset_overlay="yes"
 getargbool 0 rd.overlayfs.readonly -d rd.live.overlay.readonly && readonly_overlay="--readonly" || readonly_overlay=""
 getargbool 0 rd.live.overlay.nouserconfirmprompt && overlay_no_user_confirm_prompt="--noprompt" || overlay_no_user_confirm_prompt=""
-overlay=$(getarg rd.live.overlay)
+overlay=$(getarg rd.overlay -d rd.live.overlay)
 getargbool 0 rd.writable.fsimg && writable_fsimg="yes"
 overlay_size=$(getarg rd.live.overlay.size=)
 [ -z "$overlay_size" ] && overlay_size=32768

--- a/modules.d/70overlayfs/prepare-overlayfs.sh
+++ b/modules.d/70overlayfs/prepare-overlayfs.sh
@@ -3,7 +3,7 @@
 command -v getarg > /dev/null || . /lib/dracut-lib.sh
 
 getargbool 0 rd.overlayfs -d rd.live.overlay.overlayfs && overlayfs="yes"
-getargbool 0 rd.live.overlay.reset && reset_overlay="yes"
+getargbool 0 rd.overlay.reset -d rd.live.overlay.reset && reset_overlay="yes"
 
 if [ -n "$overlayfs" ]; then
     if ! [ -e /run/rootfsbase ]; then

--- a/test/TEST-30-DMSQUASH/assertion.sh
+++ b/test/TEST-30-DMSQUASH/assertion.sh
@@ -1,6 +1,7 @@
 #!/bin/sh
 
-if grep -qF ' rd.live.overlay=LABEL=persist ' /proc/cmdline; then
+# Check for both new (rd.overlay) and deprecated (rd.live.overlay) parameter names
+if grep -qE ' rd\.(live\.)?overlay=LABEL=persist ' /proc/cmdline; then
     # Writing to a file in the root filesystem lets test_run() verify that the autooverlay module successfully created
     # and formatted the overlay partition and that the dmsquash-live module used it when setting up the rootfs overlay.
     echo "dracut-autooverlay-success" > /overlay-marker

--- a/test/TEST-30-DMSQUASH/test.sh
+++ b/test/TEST-30-DMSQUASH/test.sh
@@ -60,6 +60,8 @@ check_autooverlay_marker() {
 # Reset root.img to single partition state for autooverlay test
 reset_overlay_partition() {
     test_marker_reset
+    sfdisk --delete "$TESTDIR"/root.img 2 2> /dev/null || true
+    dd if=/dev/zero of="$TESTDIR"/root.img bs=1M seek=320 count=50 conv=notrunc status=none
     local rootPartitions
     rootPartitions=$(sfdisk -d "$TESTDIR"/root.img | grep -c 'root\.img[0-9]')
     [ "$rootPartitions" -eq 1 ]

--- a/test/TEST-30-DMSQUASH/test.sh
+++ b/test/TEST-30-DMSQUASH/test.sh
@@ -84,7 +84,12 @@ test_run() {
     fi
 
     reset_overlay_partition
-    client_run "autooverlay" "rd.live.image rd.live.overlay=LABEL=persist rd.live.dir=LiveOS"
+    client_run "autooverlay" "rd.live.image rd.overlay=LABEL=persist rd.live.dir=LiveOS"
+    check_autooverlay_marker
+
+    # Test backward compatibility with rd.live.overlay (deprecated parameter)
+    reset_overlay_partition
+    client_run "autooverlay (deprecated rd.live.overlay)" "rd.live.image rd.live.overlay=LABEL=persist rd.live.dir=LiveOS"
     check_autooverlay_marker
 
     return 0

--- a/test/TEST-60-NFS/client-init.sh
+++ b/test/TEST-60-NFS/client-init.sh
@@ -14,8 +14,8 @@ while read -r dev _ fstype opts rest || [ -n "$dev" ]; do
     break
 done < /proc/mounts
 
-# fail the test of rd.live.overlay did not worked as expected
-if grep -qF 'rd.live.overlay' /proc/cmdline; then
+# fail the test if rd.overlay did not work as expected
+if grep -qF 'rd.overlay' /proc/cmdline; then
     if ! strstr "$(cat /proc/mounts)" LiveOS_rootfs; then
         echo "nfs-FAIL" | dd oflag=direct of=/dev/disk/by-id/scsi-0QEMU_QEMU_HARDDISK_marker status=none
     fi


### PR DESCRIPTION
## Changes

The overlay functionality can be used with both dmsquash-live and overlayfs modules, and is not limited to live images. This change improves naming of command line options with better namespace scoping.

Renames:
- `rd.live.overlay` -> `rd.overlay`
- `rd.live.overlay.reset` -> `rd.overlay.reset`

Backward compatibility is maintained through deprecation flags.

Related to #1929 

## Checklist
- [x] I have tested it locally
- [x] I have reviewed and updated any documentation if relevant
- [x] I am providing new code and test(s) for it
