### PR TITLE
fix: Include dkms path in dracut-install search path

### DIFF
--- a/src/install/dracut-install.c
+++ b/src/install/dracut-install.c
@@ -2701,7 +2701,7 @@ static int install_modules(int argc, char **argv)
                                 modinst = 1;
                         }
                 } else if (argv[i][0] == '=') {
-                        _cleanup_free_ char *path1 = NULL, *path2 = NULL, *path3 = NULL;
+                        _cleanup_free_ char *path1 = NULL, *path2 = NULL, *path3 = NULL, *path4 = NULL;
                         _cleanup_fts_close_ FTS *fts = NULL;
 
                         log_debug("Handling =%s", &argv[i][1]);
@@ -2709,9 +2709,10 @@ static int install_modules(int argc, char **argv)
                         _asprintf(&path2, "%s/kernel/%s", kerneldir, &argv[i][1]);
                         _asprintf(&path1, "%s/extra/%s", kerneldir, &argv[i][1]);
                         _asprintf(&path3, "%s/updates/%s", kerneldir, &argv[i][1]);
+                        _asprintf(&path4, "%s/updates/dkms", kerneldir);
 
                         {
-                                char *paths[] = { path1, path2, path3, NULL };
+                                char *paths[] = { path1, path2, path3, path4, NULL };
                                 fts = fts_open(paths, FTS_COMFOLLOW | FTS_NOCHDIR | FTS_NOSTAT | FTS_LOGICAL, NULL);
                         }
 


### PR DESCRIPTION
This pull request attempts to resolve #2071  by including the dkms module path in initramfs generation

## Changes

## Checklist
- [x] I have tested it locally
- [x] I have reviewed and updated any documentation if relevant
- [x] I am providing new code and test(s) for it
I have included code but have not included tests.

Fixes #2071 
