### PR TITLE
ci: use 4-space indent for YAML files

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,13 +3,13 @@ version: 2
 
 # Maintain dependencies for GitHub Actions
 updates:
-  - package-ecosystem: "github-actions"
-    directory: "/"
-    schedule:
-      interval: "weekly"
-      day: "tuesday"
-    commit-message:
-      prefix: "chore"
-      include: "scope"
-    ignore:
-      - dependency-name: "Manual test"
+    - package-ecosystem: "github-actions"
+      directory: "/"
+      schedule:
+          interval: "weekly"
+          day: "tuesday"
+      commit-message:
+          prefix: "chore"
+          include: "scope"
+      ignore:
+          - dependency-name: "Manual test"

--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,604 +1,604 @@
 ---
 repository:
-  - changed-files:
-      - any-glob-to-any-file: './*'
+    - changed-files:
+          - any-glob-to-any-file: './*'
 
 github:
-  - changed-files:
-      - any-glob-to-any-file: ['.github/*', '.github/**/*']
+    - changed-files:
+          - any-glob-to-any-file: ['.github/*', '.github/**/*']
 
 docs:
-  - changed-files:
-      - any-glob-to-any-file:
-          - antora-playbook.yaml
-          - README.*
-          - man/*
-          - doc_site/*
-          - doc_site/**/*
-          - doc_site/**/**/*
-          - doc_site/**/**/**/*
-          - doc_site/**/**/**/**/*
+    - changed-files:
+          - any-glob-to-any-file:
+                - antora-playbook.yaml
+                - README.*
+                - man/*
+                - doc_site/*
+                - doc_site/**/*
+                - doc_site/**/**/*
+                - doc_site/**/**/**/*
+                - doc_site/**/**/**/**/*
 
 man:
-  - changed-files:
-      - any-glob-to-any-file: 'man/*'
+    - changed-files:
+          - any-glob-to-any-file: 'man/*'
 
 kernel-install:
-  - changed-files:
-      - any-glob-to-any-file: 'install.d/*'
+    - changed-files:
+          - any-glob-to-any-file: 'install.d/*'
 
 shell-completion:
-  - changed-files:
-      - any-glob-to-any-file: ['shell-completion/*', 'shell-completion/**/*']
+    - changed-files:
+          - any-glob-to-any-file: ['shell-completion/*', 'shell-completion/**/*']
 
 dracut-cpio:
-  - changed-files:
-      - any-glob-to-any-file: ['src/dracut-cpio/*', 'src/dracut-cpio/**/*']
+    - changed-files:
+          - any-glob-to-any-file: ['src/dracut-cpio/*', 'src/dracut-cpio/**/*']
 
 dracut-install:
-  - changed-files:
-      - any-glob-to-any-file: 'src/install/*'
+    - changed-files:
+          - any-glob-to-any-file: 'src/install/*'
 
 dracut-util:
-  - changed-files:
-      - any-glob-to-any-file: 'src/util/*'
+    - changed-files:
+          - any-glob-to-any-file: 'src/util/*'
 
 skipcpio:
-  - changed-files:
-      - any-glob-to-any-file: 'src/skipcpio/*'
+    - changed-files:
+          - any-glob-to-any-file: 'src/skipcpio/*'
 
 c:
-  - changed-files:
-      - any-glob-to-any-file: 'src/**/*.c'
+    - changed-files:
+          - any-glob-to-any-file: 'src/**/*.c'
 
 modules:
-  - changed-files:
-      - any-glob-to-any-file: ['modules.d/*', 'modules.d/**/*']
+    - changed-files:
+          - any-glob-to-any-file: ['modules.d/*', 'modules.d/**/*']
 
 bash:
-  - changed-files:
-      - any-glob-to-any-file: 'modules.d/[0-9][0-9]bash/*'
+    - changed-files:
+          - any-glob-to-any-file: 'modules.d/[0-9][0-9]bash/*'
 
 dash:
-  - changed-files:
-      - any-glob-to-any-file: 'modules.d/[0-9][0-9]dash/*'
+    - changed-files:
+          - any-glob-to-any-file: 'modules.d/[0-9][0-9]dash/*'
 
 systemd:
-  - changed-files:
-      - any-glob-to-any-file: 'modules.d/[0-9][0-9]systemd/*'
+    - changed-files:
+          - any-glob-to-any-file: 'modules.d/[0-9][0-9]systemd/*'
 
 warpclock:
-  - changed-files:
-      - any-glob-to-any-file: 'modules.d/[0-9][0-9]warpclock/*'
+    - changed-files:
+          - any-glob-to-any-file: 'modules.d/[0-9][0-9]warpclock/*'
 
 fips:
-  - changed-files:
-      - any-glob-to-any-file: 'modules.d/[0-9][0-9]fips/*'
+    - changed-files:
+          - any-glob-to-any-file: 'modules.d/[0-9][0-9]fips/*'
 
 fips-crypto-policies:
-  - changed-files:
-      - any-glob-to-any-file: 'modules.d/[0-9][0-9]fips-crypto-policies/*'
+    - changed-files:
+          - any-glob-to-any-file: 'modules.d/[0-9][0-9]fips-crypto-policies/*'
 
 initqueue:
-  - changed-files:
-      - any-glob-to-any-file: 'modules.d/[0-9][0-9]initqueue/*'
+    - changed-files:
+          - any-glob-to-any-file: 'modules.d/[0-9][0-9]initqueue/*'
 
 systemd-battery-check:
-  - changed-files:
-      - any-glob-to-any-file: 'modules.d/[0-9][0-9]systemd-battery-check/*'
+    - changed-files:
+          - any-glob-to-any-file: 'modules.d/[0-9][0-9]systemd-battery-check/*'
 
 systemd-ac-power:
-  - changed-files:
-      - any-glob-to-any-file: 'modules.d/[0-9][0-9]systemd-ac-power/*'
+    - changed-files:
+          - any-glob-to-any-file: 'modules.d/[0-9][0-9]systemd-ac-power/*'
 
 systemd-ask-password:
-  - changed-files:
-      - any-glob-to-any-file: 'modules.d/[0-9][0-9]systemd-ask-password/*'
+    - changed-files:
+          - any-glob-to-any-file: 'modules.d/[0-9][0-9]systemd-ask-password/*'
 
 systemd-bsod:
-  - changed-files:
-      - any-glob-to-any-file: 'modules.d/[0-9][0-9]systemd-bsod/*'
+    - changed-files:
+          - any-glob-to-any-file: 'modules.d/[0-9][0-9]systemd-bsod/*'
 
 systemd-coredump:
