### PR TITLE
ci: use 2-space indent for YAML files

### DIFF
--- a/.github/workflows/container-extra.yml
+++ b/.github/workflows/container-extra.yml
@@ -4,103 +4,103 @@
 name: Container (extra)
 
 on:  # yamllint disable-line rule:truthy
-    schedule:
-        - cron: '30 11 * * *'   # every day at 11:30 UTC
-    push:
-        branches: [main]
-        paths:
-            - 'test/container/**'
-            - '.github/workflows/container-extra.yml'
-    pull_request:
-        branches: [main]
-        paths:
-            - 'test/container/**'
-            - '.github/workflows/container-extra.yml'
-    # Allows you to run this workflow manually from the Actions tab
-    workflow_dispatch:
+  schedule:
+    - cron: '30 11 * * *'   # every day at 11:30 UTC
+  push:
+    branches: [main]
+    paths:
+      - 'test/container/**'
+      - '.github/workflows/container-extra.yml'
+  pull_request:
+    branches: [main]
+    paths:
+      - 'test/container/**'
+      - '.github/workflows/container-extra.yml'
+  # Allows you to run this workflow manually from the Actions tab
+  workflow_dispatch:
 
 permissions:
-    packages: write
-    contents: read
+  packages: write
+  contents: read
 
 jobs:
-    container-extra:
-        if: github.repository == 'dracut-ng/dracut-ng' || vars.CONTAINER == 'enabled'
-        name: ${{ matrix.config.tag }}-${{ matrix.architecture.tag }}
-        runs-on: ${{ matrix.architecture.runner }}
-        concurrency:
-            group: container-extra-${{ github.workflow }}-${{ github.ref }}-${{ matrix.config.tag }}-${{ matrix.architecture.tag }}
-            cancel-in-progress: true
-        strategy:
-            fail-fast: false
-            matrix:
-                architecture:
-                    - {platform: 'linux/amd64', runner: 'ubuntu-24.04', tag: 'amd'}
-                    - {platform: 'linux/arm64', runner: 'ubuntu-24.04-arm', tag: 'arm'}
-                config:
-                    - {dockerfile: 'Dockerfile-azurelinux', tag: 'azurelinux:3.0', registry: 'mcr.microsoft.com'}
-                    - {dockerfile: 'Dockerfile-fedora', tag: 'centos:latest', registry: 'quay.io/centos'}
-                    - {dockerfile: 'Dockerfile-debian', tag: 'debian:sid'}
-                    - {dockerfile: 'Dockerfile-fedora', tag: 'fedora:rawhide', registry: 'registry.fedoraproject.org'}
-                    - {dockerfile: 'Dockerfile-gentoo', tag: 'gentoo:amd64-openrc', option: 'amd64-openrc'}
-                    - {dockerfile: 'Dockerfile-gentoo', tag: 'gentoo:latest', option: 'systemd'}
-                exclude:
-                    - config: {tag: 'arch:latest'}
-                      architecture: {platform: 'linux/arm64'}
-                    - config: {tag: 'gentoo:amd64-openrc'}
-                      architecture: {platform: 'linux/arm64'}
-        steps:
-            - name: Check out the repo
-              uses: actions/checkout@v6
-            - name: Set up Docker Buildx
-              uses: docker/setup-buildx-action@v3
-            - name: Login to GitHub Container Registry
-              uses: docker/login-action@v3
-              with:
-                  registry: ghcr.io
-                  username: ${{ github.repository_owner }}
-                  password: ${{ secrets.GITHUB_TOKEN }}
-            - name: Set up env
-              run: echo "repository_owner=${GITHUB_REPOSITORY_OWNER,,}" >>${GITHUB_ENV}
-            - name: Build and Push Container
-              uses: docker/build-push-action@v6
-              with:
-                  file: test/container/${{ matrix.config.dockerfile }}
-                  tags: ghcr.io/${{env.repository_owner}}/${{ matrix.config.tag }}-${{ matrix.architecture.tag }}
-                  push: ${{ github.event_name == 'push' || github.event_name == 'schedule' || github.event_name == 'workflow_dispatch' }}
-                  platforms: ${{ matrix.architecture.platform }}
-                  build-args: |
-                      DISTRIBUTION=${{ matrix.config.tag }}
-                      REGISTRY=${{ matrix.config.registry }}
-                      OPTION=${{ matrix.config.option }}
-    manifest:
-        needs: container-extra
-        if: github.event_name == 'push' || github.event_name == 'schedule'
-        name: ${{ matrix.config.tag }}
-        concurrency:
-            group: manifest-${{ github.workflow }}-${{ github.ref }}-${{ matrix.config.tag }}
-            cancel-in-progress: true
-        runs-on: ubuntu-latest
-        strategy:
-            matrix:
-                config:
-                    - {tag: 'azurelinux:3.0', platforms: ['amd', 'arm']}
-                    - {tag: 'centos:latest', platforms: ['amd', 'arm']}
-                    - {tag: 'debian:sid', platforms: ['amd', 'arm']}
-                    - {tag: 'fedora:rawhide', platforms: ['amd', 'arm']}
-                    - {tag: 'gentoo:latest', platforms: ['amd', 'arm']}
-                    - {tag: 'gentoo:amd64-openrc', platforms: ['amd']}
-        steps:
-            - name: Login to GitHub Container Registry
-              uses: docker/login-action@v3
-              with:
-                  registry: ghcr.io
-                  username: ${{ github.repository_owner }}
-                  password: ${{ secrets.GITHUB_TOKEN }}
-            - name: Set up env
-              run: echo "repository_owner=${GITHUB_REPOSITORY_OWNER,,}" >>${GITHUB_ENV}
-            - name: Create and Push Multi-Arch Manifest
-              run: |
-                  tag="ghcr.io/${{env.repository_owner}}/${{ matrix.config.tag }}"
-                  images="$(printf "${tag}-%s " ${{ join(matrix.config.platforms, ' ') }})"
-                  docker buildx imagetools create -t ${tag} ${images}
+  container-extra:
+    if: github.repository == 'dracut-ng/dracut-ng' || vars.CONTAINER == 'enabled'
+    name: ${{ matrix.config.tag }}-${{ matrix.architecture.tag }}
+    runs-on: ${{ matrix.architecture.runner }}
+    concurrency:
+      group: container-extra-${{ github.workflow }}-${{ github.ref }}-${{ matrix.config.tag }}-${{ matrix.architecture.tag }}
+      cancel-in-progress: true
+    strategy:
+      fail-fast: false
+      matrix:
+        architecture:
+          - {platform: 'linux/amd64', runner: 'ubuntu-24.04', tag: 'amd'}
+          - {platform: 'linux/arm64', runner: 'ubuntu-24.04-arm', tag: 'arm'}
+        config:
+          - {dockerfile: 'Dockerfile-azurelinux', tag: 'azurelinux:3.0', registry: 'mcr.microsoft.com'}
+          - {dockerfile: 'Dockerfile-fedora', tag: 'centos:latest', registry: 'quay.io/centos'}
+          - {dockerfile: 'Dockerfile-debian', tag: 'debian:sid'}
+          - {dockerfile: 'Dockerfile-fedora', tag: 'fedora:rawhide', registry: 'registry.fedoraproject.org'}
+          - {dockerfile: 'Dockerfile-gentoo', tag: 'gentoo:amd64-openrc', option: 'amd64-openrc'}
+          - {dockerfile: 'Dockerfile-gentoo', tag: 'gentoo:latest', option: 'systemd'}
+        exclude:
+          - config: {tag: 'arch:latest'}
+            architecture: {platform: 'linux/arm64'}
+          - config: {tag: 'gentoo:amd64-openrc'}
+            architecture: {platform: 'linux/arm64'}
+    steps:
+      - name: Check out the repo
+        uses: actions/checkout@v6
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Set up env
+        run: echo "repository_owner=${GITHUB_REPOSITORY_OWNER,,}" >>${GITHUB_ENV}
+      - name: Build and Push Container
+        uses: docker/build-push-action@v6
+        with:
+          file: test/container/${{ matrix.config.dockerfile }}
+          tags: ghcr.io/${{env.repository_owner}}/${{ matrix.config.tag }}-${{ matrix.architecture.tag }}
+          push: ${{ github.event_name == 'push' || github.event_name == 'schedule' || github.event_name == 'workflow_dispatch' }}
+          platforms: ${{ matrix.architecture.platform }}
+          build-args: |
+            DISTRIBUTION=${{ matrix.config.tag }}
+            REGISTRY=${{ matrix.config.registry }}
+            OPTION=${{ matrix.config.option }}
+  manifest:
+    needs: container-extra
+    if: github.event_name == 'push' || github.event_name == 'schedule'
+    name: ${{ matrix.config.tag }}
+    concurrency:
+      group: manifest-${{ github.workflow }}-${{ github.ref }}-${{ matrix.config.tag }}
+      cancel-in-progress: true
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        config:
+          - {tag: 'azurelinux:3.0', platforms: ['amd', 'arm']}
+          - {tag: 'centos:latest', platforms: ['amd', 'arm']}
+          - {tag: 'debian:sid', platforms: ['amd', 'arm']}
+          - {tag: 'fedora:rawhide', platforms: ['amd', 'arm']}
+          - {tag: 'gentoo:latest', platforms: ['amd', 'arm']}
+          - {tag: 'gentoo:amd64-openrc', platforms: ['amd']}
+    steps:
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Set up env
+        run: echo "repository_owner=${GITHUB_REPOSITORY_OWNER,,}" >>${GITHUB_ENV}
+      - name: Create and Push Multi-Arch Manifest
+        run: |
+          tag="ghcr.io/${{env.repository_owner}}/${{ matrix.config.tag }}"
+          images="$(printf "${tag}-%s " ${{ join(matrix.config.platforms, ' ') }})"
+          docker buildx imagetools create -t ${tag} ${images}

--- a/.github/workflows/container.yml
+++ b/.github/workflows/container.yml
@@ -2,105 +2,105 @@
 name: Container
 
 on:  # yamllint disable-line rule:truthy
-    schedule:
-        - cron: '30 11 * * *'   # every day at 11:30 UTC
-    push:
-        branches: [main]
-        paths:
-            - 'test/container/**'
-            - '.github/workflows/container.yml'
-    pull_request:
-        branches: [main]
-        paths:
-            - 'test/container/**'
-            - '.github/workflows/container.yml'
-    # Allows you to run this workflow manually from the Actions tab
-    workflow_dispatch:
+  schedule:
+    - cron: '30 11 * * *'   # every day at 11:30 UTC
+  push:
+    branches: [main]
+    paths:
+      - 'test/container/**'
+      - '.github/workflows/container.yml'
+  pull_request:
+    branches: [main]
+    paths:
+      - 'test/container/**'
+      - '.github/workflows/container.yml'
+  # Allows you to run this workflow manually from the Actions tab
+  workflow_dispatch:
 
 permissions:
-    packages: write
-    contents: read
+  packages: write
+  contents: read
 
 jobs:
