### PR TITLE
ci: use common multi-arch container tags

### DIFF
--- a/.github/workflows/daily-basic.yml
+++ b/.github/workflows/daily-basic.yml
@@ -55,7 +55,7 @@ jobs:
                     - container: debian:sid
                       test: "26"
         container:
-            image: ghcr.io/dracut-ng/${{ matrix.container }}-${{ matrix.architecture.tag }}
+            image: ghcr.io/dracut-ng/${{ matrix.container }}
             options: '--device=/dev/kvm --privileged'
         steps:
             - name: "Checkout Repository"
@@ -98,7 +98,7 @@ jobs:
                     - container: centos:latest
                       test: "11"
         container:
-            image: ghcr.io/dracut-ng/${{ matrix.container }}-${{ matrix.architecture.tag }}
+            image: ghcr.io/dracut-ng/${{ matrix.container }}
             options: '--device=/dev/kvm --privileged'
         steps:
             - name: "Checkout Repository"

--- a/.github/workflows/daily-busybox-x64.yml
+++ b/.github/workflows/daily-busybox-x64.yml
@@ -36,7 +36,7 @@ jobs:
                     - {test: '81', deps: ''}
                     - {test: '82', deps: 'cargo procps-ng'}
         container:
-            image: ghcr.io/dracut-ng/${{ matrix.container }}-amd
+            image: ghcr.io/dracut-ng/${{ matrix.container }}
             options: '--device=/dev/kvm --privileged'
         steps:
             - name: "Checkout Repository"

--- a/.github/workflows/daily-hostonlystrict.yml
+++ b/.github/workflows/daily-hostonlystrict.yml
@@ -43,7 +43,7 @@ jobs:
                     - "81"
                     - "82"
         container:
-            image: ghcr.io/dracut-ng/${{ matrix.container }}-${{ matrix.architecture.tag }}
+            image: ghcr.io/dracut-ng/${{ matrix.container }}
             options: '--device=/dev/kvm --privileged'
         steps:
             - name: "Checkout Repository"

--- a/.github/workflows/daily-iscsi-x64.yml
+++ b/.github/workflows/daily-iscsi-x64.yml
@@ -18,7 +18,7 @@ jobs:
         runs-on: ubuntu-24.04
         timeout-minutes: 20
         concurrency:
-            group: daily-iscsi-${{ github.workflow }}-${{ github.ref }}-${{ matrix.container }}-${{ matrix.test }}-amd
+            group: daily-iscsi-${{ github.workflow }}-${{ github.ref }}-${{ matrix.container }}-${{ matrix.test }}
             cancel-in-progress: true
         strategy:
             fail-fast: false
@@ -30,7 +30,7 @@ jobs:
                     - "70"
                     - "71"
         container:
-            image: ghcr.io/dracut-ng/${{ matrix.container }}-amd
+            image: ghcr.io/dracut-ng/${{ matrix.container }}
             options: '--device=/dev/kvm'
         steps:
             - name: "Checkout Repository"

--- a/.github/workflows/daily-kernel-install-x64.yml
+++ b/.github/workflows/daily-kernel-install-x64.yml
@@ -18,7 +18,7 @@ jobs:
         runs-on: ubuntu-24.04
         timeout-minutes: 20
         concurrency:
-            group: daily-kernel-install-${{ github.workflow }}-${{ github.ref }}-${{ matrix.container }}-${{ matrix.test }}-amd
+            group: daily-kernel-install-${{ github.workflow }}-${{ github.ref }}-${{ matrix.container }}-${{ matrix.test }}
             cancel-in-progress: true
         strategy:
             fail-fast: false
@@ -37,7 +37,7 @@ jobs:
                 test:
                     - "12"
         container:
-            image: ghcr.io/dracut-ng/${{ matrix.container }}-amd
+            image: ghcr.io/dracut-ng/${{ matrix.container }}
             options: '--device=/dev/kvm --privileged'
         steps:
             - name: "Checkout Repository"

