### PR TITLE
feat(gentoo): introduce a distro config file to default out of ukify

### DIFF
--- a/configure
+++ b/configure
@@ -36,6 +36,9 @@ case " $ID $ID_LIKE " in
     *" fedora "*)
         configprofile=fedora
         ;;
+    *" gentoo "*)
+        configprofile=gentoo
+        ;;
     *" suse "*)
         configprofile=opensuse
         ;;

--- a/dracut.conf.d/gentoo/01-gentoo.conf
+++ b/dracut.conf.d/gentoo/01-gentoo.conf
@@ -1,0 +1,2 @@
+# Gentoo specific Dracut configuration
+ukify="no"


### PR DESCRIPTION
## Changes
Gentoo maintains a down-stream patch to default out of `ukify`.

The goal of this PR is to help out Gentoo so that the downstream patch is no longer required.

Follow-up to 7ec5fbb.

## Checklist
- [ ] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it

Fixes #