-    container:
-        if: github.repository == 'dracut-ng/dracut-ng' || vars.CONTAINER == 'enabled'
-        name: ${{ matrix.config.tag }}-${{ matrix.architecture.tag }}
-        concurrency:
-            group: container-${{ github.workflow }}-${{ github.ref }}-${{ matrix.config.tag }}-${{ matrix.architecture.tag }}
-            cancel-in-progress: true
-        strategy:
-            fail-fast: false
-            matrix:
-                architecture:
-                    - {platform: 'linux/amd64', runner: 'ubuntu-24.04', tag: 'amd'}
-                    - {platform: 'linux/arm64', runner: 'ubuntu-24.04-arm', tag: 'arm'}
-                config:
-                    - {dockerfile: 'Dockerfile-alpine', tag: 'alpine:edge'}
-                    - {dockerfile: 'Dockerfile-alpine-busybox', tag: 'alpine-busybox:edge'}
-                    - {dockerfile: 'Dockerfile-arch', tag: 'arch:latest'}
-                    - {dockerfile: 'Dockerfile-debian', tag: 'debian:latest'}
-                    - {dockerfile: 'Dockerfile-fedora', tag: 'fedora:latest'}
-                    - {dockerfile: 'Dockerfile-opensuse', tag: 'opensuse:latest'}
-                    - {dockerfile: 'Dockerfile-debian', tag: 'ubuntu:devel'}
-                    - {dockerfile: 'Dockerfile-debian', tag: 'ubuntu:rolling'}
-                    - {dockerfile: 'Dockerfile-void', tag: 'void:latest'}
-                exclude:
-                    - config: {tag: 'arch:latest'}
-                      architecture: {platform: 'linux/arm64'}
-        runs-on: ${{ matrix.architecture.runner }}
-        steps:
-            - name: Check out the repo
-              uses: actions/checkout@v6
-            - name: Set up Docker Buildx
-              uses: docker/setup-buildx-action@v3
-            - name: Login to GitHub Container Registry
-              uses: docker/login-action@v3
-              with:
-                  registry: ghcr.io
-                  username: ${{ github.repository_owner }}
-                  password: ${{ secrets.GITHUB_TOKEN }}
-            - name: Set up env
-              run: echo "repository_owner=${GITHUB_REPOSITORY_OWNER,,}" >>${GITHUB_ENV}
-            - name: Build and Push Container
-              uses: docker/build-push-action@v6
-              with:
-                  file: test/container/${{ matrix.config.dockerfile }}
-                  tags: ghcr.io/${{env.repository_owner}}/${{ matrix.config.tag }}-${{ matrix.architecture.tag }}
-                  push: ${{ github.event_name == 'push' || github.event_name == 'schedule' || github.event_name == 'workflow_dispatch' }}
-                  platforms: ${{ matrix.architecture.platform }}
-                  build-args: |
-                      DISTRIBUTION=${{ matrix.config.tag }}
-    manifest:
-        needs: container
-        if: github.event_name == 'push' || github.event_name == 'schedule'
-        name: ${{ matrix.config.tag }}
-        concurrency:
-            group: manifest-${{ github.workflow }}-${{ github.ref }}-${{ matrix.config.tag }}
-            cancel-in-progress: true
-        runs-on: ubuntu-latest
-        strategy:
-            matrix:
-                config:
-                    - {tag: 'alpine:edge', platforms: ['amd', 'arm']}
-                    - {tag: 'alpine-busybox:edge', platforms: ['amd', 'arm']}
-                    - {tag: 'arch:latest', platforms: ['amd']}
-                    - {tag: 'debian:latest', platforms: ['amd', 'arm']}
-                    - {tag: 'fedora:latest', platforms: ['amd', 'arm']}
-                    - {tag: 'opensuse:latest', platforms: ['amd', 'arm']}
-                    - {tag: 'ubuntu:devel', platforms: ['amd', 'arm']}
-                    - {tag: 'ubuntu:rolling', platforms: ['amd', 'arm']}
-                    - {tag: 'void:latest', platforms: ['amd', 'arm']}
-        steps:
-            - name: Login to GitHub Container Registry
-              uses: docker/login-action@v3
-              with:
-                  registry: ghcr.io
-                  username: ${{ github.repository_owner }}
-                  password: ${{ secrets.GITHUB_TOKEN }}
-            - name: Set up env
-              run: echo "repository_owner=${GITHUB_REPOSITORY_OWNER,,}" >>${GITHUB_ENV}
-            - name: Create and Push Multi-Arch Manifest
-              run: |
-                  tag="ghcr.io/${{env.repository_owner}}/${{ matrix.config.tag }}"
-                  images="$(printf "${tag}-%s " ${{ join(matrix.config.platforms, ' ') }})"
-                  docker buildx imagetools create -t ${tag} ${images}
+  container:
+    if: github.repository == 'dracut-ng/dracut-ng' || vars.CONTAINER == 'enabled'
+    name: ${{ matrix.config.tag }}-${{ matrix.architecture.tag }}
+    concurrency:
+      group: container-${{ github.workflow }}-${{ github.ref }}-${{ matrix.config.tag }}-${{ matrix.architecture.tag }}
+      cancel-in-progress: true
+    strategy:
+      fail-fast: false
+      matrix:
+        architecture:
+          - {platform: 'linux/amd64', runner: 'ubuntu-24.04', tag: 'amd'}
+          - {platform: 'linux/arm64', runner: 'ubuntu-24.04-arm', tag: 'arm'}
+        config:
+          - {dockerfile: 'Dockerfile-alpine', tag: 'alpine:edge'}
+          - {dockerfile: 'Dockerfile-alpine-busybox', tag: 'alpine-busybox:edge'}
+          - {dockerfile: 'Dockerfile-arch', tag: 'arch:latest'}
+          - {dockerfile: 'Dockerfile-debian', tag: 'debian:latest'}
+          - {dockerfile: 'Dockerfile-fedora', tag: 'fedora:latest'}
+          - {dockerfile: 'Dockerfile-opensuse', tag: 'opensuse:latest'}
+          - {dockerfile: 'Dockerfile-debian', tag: 'ubuntu:devel'}
+          - {dockerfile: 'Dockerfile-debian', tag: 'ubuntu:rolling'}
+          - {dockerfile: 'Dockerfile-void', tag: 'void:latest'}
+        exclude:
+          - config: {tag: 'arch:latest'}
+            architecture: {platform: 'linux/arm64'}
+    runs-on: ${{ matrix.architecture.runner }}
+    steps:
+      - name: Check out the repo
+        uses: actions/checkout@v6
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Set up env
+        run: echo "repository_owner=${GITHUB_REPOSITORY_OWNER,,}" >>${GITHUB_ENV}
+      - name: Build and Push Container
+        uses: docker/build-push-action@v6
+        with:
+          file: test/container/${{ matrix.config.dockerfile }}
+          tags: ghcr.io/${{env.repository_owner}}/${{ matrix.config.tag }}-${{ matrix.architecture.tag }}
+          push: ${{ github.event_name == 'push' || github.event_name == 'schedule' || github.event_name == 'workflow_dispatch' }}
+          platforms: ${{ matrix.architecture.platform }}
+          build-args: |
+            DISTRIBUTION=${{ matrix.config.tag }}
+  manifest:
+    needs: container
+    if: github.event_name == 'push' || github.event_name == 'schedule'
+    name: ${{ matrix.config.tag }}
+    concurrency:
+      group: manifest-${{ github.workflow }}-${{ github.ref }}-${{ matrix.config.tag }}
+      cancel-in-progress: true
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        config:
+          - {tag: 'alpine:edge', platforms: ['amd', 'arm']}
+          - {tag: 'alpine-busybox:edge', platforms: ['amd', 'arm']}
+          - {tag: 'arch:latest', platforms: ['amd']}
+          - {tag: 'debian:latest', platforms: ['amd', 'arm']}
+          - {tag: 'fedora:latest', platforms: ['amd', 'arm']}
+          - {tag: 'opensuse:latest', platforms: ['amd', 'arm']}
+          - {tag: 'ubuntu:devel', platforms: ['amd', 'arm']}
+          - {tag: 'ubuntu:rolling', platforms: ['amd', 'arm']}
+          - {tag: 'void:latest', platforms: ['amd', 'arm']}
+    steps:
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Set up env
+        run: echo "repository_owner=${GITHUB_REPOSITORY_OWNER,,}" >>${GITHUB_ENV}
+      - name: Create and Push Multi-Arch Manifest
+        run: |
+          tag="ghcr.io/${{env.repository_owner}}/${{ matrix.config.tag }}"
+          images="$(printf "${tag}-%s " ${{ join(matrix.config.platforms, ' ') }})"
+          docker buildx imagetools create -t ${tag} ${images}

--- a/.github/workflows/daily-basic.yml
+++ b/.github/workflows/daily-basic.yml
@@ -2,106 +2,106 @@
 name: Daily Tests - basic
 
 on:  # yamllint disable-line rule:truthy
-    schedule:
-        - cron: '30 23 * * *'   # every day at 23:30 UTC
+  schedule:
+    - cron: '30 23 * * *'   # every day at 23:30 UTC
 
-    # Allows you to run this workflow manually from the Actions tab
-    workflow_dispatch:
+  # Allows you to run this workflow manually from the Actions tab
+  workflow_dispatch:
 
-    pull_request:
-        paths:
-            - '.github/workflows/daily-basic.yml'
+  pull_request:
+    paths:
+      - '.github/workflows/daily-basic.yml'
 
 jobs:
-    basic:
-        name: ${{ matrix.test }} on ${{ matrix.container }} on ${{ matrix.architecture.tag }}
-        runs-on: ${{ matrix.architecture.runner }}
-        timeout-minutes: 20
-        concurrency:
-            group: daily-basic-${{ github.workflow }}-${{ github.ref }}-${{ matrix.container }}-${{ matrix.test }}-${{ matrix.architecture.tag }}
-            cancel-in-progress: true
-        strategy:
-            fail-fast: false
-            matrix:
-                architecture:
-                    - {runner: 'ubuntu-24.04', tag: 'amd'}
-                    - {runner: 'ubuntu-24.04-arm', tag: 'arm'}
-                container:
-                    - debian:latest
-                    - debian:sid
-                    - gentoo:latest
-                    - opensuse:latest
-                    - ubuntu:devel
-                    - ubuntu:rolling
-                    - void:latest
-                test:
-                    - "10"
-                    - "11"
-                    - "13"
-                    - "20"
-                    - "26"
-                    - "30"
-                    - "50"
-                    - "80"
-                    - "81"
-                    - "82"
-                exclude:
-                    # https://github.com/dracut-ng/dracut-ng/issues/1988
-                    - container: debian:sid
-                      architecture: {runner: 'ubuntu-24.04-arm', tag: 'arm'}
-                    # https://github.com/dracut-ng/dracut-ng/issues/2021
-                    - container: debian:sid
-                      test: "20"
-                    - container: debian:sid
-                      test: "26"
+  basic:
+    name: ${{ matrix.test }} on ${{ matrix.container }} on ${{ matrix.architecture.tag }}
+    runs-on: ${{ matrix.architecture.runner }}
+    timeout-minutes: 20
+    concurrency:
+      group: daily-basic-${{ github.workflow }}-${{ github.ref }}-${{ matrix.container }}-${{ matrix.test }}-${{ matrix.architecture.tag }}
+      cancel-in-progress: true
+    strategy:
+      fail-fast: false
+      matrix:
+        architecture:
+          - {runner: 'ubuntu-24.04', tag: 'amd'}
+          - {runner: 'ubuntu-24.04-arm', tag: 'arm'}
         container:
