### PR TITLE
chore(gitignore): ignore html files in test directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,6 +15,6 @@
 /src/install/dracut-install
 /src/skipcpio/skipcpio
 /src/util/util
-/test/*/.testdir*
 /test/*/*.log
+/test/*/.testdir*
 build/

--- a/.gitignore
+++ b/.gitignore
@@ -15,6 +15,7 @@
 /src/install/dracut-install
 /src/skipcpio/skipcpio
 /src/util/util
+/test/*/*.html
 /test/*/*.log
 /test/*/.testdir*
 build/


### PR DESCRIPTION
This pull request changes...

## Changes

I sometimes convert the test log file to HTML using `ansi2html` to make the logs nicer to read. Ignore those HTML files in `.gitignore` as well.

## Checklist
- [x] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it

Fixes #
