### PR TITLE
ci: rename alpine-busybox:edge to alpine:busybox-edge

### DIFF
--- a/.github/workflows/container.yml
+++ b/.github/workflows/container.yml
@@ -38,7 +38,7 @@ jobs:
                     - {platform: 'linux/arm64', runner: 'ubuntu-24.04-arm', tag: 'arm'}
                 config:
                     - {dockerfile: 'Dockerfile-alpine', tag: 'alpine:edge'}
-                    - {dockerfile: 'Dockerfile-alpine-busybox', tag: 'alpine-busybox:edge'}
+                    - {dockerfile: 'Dockerfile-alpine-busybox', tag: 'alpine:busybox-edge'}
                     - {dockerfile: 'Dockerfile-arch', tag: 'arch:latest'}
                     - {dockerfile: 'Dockerfile-debian', tag: 'debian:latest'}
                     - {dockerfile: 'Dockerfile-fedora', tag: 'fedora:latest'}
@@ -84,7 +84,7 @@ jobs:
             matrix:
                 config:
                     - {tag: 'alpine:edge', platforms: ['amd', 'arm']}
-                    - {tag: 'alpine-busybox:edge', platforms: ['amd', 'arm']}
+                    - {tag: 'alpine:busybox-edge', platforms: ['amd', 'arm']}
                     - {tag: 'arch:latest', platforms: ['amd']}
                     - {tag: 'debian:latest', platforms: ['amd', 'arm']}
                     - {tag: 'fedora:latest', platforms: ['amd', 'arm']}

--- a/.github/workflows/daily-busybox-x64.yml
+++ b/.github/workflows/daily-busybox-x64.yml
@@ -26,7 +26,7 @@ jobs:
             fail-fast: false
             matrix:
                 container:
-                    - alpine-busybox:edge
+                    - alpine:busybox-edge
                 config:
                     - {test: '10', deps: ''}
                     - {test: '11', deps: 'btrfs-progs'}

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -33,7 +33,7 @@ jobs:
             matrix:
                 container:
                     - alpine:edge
-                    - alpine-busybox:edge
+                    - alpine:busybox-edge
                     - arch:latest
                     - debian:latest
                     - fedora:latest


### PR DESCRIPTION
Move busybox from the image name to the tag. That way all alpine images can be found on https://github.com/dracut-ng/dracut-ng/pkgs/container/alpine

After merging this, https://github.com/dracut-ng/dracut-ng/pkgs/container/alpine-busybox needs to be manually deleted.

## Checklist
- [ ] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it
