### PR TITLE
chore(gitignore): ignore .testdir and test logs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,6 +15,6 @@
 /src/install/dracut-install
 /src/skipcpio/skipcpio
 /src/util/util
-/test/*/.testdir
-/test/*/test.log
+/test/*/.testdir*
+/test/*/*.log
 build/


### PR DESCRIPTION
## Changes

`test/test-functions` creates a `.testdir` file with `-$TEST_RUN_ID` as suffix. It also create log files named `server.log` and `test${TEST_RUN_ID:+-$TEST_RUN_ID}.log`.

Make the `.gitignore` pattern match those files.

## Checklist
- [ ] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it

Fixes #
