### PR TITLE
docs: document dracut_rescue_image

### DIFF
--- a/man/dracut.conf.5.adoc
+++ b/man/dracut.conf.5.adoc
@@ -396,6 +396,10 @@ exists in the directory where initramfs is loaded from.
 +
 Defaults to _initramfs-$\{kernel\}.img_.
 
+*dracut_rescue_image=*"__{yes|no}__"::
+Let kernel-install create a rescue image (default=no).
+This configuration option applies only to kernel-install.
+
 == Files
 _/etc/dracut.conf_::
 Old configuration file. It is recommended to use individual files in


### PR DESCRIPTION
## Changes

Add documentation for the dracut_rescue_image in the dracut.conf man page.

Do not document default, as different distributions set defaults differently during packaging (sadly).

## Checklist
- [ ] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it

Fixes #2101
