### PR TITLE
fix(tpm2-tss): add tss user/group in addition to sysusers config

### DIFF
--- a/modules.d/73tpm2-tss/module-setup.sh
+++ b/modules.d/73tpm2-tss/module-setup.sh
@@ -32,6 +32,8 @@ installkernel() {
 install() {
     inst_sysusers tpm2-tss.conf
     inst_sysusers system-user-tss.conf
+    grep -s '^tss:' "${dracutsysrootdir-}"/etc/passwd >> "$initdir/etc/passwd"
+    grep -s '^tss:' "${dracutsysrootdir-}"/etc/group >> "$initdir/etc/group"
 
     inst_multiple -o \
         "$tmpfilesdir"/tpm2-tss-fapi.conf \


### PR DESCRIPTION
Test 10 on ubuntu:devel shows this warning:

```
[    0.608623] systemd-tmpfiles[243]: /usr/lib/tmpfiles.d/systemd.conf:33: Duplicate line for path "/var/lib/systemd", ignoring.
[    0.609389] systemd-tmpfiles[243]: /usr/lib/tmpfiles.d/tpm2-tss-fapi.conf:2: Failed to resolve user 'tss': Unknown user
[    0.610114] systemd-tmpfiles[243]: Failed to parse ACL "default:group:tss:rwx", ignoring: Invalid argument
[    0.610800] systemd-tmpfiles[243]: /usr/lib/tmpfiles.d/tpm2-tss-fapi.conf:4: Failed to resolve user 'tss': Unknown user
[    0.611515] systemd-tmpfiles[243]: Failed to parse ACL "default:group:tss:rwx", ignoring: Invalid argument
[    0.612262] systemd-tmpfiles[243]: /usr/lib/tmpfiles.d/tpm2-tss-fapi.conf:6: Failed to resolve group 'tss': Unknown group
[    0.613564] systemd-tmpfiles[243]: /usr/lib/tmpfiles.d/tpm2-tss-fapi.conf:7: Failed to resolve group 'tss': Unknown group
[    0.627211] systemd-udevd[245]: /usr/lib/udev/rules.d/60-tpm-udev.rules:3 Failed to resolve user 'tss', ignoring: Unknown user
[    0.628065] systemd-udevd[245]: /usr/lib/udev/rules.d/60-tpm-udev.rules:4 Failed to resolve user 'tss', ignoring: Unknown user
```

Debian/Ubuntu does not ship a sysusers config for the tss user/group. Instead the tpm-udev package creates a tss user and group in its postinst script.

So copy the tss user and group into the initrd in addition to shipping possible sysusers config for it.

Bug-Ubuntu: https://launchpad.net/bugs/2127725
Fixes: https://github.com/dracut-ng/dracut-ng/issues/1826

### Checklist
- [ ] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it