-            image: ghcr.io/dracut-ng/${{ matrix.container }}-${{ matrix.architecture.tag }}
-            options: '--device=/dev/kvm --privileged'
-        steps:
-            - name: "Checkout Repository"
-              uses: actions/checkout@v6
-            - name: "${{ matrix.container }} TEST-${{ matrix.test }}"
-              run: ./test/test-container.sh "TEST-${{ matrix.test }}" ${{ matrix.test }}
-    extended:
-        name: ${{ matrix.test }} on ${{ matrix.container }} on ${{ matrix.architecture.tag }}
-        runs-on: ${{ matrix.architecture.runner }}
-        timeout-minutes: 20
-        concurrency:
-            group: daily-basic-extended-${{ github.workflow }}-${{ github.ref }}-${{ matrix.container }}-${{ matrix.test }}-${{ matrix.architecture.tag }}
-            cancel-in-progress: true
-        strategy:
-            fail-fast: false
-            matrix:
-                architecture:
-                    - {runner: 'ubuntu-24.04', tag: 'amd'}
-                container:
-                    - alpine:edge
-                    - arch:latest
-                    - azurelinux:3.0
-                    - fedora:latest
-                    - fedora:rawhide
-                    - centos:latest
-                    - gentoo:amd64-openrc
-                test:
-                    - "10"
-                    - "11"
-                    - "13"
-                    - "20"
-                    - "26"
-                    - "30"
-                    - "50"
-                    - "80"
-                    - "81"
-                    - "82"
-                exclude:
-                    # btrfs kernel module is not available on CentOS Stream 10
-                    - container: centos:latest
-                      test: "11"
+          - debian:latest
+          - debian:sid
+          - gentoo:latest
+          - opensuse:latest
+          - ubuntu:devel
+          - ubuntu:rolling
+          - void:latest
+        test:
+          - "10"
+          - "11"
+          - "13"
+          - "20"
+          - "26"
+          - "30"
+          - "50"
+          - "80"
+          - "81"
+          - "82"
+        exclude:
+          # https://github.com/dracut-ng/dracut-ng/issues/1988
+          - container: debian:sid
+            architecture: {runner: 'ubuntu-24.04-arm', tag: 'arm'}
+          # https://github.com/dracut-ng/dracut-ng/issues/2021
+          - container: debian:sid
+            test: "20"
+          - container: debian:sid
+            test: "26"
+    container:
+      image: ghcr.io/dracut-ng/${{ matrix.container }}-${{ matrix.architecture.tag }}
+      options: '--device=/dev/kvm --privileged'
+    steps:
+      - name: "Checkout Repository"
+        uses: actions/checkout@v6
+      - name: "${{ matrix.container }} TEST-${{ matrix.test }}"
+        run: ./test/test-container.sh "TEST-${{ matrix.test }}" ${{ matrix.test }}
+  extended:
+    name: ${{ matrix.test }} on ${{ matrix.container }} on ${{ matrix.architecture.tag }}
+    runs-on: ${{ matrix.architecture.runner }}
+    timeout-minutes: 20
+    concurrency:
+      group: daily-basic-extended-${{ github.workflow }}-${{ github.ref }}-${{ matrix.container }}-${{ matrix.test }}-${{ matrix.architecture.tag }}
+      cancel-in-progress: true
+    strategy:
+      fail-fast: false
+      matrix:
+        architecture:
+          - {runner: 'ubuntu-24.04', tag: 'amd'}
         container:
-            image: ghcr.io/dracut-ng/${{ matrix.container }}-${{ matrix.architecture.tag }}
-            options: '--device=/dev/kvm --privileged'
-        steps:
-            - name: "Checkout Repository"
-              uses: actions/checkout@v6
-            - name: "${{ matrix.container }} TEST-${{ matrix.test }}"
-              run: ./test/test-container.sh "TEST-${{ matrix.test }}" ${{ matrix.test }}
+          - alpine:edge
+          - arch:latest
+          - azurelinux:3.0
+          - fedora:latest
+          - fedora:rawhide
+          - centos:latest
+          - gentoo:amd64-openrc
+        test:
+          - "10"
+          - "11"
+          - "13"
+          - "20"
+          - "26"
+          - "30"
+          - "50"
+          - "80"
+          - "81"
+          - "82"
+        exclude:
+          # btrfs kernel module is not available on CentOS Stream 10
+          - container: centos:latest
+            test: "11"
+    container:
+      image: ghcr.io/dracut-ng/${{ matrix.container }}-${{ matrix.architecture.tag }}
+      options: '--device=/dev/kvm --privileged'
+    steps:
+      - name: "Checkout Repository"
+        uses: actions/checkout@v6
+      - name: "${{ matrix.container }} TEST-${{ matrix.test }}"
+        run: ./test/test-container.sh "TEST-${{ matrix.test }}" ${{ matrix.test }}

--- a/.github/workflows/daily-busybox-x64.yml
+++ b/.github/workflows/daily-busybox-x64.yml
@@ -2,44 +2,44 @@
 name: Daily Tests - busybox (x64)
 
 on:  # yamllint disable-line rule:truthy
-    schedule:
-        - cron: '30 23 * * *'   # every day at 23:30 UTC
+  schedule:
+    - cron: '30 23 * * *'   # every day at 23:30 UTC
 
-    # Allows you to run this workflow manually from the Actions tab
-    workflow_dispatch:
+  # Allows you to run this workflow manually from the Actions tab
+  workflow_dispatch:
 
-    pull_request:
-        paths:
-            - '.github/workflows/daily-busybox-x64.yml'
+  pull_request:
+    paths:
+      - '.github/workflows/daily-busybox-x64.yml'
 
 jobs:
-    busybox:
-        name: ${{ matrix.config.test }}
-        runs-on: ubuntu-24.04
-        timeout-minutes: 20
-        concurrency:
-            group: daily-busybox-${{ github.workflow }}-${{ github.ref }}-${{ matrix.container }}-${{ matrix.config.test }}
-            cancel-in-progress: true
-        strategy:
-            fail-fast: false
-            matrix:
-                container:
-                    - alpine-busybox:edge
-                config:
-                    - {test: '10', deps: ''}
-                    - {test: '11', deps: 'btrfs-progs'}
-                    - {test: '13', deps: ''}
-                    - {test: '20', deps: 'lvm2 device-mapper'}
-                    - {test: '26', deps: 'cryptsetup mdadm device-mapper lvm2 partx sed'}
-                    - {test: '50', deps: 'networkmanager-initrd-generator networkmanager'}
-                    - {test: '80', deps: ''}
-                    - {test: '81', deps: ''}
-                    - {test: '82', deps: 'cargo procps-ng'}
+  busybox:
+    name: ${{ matrix.config.test }}
+    runs-on: ubuntu-24.04
+    timeout-minutes: 20
+    concurrency:
+      group: daily-busybox-${{ github.workflow }}-${{ github.ref }}-${{ matrix.container }}-${{ matrix.config.test }}
+      cancel-in-progress: true
+    strategy:
+      fail-fast: false
+      matrix:
         container:
-            image: ghcr.io/dracut-ng/${{ matrix.container }}-amd
-            options: '--device=/dev/kvm --privileged'
-        steps:
-            - name: "Checkout Repository"
-              uses: actions/checkout@v6
-            - name: "TEST-${{ matrix.config.test }}"
-              run: TEST_CONTAINER_COMMAND="apk add ${{ matrix.config.deps }}" ./test/test-container.sh "TEST-${{ matrix.config.test }}" ${{ matrix.config.test }}
+          - alpine-busybox:edge
+        config:
+          - {test: '10', deps: ''}
+          - {test: '11', deps: 'btrfs-progs'}
+          - {test: '13', deps: ''}
+          - {test: '20', deps: 'lvm2 device-mapper'}
+          - {test: '26', deps: 'cryptsetup mdadm device-mapper lvm2 partx sed'}
+          - {test: '50', deps: 'networkmanager-initrd-generator networkmanager'}
+          - {test: '80', deps: ''}
+          - {test: '81', deps: ''}
+          - {test: '82', deps: 'cargo procps-ng'}
+    container:
+      image: ghcr.io/dracut-ng/${{ matrix.container }}-amd
+      options: '--device=/dev/kvm --privileged'
+    steps:
+      - name: "Checkout Repository"
+        uses: actions/checkout@v6
+      - name: "TEST-${{ matrix.config.test }}"
+        run: TEST_CONTAINER_COMMAND="apk add ${{ matrix.config.deps }}" ./test/test-container.sh "TEST-${{ matrix.config.test }}" ${{ matrix.config.test }}

--- a/.github/workflows/daily-hostonlystrict.yml
+++ b/.github/workflows/daily-hostonlystrict.yml
@@ -2,51 +2,51 @@
 name: Daily Tests - hostonlystrict
 
 on:  # yamllint disable-line rule:truthy
-    schedule:
-        - cron: '30 23 * * *'   # every day at 23:30 UTC
+  schedule:
+    - cron: '30 23 * * *'   # every day at 23:30 UTC
 
-    # Allows you to run this workflow manually from the Actions tab
-    workflow_dispatch:
+  # Allows you to run this workflow manually from the Actions tab
+  workflow_dispatch:
 
-    pull_request:
-        paths:
-            - '.github/workflows/daily-hostonlystrict.yml'
+  pull_request:
+    paths:
+      - '.github/workflows/daily-hostonlystrict.yml'
 
 jobs:
-    hostonlystrict:
-        name: ${{ matrix.test }} on ${{ matrix.container }} with hostonly-mode strict
-        runs-on: ${{ matrix.architecture.runner }}
-        timeout-minutes: 20
-        concurrency:
-            group: daily-hostonlystrict-${{ github.workflow }}-${{ github.ref }}-${{ matrix.container }}-${{ matrix.test }}-${{ matrix.architecture.tag }}
-            cancel-in-progress: true
-        strategy:
-            fail-fast: false
-            matrix:
-                architecture:
-                    - {runner: 'ubuntu-24.04', tag: 'amd'}
-                    - {runner: 'ubuntu-24.04-arm', tag: 'arm'}
-                container:
-                    - ubuntu:devel
-                test:
-                    - "10"
-                    - "11"
-                    - "13"
-                    - "20"
-                    - "26"
-                    - "30"
-                    - "40"
-                    - "41"
-                    - "42"
-                    - "50"
-                    - "80"
-                    - "81"
-                    - "82"
+  hostonlystrict:
+    name: ${{ matrix.test }} on ${{ matrix.container }} with hostonly-mode strict
+    runs-on: ${{ matrix.architecture.runner }}
+    timeout-minutes: 20
+    concurrency:
+      group: daily-hostonlystrict-${{ github.workflow }}-${{ github.ref }}-${{ matrix.container }}-${{ matrix.test }}-${{ matrix.architecture.tag }}
+      cancel-in-progress: true
+    strategy:
+      fail-fast: false
+      matrix:
+        architecture:
+          - {runner: 'ubuntu-24.04', tag: 'amd'}
+          - {runner: 'ubuntu-24.04-arm', tag: 'arm'}
         container:
-            image: ghcr.io/dracut-ng/${{ matrix.container }}-${{ matrix.architecture.tag }}
-            options: '--device=/dev/kvm --privileged'
-        steps:
-            - name: "Checkout Repository"
-              uses: actions/checkout@v6
-            - name: "${{ matrix.container }} TEST-${{ matrix.test }}"
-              run: TEST_DRACUT_ARGS="--hostonly-mode strict" ./test/test-container.sh "TEST-${{ matrix.test }}" ${{ matrix.test }}
+          - ubuntu:devel
+        test:
+          - "10"
+          - "11"
+          - "13"
+          - "20"
+          - "26"
+          - "30"
+          - "40"
+          - "41"
+          - "42"
+          - "50"
+          - "80"
+          - "81"
+          - "82"
+    container:
+      image: ghcr.io/dracut-ng/${{ matrix.container }}-${{ matrix.architecture.tag }}
+      options: '--device=/dev/kvm --privileged'
+    steps:
+      - name: "Checkout Repository"
+        uses: actions/checkout@v6
+      - name: "${{ matrix.container }} TEST-${{ matrix.test }}"
+        run: TEST_DRACUT_ARGS="--hostonly-mode strict" ./test/test-container.sh "TEST-${{ matrix.test }}" ${{ matrix.test }}

--- a/.github/workflows/daily-iscsi-x64.yml
+++ b/.github/workflows/daily-iscsi-x64.yml
@@ -2,38 +2,38 @@
 name: Daily Tests - iscsi (x64)
 
 on:  # yamllint disable-line rule:truthy
-    schedule:
-        - cron: '30 23 * * *'   # every day at 23:30 UTC
+  schedule:
+    - cron: '30 23 * * *'   # every day at 23:30 UTC
 
-    # Allows you to run this workflow manually from the Actions tab
-    workflow_dispatch:
+  # Allows you to run this workflow manually from the Actions tab
+  workflow_dispatch:
 
-    pull_request:
-        paths:
-            - '.github/workflows/daily-iscsi-x64.yml'
+  pull_request:
+    paths:
+      - '.github/workflows/daily-iscsi-x64.yml'
 
 jobs:
