### PR TITLE
test: use check_qemu_log instead of test marker.img

### DIFF
--- a/test/TEST-10-BASIC/test.sh
+++ b/test/TEST-10-BASIC/test.sh
@@ -7,17 +7,13 @@ test_run() {
     declare -a disk_args=()
     # shellcheck disable=SC2034  # disk_index used in qemu_add_drive
     declare -i disk_index=0
-    qemu_add_drive disk_index disk_args "$TESTDIR"/marker.img marker
     qemu_add_drive disk_index disk_args "$TESTDIR"/root.img root
-
-    test_marker_reset
 
     "$testdir"/run-qemu -nic none \
         "${disk_args[@]}" \
         -append "root=LABEL=dracut $TEST_KERNEL_CMDLINE" \
         -initrd "$TESTDIR"/initramfs.testing
-
-    test_marker_check
+    check_qemu_log
 }
 
 test_setup() {

--- a/test/TEST-11-USR-MOUNT/test.sh
+++ b/test/TEST-11-USR-MOUNT/test.sh
@@ -23,19 +23,14 @@ client_run() {
 
     declare -a disk_args=()
     declare -i disk_index=0
-    qemu_add_drive disk_index disk_args "$TESTDIR"/marker.img marker
     qemu_add_drive disk_index disk_args "$TESTDIR"/root.btrfs root
 
-    test_marker_reset
     "$testdir"/run-qemu \
         "${disk_args[@]}" \
         -append "root=LABEL=dracut $TEST_KERNEL_CMDLINE $client_opts" \
         -initrd "$TESTDIR"/initramfs.testing
+    check_qemu_log
 
-    if ! test_marker_check; then
-        client_test_end "FAILED"
-        return 1
-    fi
     client_test_end
 }
 

--- a/test/TEST-13-SYSROOT/test.sh
+++ b/test/TEST-13-SYSROOT/test.sh
@@ -7,17 +7,13 @@ test_run() {
     declare -a disk_args=()
     # shellcheck disable=SC2034  # disk_index used in qemu_add_drive
     declare -i disk_index=0
-    qemu_add_drive disk_index disk_args "$TESTDIR"/marker.img marker
     qemu_add_drive disk_index disk_args "$TESTDIR"/root.img root
-
-    test_marker_reset
 
     "$testdir"/run-qemu -nic none \
         "${disk_args[@]}" \
         -append "root=LABEL=dracut $TEST_KERNEL_CMDLINE" \
         -initrd "$TESTDIR"/initramfs.testing
-
-    test_marker_check
+    check_qemu_log
 }
 
 test_setup() {

--- a/test/TEST-20-STORAGE/test.sh
+++ b/test/TEST-20-STORAGE/test.sh
@@ -35,8 +35,6 @@ client_run() {
 
     declare -a disk_args=()
     declare -i disk_index=0
-    qemu_add_drive disk_index disk_args "$TESTDIR"/marker.img marker
-
     qemu_add_drive disk_index disk_args "$TESTDIR/${disk}-1.img" disk1
 
     if ! grep -qF 'degraded' "$test_name"; then
@@ -50,12 +48,11 @@ client_run() {
         TEST_KERNEL_CMDLINE+=" root=LABEL=dracut "
     fi
 
-    test_marker_reset
     "$testdir"/run-qemu \
         "${disk_args[@]}" \
         -append "$TEST_KERNEL_CMDLINE ro $client_opts " \
         -initrd "$TESTDIR"/initramfs.testing
-    test_marker_check
+    check_qemu_log
 
     client_test_end
 }

--- a/test/TEST-26-ENC-RAID-LVM/test.sh
+++ b/test/TEST-26-ENC-RAID-LVM/test.sh
@@ -27,26 +27,22 @@ test_run() {
 
     declare -a disk_args=()
     declare -i disk_index=0
-    qemu_add_drive disk_index disk_args "$TESTDIR"/marker.img marker
     qemu_add_drive disk_index disk_args "$TESTDIR"/disk-1.img disk1
     qemu_add_drive disk_index disk_args "$TESTDIR"/disk-2.img disk2
 
-    test_marker_reset
     "$testdir"/run-qemu \
         "${disk_args[@]}" \
         -append "$TEST_KERNEL_CMDLINE root=/dev/dracut/root ro rd.auto rootwait $LUKSARGS" \
         -initrd "$TESTDIR"/initramfs.testing
-    test_marker_check
+    check_qemu_log
     client_test_end
-
-    test_marker_reset
 
     client_test_start "Any LUKS"
     "$testdir"/run-qemu \
         "${disk_args[@]}" \
         -append "$TEST_KERNEL_CMDLINE root=/dev/dracut/root rd.auto" \
         -initrd "$TESTDIR"/initramfs.testing
-    test_marker_check
+    check_qemu_log
     client_test_end
 
     return 0

--- a/test/TEST-30-DMSQUASH/test.sh
+++ b/test/TEST-30-DMSQUASH/test.sh
@@ -25,21 +25,16 @@ client_run() {
 
     declare -a disk_args=()
     declare -i disk_index=0
-    qemu_add_drive disk_index disk_args "$TESTDIR"/marker.img marker
     qemu_add_drive disk_index disk_args "$TESTDIR"/root.img root
     qemu_add_drive disk_index disk_args "$TESTDIR"/root_erofs.img root_erofs
     qemu_add_drive disk_index disk_args "$TESTDIR"/root_iso.img root_iso
 
-    test_marker_reset
     "$testdir"/run-qemu \
         "${disk_args[@]}" \
         -append "$TEST_KERNEL_CMDLINE rd.overlayfs=1 root=live:/dev/disk/by-label/dracut $client_opts" \
         -initrd "$TESTDIR"/initramfs.testing
+    check_qemu_log
 
-    if ! test_marker_check; then
-        client_test_end "FAILED"
-        return 1
-    fi
     client_test_end
 }
 

--- a/test/TEST-40-SYSTEMD/test.sh
+++ b/test/TEST-40-SYSTEMD/test.sh
@@ -12,16 +12,13 @@ test_check() {
 test_run() {
     declare -a disk_args=()
     declare -i disk_index=0
-    qemu_add_drive disk_index disk_args "$TESTDIR"/marker.img marker
     qemu_add_drive disk_index disk_args "$TESTDIR"/root.img root
 
-    test_marker_reset
     "$testdir"/run-qemu \
         "${disk_args[@]}" \
         -append "$TEST_KERNEL_CMDLINE \"root=LABEL=  rdinit=/bin/sh\" systemd.log_target=console init=/sbin/init" \
         -initrd "$TESTDIR"/initramfs.testing
-
-    test_marker_check
+    check_qemu_log
 }
 
 test_setup() {

--- a/test/TEST-41-FULL-SYSTEMD/test.sh
+++ b/test/TEST-41-FULL-SYSTEMD/test.sh
@@ -25,21 +25,16 @@ client_run() {
 
     declare -a disk_args=()
     declare -i disk_index=0
-    qemu_add_drive disk_index disk_args "$TESTDIR"/marker.img marker
     qemu_add_drive disk_index disk_args "$TESTDIR"/root.btrfs root
     qemu_add_drive disk_index disk_args "$TESTDIR"/root_crypt.btrfs root_crypt
     qemu_add_drive disk_index disk_args "$TESTDIR"/usr.btrfs usr
 
-    test_marker_reset
     "$testdir"/run-qemu \
         "${disk_args[@]}" \
         -append "root=LABEL=dracut $TEST_KERNEL_CMDLINE mount.usr=LABEL=dracutusr mount.usrflags=subvol=usr $client_opts ${DEBUGOUT-}" \
         -initrd "$TESTDIR"/initramfs.testing
+    check_qemu_log
 
-    if ! test_marker_check; then
-        client_test_end "FAILED"
-        return 1
-    fi
     client_test_end
 }
 

--- a/test/TEST-42-SYSTEMD-INITRD/test.sh
+++ b/test/TEST-42-SYSTEMD-INITRD/test.sh
@@ -19,19 +19,14 @@ client_run() {
 
     declare -a disk_args=()
     declare -i disk_index=0
-    qemu_add_drive disk_index disk_args "$TESTDIR"/marker.img marker
     qemu_add_drive disk_index disk_args "$TESTDIR"/root.img root
 
-    test_marker_reset
     "$testdir"/run-qemu \
         "${disk_args[@]}" \
         -append "root=LABEL=dracut $TEST_KERNEL_CMDLINE $client_opts" \
         -initrd "$TESTDIR"/initramfs.testing
+    check_qemu_log
 
-    if ! test_marker_check; then
-        client_test_end "FAILED"
-        return 1
-    fi
     client_test_end
 }
 

--- a/test/TEST-43-KERNEL-INSTALL/test.sh
+++ b/test/TEST-43-KERNEL-INSTALL/test.sh
@@ -14,27 +14,20 @@ test_run() {
     declare -a disk_args=()
     # shellcheck disable=SC2034  # disk_index used in qemu_add_drive
     declare -i disk_index=0
-    qemu_add_drive disk_index disk_args "$TESTDIR"/marker.img marker
     qemu_add_drive disk_index disk_args "$TESTDIR"/root.img root
-
-    test_marker_reset
 
     "$testdir"/run-qemu \
         "${disk_args[@]}" \
         -append "root=LABEL=dracut $TEST_KERNEL_CMDLINE" \
         -initrd "$BOOT_ROOT/$TOKEN/$KVERSION"/initrd
-
-    test_marker_check
-
-    test_marker_reset
+    check_qemu_log
 
     # rescue (non-hostonly) boot
     "$testdir"/run-qemu \
         "${disk_args[@]}" \
         -append "root=LABEL=dracut $TEST_KERNEL_CMDLINE" \
         -initrd "$BOOT_ROOT/$TOKEN"/0-rescue/initrd
-
-    test_marker_check
+    check_qemu_log
 }
 
 test_setup() {

--- a/test/TEST-44-DRIVERS/test.sh
+++ b/test/TEST-44-DRIVERS/test.sh
@@ -20,19 +20,15 @@ test_check() {
 test_run() {
     declare -a disk_args=()
     declare -i disk_index=0
-    qemu_add_drive disk_index disk_args "$TESTDIR"/marker.img marker
     qemu_add_drive disk_index disk_args "$TESTDIR"/root.img root
     qemu_add_drive disk_index disk_args "$TESTDIR"/mnt.img mnt
-
-    test_marker_reset
 
     # This test should fail if rd.driver.export is not passed at kernel command-line
     "$testdir"/run-qemu \
         "${disk_args[@]}" \
         -append "root=LABEL=dracut $TEST_KERNEL_CMDLINE rd.driver.export" \
         -initrd "$TESTDIR"/initramfs.testing
-
-    test_marker_check
+    check_qemu_log
 }
 
 test_setup() {

--- a/test/TEST-50-NETWORK/test.sh
+++ b/test/TEST-50-NETWORK/test.sh
@@ -10,10 +10,7 @@ test_run() {
     declare -a disk_args=()
     # shellcheck disable=SC2034  # disk_index used in qemu_add_drive
     declare -i disk_index=0
-    qemu_add_drive disk_index disk_args "$TESTDIR"/marker.img marker
     qemu_add_drive disk_index disk_args "$TESTDIR"/root.img root
-
-    test_marker_reset
 
     "$testdir"/run-qemu \
         -device "virtio-net-pci,netdev=lan0" \
@@ -21,8 +18,7 @@ test_run() {
         "${disk_args[@]}" \
         -append "root=LABEL=dracut $TEST_KERNEL_CMDLINE rd.neednet=1" \
         -initrd "$TESTDIR"/initramfs.testing
-
-    test_marker_check
+    check_qemu_log
 }
 
 test_setup() {


### PR DESCRIPTION
## Changes

Simplify the test code by reading the QEMU log instead of requiring to write to a `marker.img` inside the VM.

## Checklist
- [ ] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it

Fixes #
