### PR TITLE
test: consider SIGTERM of test-init.sh a successful termination

### DIFF
--- a/test/modules.d/70test-root/testsuite.service
+++ b/test/modules.d/70test-root/testsuite.service
@@ -7,3 +7,4 @@ ExecStart=/sbin/test-init
 Type=oneshot
 StandardInput=tty
 StandardOutput=tty
+SuccessExitStatus=SIGTERM


### PR DESCRIPTION
The `test-init.sh` will call `systemctl start poweroff.target` and get an `SIGTERM` interrupt. Since `testsuite.service` is `Type=oneshot` systemd will complain:

```
[    1.892101] systemd[1]: testsuite.service: Main process exited, code=killed, status=15/TERM
[    1.892708] systemd[1]: testsuite.service: Failed with result 'signal'.
```

Consider `SIGTERM` of `test-init.sh` a successful termination.

<!-- This pull request changes... -->

<!-- Fixes: https://github.com/dracut-ng/dracut-ng/issues/<number> -->

### Checklist
- [ ] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it
