### PR TITLE
ci: name container jobs after CI name

### DIFF
--- a/.github/workflows/container-extra.yml
+++ b/.github/workflows/container-extra.yml
@@ -24,12 +24,12 @@ permissions:
     contents: read
 
 jobs:
-    amd64:
+    container-extra:
         if: github.repository == 'dracut-ng/dracut-ng' || vars.CONTAINER == 'enabled'
         name: ${{ matrix.config.tag }} on ${{ matrix.architecture.platform }}
         runs-on: ${{ matrix.architecture.runner }}
         concurrency:
-            group: extra-amd64-${{ github.workflow }}-${{ github.ref }}-${{ matrix.config.tag }}-${{ matrix.architecture.platform }}
+            group: container-extra-${{ github.workflow }}-${{ github.ref }}-${{ matrix.config.tag }}-${{ matrix.architecture.platform }}
             cancel-in-progress: true
         strategy:
             fail-fast: false

--- a/.github/workflows/container.yml
+++ b/.github/workflows/container.yml
@@ -22,11 +22,11 @@ permissions:
     contents: read
 
 jobs:
-    amd64:
+    container:
         if: github.repository == 'dracut-ng/dracut-ng' || vars.CONTAINER == 'enabled'
         name: ${{ matrix.config.tag }} on ${{ matrix.architecture.platform }}
         concurrency:
-            group: amd64-${{ github.workflow }}-${{ github.ref }}-${{ matrix.config.tag }}-${{ matrix.architecture.platform }}
+            group: container-${{ github.workflow }}-${{ github.ref }}-${{ matrix.config.tag }}-${{ matrix.architecture.platform }}
             cancel-in-progress: true
         strategy:
             fail-fast: false


### PR DESCRIPTION
## Changes

Name the container jobs after their CI name instead of `amd64` since they also build `arm64` images.

## Checklist
- [ ] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it

Fixes #
