### PR TITLE
ci(Alpine): vmlinuz workaround

### DIFF
--- a/test/container/Dockerfile-alpine
+++ b/test/container/Dockerfile-alpine
@@ -37,3 +37,7 @@ if [ "${TARGETARCH}" == "amd64" ]; then \
     apk add --no-cache \
         ovmf \
 ; fi
+
+# workaround for https://gitlab.alpinelinux.org/alpine/aports/-/issues/17907
+RUN \
+  ln -sf /boot/vmlinuz-virt /boot/vmlinuz-$(cd /lib/modules; ls -1 | tail -1)

--- a/test/container/Dockerfile-alpine-busybox
+++ b/test/container/Dockerfile-alpine-busybox
@@ -15,3 +15,7 @@ RUN apk add --no-cache \
     musl-dev  \
     musl-fts-dev \
     qemu-system-$(uname -m)
+
+# workaround for https://gitlab.alpinelinux.org/alpine/aports/-/issues/17907
+RUN \
+  ln -sf /boot/vmlinuz-virt /boot/vmlinuz-$(cd /lib/modules; ls -1 | tail -1)


### PR DESCRIPTION
## Changes

Re-introduce vmlinuz workaround for the Alpine CI container to enable UKI testing.

Partial revert of d9497f3 .

## Checklist
- [ ] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it
