### PR TITLE
test(KERNEL-INSTALL): check kernel-install result

### DIFF
--- a/test/TEST-43-KERNEL-INSTALL/test.sh
+++ b/test/TEST-43-KERNEL-INSTALL/test.sh
@@ -61,6 +61,10 @@ test_setup() {
     # using kernell-install to invoke dracut
     mkdir -p "$BOOT_ROOT/$TOKEN/$KVERSION" "$BOOT_ROOT/loader/entries" "$BOOT_ROOT/$TOKEN/0-rescue/loader/entries"
     kernel-install add "$KVERSION" "$KIMAGE"
+    if [[ ! -e "$BOOT_ROOT/$TOKEN/$KVERSION"/initrd ]]; then
+        echo "Error: kernel-install failed to create $BOOT_ROOT/$TOKEN/$KVERSION/initrd" >&2
+        return 1
+    fi
 }
 
 # shellcheck disable=SC1090


### PR DESCRIPTION
## Changes

The kernel-install call should create an `initrd` file that the test will use later in `test_run`. Check that this file has been created to ease debugging in case of a failure.

## Checklist
- [ ] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it

Fixes #
