### PR TITLE
test: drop duplicate check for -daemonize

### DIFF
--- a/test/run-qemu
+++ b/test/run-qemu
@@ -174,7 +174,7 @@ fi
 # Provide rng device sourcing the hosts /dev/urandom and other standard parameters
 ARGS+=(-smp 2 -m "${MEMORY-1024}" -nodefaults -vga none -display none -no-reboot -watchdog-action poweroff -device "${rng_device:-virtio-rng-pci}")
 
-if ! [[ $* == *-daemonize* ]] && ! [[ $* == *-daemonize* ]]; then
+if ! [[ $* == *-daemonize* ]]; then
     ARGS+=(-serial stdio)
 fi
 


### PR DESCRIPTION
## Changes

`run-qemu` checks twice for the `-daemonize` parameter.

Fixes: a3f73298f287 ("testsuite: refactor qemu options")

## Checklist
- [ ] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it

Fixes #
