### PR TITLE
test: build the test rootfs without calling dracut

### DIFF
--- a/test/TEST-10-BASIC/test.sh
+++ b/test/TEST-10-BASIC/test.sh
@@ -15,12 +15,8 @@ test_run() {
 }
 
 test_setup() {
-    # create root filesystem
-    call_dracut --tmpdir "$TESTDIR" \
-        --add-confdir test-root \
-        -f "$TESTDIR"/initramfs.root
-
-    build_ext4_image "$TESTDIR"/dracut.*/initramfs/ "$TESTDIR"/root.img dracut
+    build_client_rootfs "$TESTDIR/rootfs"
+    build_ext4_image "$TESTDIR/rootfs" "$TESTDIR"/root.img dracut
 
     test_dracut
 }

--- a/test/TEST-11-USR-MOUNT/test.sh
+++ b/test/TEST-11-USR-MOUNT/test.sh
@@ -43,13 +43,9 @@ test_run() {
 
 test_setup() {
     # Create what will eventually be our root filesystem onto an overlay
-    call_dracut --tmpdir "$TESTDIR" \
-        --add-confdir test-root \
-        --mount "/dev/disk/by-id/scsi-0QEMU_QEMU_HARDDISK_root /usr btrfs subvol=usr,rw" \
-        -f "$TESTDIR"/initramfs.root
-    mkdir -p "$TESTDIR"/overlay/source
-    mv "$TESTDIR"/dracut.*/initramfs/* "$TESTDIR"/overlay/source
-    rm -rf "$TESTDIR"/dracut.*
+    build_client_rootfs "$TESTDIR/overlay/source"
+    echo "/dev/disk/by-id/scsi-0QEMU_QEMU_HARDDISK_root /usr btrfs subvol=usr,rw 0 2" \
+        >> "$TESTDIR/overlay/source/etc/fstab"
 
     # create an initramfs that will create the target root filesystem.
     # We do it this way so that we do not risk trashing the host mdraid

--- a/test/TEST-13-SYSROOT/test.sh
+++ b/test/TEST-13-SYSROOT/test.sh
@@ -16,11 +16,8 @@ test_run() {
 
 test_setup() {
     # create root filesystem
-    call_dracut --tmpdir "$TESTDIR" \
-        --add-confdir test-root \
-        -f "$TESTDIR"/initramfs.root
-
-    build_ext4_image "$TESTDIR"/dracut.*/initramfs/ "$TESTDIR"/root.img dracut
+    build_client_rootfs "$TESTDIR/rootfs"
+    build_ext4_image "$TESTDIR/rootfs" "$TESTDIR"/root.img dracut
 
     ln -s / "$TESTDIR"/sysroot
     test_dracut --keep --hostonly --no-hostonly-cmdline --sysroot "$TESTDIR"/sysroot

--- a/test/TEST-20-STORAGE/test.sh
+++ b/test/TEST-20-STORAGE/test.sh
@@ -110,12 +110,7 @@ test_makeroot() {
 
 test_setup() {
     # Create what will eventually be our root filesystem onto an overlay
-    call_dracut --tmpdir "$TESTDIR" \
-        --add-confdir test-root \
-        -f "$TESTDIR"/initramfs.root
-    mkdir -p "$TESTDIR"/overlay/source
-    mv "$TESTDIR"/dracut.*/initramfs/* "$TESTDIR"/overlay/source
-    rm -rf "$TESTDIR"/dracut.*
+    build_client_rootfs "$TESTDIR/overlay/source"
 
     # pass enviroment variables to make the root filesystem
     echo "TEST_FSTYPE=${TEST_FSTYPE}" > "$TESTDIR"/overlay/env

--- a/test/TEST-21-OVERLAYFS/assertion.sh
+++ b/test/TEST-21-OVERLAYFS/assertion.sh
@@ -1,5 +1,7 @@
 #!/bin/sh
 
+# required binaries: cat grep
+
 if ! grep -q " overlay " /proc/mounts; then
     echo "overlay filesystem not found in /proc/mounts" >> /run/failed
 fi

--- a/test/TEST-21-OVERLAYFS/test.sh
+++ b/test/TEST-21-OVERLAYFS/test.sh
@@ -36,12 +36,8 @@ test_run() {
 }
 
 test_setup() {
-    call_dracut --tmpdir "$TESTDIR" \
-        --add-confdir test-root \
-        -i ./assertion.sh /assertion.sh \
-        -f "$TESTDIR"/initramfs.root
-
-    build_ext4_image "$TESTDIR"/dracut.*/initramfs/ "$TESTDIR"/root.img dracut
+    build_client_rootfs "$TESTDIR/rootfs"
+    build_ext4_image "$TESTDIR/rootfs" "$TESTDIR"/root.img dracut
 
     rm -f "$TESTDIR"/overlay.img
     truncate -s 32M "$TESTDIR"/overlay.img

--- a/test/TEST-26-ENC-RAID-LVM/test.sh
+++ b/test/TEST-26-ENC-RAID-LVM/test.sh
@@ -49,12 +49,7 @@ test_run() {
 
 test_setup() {
     # Create what will eventually be our root filesystem onto an overlay
-    call_dracut --tmpdir "$TESTDIR" \
-        --add-confdir test-root \
-        -f "$TESTDIR"/initramfs.root
-    mkdir -p "$TESTDIR"/overlay/source
-    mv "$TESTDIR"/dracut.*/initramfs/* "$TESTDIR"/overlay/source
-    rm -rf "$TESTDIR"/dracut.*
+    build_client_rootfs "$TESTDIR/overlay/source"
 
     # create an initramfs that will create the target root filesystem.
     # We do it this way so that we do not risk trashing the host mdraid

--- a/test/TEST-30-DMSQUASH/assertion.sh
+++ b/test/TEST-30-DMSQUASH/assertion.sh
@@ -1,5 +1,7 @@
 #!/bin/sh
 
+# required binaries: grep sync
+
 # Check for both new (rd.overlay) and deprecated (rd.live.overlay) parameter names
 if grep -qE ' rd\.(live\.)?overlay=LABEL=persist ' /proc/cmdline; then
     # Writing to a file in the root filesystem lets test_run() verify that the autooverlay module successfully created

--- a/test/TEST-30-DMSQUASH/test.sh
+++ b/test/TEST-30-DMSQUASH/test.sh
@@ -91,13 +91,7 @@ test_run() {
 
 test_setup() {
     # Create what will eventually be our root filesystem onto an overlay
-    call_dracut --tmpdir "$TESTDIR" \
-        --add-confdir test-root \
-        -i ./assertion.sh /assertion.sh \
-        -f "$TESTDIR"/initramfs.root
-    mkdir -p "$TESTDIR"/rootfs
-    mv "$TESTDIR"/dracut.*/initramfs/* "$TESTDIR"/rootfs
-    rm -rf "$TESTDIR"/dracut.*
+    build_client_rootfs "$TESTDIR/rootfs"
 
     # test to make sure /proc /sys and /dev is not needed inside the generated initrd
     rm -rf "$TESTDIR"/rootfs/proc "$TESTDIR"/rootfs/sys "$TESTDIR"/rootfs/dev

--- a/test/TEST-31-LIVENET/test.sh
+++ b/test/TEST-31-LIVENET/test.sh
@@ -41,12 +41,8 @@ test_run() {
 }
 
 test_setup() {
-    # create root filesystem
-    call_dracut --tmpdir "$TESTDIR" \
-        --add-confdir test-root \
-        -f "$TESTDIR"/initramfs.root
-
-    mksquashfs "$TESTDIR"/dracut.*/initramfs/ "$TESTDIR/root.squashfs" -quiet
+    build_client_rootfs "$TESTDIR/rootfs"
+    mksquashfs "$TESTDIR/rootfs" "$TESTDIR/root.squashfs" -quiet
 
     test_dracut -a "livenet" --no-hostonly
 }

--- a/test/TEST-40-SYSTEMD/test.sh
+++ b/test/TEST-40-SYSTEMD/test.sh
@@ -21,11 +21,8 @@ test_run() {
 }
 
 test_setup() {
-    # Create client root filesystem
-    call_dracut --tmpdir "$TESTDIR" \
-        --add-confdir test-root \
-        -f "$TESTDIR"/initramfs.root
-    build_ext4_image "$TESTDIR"/dracut.*/initramfs/ "$TESTDIR"/root.img '  rdinit=/bin/sh'
+    build_client_rootfs "$TESTDIR/rootfs"
+    build_ext4_image "$TESTDIR/rootfs" "$TESTDIR"/root.img '  rdinit=/bin/sh'
 
     # systemd-analyze.sh calls man indirectly
     # make the man command succeed always

--- a/test/TEST-41-FULL-SYSTEMD/test.sh
+++ b/test/TEST-41-FULL-SYSTEMD/test.sh
@@ -82,8 +82,6 @@ test_setup() {
         -a "$dracut_modules" \
         -f "$TESTDIR"/initramfs.root
 
-    KVERSION=$(determine_kernel_version "$TESTDIR"/initramfs.root)
-
     mkdir -p "$TESTDIR"/overlay/source
     cp -a "$TESTDIR"/dracut.*/initramfs/* "$TESTDIR"/overlay/source
     rm -rf "$TESTDIR"/dracut.*
@@ -96,7 +94,9 @@ test_setup() {
         -a "btrfs crypt" \
         -I "mkfs.btrfs cryptsetup" \
         -i ./create-root.sh /lib/dracut/hooks/initqueue/01-create-root.sh \
-        -f "$TESTDIR"/initramfs.makeroot "$KVERSION"
+        -f "$TESTDIR"/initramfs.makeroot
+
+    KVERSION=$(determine_kernel_version "$TESTDIR"/initramfs.makeroot)
 
     # Create the blank file to use as a root filesystem
     declare -a disk_args=()

--- a/test/TEST-41-FULL-SYSTEMD/test.sh
+++ b/test/TEST-41-FULL-SYSTEMD/test.sh
@@ -77,14 +77,7 @@ test_setup() {
     fi
 
     # Create what will eventually be our root filesystem onto an overlay
-    call_dracut --tmpdir "$TESTDIR" \
-        --add-confdir test-root \
-        -a "$dracut_modules" \
-        -f "$TESTDIR"/initramfs.root
-
-    mkdir -p "$TESTDIR"/overlay/source
-    cp -a "$TESTDIR"/dracut.*/initramfs/* "$TESTDIR"/overlay/source
-    rm -rf "$TESTDIR"/dracut.*
+    build_client_rootfs "$TESTDIR/overlay/source"
 
     # create an initramfs that will create the target root filesystem.
     # We do it this way so that we do not risk trashing the host mdraid

--- a/test/TEST-42-SYSTEMD-INITRD/test.sh
+++ b/test/TEST-42-SYSTEMD-INITRD/test.sh
@@ -35,11 +35,8 @@ test_run() {
 }
 
 test_setup() {
-    # Create client root filesystem
-    call_dracut --tmpdir "$TESTDIR" \
-        --add-confdir test-root \
-        -f "$TESTDIR"/initramfs.root
-    build_ext4_image "$TESTDIR"/dracut.*/initramfs/ "$TESTDIR"/root.img dracut
+    build_client_rootfs "$TESTDIR/rootfs"
+    build_ext4_image "$TESTDIR/rootfs" "$TESTDIR"/root.img dracut
 
     # initrd for required kernel modules
     # Improve boot time by generating two initrds. Do not re-compress kernel modules

--- a/test/TEST-50-NETWORK/assertion.sh
+++ b/test/TEST-50-NETWORK/assertion.sh
@@ -1,5 +1,7 @@
 #!/bin/sh
 
+# required binaries: grep ip
+
 # Get the output of 'ip addr show' and filter out lo interface
 ip_output=$(ip -o -4 addr show | grep -v ': lo')
 

--- a/test/TEST-50-NETWORK/test.sh
+++ b/test/TEST-50-NETWORK/test.sh
@@ -21,13 +21,8 @@ test_run() {
 
 test_setup() {
     # create root filesystem
-    call_dracut --tmpdir "$TESTDIR" \
-        -I "ip" \
-        -i "./assertion.sh" "/assertion.sh" \
-        --add-confdir test-root \
-        -f "$TESTDIR"/initramfs.root "$KVERSION"
-
-    build_ext4_image "$TESTDIR"/dracut.*/initramfs/ "$TESTDIR"/root.img dracut
+    build_client_rootfs "$TESTDIR/rootfs"
+    build_ext4_image "$TESTDIR/rootfs" "$TESTDIR"/root.img dracut
 
     test_dracut --add-drivers "virtio_net" --add "qemu-net $USE_NETWORK"
 }

--- a/test/TEST-70-ISCSI/test.sh
+++ b/test/TEST-70-ISCSI/test.sh
@@ -123,14 +123,8 @@ test_check() {
 
 test_setup() {
     # Create client root filesystem
-    call_dracut --tmpdir "$TESTDIR" \
-        --add-confdir test-root \
-        -I "ip grep setsid" \
-        -f "$TESTDIR"/initramfs.root
-    mkdir -p "$TESTDIR"/overlay/source
-    mv "$TESTDIR"/dracut.*/initramfs/* "$TESTDIR"/overlay/source
-    rm -rf "$TESTDIR"/dracut.*
-
+    build_client_rootfs "$TESTDIR/overlay/source"
+    inst_multiple ip grep setsid
     mkdir -p -- "$TESTDIR"/overlay/source/var/lib/nfs/rpc_pipefs
     inst_init ./client-init.sh "$TESTDIR"/overlay/source
 

--- a/test/TEST-71-ISCSI-MULTI/test.sh
+++ b/test/TEST-71-ISCSI-MULTI/test.sh
@@ -132,14 +132,8 @@ test_check() {
 test_setup() {
     # Create client root filesystem
     rm -rf -- "$TESTDIR"/overlay
-    call_dracut --keep --tmpdir "$TESTDIR" \
-        --add-confdir test-root \
-        -I "ip grep setsid" \
-        --no-hostonly \
-        -f "$TESTDIR"/initramfs.root
-    mkdir -p "$TESTDIR"/overlay/source
-    mv "$TESTDIR"/dracut.*/initramfs/* "$TESTDIR"/overlay/source
-    rm -rf "$TESTDIR"/dracut.*
+    build_client_rootfs "$TESTDIR/overlay/source"
+    inst_multiple ip grep setsid
     mkdir -p -- "$TESTDIR"/overlay/source/var/lib/nfs/rpc_pipefs
     inst_init ./client-init.sh "$TESTDIR"/overlay/source
 

--- a/test/TEST-72-NBD/test.sh
+++ b/test/TEST-72-NBD/test.sh
@@ -174,14 +174,8 @@ client_run() {
 make_encrypted_root() {
     rm -fr "$TESTDIR"/overlay
     # Create what will eventually be our root filesystem onto an overlay
-    call_dracut --tmpdir "$TESTDIR" \
-        --add-confdir test-root \
-        -I "ip grep" \
-        --no-hostonly \
-        -f "$TESTDIR"/initramfs.root
-    mkdir -p "$TESTDIR"/overlay/source
-    mv "$TESTDIR"/dracut.*/initramfs/* "$TESTDIR"/overlay/source
-    rm -rf "$TESTDIR"/dracut.*
+    build_client_rootfs "$TESTDIR/overlay/source"
+    inst_multiple ip grep
     inst_init ./client-init.sh "$TESTDIR"/overlay/source
 
     # create an initramfs that will create the target root filesystem.
@@ -210,14 +204,8 @@ make_encrypted_root() {
 
 make_client_root() {
     rm -fr "$TESTDIR"/overlay
-    call_dracut --tmpdir "$TESTDIR" \
-        --add-confdir test-root \
-        -I "ip" \
-        --no-hostonly \
-        -f "$TESTDIR"/initramfs.root
-    mkdir -p "$TESTDIR"/overlay/source
-    mv "$TESTDIR"/dracut.*/initramfs/* "$TESTDIR"/overlay/source
-    rm -rf "$TESTDIR"/dracut.*
+    build_client_rootfs "$TESTDIR/overlay/source"
+    inst_multiple ip
     inst_init ./client-init.sh "$TESTDIR"/overlay/source
 
     build_ext4_image "$TESTDIR/overlay/source" "$TESTDIR"/unencrypted.img dracut

--- a/test/modules.d/70test-root/test-init.sh
+++ b/test/modules.d/70test-root/test-init.sh
@@ -1,5 +1,7 @@
 #!/bin/sh
 
+# required binaries: cat dd grep mkdir mount sync
+
 export PATH=/usr/sbin:/usr/bin:/sbin:/bin
 
 # shellcheck disable=SC2317,SC2329  # called via EXIT trap

--- a/test/test-functions
+++ b/test/test-functions
@@ -75,6 +75,97 @@ quote_args() {
     echo "${args[*]}"
 }
 
+# Create the base for a trivial root file system
+build_rootfs_base() {
+    local rootdir="$1"
+
+    # Create basic directory structure (with merged /usr)
+    test ! -e "${rootdir}"
+    mkdir -p "${rootdir}"
+    for subdir in etc dev proc run sys tmp usr usr/bin usr/lib usr/sbin var; do
+        mkdir "${rootdir}/${subdir}"
+    done
+    for subdir in bin lib sbin; do
+        ln -s "usr/$subdir" "${rootdir}/${subdir}"
+    done
+
+    # Include os-release to make systemd's initrd-switch-root.service happy
+    cp /usr/lib/os-release "$rootdir/usr/lib/os-release"
+}
+
+# Expects dracut-functions.sh being sourced and configured
+install_minimal_systemd() {
+    local systemdutildir=/usr/lib/systemd
+    inst_multiple \
+        "$systemdutildir"/system/basic.target \
+        "$systemdutildir"/system/ctrl-alt-del.target \
+        "$systemdutildir"/system/final.target \
+        "$systemdutildir"/system/multi-user.target \
+        "$systemdutildir"/system/poweroff.target \
+        "$systemdutildir"/system/rescue.target \
+        "$systemdutildir"/system/shutdown.target \
+        "$systemdutildir"/system/sysinit.target \
+        "$systemdutildir"/system/systemd-poweroff.service \
+        "$systemdutildir"/system/umount.target \
+        "$systemdutildir"/systemd \
+        "$systemdutildir"/systemd-executor \
+        "$systemdutildir"/systemd-shutdown \
+        systemctl umount
+
+    # Install required libraries.
+    _arch=${DRACUT_ARCH:-$(uname -m)}
+    inst_libdir_file {"tls/$_arch/",tls/,"$_arch/",}"libkmod.so*"
+
+    : > "$rootdir/etc/machine-id"
+    chmod 444 "$rootdir/etc/machine-id"
+}
+
+# Create a minimal root file system to simulate a client
+build_client_rootfs() {
+    local rootdir="$1"
+    local binaries
+
+    build_rootfs_base "$rootdir"
+
+    if [[ "$(type -t inst_multiple 2> /dev/null)" != "function" ]]; then
+        # shellcheck source=./dracut-functions.sh
+        . "$PKGLIBDIR/dracut-functions.sh"
+    fi
+    # variables for inst* functions
+    export DRACUT_NO_XATTR=1
+    initdir="$rootdir"
+
+    binaries=$(sed -n "s/^# required binaries: \(.*\)/\1/p" "$PKGLIBDIR/modules.d/70test-root/test-init.sh")
+    # shellcheck disable=SC2086
+    inst_multiple $binaries
+
+    local systemdutildir=/usr/lib/systemd
+    if [[ -x "$systemdutildir/systemd" ]]; then
+        install_minimal_systemd
+        inst_script "$PKGLIBDIR/modules.d/70test-root/test-init.sh" "/sbin/test-init"
+        inst_simple "$PKGLIBDIR/modules.d/70test-root/testsuite.service" "$systemdutildir/system/testsuite.service"
+        inst_simple "$PKGLIBDIR/modules.d/70test-root/testsuite.target" "$systemdutildir/system/testsuite.target"
+        mkdir "${rootdir}${systemdutildir}/system/testsuite.target.wants"
+        ln -sfn ../testsuite.service "${rootdir}${systemdutildir}/system/testsuite.target.wants/testsuite.service"
+        ln -sfn "testsuite.target" "${rootdir}${systemdutildir}/system/default.target"
+        ln -sfn ../lib/systemd/systemd "${rootdir}/sbin/init"
+    else
+        inst_script "$PKGLIBDIR/modules.d/70test-root/test-init.sh" /sbin/init
+        inst poweroff
+    fi
+
+    if [[ -x assertion.sh ]]; then
+        inst_script ./assertion.sh /assertion.sh
+        binaries=$(sed -n "s/^# required binaries: \(.*\)/\1/p" ./assertion.sh)
+        # shellcheck disable=SC2086
+        inst_multiple $binaries
+    fi
+
+    if command -v hardlink > /dev/null; then
+        hardlink -q "$rootdir"
+    fi
+}
+
 # Call dracut and log its call in verbose mode
 call_dracut() {
     # Uncomment this to debug failures


### PR DESCRIPTION
Build the test rootfs by using the functions from `dracut-functions.sh` instead of calling dracut. Only include the bare minimum for the client rootfs.

Tested the test execution time on a Raspberry Pi 5 running Ubuntu 26.04:

```
$ hyperfine -L commit 9d5f58b4,build-rootfs -p "git checkout {commit}" -w 1 "test/test.sh ubuntu:devel 10"
Benchmark 1: test/test.sh ubuntu:devel 10 (commit = 9d5f58b4)
  Time (mean ± σ):     49.570 s ±  2.847 s    [User: 0.185 s, System: 0.239 s]
  Range (min … max):   46.697 s … 56.466 s    10 runs

Benchmark 2: test/test.sh ubuntu:devel 10 (commit = build-rootfs)
  Time (mean ± σ):     46.627 s ±  0.625 s    [User: 0.174 s, System: 0.220 s]
  Range (min … max):   45.322 s … 47.210 s    10 runs

Summary
  test/test.sh ubuntu:devel 10 (commit = build-rootfs) ran
    1.06 ± 0.06 times faster than test/test.sh ubuntu:devel 10 (commit = 9d5f58b4)
```

### Checklist
- [x] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it