-    iscsi:
-        name: ${{ matrix.test }} on ${{ matrix.container }}
-        runs-on: ubuntu-24.04
-        timeout-minutes: 20
-        concurrency:
-            group: daily-iscsi-${{ github.workflow }}-${{ github.ref }}-${{ matrix.container }}-${{ matrix.test }}-amd
-            cancel-in-progress: true
-        strategy:
-            fail-fast: false
-            matrix:
-                container:
-                    - ubuntu:devel
-                    - ubuntu:rolling
-                test:
-                    - "70"
-                    - "71"
+  iscsi:
+    name: ${{ matrix.test }} on ${{ matrix.container }}
+    runs-on: ubuntu-24.04
+    timeout-minutes: 20
+    concurrency:
+      group: daily-iscsi-${{ github.workflow }}-${{ github.ref }}-${{ matrix.container }}-${{ matrix.test }}-amd
+      cancel-in-progress: true
+    strategy:
+      fail-fast: false
+      matrix:
         container:
-            image: ghcr.io/dracut-ng/${{ matrix.container }}-amd
-            options: '--device=/dev/kvm'
-        steps:
-            - name: "Checkout Repository"
-              uses: actions/checkout@v6
-            - name: "${{ matrix.container }} TEST-${{ matrix.test }}"
-              run: ./test/test-container.sh "TEST-${{ matrix.test }}" ${{ matrix.test }}
+          - ubuntu:devel
+          - ubuntu:rolling
+        test:
+          - "70"
+          - "71"
+    container:
+      image: ghcr.io/dracut-ng/${{ matrix.container }}-amd
+      options: '--device=/dev/kvm'
+    steps:
+      - name: "Checkout Repository"
+        uses: actions/checkout@v6
+      - name: "${{ matrix.container }} TEST-${{ matrix.test }}"
+        run: ./test/test-container.sh "TEST-${{ matrix.test }}" ${{ matrix.test }}

--- a/.github/workflows/daily-kernel-install-x64.yml
+++ b/.github/workflows/daily-kernel-install-x64.yml
@@ -2,45 +2,45 @@
 name: Daily Tests - kernel-install (x64)
 
 on:  # yamllint disable-line rule:truthy
-    schedule:
-        - cron: '30 23 * * *'   # every day at 23:30 UTC
+  schedule:
+    - cron: '30 23 * * *'   # every day at 23:30 UTC
 
-    # Allows you to run this workflow manually from the Actions tab
-    workflow_dispatch:
+  # Allows you to run this workflow manually from the Actions tab
+  workflow_dispatch:
 
-    pull_request:
-        paths:
-            - '.github/workflows/daily-kernel-install-x64.yml'
+  pull_request:
+    paths:
+      - '.github/workflows/daily-kernel-install-x64.yml'
 
 jobs:
-    kernel-install:
-        name: ${{ matrix.test }} on ${{ matrix.container }}
-        runs-on: ubuntu-24.04
-        timeout-minutes: 20
-        concurrency:
-            group: daily-kernel-install-${{ github.workflow }}-${{ github.ref }}-${{ matrix.container }}-${{ matrix.test }}-amd
-            cancel-in-progress: true
-        strategy:
-            fail-fast: false
-            matrix:
-                container:
-                    - arch:latest
-                    - debian:latest
-                    - debian:sid
-                    - fedora:latest
-                    - fedora:rawhide
-                    - gentoo:latest
-                    - opensuse:latest
-                    - ubuntu:devel
-                    - ubuntu:rolling
-                    - void:latest
-                test:
-                    - "12"
+  kernel-install:
+    name: ${{ matrix.test }} on ${{ matrix.container }}
+    runs-on: ubuntu-24.04
+    timeout-minutes: 20
+    concurrency:
+      group: daily-kernel-install-${{ github.workflow }}-${{ github.ref }}-${{ matrix.container }}-${{ matrix.test }}-amd
+      cancel-in-progress: true
+    strategy:
+      fail-fast: false
+      matrix:
         container:
-            image: ghcr.io/dracut-ng/${{ matrix.container }}-amd
-            options: '--device=/dev/kvm --privileged'
-        steps:
-            - name: "Checkout Repository"
-              uses: actions/checkout@v6
-            - name: "${{ matrix.container }} TEST-${{ matrix.test }}"
-              run: ./test/test-container.sh "TEST-${{ matrix.test }}" ${{ matrix.test }}
+          - arch:latest
+          - debian:latest
+          - debian:sid
+          - fedora:latest
+          - fedora:rawhide
+          - gentoo:latest
+          - opensuse:latest
+          - ubuntu:devel
+          - ubuntu:rolling
+          - void:latest
+        test:
+          - "12"
+    container:
+      image: ghcr.io/dracut-ng/${{ matrix.container }}-amd
+      options: '--device=/dev/kvm --privileged'
+    steps:
+      - name: "Checkout Repository"
+        uses: actions/checkout@v6
+      - name: "${{ matrix.container }} TEST-${{ matrix.test }}"
+        run: ./test/test-container.sh "TEST-${{ matrix.test }}" ${{ matrix.test }}

--- a/.github/workflows/daily-mkosi-x64.yml
+++ b/.github/workflows/daily-mkosi-x64.yml
@@ -2,36 +2,36 @@
 name: Daily Tests - mkosi (x64)
 
 on:  # yamllint disable-line rule:truthy
-    schedule:
-        - cron: '30 23 * * *'   # every day at 23:30 UTC
+  schedule:
+    - cron: '30 23 * * *'   # every day at 23:30 UTC
 
-    # Allows you to run this workflow manually from the Actions tab
-    workflow_dispatch:
+  # Allows you to run this workflow manually from the Actions tab
+  workflow_dispatch:
 
-    pull_request:
-        paths:
-            - '.github/workflows/daily-mkosi-x64.yml'
+  pull_request:
+    paths:
+      - '.github/workflows/daily-mkosi-x64.yml'
 
 jobs:
-    mkosi:
-        name: ${{ matrix.config.test }}
-        runs-on: ubuntu-24.04
-        timeout-minutes: 30
-        concurrency:
-            group: daily-mkosi-${{ github.workflow }}-${{ github.ref }}-${{ matrix.container }}-${{ matrix.config.test }}
-            cancel-in-progress: true
-        strategy:
-            fail-fast: false
-            matrix:
-                container:
-                    - opensuse:latest
-                config:
-                    - {test: '41', deps: 'mkosi-initrd'}
+  mkosi:
+    name: ${{ matrix.config.test }}
+    runs-on: ubuntu-24.04
+    timeout-minutes: 30
+    concurrency:
+      group: daily-mkosi-${{ github.workflow }}-${{ github.ref }}-${{ matrix.container }}-${{ matrix.config.test }}
+      cancel-in-progress: true
+    strategy:
+      fail-fast: false
+      matrix:
         container:
-            image: ghcr.io/dracut-ng/${{ matrix.container }}-amd
-            options: '--device=/dev/kvm --privileged'
-        steps:
-            - name: "Checkout Repository"
-              uses: actions/checkout@v6
-            - name: "TEST-${{ matrix.config.test }}"
-              run: TEST_CONTAINER_COMMAND="zypper --non-interactive install ${{ matrix.config.deps }}" ./test/test-container.sh "TEST-${{ matrix.config.test }}" ${{ matrix.config.test }}
+          - opensuse:latest
+        config:
+          - {test: '41', deps: 'mkosi-initrd'}
+    container:
+      image: ghcr.io/dracut-ng/${{ matrix.container }}-amd
+      options: '--device=/dev/kvm --privileged'
+    steps:
+      - name: "Checkout Repository"
+        uses: actions/checkout@v6
+      - name: "TEST-${{ matrix.config.test }}"
+        run: TEST_CONTAINER_COMMAND="zypper --non-interactive install ${{ matrix.config.deps }}" ./test/test-container.sh "TEST-${{ matrix.config.test }}" ${{ matrix.config.test }}

--- a/.github/workflows/daily-network-legacy.yml
+++ b/.github/workflows/daily-network-legacy.yml
@@ -2,43 +2,43 @@
 name: Daily Tests - network-legacy
 
 on:  # yamllint disable-line rule:truthy
-    schedule:
-        - cron: '30 23 * * *'   # every day at 23:30 UTC
+  schedule:
+    - cron: '30 23 * * *'   # every day at 23:30 UTC
 
-    # Allows you to run this workflow manually from the Actions tab
-    workflow_dispatch:
+  # Allows you to run this workflow manually from the Actions tab
+  workflow_dispatch:
 
-    pull_request:
-        paths:
-            - '.github/workflows/daily-network-legacy.yml'
+  pull_request:
+    paths:
+      - '.github/workflows/daily-network-legacy.yml'
 
 jobs:
-    network-legacy:
-        name: ${{ matrix.test }} on ${{ matrix.container }} ${{ matrix.network }} networking on ${{ matrix.architecture.tag }}
-        runs-on: ${{ matrix.architecture.runner }}
-        timeout-minutes: 40
-        concurrency:
-            group: daily-network-legacy-${{ github.workflow }}-${{ github.ref }}-${{ matrix.container }}-${{ matrix.test }}-${{ matrix.network }}-${{ matrix.architecture.tag }}
-            cancel-in-progress: true
-        strategy:
-            fail-fast: false
-            matrix:
-                architecture:
-                    - {runner: 'ubuntu-24.04', tag: 'amd'}
-                    - {runner: 'ubuntu-24.04-arm', tag: 'arm'}
-                network:
-                    - network-legacy
-                container:
-                    - opensuse:latest
-                test:
-                    - "50"
-                    - "60"
-                    - "72"
+  network-legacy:
+    name: ${{ matrix.test }} on ${{ matrix.container }} ${{ matrix.network }} networking on ${{ matrix.architecture.tag }}
+    runs-on: ${{ matrix.architecture.runner }}
+    timeout-minutes: 40
+    concurrency:
+      group: daily-network-legacy-${{ github.workflow }}-${{ github.ref }}-${{ matrix.container }}-${{ matrix.test }}-${{ matrix.network }}-${{ matrix.architecture.tag }}
+      cancel-in-progress: true
+    strategy:
+      fail-fast: false
+      matrix:
+        architecture:
+          - {runner: 'ubuntu-24.04', tag: 'amd'}
+          - {runner: 'ubuntu-24.04-arm', tag: 'arm'}
+        network:
+          - network-legacy
         container:
-            image: ghcr.io/dracut-ng/${{ matrix.container }}-${{ matrix.architecture.tag }}
-            options: '--device=/dev/kvm --privileged'
-        steps:
-            - name: "Checkout Repository"
-              uses: actions/checkout@v6
-            - name: "${{ matrix.container }} TEST-${{ matrix.test }}"
-              run: USE_NETWORK=${{ matrix.network }} CONFIGURE_ARG='--enable-network-legacy' ./test/test-container.sh "TEST-${{ matrix.test }}" ${{ matrix.test }}
+          - opensuse:latest
+        test:
+          - "50"
+          - "60"
+          - "72"
+    container:
+      image: ghcr.io/dracut-ng/${{ matrix.container }}-${{ matrix.architecture.tag }}
+      options: '--device=/dev/kvm --privileged'
+    steps:
+      - name: "Checkout Repository"
+        uses: actions/checkout@v6
+      - name: "${{ matrix.container }} TEST-${{ matrix.test }}"
+        run: USE_NETWORK=${{ matrix.network }} CONFIGURE_ARG='--enable-network-legacy' ./test/test-container.sh "TEST-${{ matrix.test }}" ${{ matrix.test }}

--- a/.github/workflows/daily-network.yml
+++ b/.github/workflows/daily-network.yml
@@ -2,64 +2,64 @@
 name: Daily Tests - network
 
 on:  # yamllint disable-line rule:truthy
-    schedule:
-        - cron: '30 23 * * *'   # every day at 23:30 UTC
+  schedule:
+    - cron: '30 23 * * *'   # every day at 23:30 UTC
 
-    # Allows you to run this workflow manually from the Actions tab
-    workflow_dispatch:
+  # Allows you to run this workflow manually from the Actions tab
+  workflow_dispatch:
 
-    pull_request:
-        paths:
-            - '.github/workflows/daily-network.yml'
+  pull_request:
+    paths:
+      - '.github/workflows/daily-network.yml'
 
 jobs:
