### PR TITLE
feat(livenet): support root=http:* as alias for root=live:http:*

### DIFF
--- a/man/dracut.cmdline.7.adoc
+++ b/man/dracut.cmdline.7.adoc
@@ -1278,6 +1278,19 @@ root=live:ftp://ftp.example.com/liveboot.img
 root=live:torrent://example.com/liveboot.img.torrent
 --
 
+**root=**__<http-url>__::
+This is an alias for **root=**live:__<url>__.
+Boots a live image retrieved from __<http-url>__.
+Requires the dracut 'livenet' module.
+Valid handlers: __http, https__.
++
+[listing]
+.Examples
+--
+root=http://example.com/root.squashfs
+root=https://example.com/live.sqfs
+--
+
 **rd.live.debug=**1::
 Enables debug output from the live boot process.
 

--- a/modules.d/70livenet/livenet-generator.sh
+++ b/modules.d/70livenet/livenet-generator.sh
@@ -5,7 +5,7 @@ command -v getarg > /dev/null || . /lib/dracut-lib.sh
 [ -z "$root" ] && root=$(getarg root=)
 
 # support legacy syntax of passing liveimg and then just the base root
-if getargbool 0 rd.live.image; then
+if getargbool 0 rd.live.image || str_starts "$root" "http:" || str_starts "$root" "https:"; then
     liveroot="live:$root"
 fi
 

--- a/modules.d/70livenet/parse-livenet.sh
+++ b/modules.d/70livenet/parse-livenet.sh
@@ -17,9 +17,17 @@ if [ -n "$updates" ]; then
     echo '[ -e /tmp/liveupdates.done ]' > "$hookdir"/initqueue/finished/liveupdates.sh
 fi
 
-str_starts "$root" "live:" && liveurl="$root"
-str_starts "$liveurl" "live:" || return
-liveurl="${liveurl#live:}"
+case "$root" in
+    http://* | https://*)
+        liveurl="${root}"
+        ;;
+    live:*)
+        liveurl="${root#live:}"
+        ;;
+    *)
+        return
+        ;;
+esac
 
 # setting netroot to "livenet:..." makes "livenetroot" get run after ifup
 if get_url_handler "$liveurl" > /dev/null; then

--- a/test/TEST-31-LIVENET/test.sh
+++ b/test/TEST-31-LIVENET/test.sh
@@ -65,6 +65,7 @@ test_run() {
     port=$(start_webserver)
 
     client_run "root=live:http://server/root.squashfs" "root=live:http://10.0.2.2:$port/root.squashfs"
+    client_run "root=http://server/root.squashfs" "root=http://10.0.2.2:$port/root.squashfs"
 }
 
 test_setup() {


### PR DESCRIPTION
## Changes

For compatibility with `cloud-initramfs-rooturl` support `root=http:*` as alias for `root=live:http:*` and `root=https:*` as alias for `root=live:https:*`.

## Checklist
- [x] I have tested it locally
- [x] I have reviewed and updated any documentation if relevant
- [x] I am providing new code and test(s) for it

Fixes #
