### PR TITLE
ci: test UEFI generation on Alpine

### DIFF
--- a/.github/workflows/daily-busybox-x64.yml
+++ b/.github/workflows/daily-busybox-x64.yml
@@ -28,6 +28,7 @@ jobs:
                 config:
                     - {test: '10', deps: ''}
                     - {test: '11', deps: 'btrfs-progs'}
+                    - {test: '12', deps: 'efistub ovmf squashfs-tools'}
                     - {test: '13', deps: ''}
                     - {test: '20', deps: 'lvm2 device-mapper'}
                     - {test: '26', deps: 'cryptsetup mdadm device-mapper lvm2 partx sed'}

--- a/.github/workflows/daily-kernel-install-x64.yml
+++ b/.github/workflows/daily-kernel-install-x64.yml
@@ -24,6 +24,7 @@ jobs:
             fail-fast: false
             matrix:
                 container:
+                    - alpine:edge
                     - arch:latest
                     - debian:latest
                     - debian:sid

--- a/test/test-functions
+++ b/test/test-functions
@@ -138,7 +138,7 @@ command -v test_cleanup &> /dev/null || test_cleanup() {
 }
 
 determine_kernel_version() {
-    lsinitrd "$1" | grep modules.dep | head -1 | sed 's;.*/\([^/]\+\)/modules.dep;\1;'
+    lsinitrd "$1" | grep modules.dep$ | head -1 | sed 's;.*/\([^/]\+\)/modules.dep;\1;'
 }
 
 # terminal sequence to set color to a 'success' color (currently: green)


### PR DESCRIPTION
## Changes

Strengthen determine_kernel_version (this function only used during testing) to look for files ending with `modules.dep`                                                              
to filter out entries like e.g. `modules.dep.bin`. 

## Checklist
- [ ] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it