-  - changed-files:
-      - any-glob-to-any-file: 'modules.d/[0-9][0-9]systemd-coredump/*'
+    - changed-files:
+          - any-glob-to-any-file: 'modules.d/[0-9][0-9]systemd-coredump/*'
 
 systemd-creds:
-  - changed-files:
-      - any-glob-to-any-file: 'modules.d/[0-9][0-9]systemd-creds/*'
+    - changed-files:
+          - any-glob-to-any-file: 'modules.d/[0-9][0-9]systemd-creds/*'
 
 systemd-hostnamed:
-  - changed-files:
-      - any-glob-to-any-file: 'modules.d/[0-9][0-9]systemd-hostnamed/*'
+    - changed-files:
+          - any-glob-to-any-file: 'modules.d/[0-9][0-9]systemd-hostnamed/*'
 
 systemd-initrd:
-  - changed-files:
-      - any-glob-to-any-file: 'modules.d/[0-9][0-9]systemd-initrd/*'
+    - changed-files:
+          - any-glob-to-any-file: 'modules.d/[0-9][0-9]systemd-initrd/*'
 
 systemd-integritysetup:
-  - changed-files:
-      - any-glob-to-any-file: 'modules.d/[0-9][0-9]systemd-integritysetup/*'
+    - changed-files:
+          - any-glob-to-any-file: 'modules.d/[0-9][0-9]systemd-integritysetup/*'
 
 systemd-journald:
-  - changed-files:
-      - any-glob-to-any-file: 'modules.d/[0-9][0-9]systemd-journald/*'
+    - changed-files:
+          - any-glob-to-any-file: 'modules.d/[0-9][0-9]systemd-journald/*'
 
 systemd-ldconfig:
-  - changed-files:
-      - any-glob-to-any-file: 'modules.d/[0-9][0-9]systemd-ldconfig/*'
+    - changed-files:
+          - any-glob-to-any-file: 'modules.d/[0-9][0-9]systemd-ldconfig/*'
 
 systemd-modules-load:
-  - changed-files:
-      - any-glob-to-any-file: 'modules.d/[0-9][0-9]systemd-modules-load/*'
+    - changed-files:
+          - any-glob-to-any-file: 'modules.d/[0-9][0-9]systemd-modules-load/*'
 
 systemd-networkd:
-  - changed-files:
-      - any-glob-to-any-file: 'modules.d/[0-9][0-9]systemd-networkd/*'
+    - changed-files:
+          - any-glob-to-any-file: 'modules.d/[0-9][0-9]systemd-networkd/*'
 
 systemd-network-management:
-  - changed-files:
-      - any-glob-to-any-file: 'modules.d/[0-9][0-9]systemd-network-management/*'
+    - changed-files:
+          - any-glob-to-any-file: 'modules.d/[0-9][0-9]systemd-network-management/*'
 
 systemd-pcrphase:
-  - changed-files:
-      - any-glob-to-any-file: 'modules.d/[0-9][0-9]systemd-pcrphase/*'
+    - changed-files:
+          - any-glob-to-any-file: 'modules.d/[0-9][0-9]systemd-pcrphase/*'
 
 systemd-portabled:
-  - changed-files:
-      - any-glob-to-any-file: 'modules.d/[0-9][0-9]systemd-portabled/*'
+    - changed-files:
+          - any-glob-to-any-file: 'modules.d/[0-9][0-9]systemd-portabled/*'
 
 systemd-pstore:
-  - changed-files:
-      - any-glob-to-any-file: 'modules.d/[0-9][0-9]systemd-pstore/*'
+    - changed-files:
+          - any-glob-to-any-file: 'modules.d/[0-9][0-9]systemd-pstore/*'
 
 systemd-repart:
-  - changed-files:
-      - any-glob-to-any-file: 'modules.d/[0-9][0-9]systemd-repart/*'
+    - changed-files:
+          - any-glob-to-any-file: 'modules.d/[0-9][0-9]systemd-repart/*'
 
 systemd-resolved:
-  - changed-files:
-      - any-glob-to-any-file: 'modules.d/[0-9][0-9]systemd-resolved/*'
+    - changed-files:
+          - any-glob-to-any-file: 'modules.d/[0-9][0-9]systemd-resolved/*'
 
 systemd-sysctl:
-  - changed-files:
-      - any-glob-to-any-file: 'modules.d/[0-9][0-9]systemd-sysctl/*'
+    - changed-files:
+          - any-glob-to-any-file: 'modules.d/[0-9][0-9]systemd-sysctl/*'
 
 systemd-sysext:
-  - changed-files:
-      - any-glob-to-any-file: 'modules.d/[0-9][0-9]systemd-sysext/*'
+    - changed-files:
+          - any-glob-to-any-file: 'modules.d/[0-9][0-9]systemd-sysext/*'
 
 systemd-sysusers:
-  - changed-files:
-      - any-glob-to-any-file: 'modules.d/[0-9][0-9]systemd-sysusers/*'
+    - changed-files:
+          - any-glob-to-any-file: 'modules.d/[0-9][0-9]systemd-sysusers/*'
 
 systemd-timedated:
-  - changed-files:
-      - any-glob-to-any-file: 'modules.d/[0-9][0-9]systemd-timedated/*'
+    - changed-files:
+          - any-glob-to-any-file: 'modules.d/[0-9][0-9]systemd-timedated/*'
 
 systemd-timesyncd:
-  - changed-files:
-      - any-glob-to-any-file: 'modules.d/[0-9][0-9]systemd-timesyncd/*'
+    - changed-files:
+          - any-glob-to-any-file: 'modules.d/[0-9][0-9]systemd-timesyncd/*'
 
 systemd-tmpfiles:
-  - changed-files:
-      - any-glob-to-any-file: 'modules.d/[0-9][0-9]systemd-tmpfiles/*'
+    - changed-files:
+          - any-glob-to-any-file: 'modules.d/[0-9][0-9]systemd-tmpfiles/*'
 
 systemd-udevd:
-  - changed-files:
-      - any-glob-to-any-file: 'modules.d/[0-9][0-9]systemd-udevd/*'
+    - changed-files:
+          - any-glob-to-any-file: 'modules.d/[0-9][0-9]systemd-udevd/*'
 
 systemd-veritysetup:
-  - changed-files:
-      - any-glob-to-any-file: 'modules.d/[0-9][0-9]systemd-veritysetup/*'
+    - changed-files:
+          - any-glob-to-any-file: 'modules.d/[0-9][0-9]systemd-veritysetup/*'
 
 systemd-emergency:
-  - changed-files:
-      - any-glob-to-any-file: 'modules.d/[0-9][0-9]systemd-emergency/*'
+    - changed-files:
+          - any-glob-to-any-file: 'modules.d/[0-9][0-9]systemd-emergency/*'
 
 caps:
