### PR TITLE
ci: also push tags when container jobs were triggered manually

### DIFF
--- a/.github/workflows/container-extra.yml
+++ b/.github/workflows/container-extra.yml
@@ -69,7 +69,7 @@ jobs:
               with:
                   file: test/container/${{ matrix.config.dockerfile }}
                   tags: ghcr.io/${{env.repository_owner}}/${{ matrix.config.tag }}-${{ matrix.architecture.tag }}
-                  push: ${{ github.event_name == 'push' ||  github.event_name == 'schedule' }}
+                  push: ${{ github.event_name == 'push' || github.event_name == 'schedule' || github.event_name == 'workflow_dispatch' }}
                   platforms: ${{ matrix.architecture.platform }}
                   build-args: |
                       DISTRIBUTION=${{ matrix.config.tag }}

--- a/.github/workflows/container.yml
+++ b/.github/workflows/container.yml
@@ -66,7 +66,7 @@ jobs:
               with:
                   file: test/container/${{ matrix.config.dockerfile }}
                   tags: ghcr.io/${{env.repository_owner}}/${{ matrix.config.tag }}-${{ matrix.architecture.tag }}
-                  push: ${{ github.event_name == 'push' ||  github.event_name == 'schedule' }}
+                  push: ${{ github.event_name == 'push' || github.event_name == 'schedule' || github.event_name == 'workflow_dispatch' }}
                   platforms: ${{ matrix.architecture.platform }}
                   build-args: |
                       DISTRIBUTION=${{ matrix.config.tag }}


### PR DESCRIPTION
## Changes

The CI jobs for building the containers might be triggered manually. The event name is `workflow_dispatch` then and the tag update would not be pushed. That defeats the purpose of running those jobs manually.

## Checklist
- [ ] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it

Fixes #
