### PR TITLE
chore(dracut): remove support for module-init-tools

### DIFF
--- a/dracut.sh
+++ b/dracut.sh
@@ -1458,10 +1458,6 @@ export LC_MESSAGES=C kernel
 srcmods="$(realpath -e "${dracutsysrootdir-}/lib/modules/$kernel")"
 
 [[ ${drivers_dir-} ]] && {
-    if ! command -v kmod &> /dev/null && vercmp "$(modprobe --version | cut -d' ' -f3)" lt 3.7; then
-        dfatal 'To use --kmoddir option module-init-tools >= 3.7 is required.'
-        exit 1
-    fi
     srcmods="$drivers_dir"
 }
 export srcmods


### PR DESCRIPTION
module-init-tools was EOL'ed in 2011.

partial revert of ecf42850c (from 2010).

### Checklist
- [ ] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it
