### PR TITLE
ci: create common multi-arch container tag

### DIFF
--- a/.github/workflows/container-extra.yml
+++ b/.github/workflows/container-extra.yml
@@ -73,3 +73,34 @@ jobs:
                       DISTRIBUTION=${{ matrix.config.tag }}
                       REGISTRY=${{ matrix.config.registry }}
                       OPTION=${{ matrix.config.option }}
+    manifest:
+        needs: container-extra
+        if: github.event_name == 'push' || github.event_name == 'schedule'
+        name: ${{ matrix.config.tag }}
+        concurrency:
+            group: manifest-${{ github.workflow }}-${{ github.ref }}-${{ matrix.config.tag }}
+            cancel-in-progress: true
+        runs-on: ubuntu-latest
+        strategy:
+            matrix:
+                config:
+                    - {tag: 'azurelinux:3.0', platforms: ['amd', 'arm']}
+                    - {tag: 'centos:latest', platforms: ['amd', 'arm']}
+                    - {tag: 'debian:sid', platforms: ['amd', 'arm']}
+                    - {tag: 'fedora:rawhide', platforms: ['amd', 'arm']}
+                    - {tag: 'gentoo:latest', platforms: ['amd', 'arm']}
+                    - {tag: 'gentoo:amd64-openrc', platforms: ['amd']}
+        steps:
+            - name: Login to GitHub Container Registry
+              uses: docker/login-action@v3
+              with:
+                  registry: ghcr.io
+                  username: ${{ github.repository_owner }}
+                  password: ${{ secrets.GITHUB_TOKEN }}
+            - name: Set up env
+              run: echo "repository_owner=${GITHUB_REPOSITORY_OWNER,,}" >>${GITHUB_ENV}
+            - name: Create and Push Multi-Arch Manifest
+              run: |
+                  tag="ghcr.io/${{env.repository_owner}}/${{ matrix.config.tag }}"
+                  images="$(printf "${tag}-%s " ${{ join(matrix.config.platforms, ' ') }})"
+                  docker buildx imagetools create -t ${tag} ${images}

--- a/.github/workflows/container.yml
+++ b/.github/workflows/container.yml
@@ -70,3 +70,37 @@ jobs:
                   platforms: ${{ matrix.architecture.platform }}
                   build-args: |
                       DISTRIBUTION=${{ matrix.config.tag }}
+    manifest:
+        needs: container
+        if: github.event_name == 'push' || github.event_name == 'schedule'
+        name: ${{ matrix.config.tag }}
+        concurrency:
+            group: manifest-${{ github.workflow }}-${{ github.ref }}-${{ matrix.config.tag }}
+            cancel-in-progress: true
+        runs-on: ubuntu-latest
+        strategy:
+            matrix:
+                config:
+                    - {tag: 'alpine:edge', platforms: ['amd', 'arm']}
+                    - {tag: 'alpine-busybox:edge', platforms: ['amd', 'arm']}
+                    - {tag: 'arch:latest', platforms: ['amd']}
+                    - {tag: 'debian:latest', platforms: ['amd', 'arm']}
+                    - {tag: 'fedora:latest', platforms: ['amd', 'arm']}
+                    - {tag: 'opensuse:latest', platforms: ['amd', 'arm']}
+                    - {tag: 'ubuntu:devel', platforms: ['amd', 'arm']}
+                    - {tag: 'ubuntu:rolling', platforms: ['amd', 'arm']}
+                    - {tag: 'void:latest', platforms: ['amd', 'arm']}
+        steps:
+            - name: Login to GitHub Container Registry
+              uses: docker/login-action@v3
+              with:
+                  registry: ghcr.io
+                  username: ${{ github.repository_owner }}
+                  password: ${{ secrets.GITHUB_TOKEN }}
+            - name: Set up env
+              run: echo "repository_owner=${GITHUB_REPOSITORY_OWNER,,}" >>${GITHUB_ENV}
+            - name: Create and Push Multi-Arch Manifest
+              run: |
+                  tag="ghcr.io/${{env.repository_owner}}/${{ matrix.config.tag }}"
+                  images="$(printf "${tag}-%s " ${{ join(matrix.config.platforms, ' ') }})"
+                  docker buildx imagetools create -t ${tag} ${images}


### PR DESCRIPTION
## Changes

The same container tag can be used for images with different architectures. That is the case for most common images (like `ubuntu:devel`).

I have tested this successfully in my local dracut-ng fork.

## Checklist
- [x] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it

Fixes #