-  - changed-files:
-      - any-glob-to-any-file: 'modules.d/[0-9][0-9]caps/*'
+    - changed-files:
+          - any-glob-to-any-file: 'modules.d/[0-9][0-9]caps/*'
 
 modsign:
-  - changed-files:
-      - any-glob-to-any-file: 'modules.d/[0-9][0-9]modsign/*'
+    - changed-files:
+          - any-glob-to-any-file: 'modules.d/[0-9][0-9]modsign/*'
 
 rescue:
-  - changed-files:
-      - any-glob-to-any-file: 'modules.d/[0-9][0-9]rescue/*'
+    - changed-files:
+          - any-glob-to-any-file: 'modules.d/[0-9][0-9]rescue/*'
 
 watchdog:
-  - changed-files:
-      - any-glob-to-any-file: 'modules.d/[0-9][0-9]watchdog/*'
+    - changed-files:
+          - any-glob-to-any-file: 'modules.d/[0-9][0-9]watchdog/*'
 
 watchdog-modules:
-  - changed-files:
-      - any-glob-to-any-file: 'modules.d/[0-9][0-9]watchdog-modules/*'
+    - changed-files:
+          - any-glob-to-any-file: 'modules.d/[0-9][0-9]watchdog-modules/*'
 
 busybox:
-  - changed-files:
-      - any-glob-to-any-file: 'modules.d/[0-9][0-9]busybox/*'
+    - changed-files:
+          - any-glob-to-any-file: 'modules.d/[0-9][0-9]busybox/*'
 
 dbus-broker:
-  - changed-files:
-      - any-glob-to-any-file: 'modules.d/[0-9][0-9]dbus-broker/*'
+    - changed-files:
+          - any-glob-to-any-file: 'modules.d/[0-9][0-9]dbus-broker/*'
 
 dbus-daemon:
-  - changed-files:
-      - any-glob-to-any-file: 'modules.d/[0-9][0-9]dbus-daemon/*'
+    - changed-files:
+          - any-glob-to-any-file: 'modules.d/[0-9][0-9]dbus-daemon/*'
 
 rngd:
-  - changed-files:
-      - any-glob-to-any-file: 'modules.d/[0-9][0-9]rngd/*'
+    - changed-files:
+          - any-glob-to-any-file: 'modules.d/[0-9][0-9]rngd/*'
 
 dbus:
-  - changed-files:
-      - any-glob-to-any-file: 'modules.d/[0-9][0-9]dbus/*'
+    - changed-files:
+          - any-glob-to-any-file: 'modules.d/[0-9][0-9]dbus/*'
 
 i18n:
-  - changed-files:
-      - any-glob-to-any-file: 'modules.d/[0-9][0-9]i18n/*'
+    - changed-files:
+          - any-glob-to-any-file: 'modules.d/[0-9][0-9]i18n/*'
 
 convertfs:
-  - changed-files:
-      - any-glob-to-any-file: 'modules.d/[0-9][0-9]convertfs/*'
+    - changed-files:
+          - any-glob-to-any-file: 'modules.d/[0-9][0-9]convertfs/*'
 
 connman:
-  - changed-files:
-      - any-glob-to-any-file: 'modules.d/[0-9][0-9]connman/*'
+    - changed-files:
+          - any-glob-to-any-file: 'modules.d/[0-9][0-9]connman/*'
 
 network-legacy:
-  - changed-files:
-      - any-glob-to-any-file: 'modules.d/[0-9][0-9]network-legacy/*'
+    - changed-files:
+          - any-glob-to-any-file: 'modules.d/[0-9][0-9]network-legacy/*'
 
 network-manager:
-  - changed-files:
-      - any-glob-to-any-file: 'modules.d/[0-9][0-9]network-manager/*'
+    - changed-files:
+          - any-glob-to-any-file: 'modules.d/[0-9][0-9]network-manager/*'
 
 network:
-  - changed-files:
-      - any-glob-to-any-file: 'modules.d/[0-9][0-9]network/*'
+    - changed-files:
+          - any-glob-to-any-file: 'modules.d/[0-9][0-9]network/*'
 
 url-lib:
-  - changed-files:
-      - any-glob-to-any-file: 'modules.d/[0-9][0-9]url-lib/*'
+    - changed-files:
+          - any-glob-to-any-file: 'modules.d/[0-9][0-9]url-lib/*'
 
 drm:
-  - changed-files:
-      - any-glob-to-any-file: 'modules.d/[0-9][0-9]drm/*'
+    - changed-files:
+          - any-glob-to-any-file: 'modules.d/[0-9][0-9]drm/*'
 
 plymouth:
-  - changed-files:
-      - any-glob-to-any-file: 'modules.d/[0-9][0-9]plymouth/*'
+    - changed-files:
+          - any-glob-to-any-file: 'modules.d/[0-9][0-9]plymouth/*'
 
 bluetooth:
-  - changed-files:
-      - any-glob-to-any-file: 'modules.d/[0-9][0-9]bluetooth/*'
+    - changed-files:
+          - any-glob-to-any-file: 'modules.d/[0-9][0-9]bluetooth/*'
 
 cms:
-  - changed-files:
-      - any-glob-to-any-file: 'modules.d/[0-9][0-9]cms/*'
+    - changed-files:
+          - any-glob-to-any-file: 'modules.d/[0-9][0-9]cms/*'
 
 lvmmerge:
-  - changed-files:
-      - any-glob-to-any-file: 'modules.d/[0-9][0-9]lvmmerge/*'
+    - changed-files:
+          - any-glob-to-any-file: 'modules.d/[0-9][0-9]lvmmerge/*'
 
 lvmthinpool-monitor:
-  - changed-files:
-      - any-glob-to-any-file: 'modules.d/[0-9][0-9]lvmthinpool-monitor/*'
+    - changed-files:
+          - any-glob-to-any-file: 'modules.d/[0-9][0-9]lvmthinpool-monitor/*'
 
 cio_ignore:
-  - changed-files:
-      - any-glob-to-any-file: 'modules.d/[0-9][0-9]cio_ignore/*'
+    - changed-files:
+          - any-glob-to-any-file: 'modules.d/[0-9][0-9]cio_ignore/*'
 
 btrfs:
-  - changed-files:
-      - any-glob-to-any-file: 'modules.d/[0-9][0-9]btrfs/*'
+    - changed-files:
+          - any-glob-to-any-file: 'modules.d/[0-9][0-9]btrfs/*'
 
 crypt:
-  - changed-files:
-      - any-glob-to-any-file: 'modules.d/[0-9][0-9]crypt/*'
+    - changed-files:
+          - any-glob-to-any-file: 'modules.d/[0-9][0-9]crypt/*'
 
 dm:
