### PR TITLE
test(DMSQUASH): fix autooverlay test false positive and setup

### DIFF
--- a/test/TEST-30-DMSQUASH/assertion.sh
+++ b/test/TEST-30-DMSQUASH/assertion.sh
@@ -4,4 +4,6 @@ if grep -qF ' rd.live.overlay=LABEL=persist ' /proc/cmdline; then
     # Writing to a file in the root filesystem lets test_run() verify that the autooverlay module successfully created
     # and formatted the overlay partition and that the dmsquash-live module used it when setting up the rootfs overlay.
     echo "dracut-autooverlay-success" > /overlay-marker
+    # Ensure the marker is flushed to disk before shutdown
+    sync /overlay-marker
 fi

--- a/test/TEST-30-DMSQUASH/test.sh
+++ b/test/TEST-30-DMSQUASH/test.sh
@@ -67,8 +67,13 @@ test_run() {
 
     rootPartitions=$(sfdisk -d "$TESTDIR"/root.img | grep -c 'root\.img[0-9]')
     [ "$rootPartitions" -eq 2 ]
-    # Verify that the string "dracut-autooverlay-success" occurs in the second partition in the image file.
-    test_marker_check dracut-autooverlay-success root.img
+    # Verify that the string "dracut-autooverlay-success" occurs in the second partition (overlay).
+    # Extract only the second partition to avoid false positives from the test script in the first partition.
+    part2_info=$(sfdisk -d "$TESTDIR"/root.img | grep 'root\.img2')
+    part2_start=$(echo "$part2_info" | sed -n 's/.*start= *\([0-9]*\).*/\1/p')
+    part2_size=$(echo "$part2_info" | sed -n 's/.*size= *\([0-9]*\).*/\1/p')
+    dd if="$TESTDIR"/root.img of="$TESTDIR"/overlay-part.img bs=512 skip="$part2_start" count="$part2_size" status=none
+    test_marker_check dracut-autooverlay-success overlay-part.img
 
     return 0
 }

--- a/test/TEST-30-DMSQUASH/test.sh
+++ b/test/TEST-30-DMSQUASH/test.sh
@@ -101,7 +101,8 @@ EOF
 
     rm -f "$TESTDIR/ext4.img"
     truncate -s "$((512 * 652688))" "$TESTDIR/ext4.img"
-    mkfs.ext4 -q -L dracut -d "$TESTDIR"/rootfs/ "$TESTDIR"/ext4.img
+    # Use the live structure (with LiveOS/rootfs.img squashfs) instead of raw rootfs
+    mkfs.ext4 -q -L dracut -d "$TESTDIR"/live/ "$TESTDIR"/ext4.img
     dd if="$TESTDIR"/ext4.img of="$TESTDIR"/root.img bs=512 seek=2048 conv=noerror,notrunc
 
     # erofs drive


### PR DESCRIPTION
## Changes

The autooverlay test was always passing due to multiple issues:

* The test searched for the marker string in the entire root.img, but the string also existed literally in `test-init.sh` embedded in the first partition, causing a false positive. Fix by extracting and searching only the second (overlay) partition
* `test-init.sh` tried to read `/proc/cmdline` but `/proc` was not mounted and the directory did not exist. Fix by creating and mounting `/proc` temporarily
* The test disk image contained raw rootfs instead of the live structure (LiveOS/rootfs.img), so FSIMG was empty and `do_live_overlay()` was never called. Fix by using the live structure on disk
* Add `sync` after writing the marker to ensure it is flushed to the persist partition before shutdown

## Checklist
- [x] I have tested it locally
- [x] I have reviewed and updated any documentation if relevant
- [x] I am providing new code and test(s) for it

Fixes #2054
