### PR TITLE
test: use EXIT trap to poweroff client rootfs

### DIFF
--- a/test/TEST-60-NFS/client-init.sh
+++ b/test/TEST-60-NFS/client-init.sh
@@ -4,6 +4,21 @@
 . /lib/url-lib.sh
 
 export PATH=/usr/sbin:/usr/bin:/sbin:/bin
+
+# shellcheck disable=SC2317,SC2329  # called via EXIT trap
+_poweroff() {
+    echo "Powering down."
+
+    if [ -d /usr/lib/systemd/system ]; then
+        # graceful poweroff
+        systemctl start poweroff.target --job-mode=replace-irreversibly --no-block
+    else
+        # force immediate poweroff
+        poweroff -f
+    fi
+}
+
+trap _poweroff EXIT
 exec > /dev/console 2>&1
 
 echo "made it to the NFS client rootfs!"
@@ -43,13 +58,3 @@ fi
 : > /dev/watchdog
 
 sync /dev/disk/by-id/scsi-0QEMU_QEMU_HARDDISK_marker /dev/disk/by-id/scsi-0QEMU_QEMU_HARDDISK_marker2
-
-echo "Powering down."
-
-if [ -d /usr/lib/systemd/system ]; then
-    # graceful poweroff
-    systemctl start poweroff.target --job-mode=replace-irreversibly --no-block
-else
-    # force immediate poweroff
-    poweroff -f
-fi

--- a/test/TEST-70-ISCSI/client-init.sh
+++ b/test/TEST-70-ISCSI/client-init.sh
@@ -1,6 +1,21 @@
 #!/bin/sh
 
 export PATH=/usr/sbin:/usr/bin:/sbin:/bin
+
+# shellcheck disable=SC2317,SC2329  # called via EXIT trap
+_poweroff() {
+    echo "Powering down."
+
+    if [ -d /usr/lib/systemd/system ]; then
+        # graceful poweroff
+        systemctl start poweroff.target --job-mode=replace-irreversibly --no-block
+    else
+        # force immediate poweroff
+        poweroff -f
+    fi
+}
+
+trap _poweroff EXIT
 exec > /dev/console 2>&1
 
 echo "made it to the iSCSI client rootfs!"
@@ -11,13 +26,3 @@ while read -r dev _ fstype opts rest || [ -n "$dev" ]; do
 done < /proc/mounts
 
 sync /dev/disk/by-id/scsi-0QEMU_QEMU_HARDDISK_marker
-
-echo "Powering down."
-
-if [ -d /usr/lib/systemd/system ]; then
-    # graceful poweroff
-    systemctl start poweroff.target --job-mode=replace-irreversibly --no-block
-else
-    # force immediate poweroff
-    poweroff -f
-fi

--- a/test/TEST-72-NBD/client-init.sh
+++ b/test/TEST-72-NBD/client-init.sh
@@ -2,6 +2,21 @@
 : > /dev/watchdog
 
 export PATH=/usr/sbin:/usr/bin:/sbin:/bin
+
+# shellcheck disable=SC2317,SC2329  # called via EXIT trap
+_poweroff() {
+    echo "Powering down."
+
+    if [ -d /usr/lib/systemd/system ]; then
+        # graceful poweroff
+        systemctl start poweroff.target --job-mode=replace-irreversibly --no-block
+    else
+        # force immediate poweroff
+        poweroff -f
+    fi
+}
+
+trap _poweroff EXIT
 exec > /dev/console 2>&1
 echo "made it to the NBD client rootfs!"
 
@@ -16,13 +31,3 @@ done < /proc/mounts
 mount -n -o remount,ro /
 
 sync /dev/disk/by-id/scsi-0QEMU_QEMU_HARDDISK_marker
-
-echo "Powering down."
-
-if [ -d /usr/lib/systemd/system ]; then
-    # graceful poweroff
-    systemctl start poweroff.target --job-mode=replace-irreversibly --no-block
-else
-    # force immediate poweroff
-    poweroff -f
-fi


### PR DESCRIPTION
Use an trap on `EXIT` to poweroff the client rootfs. This will cover all kinds of failure and allows using `set -eu` in the init script.

<!-- This pull request changes... -->

<!-- Fixes: https://github.com/dracut-ng/dracut-ng/issues/<number> -->

### Checklist
- [ ] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it
