### PR TITLE
fix(dracut): move defining DRACUT_LDCONFIG to dracut-functions.sh

### DIFF
--- a/dracut-functions.sh
+++ b/dracut-functions.sh
@@ -1514,6 +1514,8 @@ if ! is_func dinfo > /dev/null 2>&1; then
     dlog_init
 fi
 
+DRACUT_LDCONFIG=${DRACUT_LDCONFIG:-ldconfig}
+
 if ! [[ "${DRACUT_INSTALL-}" ]]; then
     DRACUT_INSTALL=$(find_binary dracut-install || true)
 fi

--- a/dracut.sh
+++ b/dracut.sh
@@ -1472,7 +1472,6 @@ export srcmods
 }
 
 DRACUT_TESTBIN=${DRACUT_TESTBIN:-/bin/sh}
-DRACUT_LDCONFIG=${DRACUT_LDCONFIG:-ldconfig}
 PKG_CONFIG=${PKG_CONFIG:-pkg-config}
 
 # Detect lib paths


### PR DESCRIPTION
The function `ldconfig_paths` in `dracut-functions.sh` uses `DRACUT_LDCONFIG`. Therefore move defining `DRACUT_LDCONFIG` into `dracut-functions.sh`.

<!-- This pull request changes... -->

<!-- Fixes: https://github.com/dracut-ng/dracut-ng/issues/<number> -->

### Checklist
- [ ] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it
