### PR TITLE
feat(dracut): add busybox support for 3cpio and enhanced_cpio

### DIFF
--- a/.github/workflows/daily-busybox-x64.yml
+++ b/.github/workflows/daily-busybox-x64.yml
@@ -35,6 +35,7 @@ jobs:
                     - {test: '50', deps: 'networkmanager-initrd-generator networkmanager'}
                     - {test: '80', deps: ''}
                     - {test: '81', deps: ''}
+                    - {test: '82', deps: 'cargo procps-ng'}
         container:
             image: ghcr.io/dracut-ng/${{ matrix.container }}-amd
             options: '--device=/dev/kvm --privileged'

--- a/dracut.sh
+++ b/dracut.sh
@@ -2106,11 +2106,11 @@ if [[ $enhanced_cpio == "yes" ]]; then
     enhanced_cpio="$dracutbasedir/dracut-cpio"
     if 3cpio --help 2> /dev/null | grep -q -- --data-align; then
         # align based on statfs optimal transfer size
-        cpio_align=$(stat --file-system -c "%s" -- "$initdir")
+        cpio_align=$(stat -f -c "%s" -- "$initdir")
         unset enhanced_cpio
     elif [[ -x $enhanced_cpio ]]; then
         # align based on statfs optimal transfer size
-        cpio_align=$(stat --file-system -c "%s" -- "$initdir")
+        cpio_align=$(stat -f -c "%s" -- "$initdir")
     else
         dinfo "--enhanced-cpio ignored due to lack of 3cpio >= 0.10 or dracut-cpio"
         unset enhanced_cpio

--- a/test/TEST-82-DRACUT-CPIO/test.sh
+++ b/test/TEST-82-DRACUT-CPIO/test.sh
@@ -8,7 +8,7 @@ TEST_DESCRIPTION="kernel cpio extraction tests for dracut-cpio"
 # see dracut-cpio source for unit tests
 
 test_check() {
-    if ! [[ -x "$PKGLIBDIR/dracut-cpio" ]]; then
+    if command -v dracut-cpio &> /dev/null; then
         echo "Test needs dracut-cpio... Skipping"
         return 1
     fi


### PR DESCRIPTION
## Changes

`3cpio` and `enhanced_cpio` is already supported with `coreutils`.

This PR adds support for `3cpio` and `enhanced_cpio` for `busybox` as well. `busybox` stat does not support `file-system` syntax, instead it supports `-f` syntax only.

## Checklist
- [ ] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it
