### PR TITLE
ci(LIVENET): enable livenet testing on Alpine

### DIFF
--- a/test/container/Dockerfile-alpine
+++ b/test/container/Dockerfile-alpine
@@ -26,6 +26,7 @@ RUN apk add --no-cache \
     alpine-base \
     build-base \
     cargo \
+    curl \
     dnsmasq \
     dracut-tests \
     efistub \


### PR DESCRIPTION
## Changes

Test 31 (livenet) requires curl to be available in the test CI container.

## Checklist
- [ ] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it

Fixes #