-  - changed-files:
-      - any-glob-to-any-file: 'modules.d/[0-9][0-9]dm/*'
+    - changed-files:
+          - any-glob-to-any-file: 'modules.d/[0-9][0-9]dm/*'
 
 dmraid:
-  - changed-files:
-      - any-glob-to-any-file: 'modules.d/[0-9][0-9]dmraid/*'
+    - changed-files:
+          - any-glob-to-any-file: 'modules.d/[0-9][0-9]dmraid/*'
 
 dmsquash-live:
-  - changed-files:
-      - any-glob-to-any-file: 'modules.d/[0-9][0-9]dmsquash-live/*'
+    - changed-files:
+          - any-glob-to-any-file: 'modules.d/[0-9][0-9]dmsquash-live/*'
 
 dmsquash-live-autooverlay:
-  - changed-files:
-      - any-glob-to-any-file: 'modules.d/[0-9][0-9]dmsquash-live-autooverlay/*'
+    - changed-files:
+          - any-glob-to-any-file: 'modules.d/[0-9][0-9]dmsquash-live-autooverlay/*'
 
 dmsquash-live-ntfs:
-  - changed-files:
-      - any-glob-to-any-file: 'modules.d/[0-9][0-9]dmsquash-live-ntfs/*'
+    - changed-files:
+          - any-glob-to-any-file: 'modules.d/[0-9][0-9]dmsquash-live-ntfs/*'
 
 kernel-modules:
-  - changed-files:
-      - any-glob-to-any-file: 'modules.d/[0-9][0-9]kernel-modules/*'
+    - changed-files:
+          - any-glob-to-any-file: 'modules.d/[0-9][0-9]kernel-modules/*'
 
 kernel-modules-export:
-  - changed-files:
-      - any-glob-to-any-file: 'modules.d/[0-9][0-9]kernel-modules-export/*'
+    - changed-files:
+          - any-glob-to-any-file: 'modules.d/[0-9][0-9]kernel-modules-export/*'
 
 kernel-modules-extra:
-  - changed-files:
-      - any-glob-to-any-file: 'modules.d/[0-9][0-9]kernel-modules-extra/*'
+    - changed-files:
+          - any-glob-to-any-file: 'modules.d/[0-9][0-9]kernel-modules-extra/*'
 
 kernel-network-modules:
-  - changed-files:
-      - any-glob-to-any-file: 'modules.d/[0-9][0-9]kernel-network-modules/*'
+    - changed-files:
+          - any-glob-to-any-file: 'modules.d/[0-9][0-9]kernel-network-modules/*'
 
 livenet:
-  - changed-files:
-      - any-glob-to-any-file: 'modules.d/[0-9][0-9]livenet/*'
+    - changed-files:
+          - any-glob-to-any-file: 'modules.d/[0-9][0-9]livenet/*'
 
 lvm:
-  - changed-files:
-      - any-glob-to-any-file: 'modules.d/[0-9][0-9]lvm/*'
+    - changed-files:
+          - any-glob-to-any-file: 'modules.d/[0-9][0-9]lvm/*'
 
 mdraid:
-  - changed-files:
-      - any-glob-to-any-file: 'modules.d/[0-9][0-9]mdraid/*'
+    - changed-files:
+          - any-glob-to-any-file: 'modules.d/[0-9][0-9]mdraid/*'
 
 multipath:
-  - changed-files:
-      - any-glob-to-any-file: 'modules.d/[0-9][0-9]multipath/*'
+    - changed-files:
+          - any-glob-to-any-file: 'modules.d/[0-9][0-9]multipath/*'
 
 numlock:
-  - changed-files:
-      - any-glob-to-any-file: 'modules.d/[0-9][0-9]numlock/*'
+    - changed-files:
+          - any-glob-to-any-file: 'modules.d/[0-9][0-9]numlock/*'
 
 nvdimm:
-  - changed-files:
-      - any-glob-to-any-file: 'modules.d/[0-9][0-9]nvdimm/*'
+    - changed-files:
+          - any-glob-to-any-file: 'modules.d/[0-9][0-9]nvdimm/*'
 
 overlayfs:
-  - changed-files:
-      - any-glob-to-any-file: 'modules.d/[0-9][0-9]overlayfs/*'
+    - changed-files:
+          - any-glob-to-any-file: 'modules.d/[0-9][0-9]overlayfs/*'
 
 ppcmac:
-  - changed-files:
-      - any-glob-to-any-file: 'modules.d/[0-9][0-9]ppcmac/*'
+    - changed-files:
+          - any-glob-to-any-file: 'modules.d/[0-9][0-9]ppcmac/*'
 
 qemu:
-  - changed-files:
-      - any-glob-to-any-file: 'modules.d/[0-9][0-9]qemu/*'
+    - changed-files:
+          - any-glob-to-any-file: 'modules.d/[0-9][0-9]qemu/*'
 
 qemu-net:
-  - changed-files:
-      - any-glob-to-any-file: 'modules.d/[0-9][0-9]qemu-net/*'
+    - changed-files:
+          - any-glob-to-any-file: 'modules.d/[0-9][0-9]qemu-net/*'
 
 systemd-cryptsetup:
-  - changed-files:
-      - any-glob-to-any-file: 'modules.d/[0-9][0-9]systemd-cryptsetup/*'
+    - changed-files:
+          - any-glob-to-any-file: 'modules.d/[0-9][0-9]systemd-cryptsetup/*'
 
 crypt-gpg:
-  - changed-files:
-      - any-glob-to-any-file: 'modules.d/[0-9][0-9]crypt-gpg/*'
+    - changed-files:
+          - any-glob-to-any-file: 'modules.d/[0-9][0-9]crypt-gpg/*'
 
 crypt-loop:
-  - changed-files:
-      - any-glob-to-any-file: 'modules.d/[0-9][0-9]crypt-loop/*'
+    - changed-files:
+          - any-glob-to-any-file: 'modules.d/[0-9][0-9]crypt-loop/*'
 
 fido2:
-  - changed-files:
-      - any-glob-to-any-file: 'modules.d/[0-9][0-9]fido2/*'
+    - changed-files:
+          - any-glob-to-any-file: 'modules.d/[0-9][0-9]fido2/*'
 
 pcsc:
-  - changed-files:
-      - any-glob-to-any-file: 'modules.d/[0-9][0-9]pcsc/*'
+    - changed-files:
+          - any-glob-to-any-file: 'modules.d/[0-9][0-9]pcsc/*'
 
 pkcs11:
-  - changed-files:
-      - any-glob-to-any-file: 'modules.d/[0-9][0-9]pkcs11/*'
+    - changed-files:
+          - any-glob-to-any-file: 'modules.d/[0-9][0-9]pkcs11/*'
 
 tpm2-tss:
-  - changed-files:
-      - any-glob-to-any-file: 'modules.d/[0-9][0-9]tpm2-tss/*'
+    - changed-files:
+          - any-glob-to-any-file: 'modules.d/[0-9][0-9]tpm2-tss/*'
 
 zipl:
-  - changed-files:
-      - any-glob-to-any-file: 'modules.d/[0-9][0-9]zipl/*'
+    - changed-files:
+          - any-glob-to-any-file: 'modules.d/[0-9][0-9]zipl/*'
 
 cifs:
-  - changed-files:
-      - any-glob-to-any-file: 'modules.d/[0-9][0-9]cifs/*'
+    - changed-files:
+          - any-glob-to-any-file: 'modules.d/[0-9][0-9]cifs/*'
 
 dasd:
-  - changed-files:
-      - any-glob-to-any-file: 'modules.d/[0-9][0-9]dasd/*'
+    - changed-files:
+          - any-glob-to-any-file: 'modules.d/[0-9][0-9]dasd/*'
 
 dasd_mod:
-  - changed-files:
-      - any-glob-to-any-file: 'modules.d/[0-9][0-9]dasd_mod/*'
+    - changed-files:
+          - any-glob-to-any-file: 'modules.d/[0-9][0-9]dasd_mod/*'
 
 dcssblk:
-  - changed-files:
-      - any-glob-to-any-file: 'modules.d/[0-9][0-9]dcssblk/*'
+    - changed-files:
+          - any-glob-to-any-file: 'modules.d/[0-9][0-9]dcssblk/*'
 
 debug:
-  - changed-files:
-      - any-glob-to-any-file: 'modules.d/[0-9][0-9]debug/*'
+    - changed-files:
+          - any-glob-to-any-file: 'modules.d/[0-9][0-9]debug/*'
 
 fcoe:
-  - changed-files:
-      - any-glob-to-any-file: 'modules.d/[0-9][0-9]fcoe/*'
+    - changed-files:
+          - any-glob-to-any-file: 'modules.d/[0-9][0-9]fcoe/*'
 
 fcoe-uefi:
-  - changed-files:
-      - any-glob-to-any-file: 'modules.d/[0-9][0-9]fcoe-uefi/*'
+    - changed-files:
+          - any-glob-to-any-file: 'modules.d/[0-9][0-9]fcoe-uefi/*'
 
 fstab-sys:
-  - changed-files:
-      - any-glob-to-any-file: 'modules.d/[0-9][0-9]fstab-sys/*'
+    - changed-files:
+          - any-glob-to-any-file: 'modules.d/[0-9][0-9]fstab-sys/*'
 
 hwdb:
-  - changed-files:
-      - any-glob-to-any-file: 'modules.d/[0-9][0-9]hwdb/*'
+    - changed-files:
+          - any-glob-to-any-file: 'modules.d/[0-9][0-9]hwdb/*'
 
 iscsi:
-  - changed-files:
-      - any-glob-to-any-file: 'modules.d/[0-9][0-9]iscsi/*'
+    - changed-files:
+          - any-glob-to-any-file: 'modules.d/[0-9][0-9]iscsi/*'
 
 lunmask:
-  - changed-files:
-      - any-glob-to-any-file: 'modules.d/[0-9][0-9]lunmask/*'
+    - changed-files:
+          - any-glob-to-any-file: 'modules.d/[0-9][0-9]lunmask/*'
 
 nbd:
-  - changed-files:
-      - any-glob-to-any-file: 'modules.d/[0-9][0-9]nbd/*'
+    - changed-files:
+          - any-glob-to-any-file: 'modules.d/[0-9][0-9]nbd/*'
 
 nfs:
-  - changed-files:
-      - any-glob-to-any-file: 'modules.d/[0-9][0-9]nfs/*'
+    - changed-files:
+          - any-glob-to-any-file: 'modules.d/[0-9][0-9]nfs/*'
 
 nvmf:
-  - changed-files:
-      - any-glob-to-any-file: 'modules.d/[0-9][0-9]nvmf/*'
+    - changed-files:
+          - any-glob-to-any-file: 'modules.d/[0-9][0-9]nvmf/*'
 
 resume:
-  - changed-files:
-      - any-glob-to-any-file: 'modules.d/[0-9][0-9]resume/*'
+    - changed-files:
+          - any-glob-to-any-file: 'modules.d/[0-9][0-9]resume/*'
 
 rootfs-block:
-  - changed-files:
-      - any-glob-to-any-file: 'modules.d/[0-9][0-9]rootfs-block/*'
+    - changed-files:
+          - any-glob-to-any-file: 'modules.d/[0-9][0-9]rootfs-block/*'
 
 rootfs-block-fallback:
-  - changed-files:
-      - any-glob-to-any-file: 'modules.d/[0-9][0-9]rootfs-block-fallback/*'
+    - changed-files:
+          - any-glob-to-any-file: 'modules.d/[0-9][0-9]rootfs-block-fallback/*'
 
 ssh-client:
-  - changed-files:
-      - any-glob-to-any-file: 'modules.d/[0-9][0-9]ssh-client/*'
+    - changed-files:
+          - any-glob-to-any-file: 'modules.d/[0-9][0-9]ssh-client/*'
 
 terminfo:
-  - changed-files:
-      - any-glob-to-any-file: 'modules.d/[0-9][0-9]terminfo/*'
+    - changed-files:
+          - any-glob-to-any-file: 'modules.d/[0-9][0-9]terminfo/*'
 
 udev-rules:
-  - changed-files:
-      - any-glob-to-any-file: 'modules.d/[0-9][0-9]udev-rules/*'
+    - changed-files:
+          - any-glob-to-any-file: 'modules.d/[0-9][0-9]udev-rules/*'
 
 virtfs:
-  - changed-files:
-      - any-glob-to-any-file: 'modules.d/[0-9][0-9]virtfs/*'
+    - changed-files:
+          - any-glob-to-any-file: 'modules.d/[0-9][0-9]virtfs/*'
 
 virtiofs:
-  - changed-files:
-      - any-glob-to-any-file: 'modules.d/[0-9][0-9]virtiofs/*'
+    - changed-files:
+          - any-glob-to-any-file: 'modules.d/[0-9][0-9]virtiofs/*'
 
 zfcp:
-  - changed-files:
-      - any-glob-to-any-file: 'modules.d/[0-9][0-9]zfcp/*'
+    - changed-files:
+          - any-glob-to-any-file: 'modules.d/[0-9][0-9]zfcp/*'
 
 znet:
-  - changed-files:
-      - any-glob-to-any-file: 'modules.d/[0-9][0-9]znet/*'
+    - changed-files:
+          - any-glob-to-any-file: 'modules.d/[0-9][0-9]znet/*'
 
 securityfs:
