### PR TITLE
fix(systemd-pcrphase): do not print an error if an optional binary is not found

### DIFF
--- a/modules.d/11systemd-pcrphase/module-setup.sh
+++ b/modules.d/11systemd-pcrphase/module-setup.sh
@@ -6,8 +6,9 @@
 check() {
     # If the binary(s) requirements are not fulfilled the module can't be installed.
     # systemd-255 renamed the binary, check for old and new location.
-    if ! require_binaries "$systemdutildir"/systemd-pcrphase \
-        && ! require_binaries "$systemdutildir"/systemd-pcrextend; then
+    if ! require_any_binary \
+        "$systemdutildir"/systemd-pcrextend \
+        "$systemdutildir"/systemd-pcrphase; then
         return 1
     fi
 


### PR DESCRIPTION
## Checklist
- [X] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it

Fixes #2094
