### PR TITLE
ci: always include container in job names

### DIFF
--- a/.github/workflows/daily-busybox-x64.yml
+++ b/.github/workflows/daily-busybox-x64.yml
@@ -14,7 +14,7 @@ on:  # yamllint disable-line rule:truthy
 
 jobs:
     busybox:
-        name: ${{ matrix.config.test }}
+        name: ${{ matrix.config.test }} on ${{ matrix.container }} with busybox
         runs-on: ubuntu-24.04
         timeout-minutes: 20
         concurrency:

--- a/.github/workflows/daily-mkosi-x64.yml
+++ b/.github/workflows/daily-mkosi-x64.yml
@@ -14,7 +14,7 @@ on:  # yamllint disable-line rule:truthy
 
 jobs:
     mkosi:
-        name: ${{ matrix.config.test }}
+        name: ${{ matrix.config.test }} on ${{ matrix.container }} with mkosi
         runs-on: ubuntu-24.04
         timeout-minutes: 30
         concurrency:


### PR DESCRIPTION
Always include the container name in the CI job names (for consistency).

<!-- This pull request changes... -->

<!-- Fixes: https://github.com/dracut-ng/dracut-ng/issues/<number> -->

### Checklist
- [ ] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it
