### PR TITLE
feat(dracut): expose determine_kernel_image as a public function

### DIFF
--- a/dracut-functions.sh
+++ b/dracut-functions.sh
@@ -1485,6 +1485,27 @@ require_kernel_modules() {
     return "$_ret"
 }
 
+determine_kernel_image() {
+    local kversion="$1"
+    local paths=(
+        "/lib/modules/${kversion}/vmlinuz"
+        "/lib/modules/${kversion}/vmlinux"
+        "/lib/modules/${kversion}/Image"
+        "/boot/vmlinuz-${kversion}"
+        "/boot/vmlinux-${kversion}"
+    )
+
+    for path in "${paths[@]}"; do
+        if [ -f "$path" ]; then
+            echo "$path"
+            return 0
+        fi
+    done
+
+    echo "Could not find a Linux kernel image for version '$kversion'!" >&2
+    return 1
+}
+
 if ! is_func dinfo > /dev/null 2>&1; then
     # shellcheck source=./dracut-logger.sh
     . "${BASH_SOURCE[0]%/*}/dracut-logger.sh"

--- a/dracut-functions.sh
+++ b/dracut-functions.sh
@@ -1488,15 +1488,15 @@ require_kernel_modules() {
 determine_kernel_image() {
     local kversion="$1"
     local paths=(
-        "/lib/modules/${kversion}/vmlinuz"
-        "/lib/modules/${kversion}/vmlinux"
-        "/lib/modules/${kversion}/Image"
-        "/boot/vmlinuz-${kversion}"
-        "/boot/vmlinux-${kversion}"
+        "${dracutsysrootdir-}/lib/modules/${kversion}/vmlinuz"
+        "${dracutsysrootdir-}/lib/modules/${kversion}/vmlinux"
+        "${dracutsysrootdir-}/lib/modules/${kversion}/Image"
+        "${dracutsysrootdir-}/boot/vmlinuz-${kversion}"
+        "${dracutsysrootdir-}/boot/vmlinux-${kversion}"
     )
 
     for path in "${paths[@]}"; do
-        if [ -f "$path" ]; then
+        if [ -s "$path" ]; then
             echo "$path"
             return 0
         fi

--- a/dracut.sh
+++ b/dracut.sh
@@ -2346,13 +2346,9 @@ if ! [[ $print_cmdline ]] && ! [[ $printconfig ]]; then
         fi
 
         if ! [[ $kernel_image ]]; then
-            for kernel_image in "${dracutsysrootdir-}/lib/modules/$kernel/vmlinuz" "${dracutsysrootdir-}/boot/vmlinuz-$kernel" \
-                "${dracutsysrootdir-}/lib/modules/$kernel/vmlinux" "${dracutsysrootdir-}/boot/vmlinux-$kernel" \
-                "${dracutsysrootdir-}/lib/modules/$kernel/Image"; do
-                [[ -s $kernel_image ]] || continue
-                break
-            done
+            kernel_image=$(determine_kernel_image "$kernel")
         fi
+
         if ! [[ -s $kernel_image ]]; then
             dfatal "Can't find a kernel image '$kernel_image' to create a UEFI executable"
             exit 1

--- a/man/dracut.modules.7.adoc
+++ b/man/dracut.modules.7.adoc
@@ -394,8 +394,9 @@ Issues a standardized warning message.
 
 === Initramfs Functions
 
-FIXME
+==== determine_kernel_image <kversion>
 
+Helper function for determining the path for the kernel image file.
 
 === Network Modules
 

--- a/test/TEST-12-UEFI/test.sh
+++ b/test/TEST-12-UEFI/test.sh
@@ -44,6 +44,9 @@ test_run() {
 }
 
 test_setup() {
+    # shellcheck source=./dracut-functions.sh
+    . "$PKGLIBDIR"/dracut-functions.sh
+
     # Create what will eventually be our root filesystem
     call_dracut --tmpdir "$TESTDIR" \
         --add-confdir test-root \

--- a/test/TEST-43-KERNEL-INSTALL/test.sh
+++ b/test/TEST-43-KERNEL-INSTALL/test.sh
@@ -38,6 +38,9 @@ test_run() {
 }
 
 test_setup() {
+    # shellcheck source=./dracut-functions.sh
+    . "$PKGLIBDIR"/dracut-functions.sh
+
     # create root filesystem
     # shellcheck disable=SC2153
     call_dracut --tmpdir "$TESTDIR" \

--- a/test/test-functions
+++ b/test/test-functions
@@ -141,27 +141,6 @@ determine_kernel_version() {
     lsinitrd "$1" | grep modules.dep | head -1 | sed 's;.*/\([^/]\+\)/modules.dep;\1;'
 }
 
-determine_kernel_image() {
-    local kversion="$1"
-    local paths=(
-        "/lib/modules/${kversion}/vmlinuz"
-        "/lib/modules/${kversion}/vmlinux"
-        "/lib/modules/${kversion}/Image"
-        "/boot/vmlinuz-${kversion}"
-        "/boot/vmlinux-${kversion}"
-    )
-
-    for path in "${paths[@]}"; do
-        if [ -f "$path" ]; then
-            echo "$path"
-            return 0
-        fi
-    done
-
-    echo "Could not find a Linux kernel image for version '$kversion'!" >&2
-    exit 1
-}
-
 # terminal sequence to set color to a 'success' color (currently: green)
 function SETCOLOR_SUCCESS() { echo -en '\033[0;32m'; }
 # terminal sequence to set color to a 'failure' color (currently: red)


### PR DESCRIPTION
## Changes

Expose determine_kernel_image as a public and documented helper function.

Instead of repeating and reimplementing the function to find kernel image, call the public function.   

Follow-up to df93355 .

## Checklist
- [ ] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it
