### PR TITLE
ci(busybox): disable DMSQUASH test

### DIFF
--- a/.github/workflows/daily-busybox-x64.yml
+++ b/.github/workflows/daily-busybox-x64.yml
@@ -31,7 +31,6 @@ jobs:
                     - {test: '13', deps: ''}
                     - {test: '20', deps: 'lvm2 device-mapper'}
                     - {test: '26', deps: 'cryptsetup mdadm device-mapper lvm2 partx sed'}
-                    - {test: '30', deps: 'squashfs-tools sfdisk device-mapper grep parted'}
                     - {test: '50', deps: 'networkmanager-initrd-generator networkmanager'}
                     - {test: '80', deps: ''}
                     - {test: '81', deps: ''}


### PR DESCRIPTION
## Changes

Disable running DMSQUASH test without coreutils until a proper fix is available. 

Follow up to 362ea81 .

## Checklist
- [ ] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it

Fixes #