-  - changed-files:
-      - any-glob-to-any-file: 'modules.d/[0-9][0-9]securityfs/*'
+    - changed-files:
+          - any-glob-to-any-file: 'modules.d/[0-9][0-9]securityfs/*'
 
 biosdevname:
-  - changed-files:
-      - any-glob-to-any-file: 'modules.d/[0-9][0-9]biosdevname/*'
+    - changed-files:
+          - any-glob-to-any-file: 'modules.d/[0-9][0-9]biosdevname/*'
 
 masterkey:
-  - changed-files:
-      - any-glob-to-any-file: 'modules.d/[0-9][0-9]masterkey/*'
+    - changed-files:
+          - any-glob-to-any-file: 'modules.d/[0-9][0-9]masterkey/*'
 
 dracut-systemd:
-  - changed-files:
-      - any-glob-to-any-file: 'modules.d/[0-9][0-9]dracut-systemd/*'
+    - changed-files:
+          - any-glob-to-any-file: 'modules.d/[0-9][0-9]dracut-systemd/*'
 
 ecryptfs:
-  - changed-files:
-      - any-glob-to-any-file: 'modules.d/[0-9][0-9]ecryptfs/*'
+    - changed-files:
+          - any-glob-to-any-file: 'modules.d/[0-9][0-9]ecryptfs/*'
 
 integrity:
-  - changed-files:
-      - any-glob-to-any-file: 'modules.d/[0-9][0-9]integrity/*'
+    - changed-files:
+          - any-glob-to-any-file: 'modules.d/[0-9][0-9]integrity/*'
 
 pollcdrom:
-  - changed-files:
-      - any-glob-to-any-file: 'modules.d/[0-9][0-9]pollcdrom/*'
+    - changed-files:
+          - any-glob-to-any-file: 'modules.d/[0-9][0-9]pollcdrom/*'
 
 selinux:
-  - changed-files:
-      - any-glob-to-any-file: 'modules.d/[0-9][0-9]selinux/*'
+    - changed-files:
+          - any-glob-to-any-file: 'modules.d/[0-9][0-9]selinux/*'
 
 syslog:
-  - changed-files:
-      - any-glob-to-any-file: 'modules.d/[0-9][0-9]syslog/*'
+    - changed-files:
+          - any-glob-to-any-file: 'modules.d/[0-9][0-9]syslog/*'
 
 usrmount:
-  - changed-files:
-      - any-glob-to-any-file: 'modules.d/[0-9][0-9]usrmount/*'
+    - changed-files:
+          - any-glob-to-any-file: 'modules.d/[0-9][0-9]usrmount/*'
 
 base:
-  - changed-files:
-      - any-glob-to-any-file: 'modules.d/[0-9][0-9]base/*'
+    - changed-files:
+          - any-glob-to-any-file: 'modules.d/[0-9][0-9]base/*'
 
 fs-lib:
-  - changed-files:
-      - any-glob-to-any-file: 'modules.d/[0-9][0-9]fs-lib/*'
+    - changed-files:
+          - any-glob-to-any-file: 'modules.d/[0-9][0-9]fs-lib/*'
 
 img-lib:
-  - changed-files:
-      - any-glob-to-any-file: 'modules.d/[0-9][0-9]img-lib/*'
+    - changed-files:
+          - any-glob-to-any-file: 'modules.d/[0-9][0-9]img-lib/*'
 
 memstrack:
-  - changed-files:
-      - any-glob-to-any-file: 'modules.d/[0-9][0-9]memstrack/*'
+    - changed-files:
+          - any-glob-to-any-file: 'modules.d/[0-9][0-9]memstrack/*'
 
 shutdown:
-  - changed-files:
-      - any-glob-to-any-file: 'modules.d/[0-9][0-9]shutdown/*'
+    - changed-files:
+          - any-glob-to-any-file: 'modules.d/[0-9][0-9]shutdown/*'
 
 simpledrm:
-  - changed-files:
-      - any-glob-to-any-file: 'modules.d/[0-9][0-9]simpledrm/*'
+    - changed-files:
+          - any-glob-to-any-file: 'modules.d/[0-9][0-9]simpledrm/*'
 
 squash:
-  - changed-files:
-      - any-glob-to-any-file: 'modules.d/[0-9][0-9]squash/*'
+    - changed-files:
+          - any-glob-to-any-file: 'modules.d/[0-9][0-9]squash/*'
 
 squash-lib:
-  - changed-files:
-      - any-glob-to-any-file: 'modules.d/[0-9][0-9]squash-lib/*'
+    - changed-files:
+          - any-glob-to-any-file: 'modules.d/[0-9][0-9]squash-lib/*'
 
 squash-erofs:
-  - changed-files:
-      - any-glob-to-any-file: 'modules.d/[0-9][0-9]squash/*'
+    - changed-files:
+          - any-glob-to-any-file: 'modules.d/[0-9][0-9]squash/*'
 
 squash-squashfs:
-  - changed-files:
-      - any-glob-to-any-file: 'modules.d/[0-9][0-9]squash/*'
+    - changed-files:
+          - any-glob-to-any-file: 'modules.d/[0-9][0-9]squash/*'
 
 uefi-lib:
-  - changed-files:
-      - any-glob-to-any-file: 'modules.d/[0-9][0-9]uefi-lib/*'
+    - changed-files:
+          - any-glob-to-any-file: 'modules.d/[0-9][0-9]uefi-lib/*'
 
 net-lib:
-  - changed-files:
-      - any-glob-to-any-file: 'modules.d/[0-9][0-9]net-lib/*'
+    - changed-files:
+          - any-glob-to-any-file: 'modules.d/[0-9][0-9]net-lib/*'
 
 pcmcia:
-  - changed-files:
-      - any-glob-to-any-file: 'modules.d/[0-9][0-9]pcmcia/*'
+    - changed-files:
+          - any-glob-to-any-file: 'modules.d/[0-9][0-9]pcmcia/*'
 
 shell-interpreter:
-  - changed-files:
-      - any-glob-to-any-file: 'modules.d/[0-9][0-9]shell-interpreter/*'
+    - changed-files:
+          - any-glob-to-any-file: 'modules.d/[0-9][0-9]shell-interpreter/*'
 
 test:
-  - changed-files:
-      - any-glob-to-any-file: ['test/*', 'test/**/*']
+    - changed-files:
+          - any-glob-to-any-file: ['test/*', 'test/**/*']

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -5,53 +5,53 @@
 name: "CodeQL"
 
 on:  # yamllint disable-line rule:truthy
