### PR TITLE
feat(lvm): match host lvm recovery installation

### DIFF
--- a/modules.d/70lvm/module-setup.sh
+++ b/modules.d/70lvm/module-setup.sh
@@ -50,6 +50,52 @@ installkernel() {
 install() {
     inst_multiple lvm grep
 
+    # lvm links for recovery inside the initramfs
+    inst_multiple -o \
+        lvchange \
+        lvconvert \
+        lvcreate \
+        lvdisplay \
+        lvextend \
+        lvmconfig \
+        lvmdiskscan \
+        lvmsadc \
+        lvmsar \
+        lvreduce \
+        lvremove \
+        lvrename \
+        lvresize \
+        lvs \
+        lvscan \
+        pvchange \
+        pvck \
+        pvcreate \
+        pvdisplay \
+        pvmove \
+        pvremove \
+        pvresize \
+        pvs \
+        pvscan \
+        vgcfgbackup \
+        vgcfgrestore \
+        vgchange \
+        vgck \
+        vgconvert \
+        vgcreate \
+        vgdisplay \
+        vgexport \
+        vgextend \
+        vgimport \
+        vgimportclone \
+        vgmerge \
+        vgmknodes \
+        vgreduce \
+        vgremove \
+        vgrename \
+        vgs \
+        vgscan \
+        vgsplit
+
     if [[ $hostonly_cmdline == "yes" ]]; then
         local _lvmconf
         _lvmconf=$(cmdline)


### PR DESCRIPTION
## Changes

These LVM tools are just symlinks to binaries that are already installed inside the initramfs. Dracut might as well install these symlinks to avoid people looking for them during a potentially stressful recovery time.

## Checklist
- [ ] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it