--- a/.github/workflows/daily-mkosi-x64.yml
+++ b/.github/workflows/daily-mkosi-x64.yml
@@ -28,7 +28,7 @@ jobs:
                 config:
                     - {test: '41', deps: 'mkosi-initrd'}
         container:
-            image: ghcr.io/dracut-ng/${{ matrix.container }}-amd
+            image: ghcr.io/dracut-ng/${{ matrix.container }}
             options: '--device=/dev/kvm --privileged'
         steps:
             - name: "Checkout Repository"

--- a/.github/workflows/daily-network-legacy.yml
+++ b/.github/workflows/daily-network-legacy.yml
@@ -35,7 +35,7 @@ jobs:
                     - "60"
                     - "72"
         container:
-            image: ghcr.io/dracut-ng/${{ matrix.container }}-${{ matrix.architecture.tag }}
+            image: ghcr.io/dracut-ng/${{ matrix.container }}
             options: '--device=/dev/kvm --privileged'
         steps:
             - name: "Checkout Repository"

--- a/.github/workflows/daily-network.yml
+++ b/.github/workflows/daily-network.yml
@@ -56,7 +56,7 @@ jobs:
                     - container: debian:sid
                       architecture: {runner: 'ubuntu-24.04-arm', tag: 'arm'}
         container:
-            image: ghcr.io/dracut-ng/${{ matrix.container }}-${{ matrix.architecture.tag }}
+            image: ghcr.io/dracut-ng/${{ matrix.container }}
             options: '--device=/dev/kvm --privileged'
         steps:
             - name: "Checkout Repository"

--- a/.github/workflows/daily-omitsystemd.yml
+++ b/.github/workflows/daily-omitsystemd.yml
@@ -36,7 +36,7 @@ jobs:
                     - "30"
                     - "31"
         container:
-            image: ghcr.io/dracut-ng/${{ matrix.container }}-${{ matrix.architecture.tag }}
+            image: ghcr.io/dracut-ng/${{ matrix.container }}
             options: '--device=/dev/kvm --privileged'
         steps:
             - name: "Checkout Repository"

--- a/.github/workflows/daily-systemd-networkd.yml
+++ b/.github/workflows/daily-systemd-networkd.yml
@@ -38,7 +38,7 @@ jobs:
                     - container: arch:latest
                       architecture: {runner: 'ubuntu-24.04-arm', tag: 'arm'}
         container:
-            image: ghcr.io/dracut-ng/${{ matrix.container }}-${{ matrix.architecture.tag }}
+            image: ghcr.io/dracut-ng/${{ matrix.container }}
             options: '--device=/dev/kvm --privileged'
         steps:
             - name: "Checkout Repository"

--- a/.github/workflows/daily-systemd.yml
+++ b/.github/workflows/daily-systemd.yml
@@ -73,7 +73,7 @@ jobs:
                     - container: debian:sid
                       architecture: {runner: 'ubuntu-24.04-arm', tag: 'arm'}
         container:
-            image: ghcr.io/dracut-ng/${{ matrix.container }}-${{ matrix.architecture.tag }}
+            image: ghcr.io/dracut-ng/${{ matrix.container }}
             options: '--device=/dev/kvm --privileged'
         steps:
             - name: "Checkout Repository"

--- a/.github/workflows/doc.yml
+++ b/.github/workflows/doc.yml
@@ -31,7 +31,7 @@ jobs:
                     - ubuntu:devel
                     - void:latest
         container:
-            image: ghcr.io/dracut-ng/${{ matrix.container }}-amd
+            image: ghcr.io/dracut-ng/${{ matrix.container }}
         steps:
             - name: "Checkout Repository"
               uses: actions/checkout@v6

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -42,7 +42,7 @@ jobs:
                 test:
                     - "10"
         container:
-            image: ghcr.io/dracut-ng/${{ matrix.container }}-amd
+            image: ghcr.io/dracut-ng/${{ matrix.container }}
             options: '--device=/dev/kvm'
         steps:
             - name: "Checkout Repository"
