### PR TITLE
feat: rename rd.overlayfs.readonly to rd.overlay.readonly

### DIFF
--- a/man/dracut.cmdline.7.adoc
+++ b/man/dracut.cmdline.7.adoc
@@ -1105,7 +1105,7 @@ d_type in readdir responses, such as with btrfs, ext4, f2fs, & xfs.  On
 non-vfat-formatted devices, a persistent OverlayFS overlay can extend the
 available root filesystem storage up to the capacity of the LiveOS disk device.
 +
-The **rd.overlayfs.readonly** option, which allows a persistent overlayfs to
+The **rd.overlay.readonly** option, which allows a persistent overlayfs to
 be mounted read-only through a higher level transient overlay directory, has
 been implemented through the multiple lower layers feature of OverlayFS.
 
@@ -1524,7 +1524,7 @@ EXT_KEYMAP:: vconsole.keymap.ext
 
 rd.live.overlay.overlayfs:: rd.overlayfs
 
-rd.live.overlay.readonly:: rd.overlayfs.readonly
+rd.live.overlay.readonly:: rd.overlay.readonly
 
 rd.live.overlay:: rd.overlay
 

--- a/modules.d/70dmsquash-live/dmsquash-generator.sh
+++ b/modules.d/70dmsquash-live/dmsquash-generator.sh
@@ -45,7 +45,7 @@ GENERATOR_DIR="$2"
 [ -z "$GENERATOR_DIR" ] && exit 1
 [ -d "$GENERATOR_DIR" ] || mkdir -p "$GENERATOR_DIR"
 
-getargbool 0 rd.overlayfs.readonly -d rd.live.overlayfs.readonly && readonly_overlay="--readonly" || readonly_overlay=""
+getargbool 0 rd.overlay.readonly -d rd.live.overlayfs.readonly && readonly_overlay="--readonly" || readonly_overlay=""
 getargbool 0 rd.overlayfs -d rd.live.overlay.overlayfs && overlayfs="yes"
 [ -e /xor_overlayfs ] && xor_overlayfs="yes"
 [ -e /xor_readonly ] && xor_readonly="--readonly"

--- a/modules.d/70dmsquash-live/dmsquash-live-root.sh
+++ b/modules.d/70dmsquash-live/dmsquash-live-root.sh
@@ -24,7 +24,7 @@ squash_image=$(getarg rd.live.squashimg)
 
 getargbool 0 rd.live.ram && live_ram="yes"
 getargbool 0 rd.overlay.reset -d rd.live.overlay.reset && reset_overlay="yes"
-getargbool 0 rd.overlayfs.readonly -d rd.live.overlay.readonly && readonly_overlay="--readonly" || readonly_overlay=""
+getargbool 0 rd.overlay.readonly -d rd.live.overlay.readonly && readonly_overlay="--readonly" || readonly_overlay=""
 getargbool 0 rd.live.overlay.nouserconfirmprompt && overlay_no_user_confirm_prompt="--noprompt" || overlay_no_user_confirm_prompt=""
 overlay=$(getarg rd.overlay -d rd.live.overlay)
 getargbool 0 rd.writable.fsimg && writable_fsimg="yes"

--- a/modules.d/70livenet/livenet-generator.sh
+++ b/modules.d/70livenet/livenet-generator.sh
@@ -49,7 +49,7 @@ GENERATOR_DIR="$2"
 
 [ -d "$GENERATOR_DIR" ] || mkdir -p "$GENERATOR_DIR"
 
-getargbool 0 rd.overlayfs.readonly -d rd.live.overlay.readonly && readonly_overlay="--readonly" || readonly_overlay=""
+getargbool 0 rd.overlay.readonly -d rd.live.overlay.readonly && readonly_overlay="--readonly" || readonly_overlay=""
 getargbool 0 rd.overlayfs -d rd.live.overlayfs.readonly && overlayfs="yes"
 [ -e /xor_overlayfs ] && xor_overlayfs="yes"
 [ -e /xor_readonly ] && xor_readonly="--readonly"

--- a/modules.d/70overlayfs/mount-overlayfs.sh
+++ b/modules.d/70overlayfs/mount-overlayfs.sh
@@ -3,7 +3,7 @@
 command -v getarg > /dev/null || . /lib/dracut-lib.sh
 
 getargbool 0 rd.overlayfs -d rd.live.overlay.overlayfs && overlayfs="yes"
-getargbool 0 rd.overlayfs.readonly -d rd.live.overlayfs.readonly && readonly_overlay="--readonly" || readonly_overlay=""
+getargbool 0 rd.overlay.readonly -d rd.live.overlayfs.readonly && readonly_overlay="--readonly" || readonly_overlay=""
 
 if [ -n "$overlayfs" ]; then
     if [ -n "$readonly_overlay" ] && [ -h /run/overlayfs-r ]; then


### PR DESCRIPTION
## Changes

Commit b77ae7eb8523da696fcb0f48a747ac22bdc9eb31 renamed `rd.live.overlay.readonly` to `rd.overlayfs.readonly`. Unify the overlay parameters into the `rd.overlay` namespace. There is no backward compatibility support needed for `rd.overlayfs.readonly` since it hasn't been part of a Dracut release.

## Checklist
- [ ] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it

Fixes #