-  push:
-    branches:
-      - main
-    paths:
-      - 'src/**'
-  pull_request:
-    branches:
-      - main
-    paths:
-      - 'src/**'
+    push:
+        branches:
+            - main
+        paths:
+            - 'src/**'
+    pull_request:
+        branches:
+            - main
+        paths:
+            - 'src/**'
 
 permissions:
-  contents: read
+    contents: read
 
 jobs:
-  analyze:
-    name: Analyze
-    runs-on: ubuntu-latest
-    concurrency:
-      group: codeql-${{ github.workflow }}-${{ matrix.language }}-${{ github.ref }}
-      cancel-in-progress: true
-    permissions:
-      actions: read
-      security-events: write
+    analyze:
+        name: Analyze
+        runs-on: ubuntu-latest
+        concurrency:
+            group: codeql-${{ github.workflow }}-${{ matrix.language }}-${{ github.ref }}
+            cancel-in-progress: true
+        permissions:
+            actions: read
+            security-events: write
 
-    strategy:
-      fail-fast: false
-      matrix:
-        language: ['cpp', 'python']
+        strategy:
+            fail-fast: false
+            matrix:
+                language: ['cpp', 'python']
 
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@v6
+        steps:
+            - name: Checkout repository
+              uses: actions/checkout@v6
 
-      - name: Initialize CodeQL
-        uses: github/codeql-action/init@v4
-        with:
-          languages: ${{ matrix.language }}
-          queries: +security-extended,security-and-quality
+            - name: Initialize CodeQL
+              uses: github/codeql-action/init@v4
+              with:
+                  languages: ${{ matrix.language }}
+                  queries: +security-extended,security-and-quality
 
-      - name: Install dependencies
-        run: |
-          sudo apt-get -y update
-          sudo apt-get -y install asciidoctor gcc libkmod-dev libsystemd-dev pkg-config
+            - name: Install dependencies
+              run: |
+                  sudo apt-get -y update
+                  sudo apt-get -y install asciidoctor gcc libkmod-dev libsystemd-dev pkg-config
 
-      - name: Autobuild
-        uses: github/codeql-action/autobuild@v4
+            - name: Autobuild
+              uses: github/codeql-action/autobuild@v4
 
-      - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@v4
+            - name: Perform CodeQL Analysis
+              uses: github/codeql-action/analyze@v4

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -2,61 +2,61 @@
 name: Lint
 
 on:  # yamllint disable-line rule:truthy
-  pull_request:
-    branches: [main]
-    paths-ignore:
-      - antora-playbook.yaml
-      - 'doc_site/**'
-      - 'man/**'
+    pull_request:
+        branches: [main]
+        paths-ignore:
+            - antora-playbook.yaml
+            - 'doc_site/**'
+            - 'man/**'
 
 jobs:
-  lint-shell:
-    runs-on: ubuntu-latest
+    lint-shell:
+        runs-on: ubuntu-latest
 
-    steps:
-      - uses: actions/checkout@v6
+        steps:
+            - uses: actions/checkout@v6
 
-      - name: shfmt
-        uses: luizm/action-sh-checker@v0.10.0
-        with:
-          # disable shellcheck in favor of differential-shellcheck
-          sh_checker_shellcheck_disable: true
+            - name: shfmt
+              uses: luizm/action-sh-checker@v0.10.0
+              with:
+                  # disable shellcheck in favor of differential-shellcheck
+                  sh_checker_shellcheck_disable: true
 
-  differential-shellcheck:
-    runs-on: ubuntu-latest
+    differential-shellcheck:
+        runs-on: ubuntu-latest
 
-    permissions:
-      security-events: write
+        permissions:
+            security-events: write
 
-    steps:
-      - uses: actions/checkout@v6
-        with:
-          fetch-depth: 0
+        steps:
+            - uses: actions/checkout@v6
+              with:
+                  fetch-depth: 0
 
-      - id: ShellCheck
-        name: Differential ShellCheck
-        uses: redhat-plumbers-in-action/differential-shellcheck@v5
-        with:
-          token: ${{ secrets.GITHUB_TOKEN }}
+            - id: ShellCheck
+              name: Differential ShellCheck
+              uses: redhat-plumbers-in-action/differential-shellcheck@v5
+              with:
+                  token: ${{ secrets.GITHUB_TOKEN }}
 
-      - if: ${{ always() }}
-        name: Upload artifact with ShellCheck defects in SARIF format
-        uses: actions/upload-artifact@v6
-        with:
-          name: Differential ShellCheck SARIF
-          path: ${{ steps.ShellCheck.outputs.sarif }}
+            - if: ${{ always() }}
+              name: Upload artifact with ShellCheck defects in SARIF format
+              uses: actions/upload-artifact@v6
+              with:
+                  name: Differential ShellCheck SARIF
+                  path: ${{ steps.ShellCheck.outputs.sarif }}
 
-  lint-c:
-    runs-on: ubuntu-latest
+    lint-c:
+        runs-on: ubuntu-latest
 
-    steps:
-      - uses: actions/checkout@v6
+        steps:
+            - uses: actions/checkout@v6
 
-      - name: install tools
-        run: sudo apt-get install astyle
+            - name: install tools
+              run: sudo apt-get install astyle
 
-      - name: indent
-        run: make indent-c
+            - name: indent
+              run: make indent-c
 
-      - name: check formatting
-        run: git diff --exit-code
+            - name: check formatting
+              run: git diff --exit-code

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -1,21 +1,21 @@
 ---
 name: Commisery
 on:  # yamllint disable-line rule:truthy
-  pull_request:
-    branches: [main]
+    pull_request:
+        branches: [main]
 
 jobs:
-  commit-message:
-    name: Conventional Commit Message Checker (Commisery)
-    runs-on: ubuntu-latest
-    steps:
-      - name: Check-out the repo under $GITHUB_WORKSPACE
-        uses: actions/checkout@v6
+    commit-message:
+        name: Conventional Commit Message Checker (Commisery)
+        runs-on: ubuntu-latest
+        steps:
+            - name: Check-out the repo under $GITHUB_WORKSPACE
+              uses: actions/checkout@v6
 
-      - name: Run Commisery
-        uses: tomtom-international/commisery-action@v3
-        with:
-          token: ${{ secrets.GITHUB_TOKEN }}
-          # don't validate the pull request title
-          validate-pull-request: false
-          validate-pull-request-title-bump: false
+            - name: Run Commisery
+              uses: tomtom-international/commisery-action@v3
+              with:
+                  token: ${{ secrets.GITHUB_TOKEN }}
+                  # don't validate the pull request title
+                  validate-pull-request: false
+                  validate-pull-request-title-bump: false

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -2,56 +2,56 @@
 name: Publish to GitHub Pages
 
 on:  # yamllint disable-line rule:truthy
