### PR TITLE
feat: add yamllint config

### DIFF
--- a/.yamllint
+++ b/.yamllint
@@ -1,0 +1,4 @@
+---
+rules:
+  line-length:
+    max: 120


### PR DESCRIPTION
## Changes

Add a yamllint config allowing a line length of 120 characters for the beginning. The next steps would wrap the too long lines and add a linter job running `yamllint .`.

## Checklist
- [ ] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it

Fixes #
