### PR TITLE
test: log exit code in case the client init script fails

### DIFF
--- a/test/TEST-60-NFS/client-init.sh
+++ b/test/TEST-60-NFS/client-init.sh
@@ -7,6 +7,9 @@ export PATH=/usr/sbin:/usr/bin:/sbin:/bin
 
 # shellcheck disable=SC2317,SC2329  # called via EXIT trap
 _poweroff() {
+    local exit_code="$?"
+
+    [ "$exit_code" -eq 0 ] || echo "Error: $0 failed with exit code $exit_code."
     echo "Powering down."
 
     if [ -d /usr/lib/systemd/system ]; then

--- a/test/TEST-70-ISCSI/client-init.sh
+++ b/test/TEST-70-ISCSI/client-init.sh
@@ -4,6 +4,9 @@ export PATH=/usr/sbin:/usr/bin:/sbin:/bin
 
 # shellcheck disable=SC2317,SC2329  # called via EXIT trap
 _poweroff() {
+    local exit_code="$?"
+
+    [ "$exit_code" -eq 0 ] || echo "Error: $0 failed with exit code $exit_code."
     echo "Powering down."
 
     if [ -d /usr/lib/systemd/system ]; then

--- a/test/TEST-71-ISCSI-MULTI/client-init.sh
+++ b/test/TEST-71-ISCSI-MULTI/client-init.sh
@@ -4,6 +4,9 @@ export PATH=/usr/sbin:/usr/bin:/sbin:/bin
 
 # shellcheck disable=SC2317,SC2329  # called via EXIT trap
 _poweroff() {
+    local exit_code="$?"
+
+    [ "$exit_code" -eq 0 ] || echo "Error: $0 failed with exit code $exit_code."
     echo "Powering down."
 
     if [ -d /usr/lib/systemd/system ]; then

--- a/test/TEST-72-NBD/client-init.sh
+++ b/test/TEST-72-NBD/client-init.sh
@@ -5,6 +5,9 @@ export PATH=/usr/sbin:/usr/bin:/sbin:/bin
 
 # shellcheck disable=SC2317,SC2329  # called via EXIT trap
 _poweroff() {
+    local exit_code="$?"
+
+    [ "$exit_code" -eq 0 ] || echo "Error: $0 failed with exit code $exit_code."
     echo "Powering down."
 
     if [ -d /usr/lib/systemd/system ]; then

--- a/test/modules.d/70test-root/test-init.sh
+++ b/test/modules.d/70test-root/test-init.sh
@@ -4,6 +4,9 @@ export PATH=/usr/sbin:/usr/bin:/sbin:/bin
 
 # shellcheck disable=SC2317,SC2329  # called via EXIT trap
 _poweroff() {
+    local exit_code="$?"
+
+    [ "$exit_code" -eq 0 ] || echo "Error: $0 failed with exit code $exit_code."
     echo "Powering down."
 
     if [ -d /usr/lib/systemd/system ]; then


### PR DESCRIPTION
To ease debugging, log the exit code in case the client init script fails.

<!-- This pull request changes... -->

<!-- Fixes: https://github.com/dracut-ng/dracut-ng/issues/<number> -->

### Checklist
- [x] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it
