### PR TITLE
fix(dracut-functions): check for kmod

### DIFF
--- a/dracut-functions.sh
+++ b/dracut-functions.sh
@@ -774,7 +774,9 @@ check_kernel_config() {
 # 0 if the kernel module is either built-in or available
 # 1 if the kernel module is not enabled
 check_kernel_module() {
-    modprobe -d "$drivers_dir/../../../" -S "$kernel" --dry-run "$1" &> /dev/null || return 1
+    if command -v kmod > /dev/null 2> /dev/null; then
+        modprobe -d "$drivers_dir/../../../" -S "$kernel" --dry-run "$1" &> /dev/null || return 1
+    fi
 }
 
 # get_cpu_vendor


### PR DESCRIPTION
Check for kmod before depending on a [kmod](https://github.com/kmod-project/kmod) specific functionality.

This code pattern is taken from the [base module](https://github.com/dracut-ng/dracut-ng/blob/109/modules.d/80base/init.sh#L79) which already includes a similar kmod check.

Fixes: https://github.com/dracut-ng/dracut-ng/issues/2123

### Checklist
- [ ] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it
