### PR TITLE
ci(Alpine): add support for EFI stub and ukify

### DIFF
--- a/test/container/Dockerfile-alpine
+++ b/test/container/Dockerfile-alpine
@@ -1,5 +1,4 @@
 # Test coverage provided by this container:
-# - default hostonly
 # - musl (instead of glibc)
 # - openrc (instead of systemd)
 # - eudev (instead of systemd-udev)
@@ -14,14 +13,14 @@
 # - ntfs-3g (not enabled with linux-virt)
 # - erofs-utils (not enabled with linux-virt)
 # - multipath-tools (does not work well)
-# - ovmf (systemd-boot-efistub, UEFI, UKI is not available)
 # - kernel-install is not available
 
 ARG DISTRIBUTION=alpine
 FROM docker.io/${DISTRIBUTION}
 
-# export ARG
+# export
 ARG DISTRIBUTION
+ARG TARGETARCH
 
 # Use dracut-tests package to install dependencies for test suite
 RUN apk add --no-cache \
@@ -29,4 +28,12 @@ RUN apk add --no-cache \
     build-base \
     cargo \
     dnsmasq \
-    dracut-tests
+    dracut-tests \
+    efistub \
+    ukify
+
+RUN \
+if [ "${TARGETARCH}" == "amd64" ]; then \
+    apk add --no-cache \
+        ovmf \
+; fi


### PR DESCRIPTION
## Changes

alpine:edge has support for [EFI stub](https://pkgs.alpinelinux.org/package/edge/main/x86_64/systemd-efistub) and [ukify](https://pkgs.alpinelinux.org/package/edge/main/x86_64/ukify). Adding these packages would allow the product to increase CI test coverage.

## Checklist
- [ ] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it

