### PR TITLE
fix(test-root): run testsuite.service after plymouth-quit-wait.service

### DIFF
--- a/test/modules.d/70test-root/testsuite.service
+++ b/test/modules.d/70test-root/testsuite.service
@@ -1,6 +1,6 @@
 [Unit]
 Description=Testsuite service
-After=basic.target multi-user.target
+After=basic.target multi-user.target plymouth-quit-wait.service
 
 [Service]
 ExecStart=/sbin/test-init


### PR DESCRIPTION
After commit d36012143c7c ("test: use systemd inside client test rootfs if available") some tests became racy (for example test 20 on debian:latest or fedora:latest). Example log snippet:

```
[  OK  ] Stopped plymouth-switch-root.service.
[  OK  ] Stopped systemd-cryptsetup@testluks.service.
[    7.848991] watchdog: watchdog0: watchdog did not stop!
[  OK  ] Stopped systemd-fsck-root.service.
         Starting testsuite.service - Testsuite service...
systemd[1]: systemd-journald.service: Deactivated successfully.
made it to the test rootfs!
systemd[1]: Stopped systemd-journald.service.
systemd[1]: initrd-switch-root.service: Deactivated successfully.
systemd[1]: Stopped initrd-switch-root.service.
[    7.869918] systemd[1]: plymouth-start.service: Deactivated successfully.
[    7.872470] systemd[1]: Stopped plymouth-start.service.
[  OK  ] Stopped plymouth-start.service.
```

So there is `made it to the test rootfs!` in the logs but not the `All OK`.

`plymouth-start.service` stopped after `testsuite.service` started. Maybe Plymouth interferes with the log output of test-init.sh.

So let `testsuite.service` start after Plymouth quits.

Hopefully fixes: https://github.com/dracut-ng/dracut-ng/issues/2137

### Checklist
- [ ] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it