-    network:
-        name: ${{ matrix.test }} on ${{ matrix.container }} on ${{ matrix.architecture.tag }}
-        runs-on: ${{ matrix.architecture.runner }}
-        timeout-minutes: 40
-        concurrency:
-            group: daily-network-${{ github.workflow }}-${{ github.ref }}-${{ matrix.container }}-${{ matrix.test }}-${{ matrix.architecture.tag }}
-            cancel-in-progress: true
-        strategy:
-            fail-fast: false
-            matrix:
-                architecture:
-                    - {runner: 'ubuntu-24.04', tag: 'amd'}
-                    - {runner: 'ubuntu-24.04-arm', tag: 'arm'}
-                container:
-                    - arch:latest
-                    - debian:latest
-                    - debian:sid
-                    - fedora:latest
-                    - fedora:rawhide
-                    - opensuse:latest
-                    - ubuntu:devel
-                    - ubuntu:rolling
-                test:
-                    - "31"
-                    - "60"
-                    - "72"
-                exclude:
-                    - container: arch:latest
-                      architecture: {runner: 'ubuntu-24.04-arm', tag: 'arm'}
-                    - container: fedora:latest
-                      architecture: {runner: 'ubuntu-24.04-arm', tag: 'arm'}
-                    - container: fedora:rawhide
-                      architecture: {runner: 'ubuntu-24.04-arm', tag: 'arm'}
-                    # https://github.com/dracut-ng/dracut-ng/issues/1815
-                    - container: ubuntu:devel
-                      test: "72"
-                    # https://github.com/dracut-ng/dracut-ng/issues/1815
-                    - container: ubuntu:rolling
-                      test: "72"
-                    # https://github.com/dracut-ng/dracut-ng/issues/1988
-                    - container: debian:sid
-                      architecture: {runner: 'ubuntu-24.04-arm', tag: 'arm'}
+  network:
+    name: ${{ matrix.test }} on ${{ matrix.container }} on ${{ matrix.architecture.tag }}
+    runs-on: ${{ matrix.architecture.runner }}
+    timeout-minutes: 40
+    concurrency:
+      group: daily-network-${{ github.workflow }}-${{ github.ref }}-${{ matrix.container }}-${{ matrix.test }}-${{ matrix.architecture.tag }}
+      cancel-in-progress: true
+    strategy:
+      fail-fast: false
+      matrix:
+        architecture:
+          - {runner: 'ubuntu-24.04', tag: 'amd'}
+          - {runner: 'ubuntu-24.04-arm', tag: 'arm'}
         container:
-            image: ghcr.io/dracut-ng/${{ matrix.container }}-${{ matrix.architecture.tag }}
-            options: '--device=/dev/kvm --privileged'
-        steps:
-            - name: "Checkout Repository"
-              uses: actions/checkout@v6
-            - name: "${{ matrix.container }} TEST-${{ matrix.test }}"
-              run: ./test/test-container.sh "TEST-${{ matrix.test }}" ${{ matrix.test }}
+          - arch:latest
+          - debian:latest
+          - debian:sid
+          - fedora:latest
+          - fedora:rawhide
+          - opensuse:latest
+          - ubuntu:devel
+          - ubuntu:rolling
+        test:
+          - "31"
+          - "60"
+          - "72"
+        exclude:
+          - container: arch:latest
+            architecture: {runner: 'ubuntu-24.04-arm', tag: 'arm'}
+          - container: fedora:latest
+            architecture: {runner: 'ubuntu-24.04-arm', tag: 'arm'}
+          - container: fedora:rawhide
+            architecture: {runner: 'ubuntu-24.04-arm', tag: 'arm'}
+          # https://github.com/dracut-ng/dracut-ng/issues/1815
+          - container: ubuntu:devel
+            test: "72"
+          # https://github.com/dracut-ng/dracut-ng/issues/1815
+          - container: ubuntu:rolling
+            test: "72"
+          # https://github.com/dracut-ng/dracut-ng/issues/1988
+          - container: debian:sid
+            architecture: {runner: 'ubuntu-24.04-arm', tag: 'arm'}
+    container:
+      image: ghcr.io/dracut-ng/${{ matrix.container }}-${{ matrix.architecture.tag }}
+      options: '--device=/dev/kvm --privileged'
+    steps:
+      - name: "Checkout Repository"
+        uses: actions/checkout@v6
+      - name: "${{ matrix.container }} TEST-${{ matrix.test }}"
+        run: ./test/test-container.sh "TEST-${{ matrix.test }}" ${{ matrix.test }}

--- a/.github/workflows/daily-omitsystemd.yml
+++ b/.github/workflows/daily-omitsystemd.yml
@@ -2,44 +2,44 @@
 name: Daily Tests - omitsystemd
 
 on:  # yamllint disable-line rule:truthy
-    schedule:
-        - cron: '30 23 * * *'   # every day at 23:30 UTC
+  schedule:
+    - cron: '30 23 * * *'   # every day at 23:30 UTC
 
-    # Allows you to run this workflow manually from the Actions tab
-    workflow_dispatch:
+  # Allows you to run this workflow manually from the Actions tab
+  workflow_dispatch:
 
-    pull_request:
-        paths:
-            - '.github/workflows/daily-omitsystemd.yml'
+  pull_request:
+    paths:
+      - '.github/workflows/daily-omitsystemd.yml'
 
 jobs:
-    omitsystemd:
-        name: ${{ matrix.test }} on ${{ matrix.container }} on ${{ matrix.architecture.tag }} with no systemd
-        runs-on: ${{ matrix.architecture.runner }}
-        timeout-minutes: 20
-        concurrency:
-            group: daily-omitsystemd-${{ github.workflow }}-${{ github.ref }}-${{ matrix.container }}-${{ matrix.test }}-${{ matrix.architecture.tag }}
-            cancel-in-progress: true
-        strategy:
-            fail-fast: false
-            matrix:
-                architecture:
-                    - {runner: 'ubuntu-24.04', tag: 'amd'}
-                    - {runner: 'ubuntu-24.04-arm', tag: 'arm'}
-                container:
-                    - ubuntu:devel
-                test:
-                    - "10"
-                    - "11"
-                    - "20"
-                    - "26"
-                    - "30"
-                    - "31"
+  omitsystemd:
+    name: ${{ matrix.test }} on ${{ matrix.container }} on ${{ matrix.architecture.tag }} with no systemd
+    runs-on: ${{ matrix.architecture.runner }}
+    timeout-minutes: 20
+    concurrency:
+      group: daily-omitsystemd-${{ github.workflow }}-${{ github.ref }}-${{ matrix.container }}-${{ matrix.test }}-${{ matrix.architecture.tag }}
+      cancel-in-progress: true
+    strategy:
+      fail-fast: false
+      matrix:
+        architecture:
+          - {runner: 'ubuntu-24.04', tag: 'amd'}
+          - {runner: 'ubuntu-24.04-arm', tag: 'arm'}
         container:
-            image: ghcr.io/dracut-ng/${{ matrix.container }}-${{ matrix.architecture.tag }}
-            options: '--device=/dev/kvm --privileged'
-        steps:
-            - name: "Checkout Repository"
-              uses: actions/checkout@v6
-            - name: "${{ matrix.container }} TEST-${{ matrix.test }}"
-              run: TEST_DRACUT_ARGS="--omit systemd" ./test/test-container.sh "TEST-${{ matrix.test }}" ${{ matrix.test }}
+          - ubuntu:devel
+        test:
+          - "10"
+          - "11"
+          - "20"
+          - "26"
+          - "30"
+          - "31"
+    container:
+      image: ghcr.io/dracut-ng/${{ matrix.container }}-${{ matrix.architecture.tag }}
+      options: '--device=/dev/kvm --privileged'
+    steps:
+      - name: "Checkout Repository"
+        uses: actions/checkout@v6
+      - name: "${{ matrix.container }} TEST-${{ matrix.test }}"
+        run: TEST_DRACUT_ARGS="--omit systemd" ./test/test-container.sh "TEST-${{ matrix.test }}" ${{ matrix.test }}

--- a/.github/workflows/daily-systemd-networkd.yml
+++ b/.github/workflows/daily-systemd-networkd.yml
@@ -2,46 +2,46 @@
 name: Daily Tests - systemd-networkd
 
 on:  # yamllint disable-line rule:truthy
-    schedule:
-        - cron: '30 23 * * *'   # every day at 23:30 UTC
+  schedule:
+    - cron: '30 23 * * *'   # every day at 23:30 UTC
 
-    # Allows you to run this workflow manually from the Actions tab
-    workflow_dispatch:
+  # Allows you to run this workflow manually from the Actions tab
+  workflow_dispatch:
 
-    pull_request:
-        paths:
-            - '.github/workflows/daily-systemd-networkd.yml'
+  pull_request:
+    paths:
+      - '.github/workflows/daily-systemd-networkd.yml'
 
 jobs:
-    systemd-networkd:
-        name: ${{ matrix.test }} on ${{ matrix.container }} ${{ matrix.network }} networking on ${{ matrix.architecture.tag }}
-        runs-on: ${{ matrix.architecture.runner }}
-        timeout-minutes: 40
-        concurrency:
-            group: daily-systemd-networkd-${{ github.workflow }}-${{ github.ref }}-${{ matrix.container }}-${{ matrix.test }}-${{ matrix.network }}-${{ matrix.architecture.tag }}
-            cancel-in-progress: true
-        strategy:
-            fail-fast: false
-            matrix:
-                architecture:
-                    - {runner: 'ubuntu-24.04', tag: 'amd'}
-                    - {runner: 'ubuntu-24.04-arm', tag: 'arm'}
-                network:
-                    - systemd-networkd
-                container:
-                    - arch:latest
-                    - ubuntu:devel
-                    - ubuntu:rolling
-                test:
-                    - "50"
-                exclude:
-                    - container: arch:latest
-                      architecture: {runner: 'ubuntu-24.04-arm', tag: 'arm'}
+  systemd-networkd:
+    name: ${{ matrix.test }} on ${{ matrix.container }} ${{ matrix.network }} networking on ${{ matrix.architecture.tag }}
+    runs-on: ${{ matrix.architecture.runner }}
+    timeout-minutes: 40
+    concurrency:
+      group: daily-systemd-networkd-${{ github.workflow }}-${{ github.ref }}-${{ matrix.container }}-${{ matrix.test }}-${{ matrix.network }}-${{ matrix.architecture.tag }}
+      cancel-in-progress: true
+    strategy:
+      fail-fast: false
+      matrix:
+        architecture:
+          - {runner: 'ubuntu-24.04', tag: 'amd'}
+          - {runner: 'ubuntu-24.04-arm', tag: 'arm'}
+        network:
+          - systemd-networkd
         container:
-            image: ghcr.io/dracut-ng/${{ matrix.container }}-${{ matrix.architecture.tag }}
-            options: '--device=/dev/kvm --privileged'
-        steps:
-            - name: "Checkout Repository"
-              uses: actions/checkout@v6
-            - name: "${{ matrix.container }} TEST-${{ matrix.test }}"
-              run: USE_NETWORK=${{ matrix.network }} ./test/test-container.sh "TEST-${{ matrix.test }}" ${{ matrix.test }}
+          - arch:latest
+          - ubuntu:devel
+          - ubuntu:rolling
+        test:
+          - "50"
+        exclude:
+          - container: arch:latest
+            architecture: {runner: 'ubuntu-24.04-arm', tag: 'arm'}
+    container:
+      image: ghcr.io/dracut-ng/${{ matrix.container }}-${{ matrix.architecture.tag }}
+      options: '--device=/dev/kvm --privileged'
+    steps:
+      - name: "Checkout Repository"
+        uses: actions/checkout@v6
+      - name: "${{ matrix.container }} TEST-${{ matrix.test }}"
+        run: USE_NETWORK=${{ matrix.network }} ./test/test-container.sh "TEST-${{ matrix.test }}" ${{ matrix.test }}

--- a/.github/workflows/daily-systemd.yml
+++ b/.github/workflows/daily-systemd.yml
@@ -2,81 +2,81 @@
 name: Daily Tests - systemd
 
 on:  # yamllint disable-line rule:truthy
-    schedule:
-        - cron: '30 23 * * *'   # every day at 23:30 UTC
+  schedule:
+    - cron: '30 23 * * *'   # every day at 23:30 UTC
 
