### PR TITLE
test: include systemd-journald in client test rootfs

### DIFF
--- a/test/modules.d/70test-root/module-setup.sh
+++ b/test/modules.d/70test-root/module-setup.sh
@@ -15,7 +15,7 @@ depends() {
 
     # Use systemd if available
     if [[ -e "$systemdutildir"/systemd ]]; then
-        deps+=" systemd"
+        deps+=" systemd systemd-journald"
     fi
 
     echo "$deps"


### PR DESCRIPTION
After commit d36012143c7c ("test: use systemd inside client test rootfs if available") some tests became racy (for example test 20 on debian:latest or fedora:latest). There is `made it to the test rootfs!` in the logs but not the `All OK`.

Following warning can be found in the logs:

```
systemd[1]: systemd-journald.socket: Unit configuration changed while unit was running, and no socket file descriptors are open. Unit not functional until restarted.
systemd[1]: systemd-udevd-kernel.socket: Unit configuration changed while unit was running, and no socket file descriptors are open. Unit not functional until restarted.
systemd[1]: systemd-journald-dev-log.socket: Unit configuration changed while unit was running, and no socket file descriptors are open. Unit not functional until restarted.
```

Include `systemd-journald` in client test root file system when systemd is used to ensure that systemd-journald continues working.

Hopefully fixes: https://github.com/dracut-ng/dracut-ng/issues/2137

### Checklist
- [ ] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it
