### PR TITLE
feat: memdisk dracut module

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -555,6 +555,10 @@ img-lib:
   - changed-files:
       - any-glob-to-any-file: 'modules.d/[0-9][0-9]img-lib/*'
 
+memdisk:
+  - changed-files:
+      - any-glob-to-any-file: 'modules.d/[0-9][0-9]memdisk/*'
+
 memstrack:
   - changed-files:
       - any-glob-to-any-file: 'modules.d/[0-9][0-9]memstrack/*'

--- a/doc_site/modules/ROOT/pages/modules/core.adoc
+++ b/doc_site/modules/ROOT/pages/modules/core.adoc
@@ -145,6 +145,10 @@ code, there are no specific types or categories for dracut modules.
 | masterkey that can be used to decrypt other keys and https://repology.org/project/keyutils/[keyutils]
 |
 
+| memdisk
+| memdisk ISO emulation with the memdiskfind utility of the https://repology.org/project/syslinux/[syslinux] project
+| device
+
 | mdraid
 | kernel module for https://docs.kernel.org/driver-api/md/md-cluster.html[md raid cluster], https://repology.org/project/mdadm[mdadm]
 | device

--- a/modules.d/70memdisk/memdisk.sh
+++ b/modules.d/70memdisk/memdisk.sh
@@ -1,0 +1,37 @@
+#!/bin/sh
+
+set -e
+
+if ! [ -x /usr/bin/memdiskfind ]; then
+    exit 0
+fi
+
+if ! dd if=/dev/mem of=/dev/null bs=1 count=1 > /dev/null 2>&1; then
+    # Skip memdiskfind under Secure Boot and other conditions
+    # where /dev/mem is unreadable.
+    # Avoids ugly error message from memdiskfind.
+    printf "access to /dev/mem is restricted, skipping memdisk setup"
+    exit 0
+fi
+
+if ! MEMDISK=$(/usr/bin/memdiskfind); then
+    exit 0
+fi
+
+# We found a memdisk, set up phram
+# Sometimes "modprobe phram" can not successfully create /dev/mtd0.
+# Have to try several times.
+max_try=20
+while [ ! -c /dev/mtd0 ] && [ "$max_try" -gt 0 ]; do
+    modprobe phram "phram=memdisk,${MEMDISK}"
+    sleep 0.2
+    if [ -c /dev/mtd0 ]; then
+        break
+    else
+        rmmod phram
+    fi
+    max_try=$((max_try - 1))
+done
+
+# Load mtdblock, the memdisk will be /dev/mtdblock0
+modprobe mtdblock

--- a/modules.d/70memdisk/module-setup.sh
+++ b/modules.d/70memdisk/module-setup.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+
+check() {
+    require_binaries memdiskfind || return 1
+    return 255
+}
+
+installkernel() {
+    hostonly='' instmods \
+        "=drivers/mtd/devices/phram" \
+        "=drivers/mtd/mtdblock"
+}
+
+install() {
+    inst memdiskfind
+    inst_hook cmdline 30 "$moddir/memdisk.sh"
+}


### PR DESCRIPTION
Memdisk ISO emulation with the memdiskfind utility of the  syslinux project.                                                                                                                                                                                                                     
                                                                                                                                                                                                                                      
The hook of the memdisk dracut module is based on                                                                                                                                                                                     
https://salsa.debian.org/live-team/live-boot/-/blob/master/components/3050-memdisk.sh .  

## Checklist
- [ ] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it

