### PR TITLE
ci: use uutil's coreutils on ubuntu:devel (resolute)

### DIFF
--- a/test/container/Dockerfile-debian
+++ b/test/container/Dockerfile-debian
@@ -24,7 +24,7 @@ RUN if [ "$DISTRIBUTION" != "debian:latest" ] ; then cpio=3cpio; else cpio=cpio;
     $cpio
 
 # use GNU coreutils instead of uutil's coreutils until https://github.com/uutils/coreutils/issues/9057 and https://launchpad.net/bugs/2129037 are fixed
-RUN if [ "$DISTRIBUTION" = "ubuntu:devel" ] || [ "$DISTRIBUTION" = "ubuntu:rolling" ]; then \
+RUN if [ "$DISTRIBUTION" = "ubuntu:rolling" ]; then \
     DEBIAN_FRONTEND=noninteractive apt-get install -y -qq --no-install-recommends -o Dpkg::Use-Pty=0 \
     coreutils-from-gnu coreutils-from-uutils- --allow-remove-essential; \
     fi


### PR DESCRIPTION
rust-coreutils 0.5.0 landed in Ubuntu 26.04 (resolute). Therefore https://github.com/uutils/coreutils/issues/9057 and https://launchpad.net/bugs/2129037 are fixed in ubuntu:devel.

<!-- This pull request changes... -->

<!-- Fixes: https://github.com/dracut-ng/dracut-ng/issues/<number> -->

### Checklist
- [ ] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it
