### PR TITLE
test(DRACUT-CPIO): correct test_check condition

### DIFF
--- a/test/TEST-82-DRACUT-CPIO/test.sh
+++ b/test/TEST-82-DRACUT-CPIO/test.sh
@@ -8,7 +8,7 @@ TEST_DESCRIPTION="kernel cpio extraction tests for dracut-cpio"
 # see dracut-cpio source for unit tests
 
 test_check() {
-    if command -v dracut-cpio &> /dev/null; then
+    if ! [[ -x "$PKGLIBDIR/dracut-cpio" ]]; then
         echo "Test needs dracut-cpio... Skipping"
         return 1
     fi


### PR DESCRIPTION
## Changes

Partial revert to correct test_check condition.

The current code checks if dracut-cpio is found in PATH and skips  the test in case dracut-cpio is found. 

Follow-up to b687756 .

## Checklist
- [ ] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it
