### PR TITLE
test: exclude systemd from server rootfs

### DIFF
--- a/test/TEST-60-NFS/test.sh
+++ b/test/TEST-60-NFS/test.sh
@@ -221,7 +221,7 @@ test_run() {
 
 test_setup() {
     call_dracut --tmpdir "$TESTDIR" \
-        --add-confdir test-root \
+        --add-confdir test-root --omit systemd \
         -a "$USE_NETWORK url-lib nfs" \
         -I "ip grep setsid" \
         -f "$TESTDIR"/initramfs.root || return 1
@@ -230,7 +230,7 @@ test_setup() {
 
     # Create what will eventually be the server root filesystem onto an overlay
     call_dracut --tmpdir "$TESTDIR"/server/overlay \
-        --add-confdir test-root \
+        --add-confdir test-root --omit systemd \
         -a "bash $USE_NETWORK nfs" \
         --add-drivers "nfsd sunrpc lockd" \
         -I "exportfs pidof rpc.nfsd rpc.mountd dhcpd" \

--- a/test/TEST-70-ISCSI/test.sh
+++ b/test/TEST-70-ISCSI/test.sh
@@ -164,7 +164,7 @@ test_setup() {
 
     # Create what will eventually be the server root filesystem onto an overlay
     call_dracut --tmpdir "$TESTDIR" \
-        --add-confdir test-root \
+        --add-confdir test-root --omit systemd \
         -a "$USE_NETWORK" \
         -d "iscsi_tcp crc32c ipv6" \
         -I "modprobe chmod ip setsid pidof tgtd tgtadm /etc/passwd" \

--- a/test/TEST-71-ISCSI-MULTI/test.sh
+++ b/test/TEST-71-ISCSI-MULTI/test.sh
@@ -173,7 +173,7 @@ test_setup() {
 
     rm -rf -- "$TESTDIR"/overlay
     call_dracut --tmpdir "$TESTDIR" \
-        --add-confdir test-root \
+        --add-confdir test-root --omit systemd \
         -a "$USE_NETWORK iscsi" \
         -d "iscsi_tcp crc32c ipv6 af_packet" \
         -I "ip grep sleep setsid chmod modprobe pidof tgtd tgtadm" \

--- a/test/TEST-72-NBD/test.sh
+++ b/test/TEST-72-NBD/test.sh
@@ -261,7 +261,7 @@ bs = 4096
 EOF
 
     call_dracut --keep --tmpdir "$TESTDIR" \
-        --add-confdir test-root \
+        --add-confdir test-root --omit systemd \
         -a "$USE_NETWORK" \
         -I "ip grep sleep nbd-server chmod modprobe pidof" \
         --install-optional "/etc/netconfig dhcpd /etc/group /etc/nsswitch.conf /etc/rpc /etc/protocols /etc/services /usr/etc/nsswitch.conf /usr/etc/rpc /usr/etc/protocols /usr/etc/services" \

--- a/test/modules.d/70test-root/module-setup.sh
+++ b/test/modules.d/70test-root/module-setup.sh
@@ -14,7 +14,7 @@ depends() {
     fi
 
     # Use systemd if available
-    if [[ -e "$systemdutildir"/systemd ]]; then
+    if [[ -e "$systemdutildir"/systemd ]] && ! [[ " $omit_dracutmodules " == *\ systemd\ * ]]; then
         deps+=" systemd systemd-journald"
     fi
 


### PR DESCRIPTION
After commit d36012143c7c ("test: use systemd inside client test rootfs if available") and commit 4aaf8f24110f ("test: include systemd-journald in client test rootfs") the test 60 on opensuse:latest fails due to not enough memory on the server rootfs image.

So revert those two changes partially: create the server rootfs images without systemd. Also create the client test rootfs without systemd.

<!-- This pull request changes... -->

<!-- Fixes: https://github.com/dracut-ng/dracut-ng/issues/<number> -->

### Checklist
- [ ] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it
