### PR TITLE
fix(dracut): remove null characters from SBATs when building UKIs

### DIFF
--- a/dracut.sh
+++ b/dracut.sh
@@ -3438,6 +3438,7 @@ get_sbat_string() {
     local inp=$1
     local out=$uefi_outdir/$2
     "${OBJCOPY:-objcopy}" -O binary --only-section=.sbat "$inp" "$out"
+    sed -i 's/\x00*$//' "$out"
     clean_sbat_string "$out"
 }
 


### PR DESCRIPTION
SBAT of kernel has null character paddings at the end. Using tools like ukify will display massive amount of '\0' in SBAT. Ukify is doing ".rstrip('b\x00')" when merging SBATs.

This pull request changes...

## Changes

## Checklist
- [X] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it

Fixes #2048