-  push:
-    branches: [main]
-    paths-ignore:
-      - 'modules.d/**'
-      - 'test/**'
-      - 'src/**'
+    push:
+        branches: [main]
+        paths-ignore:
+            - 'modules.d/**'
+            - 'test/**'
+            - 'src/**'
 
-  # Allows you to run this workflow manually from the Actions tab
-  workflow_dispatch:
+    # Allows you to run this workflow manually from the Actions tab
+    workflow_dispatch:
 
 concurrency:
-  group: github-pages
-  cancel-in-progress: false
+    group: github-pages
+    cancel-in-progress: false
 
 # Sets permissions of the GITHUB_TOKEN to allow deployment to GitHub Pages
 permissions:
-  contents: read
-  pages: write
-  id-token: write
+    contents: read
+    pages: write
+    id-token: write
 
 jobs:
-  build:
-    if: github.repository == 'dracut-ng/dracut-ng'
-    runs-on: ubuntu-latest
-    environment:
-      name: github-pages
-      url: ${{ steps.deployment.outputs.page_url }}
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@v6
-        with:
-          fetch-depth: 0
-      - name: Configure Pages
-        uses: actions/configure-pages@v5
-      - name: Install Node.js
-        uses: actions/setup-node@v6
-        with:
-          node-version: '18'
-      - name: Install dependencies
-        run: |
-          sudo apt-get -y update
-          sudo apt-get -y install make asciidoctor
-      - name: Install Antora
-        run: npm i antora
-      - name: Generate Site
-        run: make doc_site
-      - name: Upload Artifacts
-        uses: actions/upload-pages-artifact@v4
-        with:
-          path: build/site
-      - name: Deploy to GitHub Pages
-        id: deployment
-        uses: actions/deploy-pages@v4
+    build:
+        if: github.repository == 'dracut-ng/dracut-ng'
+        runs-on: ubuntu-latest
+        environment:
+            name: github-pages
+            url: ${{ steps.deployment.outputs.page_url }}
+        steps:
+            - name: Checkout repository
+              uses: actions/checkout@v6
+              with:
+                  fetch-depth: 0
+            - name: Configure Pages
+              uses: actions/configure-pages@v5
+            - name: Install Node.js
+              uses: actions/setup-node@v6
+              with:
+                  node-version: '18'
+            - name: Install dependencies
+              run: |
+                  sudo apt-get -y update
+                  sudo apt-get -y install make asciidoctor
+            - name: Install Antora
+              run: npm i antora
+            - name: Generate Site
+              run: make doc_site
+            - name: Upload Artifacts
+              uses: actions/upload-pages-artifact@v4
+              with:
+                  path: build/site
+            - name: Deploy to GitHub Pages
+              id: deployment
+              uses: actions/deploy-pages@v4

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,26 +2,26 @@
 name: Release
 
 on:  # yamllint disable-line rule:truthy
-  schedule:
-    ## Schedule the job quarterly to run on Feb-1, May-1, Aug-1, and Nov-1
-    - cron: '0 0 1 FEB,MAY,AUG,NOV *'
-  workflow_dispatch:
-    inputs:
-      tag:
-        description: "release version number (3 digits)"
-        required: true
+    schedule:
+        ## Schedule the job quarterly to run on Feb-1, May-1, Aug-1, and Nov-1
+        - cron: '0 0 1 FEB,MAY,AUG,NOV *'
+    workflow_dispatch:
+        inputs:
+            tag:
+                description: "release version number (3 digits)"
+                required: true
 
 permissions:
-  contents: write
+    contents: write
 
 jobs:
-  release:
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v6
-        with:
-          fetch-depth: 0
+    release:
+        runs-on: ubuntu-latest
+        steps:
+            - name: Checkout
+              uses: actions/checkout@v6
+              with:
+                  fetch-depth: 0
 
-      - name: Build
-        run: bash ${GITHUB_WORKSPACE}/tools/release.sh ${{ inputs.tag }}
+            - name: Build
+              run: bash ${GITHUB_WORKSPACE}/tools/release.sh ${{ inputs.tag }}

--- a/.yamllint
+++ b/.yamllint
@@ -1,4 +1,6 @@
 ---
 rules:
-  line-length:
-    max: 120
+    line-length:
+        max: 120
+    indentation:
+        spaces: 4

--- a/antora-playbook.yml
+++ b/antora-playbook.yml
@@ -1,22 +1,22 @@
 ---
 site:
-  title: Dracut
-  url: https://dracut-ng.github.io
+    title: Dracut
+    url: https://dracut-ng.github.io
 content:
-  sources:
-    - url: .
-      branches: HEAD
-      start_path: doc_site
+    sources:
+        - url: .
+          branches: HEAD
+          start_path: doc_site
 ui:
-  bundle:
-    url: https://gitlab.com/antora/antora-ui-default/-/jobs/artifacts/HEAD/raw/build/ui-bundle.zip?job=bundle-stable
-    snapshot: true
-  supplemental_files: ./doc_site/supplemental-ui
+    bundle:
+        url: https://gitlab.com/antora/antora-ui-default/-/jobs/artifacts/HEAD/raw/build/ui-bundle.zip?job=bundle-stable
+        snapshot: true
+    supplemental_files: ./doc_site/supplemental-ui
 runtime:
-  log:
-    # In C terms, -Werror
-    failure_level: warn
+    log:
+        # In C terms, -Werror
+        failure_level: warn
 
 asciidoc:
-  extensions:
-    - ./doc_site/extensions/man.js
+    extensions:
+        - ./doc_site/extensions/man.js

--- a/doc_site/antora.yml
+++ b/doc_site/antora.yml
@@ -3,4 +3,4 @@ name: ROOT
 title: dracut-ng
 version: ~
 nav:
-  - modules/ROOT/nav.adoc
+    - modules/ROOT/nav.adoc

--- a/doc_site/supplemental-ui/ui.yml
+++ b/doc_site/supplemental-ui/ui.yml
@@ -1,4 +1,4 @@
 ---
 static_files:
-  - images/dracut.svg
-  - css/dracut.css
+    - images/dracut.svg
+    - css/dracut.css


### PR DESCRIPTION
## Changes

Some YAML files use 2-space indent and others use 4-space indent. Use 4-space indent for all YAML files. Use this one-liner to convert them:

```
perl -i -pe 's/^((?: {2})+)/"    " x (length($1) \/ 2)/e' antora-playbook.yml \
    doc_site/antora.yml doc_site/supplemental-ui/ui.yml \
    .github/{labeler,dependabot}.yml .github/workflows/{codeql,lint,release,publish,pr}.yml
```

Plus some manual clean-up afterwards.

Verified with yamllint that the indentation is correct afterwards.

## Checklist
- [ ] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it

Fixes #
