### PR TITLE
test: fix run-qemu to create a log file even with busybox

### DIFF
--- a/test/run-qemu
+++ b/test/run-qemu
@@ -198,7 +198,9 @@ if ! [[ $* == *-daemonize* ]] && timeout --help 2> /dev/null | grep -q -- --fore
     # Run QEMU with a timeout (defaut: 10min) unless daemonized
     ARGS=(--foreground "${QEMU_TIMEOUT-600}" "$BIN" "${ARGS[@]}")
     BIN=timeout
+fi
 
+if ! [[ $* == *-daemonize* ]]; then
     if [[ ${QEMU_LOGFILE-} ]]; then
         exec > >(tee "$QEMU_LOGFILE")
     fi


### PR DESCRIPTION
## Changes

Busybox timeout does not support `--foregroud` and therefore the tests are run without a timeout when using busybox (for example on alpine-busybox:edge). The code path for writing to `QEMU_LOGFILE` was also skipped in this case.

Move checking the condition for writing to a log file into a separate if-condition.

Fixes: e794ed6b14cf ("test: let run-qemu create a log file")

## Checklist
- [x] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it

Fixes #
