### PR TITLE
test: use systemd inside client test rootfs if available

### DIFF
--- a/test/modules.d/70test-root/module-setup.sh
+++ b/test/modules.d/70test-root/module-setup.sh
@@ -13,6 +13,11 @@ depends() {
         deps+=" debug"
     fi
 
+    # Use systemd if available
+    if [[ -e "$systemdutildir"/systemd ]]; then
+        deps+=" systemd"
+    fi
+
     echo "$deps"
     return 0
 }
@@ -28,6 +33,7 @@ install() {
         $SYSTEMCTL -q --root "$initdir" add-wants testsuite.target "testsuite.service"
         ln_r "${systemdsystemunitdir}/testsuite.target" "${systemdsystemunitdir}/default.target"
         inst_script "$moddir/test-init.sh" "/sbin/test-init"
+        ln -sfn ../lib/systemd/systemd "$initdir/sbin/init"
     else
         inst_script "$moddir/test-init.sh" "/sbin/init"
     fi


### PR DESCRIPTION
Some tests (for example test 10 on ubuntu:devel) show this warning:

```
System has not been booted with systemd as init system (PID 1). Can't operate.
Failed to connect to system scope bus via local transport: Host is down
```

This is caused by calling `systemctl --failed` in the client test rootfs where systemd is not available/used.

Use systemd inside the client test rootfs if available to allow querying the failed services from the initrd.

<!-- This pull request changes... -->

<!-- Fixes: https://github.com/dracut-ng/dracut-ng/issues/<number> -->

### Checklist
- [ ] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it
