### PR TITLE
ci: use container tag name as job name

### DIFF
--- a/.github/workflows/container-extra.yml
+++ b/.github/workflows/container-extra.yml
@@ -26,10 +26,10 @@ permissions:
 jobs:
     container-extra:
         if: github.repository == 'dracut-ng/dracut-ng' || vars.CONTAINER == 'enabled'
-        name: ${{ matrix.config.tag }} on ${{ matrix.architecture.platform }}
+        name: ${{ matrix.config.tag }}-${{ matrix.architecture.tag }}
         runs-on: ${{ matrix.architecture.runner }}
         concurrency:
-            group: container-extra-${{ github.workflow }}-${{ github.ref }}-${{ matrix.config.tag }}-${{ matrix.architecture.platform }}
+            group: container-extra-${{ github.workflow }}-${{ github.ref }}-${{ matrix.config.tag }}-${{ matrix.architecture.tag }}
             cancel-in-progress: true
         strategy:
             fail-fast: false

--- a/.github/workflows/container.yml
+++ b/.github/workflows/container.yml
@@ -24,9 +24,9 @@ permissions:
 jobs:
     container:
         if: github.repository == 'dracut-ng/dracut-ng' || vars.CONTAINER == 'enabled'
-        name: ${{ matrix.config.tag }} on ${{ matrix.architecture.platform }}
+        name: ${{ matrix.config.tag }}-${{ matrix.architecture.tag }}
         concurrency:
-            group: container-${{ github.workflow }}-${{ github.ref }}-${{ matrix.config.tag }}-${{ matrix.architecture.platform }}
+            group: container-${{ github.workflow }}-${{ github.ref }}-${{ matrix.config.tag }}-${{ matrix.architecture.tag }}
             cancel-in-progress: true
         strategy:
             fail-fast: false


### PR DESCRIPTION
## Changes

Use the full container tag name as job name (e. g. `ubuntu:devel-amd`). This is shorter and easy to read.

## Checklist
- [ ] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it

Fixes #