@@ -93,7 +93,7 @@ jobs:
                     - "80"
                     - "81"
         container:
-            image: ghcr.io/dracut-ng/${{ matrix.container }}-amd
+            image: ghcr.io/dracut-ng/${{ matrix.container }}
             options: '--device=/dev/kvm'
         steps:
             - name: "Checkout Repository"
@@ -129,7 +129,7 @@ jobs:
                     - container: arch:latest
                       test: "41"
         container:
-            image: ghcr.io/dracut-ng/${{ matrix.container }}-amd
+            image: ghcr.io/dracut-ng/${{ matrix.container }}
             options: '--device=/dev/kvm --privileged'
         steps:
             - name: "Checkout Repository"
@@ -153,7 +153,7 @@ jobs:
                 test:
                     - "82"
         container:
-            image: ghcr.io/dracut-ng/${{ matrix.container }}-amd
+            image: ghcr.io/dracut-ng/${{ matrix.container }}
             options: '--device=/dev/kvm'
         steps:
             - name: "Checkout Repository"
@@ -181,7 +181,7 @@ jobs:
                     - "31"
                     - "60"
         container:
-            image: ghcr.io/dracut-ng/${{ matrix.container }}-amd
+            image: ghcr.io/dracut-ng/${{ matrix.container }}
             options: '--device=/dev/kvm'
         steps:
             - name: "Checkout Repository"
@@ -208,7 +208,7 @@ jobs:
                     - "70"
                     - "71"
         container:
-            image: ghcr.io/dracut-ng/${{ matrix.container }}-amd
+            image: ghcr.io/dracut-ng/${{ matrix.container }}
             options: '--device=/dev/kvm'
         steps:
             - name: "Checkout Repository"
@@ -233,7 +233,7 @@ jobs:
                 test:
                     - "72"
         container:
-            image: ghcr.io/dracut-ng/${{ matrix.container }}-amd
+            image: ghcr.io/dracut-ng/${{ matrix.container }}
             options: '--device=/dev/kvm'
         steps:
             - name: "Checkout Repository"
@@ -259,7 +259,7 @@ jobs:
                 test:
                     - "10"
         container:
-            image: ghcr.io/dracut-ng/${{ matrix.container }}-arm
+            image: ghcr.io/dracut-ng/${{ matrix.container }}
             options: '--device=/dev/kvm --privileged'
         steps:
             - name: "Checkout Repository"

--- a/.github/workflows/manualtest.yml
+++ b/.github/workflows/manualtest.yml
@@ -69,7 +69,7 @@ jobs:
                 test: ${{ fromJSON(needs.matrix.outputs.tests) }}
             fail-fast: false
         container:
-            image: ${{ fromJSON(needs.matrix.outputs.registry) }}/${{ matrix.container }}-amd
+            image: ${{ fromJSON(needs.matrix.outputs.registry) }}/${{ matrix.container }}
             options: "--privileged -v /dev:/dev"
         steps:
             - name: "Checkout Repository"

--- a/test/test.sh
+++ b/test/test.sh
@@ -20,17 +20,6 @@ if [[ $CONTAINER != *":"* ]]; then
     CONTAINER="$CONTAINER:latest"
 fi
 
-# add architecture tag, see commit d8ff139
-ARCH="${ARCH-$(uname -m)}"
-case "$ARCH" in
-    aarch64 | arm64)
-        CONTAINER="$CONTAINER-arm"
-        ;;
-    amd64 | i?86 | x86_64)
-        CONTAINER="$CONTAINER-amd"
-        ;;
-esac
-
 echo "Running in a container from $CONTAINER"
 
 if command -v podman &> /dev/null; then


### PR DESCRIPTION
## Changes

Commit 5dd694a4834ec7643b02d04d73f87d5c760b7ede created multi-arch container tag. Use those in the CI jobs to simplify the jobs.

## Checklist
- [ ] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it

Fixes #
