### PR TITLE
feat(qemu-net): auto-add qemu-net if net-lib and qemu included

### DIFF
--- a/modules.d/70qemu-net/module-setup.sh
+++ b/modules.d/70qemu-net/module-setup.sh
@@ -2,6 +2,11 @@
 
 # called by dracut
 check() {
+    if [[ $hostonly_mode != "strict" ]] && dracut_module_included "net-lib" \
+        && dracut_module_included "qemu"; then
+        return 0
+    fi
+
     is_qemu_virtualized && return 0
 
     if [[ $hostonly ]] || [[ $mount_needs ]]; then


### PR DESCRIPTION
## Changes

In the interest of improving defaults, if network and qemu dracut modules are included than automatically include dracut-net dracut modules as well.

I tested with the following dracut invocation

`dracut -a "network qemu"`

## Checklist
- [ ] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it
