### PR TITLE
ci: explicitly install python3 in containers

### DIFF
--- a/test/container/Dockerfile-arch
+++ b/test/container/Dockerfile-arch
@@ -52,6 +52,7 @@ RUN pacman --noconfirm -Syu \
     pciutils \
     pkgconf \
     plymouth \
+    python \
     qemu \
     qrencode \
     sbsigntools \

--- a/test/container/Dockerfile-debian
+++ b/test/container/Dockerfile-debian
@@ -79,6 +79,7 @@ RUN \
     pkg-config \
     plymouth-themes \
     procps \
+    python3 \
     qemu-efi-aarch64 \
     qemu-kvm \
     qemu-system \

--- a/test/container/Dockerfile-fedora
+++ b/test/container/Dockerfile-fedora
@@ -82,6 +82,7 @@ RUN dnf -y install --setopt=install_weak_deps=False \
     parted \
     pcsc-lite \
     plymouth \
+    python3 \
     qemu-kvm \
     rng-tools \
     rsyslog \

--- a/test/container/Dockerfile-gentoo
+++ b/test/container/Dockerfile-gentoo
@@ -49,6 +49,7 @@ emerge --quiet --deep --autounmask-continue=y --with-bdeps=n --noreplace \
     app-misc/jq \
     app-portage/gentoolkit \
     dev-lang/perl \
+    dev-lang/python \
     dev-lang/rust-bin \
     dev-libs/libfido2 \
     dev-libs/libxslt \

--- a/test/container/Dockerfile-opensuse
+++ b/test/container/Dockerfile-opensuse
@@ -42,6 +42,7 @@ RUN zypper --non-interactive install --no-recommends \
     open-iscsi \
     parted \
     pciutils \
+    python3 \
     python3-pefile \
     qemu \
     ruby4.0-rubygem-asciidoctor \

--- a/test/container/Dockerfile-void
+++ b/test/container/Dockerfile-void
@@ -54,6 +54,7 @@ RUN xbps-install -Syu xbps && xbps-install -yu \
     parted \
     pkg-config \
     plymouth \
+    python3 \
     qemu \
     ruby-asciidoctor \
     squashfs-tools \


### PR DESCRIPTION
## Changes

Explicitly install python3 in the containers to allow testing the `livenet` module using Python 3 `http.server` as HTTP server. Many of the containers already have Python installed as dependency.

## Checklist
- [ ] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it

Fixes #
