### PR TITLE
feat(xen): introduce a new dracut module for xen kernel drivers

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -599,6 +599,10 @@ shell-interpreter:
   - changed-files:
       - any-glob-to-any-file: 'modules.d/[0-9][0-9]shell-interpreter/*'
 
+xen:
+  - changed-files:
+      - any-glob-to-any-file: 'modules.d/[0-9][0-9]xen/*'
+
 test:
   - changed-files:
       - any-glob-to-any-file: ['test/*', 'test/**/*']

--- a/doc_site/modules/ROOT/pages/modules/core.adoc
+++ b/doc_site/modules/ROOT/pages/modules/core.adoc
@@ -264,4 +264,8 @@ code, there are no specific types or categories for dracut modules.
 | watchdog-modules
 | kernel modules for watchdog loaded early in booting
 | kernel
+
+| xen
+| kernel modules for xen
+| kernel
 |===

--- a/modules.d/70xen/module-setup.sh
+++ b/modules.d/70xen/module-setup.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+
+check() {
+    return 255
+}
+
+installkernel() {
+    hostonly='' instmods \
+        xen-blkfront \
+        xen-evtchn \
+        xen-gntalloc \
+        xen-gntdev \
+        xen-pciback \
+        xen-privcmd \
+        xen-scsifront \
+        xenfs
+}


### PR DESCRIPTION
## Changes

This PR introduces a dedicated dracut module for adding xen kernel drivers to the generated initramfs.

## Checklist
- [ ] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it

Fixes #2051