-    # Allows you to run this workflow manually from the Actions tab
-    workflow_dispatch:
+  # Allows you to run this workflow manually from the Actions tab
+  workflow_dispatch:
 
-    pull_request:
-        paths:
-            - '.github/workflows/daily-systemd.yml'
+  pull_request:
+    paths:
+      - '.github/workflows/daily-systemd.yml'
 
 jobs:
-    systemd:
-        name: ${{ matrix.test }} on ${{ matrix.container }} on ${{ matrix.architecture.tag }}
-        runs-on: ${{ matrix.architecture.runner }}
-        timeout-minutes: 20
-        concurrency:
-            group: daily-systemd-${{ github.workflow }}-${{ github.ref }}-${{ matrix.container }}-${{ matrix.test }}-${{ matrix.architecture.tag }}
-            cancel-in-progress: true
-        strategy:
-            fail-fast: false
-            matrix:
-                architecture:
-                    - {runner: 'ubuntu-24.04', tag: 'amd'}
-                    - {runner: 'ubuntu-24.04-arm', tag: 'arm'}
-                container:
-                    - arch:latest
-                    - azurelinux:3.0
-                    - debian:latest
-                    - debian:sid
-                    - fedora:latest
-                    - fedora:rawhide
-                    - centos:latest
-                    - gentoo:latest
-                    - opensuse:latest
-                    - ubuntu:devel
-                    - ubuntu:rolling
-                test:
-                    - "40"
-                    - "41"
-                    - "42"
-                    - "43"
-                    - "44"
-                exclude:
-                    - container: arch:latest
-                      architecture: {runner: 'ubuntu-24.04-arm', tag: 'arm'}
-                    - container: azurelinux:3.0
-                      architecture: {runner: 'ubuntu-24.04-arm', tag: 'arm'}
-                    - container: fedora:latest
-                      architecture: {runner: 'ubuntu-24.04-arm', tag: 'arm'}
-                    - container: fedora:rawhide
-                      architecture: {runner: 'ubuntu-24.04-arm', tag: 'arm'}
-                    - container: centos:latest
-                      architecture: {runner: 'ubuntu-24.04-arm', tag: 'arm'}
-                    # https://github.com/dracut-ng/dracut-ng/issues/1677
-                    - container: arch:latest
-                      test: "41"
-                    # intentionally skipped
-                    - container: centos:latest
-                      test: "41"
-                    # /boot/vmlinuz-... is missing .efi suffix: https://launchpad.net/bugs/2133402
-                    - container: ubuntu:devel
-                      architecture: {runner: 'ubuntu-24.04-arm', tag: 'arm'}
-                      test: "43"
-                    # /boot/vmlinuz-... is missing .efi suffix: https://launchpad.net/bugs/2133402
-                    - container: ubuntu:rolling
-                      architecture: {runner: 'ubuntu-24.04-arm', tag: 'arm'}
-                      test: "43"
-                    # https://github.com/dracut-ng/dracut-ng/issues/1988
-                    - container: debian:sid
-                      architecture: {runner: 'ubuntu-24.04-arm', tag: 'arm'}
+  systemd:
+    name: ${{ matrix.test }} on ${{ matrix.container }} on ${{ matrix.architecture.tag }}
+    runs-on: ${{ matrix.architecture.runner }}
+    timeout-minutes: 20
+    concurrency:
+      group: daily-systemd-${{ github.workflow }}-${{ github.ref }}-${{ matrix.container }}-${{ matrix.test }}-${{ matrix.architecture.tag }}
+      cancel-in-progress: true
+    strategy:
+      fail-fast: false
+      matrix:
+        architecture:
+          - {runner: 'ubuntu-24.04', tag: 'amd'}
+          - {runner: 'ubuntu-24.04-arm', tag: 'arm'}
         container:
-            image: ghcr.io/dracut-ng/${{ matrix.container }}-${{ matrix.architecture.tag }}
-            options: '--device=/dev/kvm --privileged'
-        steps:
-            - name: "Checkout Repository"
-              uses: actions/checkout@v6
-            - name: "${{ matrix.container }} TEST-${{ matrix.test }}"
-              run: ./test/test-container.sh "TEST-${{ matrix.test }}" ${{ matrix.test }}
+          - arch:latest
+          - azurelinux:3.0
+          - debian:latest
+          - debian:sid
+          - fedora:latest
+          - fedora:rawhide
+          - centos:latest
+          - gentoo:latest
+          - opensuse:latest
+          - ubuntu:devel
+          - ubuntu:rolling
+        test:
+          - "40"
+          - "41"
+          - "42"
+          - "43"
+          - "44"
+        exclude:
+          - container: arch:latest
+            architecture: {runner: 'ubuntu-24.04-arm', tag: 'arm'}
+          - container: azurelinux:3.0
+            architecture: {runner: 'ubuntu-24.04-arm', tag: 'arm'}
+          - container: fedora:latest
+            architecture: {runner: 'ubuntu-24.04-arm', tag: 'arm'}
+          - container: fedora:rawhide
+            architecture: {runner: 'ubuntu-24.04-arm', tag: 'arm'}
+          - container: centos:latest
+            architecture: {runner: 'ubuntu-24.04-arm', tag: 'arm'}
+          # https://github.com/dracut-ng/dracut-ng/issues/1677
+          - container: arch:latest
+            test: "41"
+          # intentionally skipped
+          - container: centos:latest
+            test: "41"
+          # /boot/vmlinuz-... is missing .efi suffix: https://launchpad.net/bugs/2133402
+          - container: ubuntu:devel
+            architecture: {runner: 'ubuntu-24.04-arm', tag: 'arm'}
+            test: "43"
+          # /boot/vmlinuz-... is missing .efi suffix: https://launchpad.net/bugs/2133402
+          - container: ubuntu:rolling
+            architecture: {runner: 'ubuntu-24.04-arm', tag: 'arm'}
+            test: "43"
+          # https://github.com/dracut-ng/dracut-ng/issues/1988
+          - container: debian:sid
+            architecture: {runner: 'ubuntu-24.04-arm', tag: 'arm'}
+    container:
+      image: ghcr.io/dracut-ng/${{ matrix.container }}-${{ matrix.architecture.tag }}
+      options: '--device=/dev/kvm --privileged'
+    steps:
+      - name: "Checkout Repository"
+        uses: actions/checkout@v6
+      - name: "${{ matrix.container }} TEST-${{ matrix.test }}"
+        run: ./test/test-container.sh "TEST-${{ matrix.test }}" ${{ matrix.test }}

--- a/.github/workflows/doc.yml
+++ b/.github/workflows/doc.yml
@@ -2,38 +2,38 @@
 name: Doc Test
 
 on:  # yamllint disable-line rule:truthy
-    pull_request:
-        branches: [main]
-        paths:
-            - 'man/**'
-            - '.github/workflows/doc.yml'
-    # Allows you to run this workflow manually from the Actions tab
-    workflow_dispatch:
+  pull_request:
+    branches: [main]
+    paths:
+      - 'man/**'
+      - '.github/workflows/doc.yml'
+  # Allows you to run this workflow manually from the Actions tab
+  workflow_dispatch:
 
 jobs:
