### PR TITLE
fix(dracut): move libdirs to dracut-functions.sh

### DIFF
--- a/dracut.sh
+++ b/dracut.sh
@@ -1471,34 +1471,7 @@ export srcmods
     export hookdirs
 }
 
-DRACUT_TESTBIN=${DRACUT_TESTBIN:-/bin/sh}
 PKG_CONFIG=${PKG_CONFIG:-pkg-config}
-
-_detect_library_directories() {
-    local libdirs=""
-
-    if [[ $($DRACUT_INSTALL ${dracutsysrootdir:+-r "$dracutsysrootdir"} --dry-run -R "$DRACUT_TESTBIN") == */lib64/* ]] &> /dev/null \
-        && [[ -d "${dracutsysrootdir-}/lib64" ]]; then
-        libdirs+=" /lib64"
-        [[ -d "${dracutsysrootdir-}/usr/lib64" ]] && libdirs+=" /usr/lib64"
-
-    fi
-
-    if [[ -d "${dracutsysrootdir-}/lib" ]]; then
-        libdirs+=" /lib"
-        [[ -d "${dracutsysrootdir-}/usr/lib" ]] && libdirs+=" /usr/lib"
-    fi
-
-    # shellcheck disable=SC2046  # word splitting is wanted, libraries must not contain spaces
-    libdirs+="$(printf ' %s' $(ldconfig_paths))"
-
-    echo "${libdirs# }"
-}
-
-# Detect lib paths
-if ! [[ ${libdirs-} ]]; then
-    libdirs=$(_detect_library_directories)
-fi
 
 dracut_module_included() {
     [[ " $mods_to_load $modules_loaded " == *\ $*\ * ]]

--- a/dracut.sh
+++ b/dracut.sh
@@ -1474,8 +1474,9 @@ export srcmods
 DRACUT_TESTBIN=${DRACUT_TESTBIN:-/bin/sh}
 PKG_CONFIG=${PKG_CONFIG:-pkg-config}
 
-# Detect lib paths
-if ! [[ ${libdirs-} ]]; then
+_detect_library_directories() {
+    local libdirs=""
+
     if [[ $($DRACUT_INSTALL ${dracutsysrootdir:+-r "$dracutsysrootdir"} --dry-run -R "$DRACUT_TESTBIN") == */lib64/* ]] &> /dev/null \
         && [[ -d "${dracutsysrootdir-}/lib64" ]]; then
         libdirs+=" /lib64"
@@ -1491,7 +1492,12 @@ if ! [[ ${libdirs-} ]]; then
     # shellcheck disable=SC2046  # word splitting is wanted, libraries must not contain spaces
     libdirs+="$(printf ' %s' $(ldconfig_paths))"
 
-    libdirs="${libdirs# }"
+    echo "${libdirs# }"
+}
+
+# Detect lib paths
+if ! [[ ${libdirs-} ]]; then
+    libdirs=$(_detect_library_directories)
     export libdirs
 fi
 

--- a/dracut.sh
+++ b/dracut.sh
@@ -1498,7 +1498,6 @@ _detect_library_directories() {
 # Detect lib paths
 if ! [[ ${libdirs-} ]]; then
     libdirs=$(_detect_library_directories)
-    export libdirs
 fi
 
 dracut_module_included() {


### PR DESCRIPTION
The variable `libdirs` is used by functions defined in `dracut-functions.sh` (for example `inst_libdir_file`).

So move initializing `libdirs` to `dracut-functions.sh`.

### Checklist
- [ ] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it
