### PR TITLE
fix(dmsquash-live-autooverlay): re-read partition table after creation

### DIFF
--- a/modules.d/70dmsquash-live-autooverlay/create-overlay.sh
+++ b/modules.d/70dmsquash-live-autooverlay/create-overlay.sh
@@ -78,6 +78,7 @@ gatherData() {
 
 createPartition() {
     parted --script --align optimal "${blockDevice}" mkpart primary ${partitionStart}% 100%
+    blockdev --rereadpt "${blockDevice}"
 }
 
 createFilesystem() {


### PR DESCRIPTION
This PR is a follow-up on https://github.com/dracut-ng/dracut-ng/pull/2064#issuecomment-3782037835

## Changes

After parted creates the overlay partition, the kernel's in-memory partition table is not automatically updated. This causes mkfs to fail with "The file /dev/sdX does not exist" on some systems.

Add `blockdev --rereadpt` to force the kernel to re-read the partition table before attempting to create the filesystem.

## Checklist
- [x] I have tested it locally
- [x] I have reviewed and updated any documentation if relevant
- [x] I am providing new code and test(s) for it
