### PR TITLE
fix(dracut-systemd): do not error out with new root= options handled by systemd

### DIFF
--- a/modules.d/77dracut-systemd/dracut-cmdline.sh
+++ b/modules.d/77dracut-systemd/dracut-cmdline.sh
@@ -59,7 +59,7 @@ case "${root#block:}${root_unset}" in
         root="block:${root#block:}"
         rootok=1
         ;;
-    UNSET | gpt-auto | tmpfs)
+    UNSET | gpt-auto | gpt-auto-force | dissect | dissect-force | fstab | tmpfs | off)
         # systemd's gpt-auto-generator/fstab-generator handles this case.
         rootok=1
         ;;


### PR DESCRIPTION
systemd-v258 [1] (gpt-auto-generator/fstab-generator) handles new options for `root=`: gpt-auto-force, dissect, dissect-force, fstab, off.

[1] https://github.com/systemd/systemd/commit/3777c6e65aaa8dacacbd5be6e43ba644babe1ecd

## Checklist
- [X] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it
