### PR TITLE
ci(busybox): do not mix kmod and busybox binaries

### DIFF
--- a/test/container/Dockerfile-alpine
+++ b/test/container/Dockerfile-alpine
@@ -43,7 +43,7 @@ RUN \
   ln -sf /boot/vmlinuz-virt /boot/vmlinuz-$(cd /lib/modules; ls -1 | tail -1)
 
 # busybox container
-# replace all GNU coreutils and GNU util-linux binaries with busybox binaries
+# replace GNU coreutils, util-linux, kmod binaries with busybox binaries
 RUN \
 if [ "$OPTION" == "busybox" ] ; then \
   mkdir /busybox && cd /busybox && /bin/busybox --install -s /busybox ;\
@@ -51,4 +51,5 @@ if [ "$OPTION" == "busybox" ] ; then \
   cp -a /busybox/* /sbin/ ;\
   cp -a /busybox/* /usr/bin/ ;\
   cp -a /busybox/* /usr/sbin/ ;\
+  rm -f /bin/kmod ;\
 fi


### PR DESCRIPTION
Busybox provides applets for all (e.g. modprobe, rmmod) kmod binaries (under /sbin). These kmod binaries are all copied over in the busybox CI container except kmod binary itself, which will confuse dracut (as `command kmod` will return tue).

Remove kmod from /bin/kmod from the busybox container.

<!-- This pull request changes... -->

<!-- Fixes: https://github.com/dracut-ng/dracut-ng/issues/<number> -->

### Checklist
- [ ] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it
