### PR TITLE
test: let run-qemu create a log file

### DIFF
--- a/test/TEST-31-LIVENET/test.sh
+++ b/test/TEST-31-LIVENET/test.sh
@@ -37,16 +37,6 @@ start_webserver() {
     echo "$port"
 }
 
-check_log() {
-    local msg="$1"
-    local logfile="$2"
-
-    if ! grep -q "${msg}" "${logfile}"; then
-        echo >&2 "E: Message '${msg}' not found in QEMU log output '${logfile}'."
-        return 1
-    fi
-}
-
 client_run() {
     local test_name="$1"
     local append="$2"
@@ -57,7 +47,7 @@ client_run() {
         -netdev "user,id=lan0,net=10.0.2.0/24,dhcpstart=10.0.2.15" \
         -append "$append $TEST_KERNEL_CMDLINE" \
         -initrd "$TESTDIR/initramfs.testing" | tee "$TESTDIR/qemu.log"
-    check_log '^All OK' "$TESTDIR/qemu.log"
+    check_qemu_log "$TESTDIR/qemu.log"
     client_test_end
 }
 

--- a/test/TEST-31-LIVENET/test.sh
+++ b/test/TEST-31-LIVENET/test.sh
@@ -46,8 +46,8 @@ client_run() {
         -device "virtio-net-pci,netdev=lan0" \
         -netdev "user,id=lan0,net=10.0.2.0/24,dhcpstart=10.0.2.15" \
         -append "$append $TEST_KERNEL_CMDLINE" \
-        -initrd "$TESTDIR/initramfs.testing" | tee "$TESTDIR/qemu.log"
-    check_qemu_log "$TESTDIR/qemu.log"
+        -initrd "$TESTDIR/initramfs.testing"
+    check_qemu_log
     client_test_end
 }
 

--- a/test/run-qemu
+++ b/test/run-qemu
@@ -198,6 +198,10 @@ if ! [[ $* == *-daemonize* ]] && timeout --help 2> /dev/null | grep -q -- --fore
     # Run QEMU with a timeout (defaut: 10min) unless daemonized
     ARGS=(--foreground "${QEMU_TIMEOUT-600}" "$BIN" "${ARGS[@]}")
     BIN=timeout
+
+    if [[ ${QEMU_LOGFILE-} ]]; then
+        exec > >(tee "$QEMU_LOGFILE")
+    fi
 fi
 
 echo "${0##*/}: $BIN $(quote_args "${ARGS[@]}")"

--- a/test/test-functions
+++ b/test/test-functions
@@ -84,6 +84,16 @@ call_dracut() {
     "$DRACUT" "$@"
 }
 
+# Check QEMU logs for success marker
+check_qemu_log() {
+    local logfile="$1"
+
+    if ! grep -q "^All OK" "${logfile}"; then
+        echo >&2 "E: Message 'All OK' not found in QEMU log output '${logfile}'."
+        return 1
+    fi
+}
+
 # Log the start of a client test.
 client_test_start() {
     local test_name="$1"

--- a/test/test-functions
+++ b/test/test-functions
@@ -10,6 +10,7 @@ fi
 echo "TESTDIR=\"$TESTDIR\"" > .testdir${TEST_RUN_ID:+-$TEST_RUN_ID}
 export TESTDIR
 export BOOT_ROOT="$TESTDIR"
+export QEMU_LOGFILE="$TESTDIR/qemu.log"
 
 if [[ -z ${basedir-} ]]; then basedir="$(realpath ../..)"; fi
 
@@ -86,7 +87,7 @@ call_dracut() {
 
 # Check QEMU logs for success marker
 check_qemu_log() {
-    local logfile="$1"
+    local logfile="${1-$QEMU_LOGFILE}"
 
     if ! grep -q "^All OK" "${logfile}"; then
         echo >&2 "E: Message 'All OK' not found in QEMU log output '${logfile}'."


### PR DESCRIPTION
## Changes

Move `check_log` to `test/test-functions`, name it `check_qemu_log`, and do not require to specify the success message (which will be the same for all tests). Let `run-qemu` create a log file if `QEMU_LOGFILE` is set and the QEMU is not run in `-daemonize` mode.

This is a preparation to use `check_qemu_log` in other tests as well.

## Checklist
- [ ] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it

Fixes #
