### PR TITLE
ci: only publish to GitHub Pages for dracut-ng repo

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -24,6 +24,7 @@ permissions:
 
 jobs:
   build:
+    if: github.repository == 'dracut-ng/dracut-ng'
     runs-on: ubuntu-latest
     environment:
       name: github-pages


### PR DESCRIPTION
## Changes

Forking dracut-ng will also fork the CI configs and pushes to the forked main branch will trigger the publish job which will fail (unless pages are explicitly enabled).

So only publish to GitHub Pages when triggered from the dracut-ng repository.

## Checklist
- [ ] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it

Fixes #
