### PR TITLE
perf(dracut): replace grep by bash pattern matching and re-use cached 3cpio --help output

### DIFF
--- a/dracut.sh
+++ b/dracut.sh
@@ -2093,7 +2093,7 @@ fi
 
 if [[ $enhanced_cpio == "yes" ]]; then
     enhanced_cpio="$dracutbasedir/dracut-cpio"
-    if 3cpio --help 2> /dev/null | grep -q -- --data-align; then
+    if [[ $threecpio_help_output == *--data-align* ]]; then
         # align based on statfs optimal transfer size
         cpio_align=$(stat -f -c "%s" -- "$initdir")
         unset enhanced_cpio

--- a/dracut.sh
+++ b/dracut.sh
@@ -2107,6 +2107,7 @@ if [[ $enhanced_cpio == "yes" ]]; then
 else
     unset enhanced_cpio
 fi
+unset threecpio_help_output
 
 if [[ $no_kernel != yes ]] && ! [[ -d $srcmods ]]; then
     dfatal "Cannot find module directory $srcmods"

--- a/dracut.sh
+++ b/dracut.sh
@@ -2077,8 +2077,8 @@ fi
 
 CPIO=cpio
 if command -v 3cpio > /dev/null; then
-    if help_output=$(3cpio --help); then
-        if echo "$help_output" | grep -q -- --create; then
+    if threecpio_help_output=$(3cpio --help); then
+        if echo "$threecpio_help_output" | grep -q -- --create; then
             CPIO=3cpio
         else
             dinfo "3cpio does not support --create. Falling back to cpio."

--- a/dracut.sh
+++ b/dracut.sh
@@ -2078,7 +2078,7 @@ fi
 CPIO=cpio
 if command -v 3cpio > /dev/null; then
     if threecpio_help_output=$(3cpio --help); then
-        if echo "$threecpio_help_output" | grep -q -- --create; then
+        if [[ $threecpio_help_output == *--create* ]]; then
             CPIO=3cpio
         else
             dinfo "3cpio does not support --create. Falling back to cpio."

--- a/lsinitrd.sh
+++ b/lsinitrd.sh
@@ -108,6 +108,7 @@ if command -v 3cpio > /dev/null; then
         echo "Warning: Calling '3cpio --help' failed. Cannot check if 3cpio supports --make-directories."
         CPIO=3cpio
     fi
+    unset threecpio_help_output
 fi
 
 if ! [[ $KERNEL_VERSION ]]; then

--- a/lsinitrd.sh
+++ b/lsinitrd.sh
@@ -98,8 +98,8 @@ done
 
 CPIO=cpio
 if command -v 3cpio > /dev/null; then
-    if help_output=$(3cpio --help); then
-        if echo "$help_output" | grep -q -- --make-directories; then
+    if threecpio_help_output=$(3cpio --help); then
+        if echo "$threecpio_help_output" | grep -q -- --make-directories; then
             CPIO=3cpio
         fi
     elif command -v cpio > /dev/null; then

--- a/lsinitrd.sh
+++ b/lsinitrd.sh
@@ -99,7 +99,7 @@ done
 CPIO=cpio
 if command -v 3cpio > /dev/null; then
     if threecpio_help_output=$(3cpio --help); then
-        if echo "$threecpio_help_output" | grep -q -- --make-directories; then
+        if [[ $threecpio_help_output == *--make-directories* ]]; then
             CPIO=3cpio
         fi
     elif command -v cpio > /dev/null; then


### PR DESCRIPTION
## Changes

* Replace `echo | grep` by a bash pattern matching to avoid spawning external processes. The bash pattern matching should be faster.
* Re-use `threecpio_help_output` instead of calling `3cpio` again. This should be faster.
* Reduce the memory consumption by unsetting `threecpio_help_output` after usage.

## Checklist
- [ ] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it

Fixes #
