### PR TITLE
test: use assertion.sh hook for test-root

### DIFF
--- a/test/TEST-30-DMSQUASH/assertion.sh
+++ b/test/TEST-30-DMSQUASH/assertion.sh
@@ -5,6 +5,3 @@ if grep -qF ' rd.live.overlay=LABEL=persist ' /proc/cmdline; then
     # and formatted the overlay partition and that the dmsquash-live module used it when setting up the rootfs overlay.
     echo "dracut-autooverlay-success" > /overlay-marker
 fi
-
-# call the rest of the init
-. /sbin/init

--- a/test/TEST-30-DMSQUASH/test.sh
+++ b/test/TEST-30-DMSQUASH/test.sh
@@ -63,7 +63,7 @@ test_run() {
     rootPartitions=$(sfdisk -d "$TESTDIR"/root.img | grep -c 'root\.img[0-9]')
     [ "$rootPartitions" -eq 1 ]
 
-    client_run "autooverlay" "init=/sbin/init-persist rd.live.image rd.live.overlay=LABEL=persist rd.live.dir=LiveOS"
+    client_run "autooverlay" "rd.live.image rd.live.overlay=LABEL=persist rd.live.dir=LiveOS"
 
     rootPartitions=$(sfdisk -d "$TESTDIR"/root.img | grep -c 'root\.img[0-9]')
     [ "$rootPartitions" -eq 2 ]
@@ -77,7 +77,7 @@ test_setup() {
     # Create what will eventually be our root filesystem onto an overlay
     call_dracut --tmpdir "$TESTDIR" \
         --add-confdir test-root \
-        -i ./test-init.sh /sbin/init-persist \
+        -i ./assertion.sh /assertion.sh \
         -f "$TESTDIR"/initramfs.root
     mkdir -p "$TESTDIR"/rootfs
     mv "$TESTDIR"/dracut.*/initramfs/* "$TESTDIR"/rootfs


### PR DESCRIPTION
## Changes

The test-root `test-init.sh` script can run test case specific test assertion if `/assertion.sh` is present.

Use this infrastructure for `TEST-30-DMSQUASH`. This fixes the issue (found by Nadzeya) that `test-init.sh` tried to read `/proc/cmdline` but `/proc` was not mounted and the directory did not exist. `test-init.sh` takes care of mounting `/proc`.

## Checklist
- [ ] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it

Fixes #
