### PR TITLE
test: avoid printing wall message on shutdown

### DIFF
--- a/test/TEST-60-NFS/client-init.sh
+++ b/test/TEST-60-NFS/client-init.sh
@@ -48,7 +48,7 @@ echo "Powering down."
 
 if [ -d /usr/lib/systemd/system ]; then
     # graceful poweroff
-    systemctl poweroff
+    systemctl start poweroff.target --job-mode=replace-irreversibly --no-block
 else
     # force immediate poweroff
     poweroff -f

--- a/test/TEST-70-ISCSI/client-init.sh
+++ b/test/TEST-70-ISCSI/client-init.sh
@@ -16,7 +16,7 @@ echo "Powering down."
 
 if [ -d /usr/lib/systemd/system ]; then
     # graceful poweroff
-    systemctl poweroff
+    systemctl start poweroff.target --job-mode=replace-irreversibly --no-block
 else
     # force immediate poweroff
     poweroff -f

--- a/test/TEST-71-ISCSI-MULTI/client-init.sh
+++ b/test/TEST-71-ISCSI-MULTI/client-init.sh
@@ -16,7 +16,7 @@ echo "Powering down."
 
 if [ -d /usr/lib/systemd/system ]; then
     # graceful poweroff
-    systemctl poweroff
+    systemctl start poweroff.target --job-mode=replace-irreversibly --no-block
 else
     # force immediate poweroff
     poweroff -f

--- a/test/TEST-72-NBD/client-init.sh
+++ b/test/TEST-72-NBD/client-init.sh
@@ -21,7 +21,7 @@ echo "Powering down."
 
 if [ -d /usr/lib/systemd/system ]; then
     # graceful poweroff
-    systemctl poweroff
+    systemctl start poweroff.target --job-mode=replace-irreversibly --no-block
 else
     # force immediate poweroff
     poweroff -f

--- a/test/modules.d/70test-root/test-init.sh
+++ b/test/modules.d/70test-root/test-init.sh
@@ -42,7 +42,7 @@ echo "Powering down."
 
 if [ -d /usr/lib/systemd/system ]; then
     # graceful poweroff
-    systemctl poweroff
+    systemctl start poweroff.target --job-mode=replace-irreversibly --no-block
 else
     # force immediate poweroff
     poweroff -f


### PR DESCRIPTION
Calling `systemctl poweroff` in the client test rootfs causes this warning:

```
Failed to connect to system scope bus via local transport: No such file or directory
```

Installing D-Bus in the client test rootfs changes the warning to:

```
Failed to set wall message, ignoring: Transport endpoint is not connected
Call to PowerOff failed: Transport endpoint is not connected
```

The man page for systemctl poweroff says: "Shut down and power-off the system. This is mostly equivalent to systemctl start poweroff.target --job-mode=replace-irreversibly --no-block, but also prints a wall message to all users."

So call this equivalent command instead to not trying to print wall message on shutdown.

<!-- This pull request changes... -->

<!-- Fixes: https://github.com/dracut-ng/dracut-ng/issues/<number> -->

### Checklist
- [ ] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it
