### PR TITLE
ci: sort container job configs by tag name

### DIFF
--- a/.github/workflows/container-extra.yml
+++ b/.github/workflows/container-extra.yml
@@ -38,12 +38,12 @@ jobs:
                     - {platform: 'linux/amd64', runner: 'ubuntu-24.04', tag: 'amd'}
                     - {platform: 'linux/arm64', runner: 'ubuntu-24.04-arm', tag: 'arm'}
                 config:
-                    - {dockerfile: 'Dockerfile-debian', tag: 'debian:sid'}
-                    - {dockerfile: 'Dockerfile-gentoo', tag: 'gentoo:latest', option: 'systemd'}
-                    - {dockerfile: 'Dockerfile-gentoo', tag: 'gentoo:amd64-openrc', option: 'amd64-openrc'}
-                    - {dockerfile: 'Dockerfile-fedora', tag: 'fedora:rawhide', registry: 'registry.fedoraproject.org'}
-                    - {dockerfile: 'Dockerfile-fedora', tag: 'centos:latest', registry: 'quay.io/centos'}
                     - {dockerfile: 'Dockerfile-azurelinux', tag: 'azurelinux:3.0', registry: 'mcr.microsoft.com'}
+                    - {dockerfile: 'Dockerfile-fedora', tag: 'centos:latest', registry: 'quay.io/centos'}
+                    - {dockerfile: 'Dockerfile-debian', tag: 'debian:sid'}
+                    - {dockerfile: 'Dockerfile-fedora', tag: 'fedora:rawhide', registry: 'registry.fedoraproject.org'}
+                    - {dockerfile: 'Dockerfile-gentoo', tag: 'gentoo:amd64-openrc', option: 'amd64-openrc'}
+                    - {dockerfile: 'Dockerfile-gentoo', tag: 'gentoo:latest', option: 'systemd'}
                 exclude:
                     - config: {tag: 'arch:latest'}
                       architecture: {platform: 'linux/arm64'}

--- a/.github/workflows/container.yml
+++ b/.github/workflows/container.yml
@@ -35,14 +35,14 @@ jobs:
                     - {platform: 'linux/amd64', runner: 'ubuntu-24.04', tag: 'amd'}
                     - {platform: 'linux/arm64', runner: 'ubuntu-24.04-arm', tag: 'arm'}
                 config:
+                    - {dockerfile: 'Dockerfile-alpine', tag: 'alpine:edge'}
+                    - {dockerfile: 'Dockerfile-alpine-busybox', tag: 'alpine-busybox:edge'}
+                    - {dockerfile: 'Dockerfile-arch', tag: 'arch:latest'}
                     - {dockerfile: 'Dockerfile-debian', tag: 'debian:latest'}
                     - {dockerfile: 'Dockerfile-fedora', tag: 'fedora:latest'}
                     - {dockerfile: 'Dockerfile-opensuse', tag: 'opensuse:latest'}
-                    - {dockerfile: 'Dockerfile-arch', tag: 'arch:latest'}
                     - {dockerfile: 'Dockerfile-debian', tag: 'ubuntu:devel'}
                     - {dockerfile: 'Dockerfile-debian', tag: 'ubuntu:rolling'}
-                    - {dockerfile: 'Dockerfile-alpine', tag: 'alpine:edge'}
-                    - {dockerfile: 'Dockerfile-alpine-busybox', tag: 'alpine-busybox:edge'}
                     - {dockerfile: 'Dockerfile-void', tag: 'void:latest'}
                 exclude:
                     - config: {tag: 'arch:latest'}


### PR DESCRIPTION
## Changes

Sort container job configs by tag name because the tag name is used as job name.

## Checklist
- [ ] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it

Fixes #