-    doc:
-        name: doc on ${{ matrix.container }}
-        runs-on: ubuntu-latest
-        timeout-minutes: 10
-        concurrency:
-            group: doc-${{ github.workflow }}-${{ github.ref }}-${{ matrix.container }}
-            cancel-in-progress: true
-        strategy:
-            fail-fast: false
-            matrix:
-                container:
-                    - alpine:edge
-                    - arch:latest
-                    - debian:latest
-                    - fedora:latest
-                    - gentoo:latest
-                    - opensuse:latest
-                    - ubuntu:devel
-                    - void:latest
+  doc:
+    name: doc on ${{ matrix.container }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    concurrency:
+      group: doc-${{ github.workflow }}-${{ github.ref }}-${{ matrix.container }}
+      cancel-in-progress: true
+    strategy:
+      fail-fast: false
+      matrix:
         container:
-            image: ghcr.io/dracut-ng/${{ matrix.container }}-amd
-        steps:
-            - name: "Checkout Repository"
-              uses: actions/checkout@v6
-            - name: doc on "${{ matrix.container }}"
-              run: TARGETS=all enable_documentation=yes ./test/test-container.sh
+          - alpine:edge
+          - arch:latest
+          - debian:latest
+          - fedora:latest
+          - gentoo:latest
+          - opensuse:latest
+          - ubuntu:devel
+          - void:latest
+    container:
+      image: ghcr.io/dracut-ng/${{ matrix.container }}-amd
+    steps:
+      - name: "Checkout Repository"
+        uses: actions/checkout@v6
+      - name: doc on "${{ matrix.container }}"
+        run: TARGETS=all enable_documentation=yes ./test/test-container.sh

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -2,267 +2,267 @@
 name: Integration Test
 
 on:  # yamllint disable-line rule:truthy
-    pull_request:
-        branches: [main]
-        paths-ignore:
-            - antora-playbook.yaml
-            - 'doc_site/**'
-            - 'man/**'
+  pull_request:
+    branches: [main]
+    paths-ignore:
+      - antora-playbook.yaml
+      - 'doc_site/**'
+      - 'man/**'
 
-    # Allows you to run this workflow manually from the Actions tab
-    workflow_dispatch:
+  # Allows you to run this workflow manually from the Actions tab
+  workflow_dispatch:
 
 env:
-    # set V to 2 when re-running jobs with debug logging enabled
-    # see https://docs.github.com/en/actions/monitoring-and-troubleshooting-workflows/troubleshooting-workflows/enabling-debug-logging
-    V: "${{ secrets.ACTIONS_STEP_DEBUG && '2' }}"
+  # set V to 2 when re-running jobs with debug logging enabled
+  # see https://docs.github.com/en/actions/monitoring-and-troubleshooting-workflows/troubleshooting-workflows/enabling-debug-logging
+  V: "${{ secrets.ACTIONS_STEP_DEBUG && '2' }}"
 
 jobs:
-    basic:
-        # run this test on all containers
-        name: ${{ matrix.test }} on ${{ matrix.container }}
-        runs-on: ubuntu-24.04
-        timeout-minutes: 20
-        concurrency:
-            group: basic-${{ github.workflow }}-${{ github.ref }}-${{ matrix.container }}-${{ matrix.test }}
-            cancel-in-progress: true
-        strategy:
-            fail-fast: false
-            matrix:
-                container:
-                    - alpine:edge
-                    - alpine-busybox:edge
-                    - arch:latest
-                    - debian:latest
-                    - fedora:latest
-                    - gentoo:latest
-                    - opensuse:latest
-                    - ubuntu:devel
-                    - void:latest
-                test:
-                    - "10"
+  basic:
+    # run this test on all containers
+    name: ${{ matrix.test }} on ${{ matrix.container }}
+    runs-on: ubuntu-24.04
+    timeout-minutes: 20
+    concurrency:
+      group: basic-${{ github.workflow }}-${{ github.ref }}-${{ matrix.container }}-${{ matrix.test }}
+      cancel-in-progress: true
+    strategy:
+      fail-fast: false
+      matrix:
         container:
-            image: ghcr.io/dracut-ng/${{ matrix.container }}-amd
-            options: '--device=/dev/kvm'
-        steps:
-            - name: "Checkout Repository"
-              uses: actions/checkout@v6
-            - name: "${{ matrix.container }} TEST-${{ matrix.test }}"
-              run: ./test/test-container.sh "TEST-${{ matrix.test }}" ${{ matrix.test }}
+          - alpine:edge
+          - alpine-busybox:edge
+          - arch:latest
+          - debian:latest
+          - fedora:latest
+          - gentoo:latest
+          - opensuse:latest
+          - ubuntu:devel
+          - void:latest
+        test:
+          - "10"
+    container:
+      image: ghcr.io/dracut-ng/${{ matrix.container }}-amd
+      options: '--device=/dev/kvm'
+    steps:
+      - name: "Checkout Repository"
+        uses: actions/checkout@v6
+      - name: "${{ matrix.container }} TEST-${{ matrix.test }}"
+        run: ./test/test-container.sh "TEST-${{ matrix.test }}" ${{ matrix.test }}
 
-    # syncheck
-    syncheck:
-        needs: basic
-        name: syncheck
-        runs-on: ubuntu-24.04
-        container:
-            image: ubuntu:devel
-        steps:
-            - name: "Checkout Repository"
-              uses: actions/checkout@v6
-            - name: Install dependencies
-              run: apt-get update && apt-get -y install make shellcheck shfmt
-            - run: make syncheck
+  # syncheck
+  syncheck:
+    needs: basic
+    name: syncheck
+    runs-on: ubuntu-24.04
+    container:
+      image: ubuntu:devel
+    steps:
+      - name: "Checkout Repository"
+        uses: actions/checkout@v6
+      - name: Install dependencies
+        run: apt-get update && apt-get -y install make shellcheck shfmt
+      - run: make syncheck
 
-    extended:
-        needs: basic
-        name: ${{ matrix.test }} on ${{ matrix.container }}
-        runs-on: ubuntu-24.04
-        timeout-minutes: 20
-        concurrency:
-            group: extended-${{ github.workflow }}-${{ github.ref }}-${{ matrix.container }}-${{ matrix.test }}
-            cancel-in-progress: true
-        strategy:
-            fail-fast: false
-            matrix:
-                container:
-                    - arch:latest
-                    - fedora:latest
-                    - gentoo:latest
-                    - opensuse:latest
-                    - ubuntu:devel
-                    - void:latest
-                test:
-                    - "11"
-                    - "12"
-                    - "13"
-                    - "20"
-                    - "26"
-                    - "30"
-                    - "50"
-                    - "80"
-                    - "81"
+  extended:
+    needs: basic
+    name: ${{ matrix.test }} on ${{ matrix.container }}
+    runs-on: ubuntu-24.04
+    timeout-minutes: 20
+    concurrency:
+      group: extended-${{ github.workflow }}-${{ github.ref }}-${{ matrix.container }}-${{ matrix.test }}
+      cancel-in-progress: true
+    strategy:
+      fail-fast: false
+      matrix:
         container:
-            image: ghcr.io/dracut-ng/${{ matrix.container }}-amd
-            options: '--device=/dev/kvm'
-        steps:
-            - name: "Checkout Repository"
-              uses: actions/checkout@v6
-            - name: "${{ matrix.container }} TEST-${{ matrix.test }}"
-              run: ./test/test-container.sh "TEST-${{ matrix.test }}" ${{ matrix.test }}
+          - arch:latest
+          - fedora:latest
+          - gentoo:latest
+          - opensuse:latest
+          - ubuntu:devel
+          - void:latest
+        test:
+          - "11"
+          - "12"
+          - "13"
+          - "20"
+          - "26"
+          - "30"
+          - "50"
+          - "80"
+          - "81"
+    container:
+      image: ghcr.io/dracut-ng/${{ matrix.container }}-amd
+      options: '--device=/dev/kvm'
+    steps:
+      - name: "Checkout Repository"
+        uses: actions/checkout@v6
+      - name: "${{ matrix.container }} TEST-${{ matrix.test }}"
+        run: ./test/test-container.sh "TEST-${{ matrix.test }}" ${{ matrix.test }}
 
-    extended-systemd:
-        needs: basic
-        name: ${{ matrix.test }} on ${{ matrix.container }}
-        runs-on: ubuntu-24.04
-        timeout-minutes: 20
-        concurrency:
-            group: extended-systemd-${{ github.workflow }}-${{ github.ref }}-${{ matrix.container }}-${{ matrix.test }}
-            cancel-in-progress: true
-        strategy:
-            fail-fast: false
-            matrix:
-                container:
-                    - arch:latest
-                    - fedora:latest
-                    - gentoo:latest
-                    - opensuse:latest
-                    - ubuntu:devel
-                test:
-                    - "40"
-                    - "41"
-                    - "42"
-                    - "43"
-                    - "44"
-                exclude:
-                    # https://github.com/dracut-ng/dracut-ng/issues/1677
-                    - container: arch:latest
-                      test: "41"
+  extended-systemd:
+    needs: basic
+    name: ${{ matrix.test }} on ${{ matrix.container }}
+    runs-on: ubuntu-24.04
+    timeout-minutes: 20
+    concurrency:
+      group: extended-systemd-${{ github.workflow }}-${{ github.ref }}-${{ matrix.container }}-${{ matrix.test }}
+      cancel-in-progress: true
+    strategy:
+      fail-fast: false
+      matrix:
         container:
-            image: ghcr.io/dracut-ng/${{ matrix.container }}-amd
-            options: '--device=/dev/kvm --privileged'
-        steps:
-            - name: "Checkout Repository"
-              uses: actions/checkout@v6
-            - name: "${{ matrix.container }} TEST-${{ matrix.test }}"
-              run: ./test/test-container.sh "TEST-${{ matrix.test }}" ${{ matrix.test }}
+          - arch:latest
+          - fedora:latest
+          - gentoo:latest
+          - opensuse:latest
+          - ubuntu:devel
+        test:
+          - "40"
+          - "41"
+          - "42"
+          - "43"
+          - "44"
+        exclude:
+          # https://github.com/dracut-ng/dracut-ng/issues/1677
+          - container: arch:latest
+            test: "41"
+    container:
+      image: ghcr.io/dracut-ng/${{ matrix.container }}-amd
+      options: '--device=/dev/kvm --privileged'
+    steps:
+      - name: "Checkout Repository"
+        uses: actions/checkout@v6
+      - name: "${{ matrix.container }} TEST-${{ matrix.test }}"
+        run: ./test/test-container.sh "TEST-${{ matrix.test }}" ${{ matrix.test }}
 
-    dracut-cpio:
-        needs: basic
-        name: ${{ matrix.test }} on ${{ matrix.container }}
-        runs-on: ubuntu-24.04
-        timeout-minutes: 20
-        concurrency:
-            group: dracut-cpio-${{ github.workflow }}-${{ github.ref }}-${{ matrix.container }}-${{ matrix.test }}
-            cancel-in-progress: true
-        strategy:
-            fail-fast: false
-            matrix:
-                container:
-                    - opensuse:latest
-                test:
-                    - "82"
+  dracut-cpio:
+    needs: basic
+    name: ${{ matrix.test }} on ${{ matrix.container }}
+    runs-on: ubuntu-24.04
+    timeout-minutes: 20
+    concurrency:
+      group: dracut-cpio-${{ github.workflow }}-${{ github.ref }}-${{ matrix.container }}-${{ matrix.test }}
+      cancel-in-progress: true
+    strategy:
+      fail-fast: false
+      matrix:
         container:
-            image: ghcr.io/dracut-ng/${{ matrix.container }}-amd
-            options: '--device=/dev/kvm'
-        steps:
-            - name: "Checkout Repository"
-              uses: actions/checkout@v6
-            - name: "${{ matrix.container }} TEST-${{ matrix.test }}"
-              run: ./test/test-container.sh "TEST-${{ matrix.test }}" ${{ matrix.test }}
-    network:
-        needs: basic
-        # all nfs based on default networking
-        name: ${{ matrix.test }} on ${{ matrix.container }}
-        runs-on: ubuntu-24.04
-        timeout-minutes: 20
-        concurrency:
-            group: network-${{ github.workflow }}-${{ github.ref }}-${{ matrix.container }}-${{ matrix.test }}-${{ matrix.network }}
-            cancel-in-progress: true
-        strategy:
-            fail-fast: false
-            matrix:
-                container:
-                    - arch:latest
-                    - fedora:latest
-                    - opensuse:latest
-                    - ubuntu:devel
-                test:
-                    - "31"
-                    - "60"
+          - opensuse:latest
+        test:
+          - "82"
+    container:
+      image: ghcr.io/dracut-ng/${{ matrix.container }}-amd
+      options: '--device=/dev/kvm'
+    steps:
+      - name: "Checkout Repository"
+        uses: actions/checkout@v6
+      - name: "${{ matrix.container }} TEST-${{ matrix.test }}"
+        run: ./test/test-container.sh "TEST-${{ matrix.test }}" ${{ matrix.test }}
+  network:
+    needs: basic
+    # all nfs based on default networking
+    name: ${{ matrix.test }} on ${{ matrix.container }}
+    runs-on: ubuntu-24.04
+    timeout-minutes: 20
+    concurrency:
+      group: network-${{ github.workflow }}-${{ github.ref }}-${{ matrix.container }}-${{ matrix.test }}-${{ matrix.network }}
+      cancel-in-progress: true
+    strategy:
+      fail-fast: false
+      matrix:
         container:
-            image: ghcr.io/dracut-ng/${{ matrix.container }}-amd
-            options: '--device=/dev/kvm'
-        steps:
-            - name: "Checkout Repository"
-              uses: actions/checkout@v6
-            - name: "${{ matrix.container }} TEST-${{ matrix.test }}"
-              run: USE_NETWORK=${{ matrix.network }} ./test/test-container.sh "TEST-${{ matrix.test }}" ${{ matrix.test }}
-    network-iscsi:
-        needs: basic
-        name: ${{ matrix.test }} on ${{ matrix.container }}
-        runs-on: ubuntu-24.04
-        timeout-minutes: 20
-        concurrency:
-            group: network-iscsi-${{ github.workflow }}-${{ github.ref }}-${{ matrix.container }}-${{ matrix.test }}-${{ matrix.network }}
-            cancel-in-progress: true
-        strategy:
-            fail-fast: false
-            matrix:
-                network:
-                    - network-manager
-                container:
-                    - debian:latest
-                    - ubuntu:devel
-                test:
-                    - "70"
-                    - "71"
+          - arch:latest
+          - fedora:latest
+          - opensuse:latest
+          - ubuntu:devel
+        test:
+          - "31"
+          - "60"
+    container:
+      image: ghcr.io/dracut-ng/${{ matrix.container }}-amd
+      options: '--device=/dev/kvm'
+    steps:
+      - name: "Checkout Repository"
+        uses: actions/checkout@v6
+      - name: "${{ matrix.container }} TEST-${{ matrix.test }}"
+        run: USE_NETWORK=${{ matrix.network }} ./test/test-container.sh "TEST-${{ matrix.test }}" ${{ matrix.test }}
+  network-iscsi:
+    needs: basic
+    name: ${{ matrix.test }} on ${{ matrix.container }}
+    runs-on: ubuntu-24.04
+    timeout-minutes: 20
+    concurrency:
+      group: network-iscsi-${{ github.workflow }}-${{ github.ref }}-${{ matrix.container }}-${{ matrix.test }}-${{ matrix.network }}
+      cancel-in-progress: true
+    strategy:
+      fail-fast: false
+      matrix:
+        network:
+          - network-manager
         container:
-            image: ghcr.io/dracut-ng/${{ matrix.container }}-amd
-            options: '--device=/dev/kvm'
-        steps:
-            - name: "Checkout Repository"
-              uses: actions/checkout@v6
-            - name: "${{ matrix.container }} TEST-${{ matrix.test }}"
-              run: USE_NETWORK=${{ matrix.network }} ./test/test-container.sh "TEST-${{ matrix.test }}" ${{ matrix.test }}
-    network-nbd:
-        needs: basic
-        name: ${{ matrix.test }} on ${{ matrix.container }}
-        runs-on: ubuntu-24.04
-        timeout-minutes: 20
-        concurrency:
-            group: network-nbd-${{ github.workflow }}-${{ github.ref }}-${{ matrix.container }}-${{ matrix.test }}-${{ matrix.network }}
-            cancel-in-progress: true
-        strategy:
-            fail-fast: false
-            matrix:
-                container:
-                    - arch:latest
-                    - debian:latest
-                    - opensuse:latest
-                test:
-                    - "72"
+          - debian:latest
+          - ubuntu:devel
+        test:
+          - "70"
+          - "71"
+    container:
+      image: ghcr.io/dracut-ng/${{ matrix.container }}-amd
+      options: '--device=/dev/kvm'
+    steps:
+      - name: "Checkout Repository"
+        uses: actions/checkout@v6
+      - name: "${{ matrix.container }} TEST-${{ matrix.test }}"
+        run: USE_NETWORK=${{ matrix.network }} ./test/test-container.sh "TEST-${{ matrix.test }}" ${{ matrix.test }}
+  network-nbd:
+    needs: basic
+    name: ${{ matrix.test }} on ${{ matrix.container }}
+    runs-on: ubuntu-24.04
+    timeout-minutes: 20
+    concurrency:
+      group: network-nbd-${{ github.workflow }}-${{ github.ref }}-${{ matrix.container }}-${{ matrix.test }}-${{ matrix.network }}
+      cancel-in-progress: true
+    strategy:
+      fail-fast: false
+      matrix:
         container:
-            image: ghcr.io/dracut-ng/${{ matrix.container }}-amd
-            options: '--device=/dev/kvm'
-        steps:
-            - name: "Checkout Repository"
-              uses: actions/checkout@v6
-            - name: "${{ matrix.container }} TEST-${{ matrix.test }}"
-              run: USE_NETWORK=${{ matrix.network }} ./test/test-container.sh "TEST-${{ matrix.test }}" ${{ matrix.test }}
-    arm64:
-        needs: basic
-        name: ${{ matrix.test }} on ${{ matrix.container }} on arm64
-        runs-on: ubuntu-24.04-arm
-        timeout-minutes: 20
-        concurrency:
-            group: arm64-${{ github.workflow }}-${{ github.ref }}-${{ matrix.container }}-${{ matrix.test }}
-            cancel-in-progress: true
-        strategy:
-            fail-fast: false
-            matrix:
-                container:
-                    - debian:latest
-                    - opensuse:latest
-                    - ubuntu:rolling
-                    - void:latest
-                test:
-                    - "10"
+          - arch:latest
+          - debian:latest
+          - opensuse:latest
+        test:
+          - "72"
+    container:
+      image: ghcr.io/dracut-ng/${{ matrix.container }}-amd
+      options: '--device=/dev/kvm'
+    steps:
+      - name: "Checkout Repository"
+        uses: actions/checkout@v6
+      - name: "${{ matrix.container }} TEST-${{ matrix.test }}"
+        run: USE_NETWORK=${{ matrix.network }} ./test/test-container.sh "TEST-${{ matrix.test }}" ${{ matrix.test }}
+  arm64:
+    needs: basic
+    name: ${{ matrix.test }} on ${{ matrix.container }} on arm64
+    runs-on: ubuntu-24.04-arm
+    timeout-minutes: 20
+    concurrency:
+      group: arm64-${{ github.workflow }}-${{ github.ref }}-${{ matrix.container }}-${{ matrix.test }}
+      cancel-in-progress: true
+    strategy:
+      fail-fast: false
+      matrix:
         container:
-            image: ghcr.io/dracut-ng/${{ matrix.container }}-arm
-            options: '--device=/dev/kvm --privileged'
-        steps:
-            - name: "Checkout Repository"
-              uses: actions/checkout@v6
-            - name: "${{ matrix.container }} TEST-${{ matrix.test }}"
-              run: ./test/test-container.sh "TEST-${{ matrix.test }}" ${{ matrix.test }}
+          - debian:latest
+          - opensuse:latest
+          - ubuntu:rolling
+          - void:latest
+        test:
+          - "10"
+    container:
+      image: ghcr.io/dracut-ng/${{ matrix.container }}-arm
+      options: '--device=/dev/kvm --privileged'
+    steps:
+      - name: "Checkout Repository"
+        uses: actions/checkout@v6
+      - name: "${{ matrix.container }} TEST-${{ matrix.test }}"
+        run: ./test/test-container.sh "TEST-${{ matrix.test }}" ${{ matrix.test }}

--- a/.github/workflows/labels.yml
+++ b/.github/workflows/labels.yml
@@ -4,12 +4,12 @@ name: "Labeler"
 # runs on pull_request_target instead of pull_request
 # see https://github.com/actions/labeler?tab=readme-ov-file#permissions
 on:  # yamllint disable-line rule:truthy
-    pull_request_target:
+  pull_request_target:
 
 jobs:
-    triage:
-        runs-on: ubuntu-latest
-        steps:
-            - uses: actions/labeler@main
-              with:
-                  repo-token: "${{ secrets.GITHUB_TOKEN }}"
+  triage:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/labeler@main
+        with:
+          repo-token: "${{ secrets.GITHUB_TOKEN }}"

--- a/.github/workflows/manualtest.yml
+++ b/.github/workflows/manualtest.yml
@@ -2,79 +2,79 @@
 name: Manual test
 
 on:  # yamllint disable-line rule:truthy
-    workflow_dispatch:
-        inputs:
-            test:
-                description: "Array of tests to run, such as [11,12]"
-                default: "[]"
-            container:
-                type: choice
-                description: 'distro'
-                default: 'all'
-                options:
-                    - "all"
-                    - "alpine:edge"
-                    - "azurelinux:3.0"
-                    - "centos:latest"
-                    - "fedora:latest"
-                    - "fedora:rawhide"
-                    - "arch:latest"
-                    - "debian:latest"
-                    - "debian:sid"
-                    - "ubuntu:devel"
-                    - "ubuntu:rolling"
-                    - "opensuse:latest"
-                    - "gentoo:latest"
-                    - "void:latest"
-            env:
-                description: 'Environment (optional)'
-                default: '{"DEBUGFAIL": "rd.debug"}'
-            registry:
-                description: 'Registry for containers, such as ghcr.io/dracut-ng'
+  workflow_dispatch:
+    inputs:
+      test:
+        description: "Array of tests to run, such as [11,12]"
+        default: "[]"
+      container:
+        type: choice
+        description: 'distro'
+        default: 'all'
+        options:
+          - "all"
+          - "alpine:edge"
+          - "azurelinux:3.0"
+          - "centos:latest"
+          - "fedora:latest"
+          - "fedora:rawhide"
+          - "arch:latest"
+          - "debian:latest"
+          - "debian:sid"
+          - "ubuntu:devel"
+          - "ubuntu:rolling"
+          - "opensuse:latest"
+          - "gentoo:latest"
+          - "void:latest"
+      env:
+        description: 'Environment (optional)'
+        default: '{"DEBUGFAIL": "rd.debug"}'
+      registry:
+        description: 'Registry for containers, such as ghcr.io/dracut-ng'
 
 env:
-    ${{ fromJSON(inputs.env) }}
+  ${{ fromJSON(inputs.env) }}
 
 jobs:
-    matrix:
-        runs-on: ubuntu-24.04
-        outputs:
-            registry: ${{ steps.set-matrix.outputs.registry }}
-            container: ${{ steps.set-matrix.outputs.container }}
-            tests: ${{ steps.set-matrix.outputs.tests }}
-        steps:
-            - name: "Checkout Repository"
-              uses: actions/checkout@v6
-              with:
-                  fetch-depth: 0
-            - id: set-matrix
-              name: "Set Matrix"
-              run: |
-                   [[ "${{ inputs.registry }}" != '' ]] && echo "registry=\"${{ inputs.registry }}\"" >> $GITHUB_OUTPUT \
-                   || ( echo "registry=\"ghcr.io/${{ github.repository_owner }}\"" >> $GITHUB_OUTPUT )
-                   [[ "${{ inputs.container }}" != 'all' ]] && echo "container=[\"${{ inputs.container }}\"]" >> $GITHUB_OUTPUT \
-                   || ( containers=$(find test/container -name "Dockerfile-*" | cut -d\- -f2 | tr '[:upper:]' '[:lower:]' | sed -z 's/\n/","/g'); echo "container=[\"${containers%??}]" >> $GITHUB_OUTPUT )
-                   [[ "${{ toJson(fromJson(inputs.test)) }}" != '[]' ]] && echo "tests=${{ inputs.test }}" >> $GITHUB_OUTPUT \
-                   || ( tests=$(find test -type d -a -name "TEST-*" | cut -d\- -f2 | sed -z 's/\n/","/g' ); echo "tests=[\"${tests%??}]" >> $GITHUB_OUTPUT )
-    test:
-        needs: matrix
-        runs-on: ubuntu-24.04
-        timeout-minutes: 20
-        concurrency:
-            group: manual-${{ github.workflow }}-${{ github.ref }}-${{ matrix.container }}-${{ matrix.test }}
-            cancel-in-progress: true
-        strategy:
-            matrix:
-                container: ${{ fromJSON(needs.matrix.outputs.container) }}
-                test: ${{ fromJSON(needs.matrix.outputs.tests) }}
-            fail-fast: false
-        container:
-            image: ${{ fromJSON(needs.matrix.outputs.registry) }}/${{ matrix.container }}-amd
-            options: "--privileged -v /dev:/dev"
-        steps:
-            - name: "Checkout Repository"
-              uses: actions/checkout@v6
-              with:
-                  fetch-depth: 0
-            - name: "${{ matrix.container }} ${{ matrix.test }}"
-              run: ./test/test-container.sh "TEST-${{ matrix.test }}" ${{ matrix.test }}
+  matrix:
+    runs-on: ubuntu-24.04
+    outputs:
+      registry: ${{ steps.set-matrix.outputs.registry }}
+      container: ${{ steps.set-matrix.outputs.container }}
+      tests: ${{ steps.set-matrix.outputs.tests }}
+    steps:
+      - name: "Checkout Repository"
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+      - id: set-matrix
+        name: "Set Matrix"
+        run: |
+           [[ "${{ inputs.registry }}" != '' ]] && echo "registry=\"${{ inputs.registry }}\"" >> $GITHUB_OUTPUT \
+           || ( echo "registry=\"ghcr.io/${{ github.repository_owner }}\"" >> $GITHUB_OUTPUT )
+           [[ "${{ inputs.container }}" != 'all' ]] && echo "container=[\"${{ inputs.container }}\"]" >> $GITHUB_OUTPUT \
+           || ( containers=$(find test/container -name "Dockerfile-*" | cut -d\- -f2 | tr '[:upper:]' '[:lower:]' | sed -z 's/\n/","/g'); echo "container=[\"${containers%??}]" >> $GITHUB_OUTPUT )
+           [[ "${{ toJson(fromJson(inputs.test)) }}" != '[]' ]] && echo "tests=${{ inputs.test }}" >> $GITHUB_OUTPUT \
+           || ( tests=$(find test -type d -a -name "TEST-*" | cut -d\- -f2 | sed -z 's/\n/","/g' ); echo "tests=[\"${tests%??}]" >> $GITHUB_OUTPUT )
+  test:
+    needs: matrix
+    runs-on: ubuntu-24.04
+    timeout-minutes: 20
+    concurrency:
+      group: manual-${{ github.workflow }}-${{ github.ref }}-${{ matrix.container }}-${{ matrix.test }}
+      cancel-in-progress: true
+    strategy:
+      matrix:
+        container: ${{ fromJSON(needs.matrix.outputs.container) }}
+        test: ${{ fromJSON(needs.matrix.outputs.tests) }}
+      fail-fast: false
+    container:
+      image: ${{ fromJSON(needs.matrix.outputs.registry) }}/${{ matrix.container }}-amd
+      options: "--privileged -v /dev:/dev"
+    steps:
+      - name: "Checkout Repository"
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+      - name: "${{ matrix.container }} ${{ matrix.test }}"
+        run: ./test/test-container.sh "TEST-${{ matrix.test }}" ${{ matrix.test }}

--- a/.yamllint
+++ b/.yamllint
@@ -2,3 +2,5 @@
 rules:
   line-length:
     max: 120
+  indentation:
+    spaces: 2


### PR DESCRIPTION
## Changes

Some YAML files use 2-space indent and others use 4-space indent. Use 2-space indent for all YAML files. Use this one-liner to convert them:

```
perl -i -pe 's/^((?: {4})+)/"  " x (length($1) \/ 4)/e' .github/workflows/container*.yml \
  .github/workflows/daily*.yml .github/workflows/{doc,manualtest,integration,labels}.yml
```

Verified with yamllint that the indentation is correct afterwards.

## Checklist
- [ ] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it

Fixes #
