### PR TITLE
test: drop index parameter from qemu_add_drive

### DIFF
--- a/test/TEST-10-BASIC/test.sh
+++ b/test/TEST-10-BASIC/test.sh
@@ -5,9 +5,7 @@ TEST_DESCRIPTION="root filesystem on ext4 filesystem"
 
 test_run() {
     declare -a disk_args=()
-    # shellcheck disable=SC2034  # disk_index used in qemu_add_drive
-    declare -i disk_index=0
-    qemu_add_drive disk_index disk_args "$TESTDIR"/root.img root
+    qemu_add_drive disk_args "$TESTDIR"/root.img root
 
     "$testdir"/run-qemu -nic none \
         "${disk_args[@]}" \

--- a/test/TEST-11-USR-MOUNT/test.sh
+++ b/test/TEST-11-USR-MOUNT/test.sh
@@ -22,8 +22,7 @@ client_run() {
     client_test_start "$test_name"
 
     declare -a disk_args=()
-    declare -i disk_index=0
-    qemu_add_drive disk_index disk_args "$TESTDIR"/root.btrfs root
+    qemu_add_drive disk_args "$TESTDIR"/root.btrfs root
 
     "$testdir"/run-qemu \
         "${disk_args[@]}" \
@@ -63,10 +62,8 @@ test_setup() {
 
     # Create the blank file to use as a root filesystem
     declare -a disk_args=()
-    # shellcheck disable=SC2034  # disk_index used in qemu_add_drive
-    declare -i disk_index=0
-    qemu_add_drive disk_index disk_args "$TESTDIR"/marker.img marker 1
-    qemu_add_drive disk_index disk_args "$TESTDIR"/root.btrfs root 1
+    qemu_add_drive disk_args "$TESTDIR"/marker.img marker 1
+    qemu_add_drive disk_args "$TESTDIR"/root.btrfs root 1
 
     # Invoke KVM and/or QEMU to actually create the target filesystem.
     "$testdir"/run-qemu \

--- a/test/TEST-12-UEFI/test.sh
+++ b/test/TEST-12-UEFI/test.sh
@@ -29,7 +29,7 @@ client_run() {
 
     declare -a disk_args=()
     # shellcheck disable=SC2034  # disk_index used in qemu_add_drive
-    declare -i disk_index=1
+    declare -i disk_index=0
     qemu_add_drive disk_index disk_args "$TESTDIR"/marker.img marker
     qemu_add_drive disk_index disk_args "$TESTDIR"/squashfs.img root
 

--- a/test/TEST-12-UEFI/test.sh
+++ b/test/TEST-12-UEFI/test.sh
@@ -28,10 +28,8 @@ client_run() {
     client_test_start "$test_name"
 
     declare -a disk_args=()
-    # shellcheck disable=SC2034  # disk_index used in qemu_add_drive
-    declare -i disk_index=0
-    qemu_add_drive disk_index disk_args "$TESTDIR"/marker.img marker
-    qemu_add_drive disk_index disk_args "$TESTDIR"/squashfs.img root
+    qemu_add_drive disk_args "$TESTDIR"/marker.img marker
+    qemu_add_drive disk_args "$TESTDIR"/squashfs.img root
 
     test_marker_reset
     "$testdir"/run-qemu "${disk_args[@]}" -net none \

--- a/test/TEST-13-SYSROOT/test.sh
+++ b/test/TEST-13-SYSROOT/test.sh
@@ -5,9 +5,7 @@ TEST_DESCRIPTION="initramfs created from sysroot"
 
 test_run() {
     declare -a disk_args=()
-    # shellcheck disable=SC2034  # disk_index used in qemu_add_drive
-    declare -i disk_index=0
-    qemu_add_drive disk_index disk_args "$TESTDIR"/root.img root
+    qemu_add_drive disk_args "$TESTDIR"/root.img root
 
     "$testdir"/run-qemu -nic none \
         "${disk_args[@]}" \

--- a/test/TEST-20-STORAGE/test.sh
+++ b/test/TEST-20-STORAGE/test.sh
@@ -34,12 +34,11 @@ client_run() {
     client_test_start "$test_name"
 
     declare -a disk_args=()
-    declare -i disk_index=0
-    qemu_add_drive disk_index disk_args "$TESTDIR/${disk}-1.img" disk1
+    qemu_add_drive disk_args "$TESTDIR/${disk}-1.img" disk1
 
     if ! grep -qF 'degraded' "$test_name"; then
         # only add disk2 if RAID is NOT degraded
-        qemu_add_drive disk_index disk_args "$TESTDIR/${disk}-2.img" disk2
+        qemu_add_drive disk_args "$TESTDIR/${disk}-2.img" disk2
     fi
 
     if [ "$TEST_FSTYPE" = "zfs" ]; then
@@ -96,11 +95,9 @@ test_makeroot() {
 
     # Create the blank files to use as a root filesystem
     declare -a disk_args=()
-    # shellcheck disable=SC2034
-    declare -i disk_index=0
-    qemu_add_drive disk_index disk_args "$TESTDIR"/marker.img marker 1
-    qemu_add_drive disk_index disk_args "$TESTDIR/${disk}-1.img" disk1 1
-    qemu_add_drive disk_index disk_args "$TESTDIR/${disk}-2.img" disk2 1
+    qemu_add_drive disk_args "$TESTDIR"/marker.img marker 1
+    qemu_add_drive disk_args "$TESTDIR/${disk}-1.img" disk1 1
+    qemu_add_drive disk_args "$TESTDIR/${disk}-2.img" disk2 1
 
     "$testdir"/run-qemu \
         "${disk_args[@]}" \

--- a/test/TEST-26-ENC-RAID-LVM/test.sh
+++ b/test/TEST-26-ENC-RAID-LVM/test.sh
@@ -26,9 +26,8 @@ test_run() {
     client_test_start "$LUKSARGS"
 
     declare -a disk_args=()
-    declare -i disk_index=0
-    qemu_add_drive disk_index disk_args "$TESTDIR"/disk-1.img disk1
-    qemu_add_drive disk_index disk_args "$TESTDIR"/disk-2.img disk2
+    qemu_add_drive disk_args "$TESTDIR"/disk-1.img disk1
+    qemu_add_drive disk_args "$TESTDIR"/disk-2.img disk2
 
     "$testdir"/run-qemu \
         "${disk_args[@]}" \
@@ -69,11 +68,9 @@ test_setup() {
 
     # Create the blank files to use as a root filesystem
     declare -a disk_args=()
-    # shellcheck disable=SC2034  # disk_index used in qemu_add_drive
-    declare -i disk_index=0
-    qemu_add_drive disk_index disk_args "$TESTDIR"/marker.img marker 1
-    qemu_add_drive disk_index disk_args "$TESTDIR"/disk-1.img disk1 1
-    qemu_add_drive disk_index disk_args "$TESTDIR"/disk-2.img disk2 1
+    qemu_add_drive disk_args "$TESTDIR"/marker.img marker 1
+    qemu_add_drive disk_args "$TESTDIR"/disk-1.img disk1 1
+    qemu_add_drive disk_args "$TESTDIR"/disk-2.img disk2 1
 
     "$testdir"/run-qemu \
         "${disk_args[@]}" \

--- a/test/TEST-30-DMSQUASH/test.sh
+++ b/test/TEST-30-DMSQUASH/test.sh
@@ -24,10 +24,9 @@ client_run() {
     client_test_start "$test_name"
 
     declare -a disk_args=()
-    declare -i disk_index=0
-    qemu_add_drive disk_index disk_args "$TESTDIR"/root.img root
-    qemu_add_drive disk_index disk_args "$TESTDIR"/root_erofs.img root_erofs
-    qemu_add_drive disk_index disk_args "$TESTDIR"/root_iso.img root_iso
+    qemu_add_drive disk_args "$TESTDIR"/root.img root
+    qemu_add_drive disk_args "$TESTDIR"/root_erofs.img root_erofs
+    qemu_add_drive disk_args "$TESTDIR"/root_iso.img root_iso
 
     "$testdir"/run-qemu \
         "${disk_args[@]}" \
@@ -108,9 +107,7 @@ test_setup() {
 
     # Create the blank file to use as a root filesystem
     declare -a disk_args=()
-    # shellcheck disable=SC2034  # disk_index used in qemu_add_drive
-    declare -i disk_index=0
-    qemu_add_drive disk_index disk_args "$TESTDIR"/root.img root 1
+    qemu_add_drive disk_args "$TESTDIR"/root.img root 1
 
     sfdisk "$TESTDIR"/root.img << EOF
 2048,652688
@@ -123,7 +120,7 @@ EOF
     dd if="$TESTDIR"/ext4.img of="$TESTDIR"/root.img bs=512 seek=2048 conv=noerror,notrunc
 
     # erofs drive
-    qemu_add_drive disk_index disk_args "$TESTDIR"/root_erofs.img root_erofs 1
+    qemu_add_drive disk_args "$TESTDIR"/root_erofs.img root_erofs 1
 
     # Write the erofs compressed filesystem to the partition
     if command -v mkfs.erofs &> /dev/null; then
@@ -131,7 +128,7 @@ EOF
     fi
 
     # iso drive
-    qemu_add_drive disk_index disk_args "$TESTDIR"/root_iso.img root_iso 1
+    qemu_add_drive disk_args "$TESTDIR"/root_iso.img root_iso 1
 
     # Write the iso to the partition
     if command -v xorriso &> /dev/null; then

--- a/test/TEST-40-SYSTEMD/test.sh
+++ b/test/TEST-40-SYSTEMD/test.sh
@@ -11,8 +11,7 @@ test_check() {
 #DEBUGFAIL="rd.shell=1 rd.break=pre-mount"
 test_run() {
     declare -a disk_args=()
-    declare -i disk_index=0
-    qemu_add_drive disk_index disk_args "$TESTDIR"/root.img root
+    qemu_add_drive disk_args "$TESTDIR"/root.img root
 
     "$testdir"/run-qemu \
         "${disk_args[@]}" \
@@ -39,10 +38,8 @@ test_setup() {
         -f "$TESTDIR"/initramfs.makeroot
 
     declare -a disk_args=()
-    # shellcheck disable=SC2034  # disk_index used in qemu_add_drive
-    declare -i disk_index=0
-    qemu_add_drive disk_index disk_args "$TESTDIR"/marker.img marker 1
-    qemu_add_drive disk_index disk_args "$TESTDIR"/root.img root 1
+    qemu_add_drive disk_args "$TESTDIR"/marker.img marker 1
+    qemu_add_drive disk_args "$TESTDIR"/root.img root 1
 
     # Invoke KVM and/or QEMU to actually create the target filesystem.
     "$testdir"/run-qemu \

--- a/test/TEST-41-FULL-SYSTEMD/test.sh
+++ b/test/TEST-41-FULL-SYSTEMD/test.sh
@@ -24,10 +24,9 @@ client_run() {
     client_test_start "$test_name"
 
     declare -a disk_args=()
-    declare -i disk_index=0
-    qemu_add_drive disk_index disk_args "$TESTDIR"/root.btrfs root
-    qemu_add_drive disk_index disk_args "$TESTDIR"/root_crypt.btrfs root_crypt
-    qemu_add_drive disk_index disk_args "$TESTDIR"/usr.btrfs usr
+    qemu_add_drive disk_args "$TESTDIR"/root.btrfs root
+    qemu_add_drive disk_args "$TESTDIR"/root_crypt.btrfs root_crypt
+    qemu_add_drive disk_args "$TESTDIR"/usr.btrfs usr
 
     "$testdir"/run-qemu \
         "${disk_args[@]}" \
@@ -101,12 +100,10 @@ test_setup() {
 
     # Create the blank file to use as a root filesystem
     declare -a disk_args=()
-    # shellcheck disable=SC2034
-    declare -i disk_index=0
-    qemu_add_drive disk_index disk_args "$TESTDIR"/marker.img marker 1
-    qemu_add_drive disk_index disk_args "$TESTDIR"/root.btrfs root 1
-    qemu_add_drive disk_index disk_args "$TESTDIR"/root_crypt.btrfs root_crypt 1
-    qemu_add_drive disk_index disk_args "$TESTDIR"/usr.btrfs usr 1
+    qemu_add_drive disk_args "$TESTDIR"/marker.img marker 1
+    qemu_add_drive disk_args "$TESTDIR"/root.btrfs root 1
+    qemu_add_drive disk_args "$TESTDIR"/root_crypt.btrfs root_crypt 1
+    qemu_add_drive disk_args "$TESTDIR"/usr.btrfs usr 1
 
     # Invoke KVM and/or QEMU to actually create the target filesystem.
     "$testdir"/run-qemu \

--- a/test/TEST-42-SYSTEMD-INITRD/test.sh
+++ b/test/TEST-42-SYSTEMD-INITRD/test.sh
@@ -18,8 +18,7 @@ client_run() {
     client_test_start "$test_name"
 
     declare -a disk_args=()
-    declare -i disk_index=0
-    qemu_add_drive disk_index disk_args "$TESTDIR"/root.img root
+    qemu_add_drive disk_args "$TESTDIR"/root.img root
 
     "$testdir"/run-qemu \
         "${disk_args[@]}" \
@@ -53,10 +52,8 @@ test_setup() {
         -f "$TESTDIR"/initramfs.makeroot
 
     declare -a disk_args=()
-    # shellcheck disable=SC2034  # disk_index used in qemu_add_drive
-    declare -i disk_index=0
-    qemu_add_drive disk_index disk_args "$TESTDIR"/marker.img marker 1
-    qemu_add_drive disk_index disk_args "$TESTDIR"/root.img root 1
+    qemu_add_drive disk_args "$TESTDIR"/marker.img marker 1
+    qemu_add_drive disk_args "$TESTDIR"/root.img root 1
 
     # Invoke KVM and/or QEMU to actually create the target filesystem.
     "$testdir"/run-qemu \

--- a/test/TEST-43-KERNEL-INSTALL/test.sh
+++ b/test/TEST-43-KERNEL-INSTALL/test.sh
@@ -12,9 +12,7 @@ test_check() {
 
 test_run() {
     declare -a disk_args=()
-    # shellcheck disable=SC2034  # disk_index used in qemu_add_drive
-    declare -i disk_index=0
-    qemu_add_drive disk_index disk_args "$TESTDIR"/root.img root
+    qemu_add_drive disk_args "$TESTDIR"/root.img root
 
     "$testdir"/run-qemu \
         "${disk_args[@]}" \

--- a/test/TEST-44-DRIVERS/test.sh
+++ b/test/TEST-44-DRIVERS/test.sh
@@ -19,9 +19,8 @@ test_check() {
 #DEBUGFAIL="rd.shell=1 rd.break=pre-mount"
 test_run() {
     declare -a disk_args=()
-    declare -i disk_index=0
-    qemu_add_drive disk_index disk_args "$TESTDIR"/root.img root
-    qemu_add_drive disk_index disk_args "$TESTDIR"/mnt.img mnt
+    qemu_add_drive disk_args "$TESTDIR"/root.img root
+    qemu_add_drive disk_args "$TESTDIR"/mnt.img mnt
 
     # This test should fail if rd.driver.export is not passed at kernel command-line
     "$testdir"/run-qemu \
@@ -59,11 +58,9 @@ test_setup() {
         -f "$TESTDIR"/initramfs.makeroot
 
     declare -a disk_args=()
-    # shellcheck disable=SC2034  # disk_index used in qemu_add_drive
-    declare -i disk_index=0
-    qemu_add_drive disk_index disk_args "$TESTDIR"/marker.img marker 1
-    qemu_add_drive disk_index disk_args "$TESTDIR"/root.img root 1
-    qemu_add_drive disk_index disk_args "$TESTDIR"/mnt.img mnt 1
+    qemu_add_drive disk_args "$TESTDIR"/marker.img marker 1
+    qemu_add_drive disk_args "$TESTDIR"/root.img root 1
+    qemu_add_drive disk_args "$TESTDIR"/mnt.img mnt 1
 
     # Invoke KVM and/or QEMU to actually create the target filesystem.
     "$testdir"/run-qemu \

--- a/test/TEST-50-NETWORK/test.sh
+++ b/test/TEST-50-NETWORK/test.sh
@@ -8,9 +8,7 @@ TEST_DESCRIPTION="bring up network without netroot set with $USE_NETWORK"
 
 test_run() {
     declare -a disk_args=()
-    # shellcheck disable=SC2034  # disk_index used in qemu_add_drive
-    declare -i disk_index=0
-    qemu_add_drive disk_index disk_args "$TESTDIR"/root.img root
+    qemu_add_drive disk_args "$TESTDIR"/root.img root
 
     "$testdir"/run-qemu \
         -device "virtio-net-pci,netdev=lan0" \

--- a/test/TEST-60-NFS/test.sh
+++ b/test/TEST-60-NFS/test.sh
@@ -24,9 +24,7 @@ run_server() {
     # Start server first
     echo "NFS TEST SETUP: Starting DHCP/NFS server"
     declare -a disk_args=()
-    # shellcheck disable=SC2034
-    declare -i disk_index=0
-    qemu_add_drive disk_index disk_args "$TESTDIR"/server.img root 0 1
+    qemu_add_drive disk_args "$TESTDIR"/server.img root 0 1
 
     "$testdir"/run-qemu \
         "${disk_args[@]}" \
@@ -58,10 +56,8 @@ client_test() {
 
     # Need this so kvm-qemu will boot (needs non-/dev/zero local disk)
     declare -a disk_args=()
-    # shellcheck disable=SC2034
-    declare -i disk_index=0
-    qemu_add_drive disk_index disk_args "$TESTDIR"/marker.img marker 1
-    qemu_add_drive disk_index disk_args "$TESTDIR"/marker2.img marker2 1
+    qemu_add_drive disk_args "$TESTDIR"/marker.img marker 1
+    qemu_add_drive disk_args "$TESTDIR"/marker2.img marker2 1
 
     "$testdir"/run-qemu \
         "${disk_args[@]}" \

--- a/test/TEST-70-ISCSI/test.sh
+++ b/test/TEST-70-ISCSI/test.sh
@@ -15,11 +15,10 @@ run_server() {
     echo "iSCSI TEST SETUP: Starting DHCP/iSCSI server"
 
     declare -a disk_args=()
-    declare -i disk_index=0
-    qemu_add_drive disk_index disk_args "$TESTDIR"/server.img serverroot 0 1
-    qemu_add_drive disk_index disk_args "$TESTDIR"/singleroot.img singleroot
-    qemu_add_drive disk_index disk_args "$TESTDIR"/raid0-1.img raid0-1
-    qemu_add_drive disk_index disk_args "$TESTDIR"/raid0-2.img raid0-2
+    qemu_add_drive disk_args "$TESTDIR"/server.img serverroot 0 1
+    qemu_add_drive disk_args "$TESTDIR"/singleroot.img singleroot
+    qemu_add_drive disk_args "$TESTDIR"/raid0-1.img raid0-1
+    qemu_add_drive disk_args "$TESTDIR"/raid0-2.img raid0-2
 
     "$testdir"/run-qemu \
         "${disk_args[@]}" \
@@ -48,8 +47,7 @@ run_client() {
     client_test_start "$test_name"
 
     declare -a disk_args=()
-    declare -i disk_index=0
-    qemu_add_drive disk_index disk_args "$TESTDIR"/marker.img marker
+    qemu_add_drive disk_args "$TESTDIR"/marker.img marker
 
     test_marker_reset
     "$testdir"/run-qemu \
@@ -148,11 +146,10 @@ test_setup() {
     rm -rf -- "$TESTDIR"/overlay
 
     declare -a disk_args=()
-    declare -i disk_index=0
-    qemu_add_drive disk_index disk_args "$TESTDIR"/marker.img marker 1
-    qemu_add_drive disk_index disk_args "$TESTDIR"/singleroot.img singleroot 1
-    qemu_add_drive disk_index disk_args "$TESTDIR"/raid0-1.img raid0-1 1
-    qemu_add_drive disk_index disk_args "$TESTDIR"/raid0-2.img raid0-2 1
+    qemu_add_drive disk_args "$TESTDIR"/marker.img marker 1
+    qemu_add_drive disk_args "$TESTDIR"/singleroot.img singleroot 1
+    qemu_add_drive disk_args "$TESTDIR"/raid0-1.img raid0-1 1
+    qemu_add_drive disk_args "$TESTDIR"/raid0-2.img raid0-2 1
 
     # Invoke KVM and/or QEMU to actually create the target filesystem.
     "$testdir"/run-qemu \
@@ -188,10 +185,8 @@ test_setup() {
     rm -rf -- "$TESTDIR"/overlay
 
     declare -a disk_args=()
-    # shellcheck disable=SC2034
-    declare -i disk_index=0
-    qemu_add_drive disk_index disk_args "$TESTDIR"/marker.img marker 1
-    qemu_add_drive disk_index disk_args "$TESTDIR"/server.img root 1
+    qemu_add_drive disk_args "$TESTDIR"/marker.img marker 1
+    qemu_add_drive disk_args "$TESTDIR"/server.img root 1
 
     # Invoke KVM and/or QEMU to actually create the target filesystem.
     "$testdir"/run-qemu \

--- a/test/TEST-71-ISCSI-MULTI/test.sh
+++ b/test/TEST-71-ISCSI-MULTI/test.sh
@@ -15,11 +15,10 @@ run_server() {
     echo "iSCSI TEST SETUP: Starting DHCP/iSCSI server"
 
     declare -a disk_args=()
-    declare -i disk_index=0
-    qemu_add_drive disk_index disk_args "$TESTDIR"/server.img serverroot 0 1
-    qemu_add_drive disk_index disk_args "$TESTDIR"/singleroot.img singleroot
-    qemu_add_drive disk_index disk_args "$TESTDIR"/raid0-1.img raid0-1
-    qemu_add_drive disk_index disk_args "$TESTDIR"/raid0-2.img raid0-2
+    qemu_add_drive disk_args "$TESTDIR"/server.img serverroot 0 1
+    qemu_add_drive disk_args "$TESTDIR"/singleroot.img singleroot
+    qemu_add_drive disk_args "$TESTDIR"/raid0-1.img raid0-1
+    qemu_add_drive disk_args "$TESTDIR"/raid0-2.img raid0-2
 
     "$testdir"/run-qemu \
         "${disk_args[@]}" \
@@ -46,8 +45,7 @@ run_client() {
     client_test_start "$test_name"
 
     declare -a disk_args=()
-    declare -i disk_index=0
-    qemu_add_drive disk_index disk_args "$TESTDIR"/marker.img marker
+    qemu_add_drive disk_args "$TESTDIR"/marker.img marker
 
     test_marker_reset
     "$testdir"/run-qemu \
@@ -157,11 +155,10 @@ test_setup() {
     rm -rf -- "$TESTDIR"/overlay
 
     declare -a disk_args=()
-    declare -i disk_index=0
-    qemu_add_drive disk_index disk_args "$TESTDIR"/marker.img marker 1
-    qemu_add_drive disk_index disk_args "$TESTDIR"/singleroot.img singleroot 1
-    qemu_add_drive disk_index disk_args "$TESTDIR"/raid0-1.img raid0-1 1
-    qemu_add_drive disk_index disk_args "$TESTDIR"/raid0-2.img raid0-2 1
+    qemu_add_drive disk_args "$TESTDIR"/marker.img marker 1
+    qemu_add_drive disk_args "$TESTDIR"/singleroot.img singleroot 1
+    qemu_add_drive disk_args "$TESTDIR"/raid0-1.img raid0-1 1
+    qemu_add_drive disk_args "$TESTDIR"/raid0-2.img raid0-2 1
 
     # Invoke KVM and/or QEMU to actually create the target filesystem.
     "$testdir"/run-qemu \
@@ -198,10 +195,8 @@ test_setup() {
     rm -rf -- "$TESTDIR"/overlay
 
     declare -a disk_args=()
-    # shellcheck disable=SC2034  # disk_index used in qemu_add_drive
-    declare -i disk_index=0
-    qemu_add_drive disk_index disk_args "$TESTDIR"/marker.img marker 1
-    qemu_add_drive disk_index disk_args "$TESTDIR"/server.img root 1
+    qemu_add_drive disk_args "$TESTDIR"/marker.img marker 1
+    qemu_add_drive disk_args "$TESTDIR"/server.img root 1
 
     # Invoke KVM and/or QEMU to actually create the target filesystem.
     "$testdir"/run-qemu \

--- a/test/TEST-72-NBD/test.sh
+++ b/test/TEST-72-NBD/test.sh
@@ -26,10 +26,9 @@ run_server() {
     echo "NBD TEST SETUP: Starting DHCP/NBD server"
 
     declare -a disk_args=()
-    declare -i disk_index=0
-    qemu_add_drive disk_index disk_args "$TESTDIR"/unencrypted.img unencrypted
-    qemu_add_drive disk_index disk_args "$TESTDIR"/encrypted.img encrypted
-    qemu_add_drive disk_index disk_args "$TESTDIR"/server.img serverroot
+    qemu_add_drive disk_args "$TESTDIR"/unencrypted.img unencrypted
+    qemu_add_drive disk_args "$TESTDIR"/encrypted.img encrypted
+    qemu_add_drive disk_args "$TESTDIR"/server.img serverroot
 
     "$testdir"/run-qemu \
         "${disk_args[@]}" \
@@ -60,8 +59,7 @@ client_test() {
     client_test_start "$test_name"
 
     declare -a disk_args=()
-    declare -i disk_index=0
-    qemu_add_drive disk_index disk_args "$TESTDIR"/marker.img marker
+    qemu_add_drive disk_args "$TESTDIR"/marker.img marker
 
     test_marker_reset
     "$testdir"/run-qemu \
@@ -198,9 +196,8 @@ make_encrypted_root() {
     rm -rf -- "$TESTDIR"/overlay
 
     declare -a disk_args=()
-    declare -i disk_index=0
-    qemu_add_drive disk_index disk_args "$TESTDIR"/marker.img marker 1
-    qemu_add_drive disk_index disk_args "$TESTDIR"/encrypted.img root 1
+    qemu_add_drive disk_args "$TESTDIR"/marker.img marker 1
+    qemu_add_drive disk_args "$TESTDIR"/encrypted.img root 1
 
     # Invoke KVM and/or QEMU to actually create the target filesystem.
     "$testdir"/run-qemu \
@@ -232,9 +229,8 @@ make_client_root() {
         -f "$TESTDIR"/initramfs.makeroot
 
     declare -a disk_args=()
-    declare -i disk_index=0
-    qemu_add_drive disk_index disk_args "$TESTDIR"/marker.img marker 1
-    qemu_add_drive disk_index disk_args "$TESTDIR"/unencrypted.img root 1
+    qemu_add_drive disk_args "$TESTDIR"/marker.img marker 1
+    qemu_add_drive disk_args "$TESTDIR"/unencrypted.img root 1
 
     # Invoke KVM and/or QEMU to actually create the target filesystem.
     "$testdir"/run-qemu \
@@ -285,10 +281,8 @@ EOF
         -f "$TESTDIR"/initramfs.makeroot
 
     declare -a disk_args=()
-    # shellcheck disable=SC2034  # disk_index used in qemu_add_drive
-    declare -i disk_index=0
-    qemu_add_drive disk_index disk_args "$TESTDIR"/marker.img marker 1
-    qemu_add_drive disk_index disk_args "$TESTDIR"/server.img root 1
+    qemu_add_drive disk_args "$TESTDIR"/marker.img marker 1
+    qemu_add_drive disk_args "$TESTDIR"/server.img root 1
 
     # Invoke KVM and/or QEMU to actually create the target filesystem.
     "$testdir"/run-qemu \

--- a/test/test-functions
+++ b/test/test-functions
@@ -222,7 +222,7 @@ inst_init() {
 qemu_add_drive() {
     local index=${!1}
     local file=$3
-    local name=${4:-$index}
+    local name=$4
     local size=${5:-0}
     local bootindex=${6-}
 

--- a/test/test-functions
+++ b/test/test-functions
@@ -195,9 +195,8 @@ inst_init() {
 
 # generate qemu arguments for named raw disks
 #
-# qemu_add_drive <index> <args> <filename> <id-name> [<bootindex>]
+# qemu_add_drive <args> <filename> <id-name> [<bootindex>]
 #
-# index: name of the index variable (set to 0 at start)
 # args: name of the argument array variable (set to () at start)
 # filename: filename of the raw disk image
 # id-name: name of the disk in /dev/disk/by-id -> /dev/disk/by-id/scsi-0QEMU_QEMU_HARDDISK_$name
@@ -212,21 +211,24 @@ inst_init() {
 # # EXAMPLES
 # ```
 #   declare -a disk_args=()
-#   declare -i disk_index=0
-#   qemu_add_drive disk_index disk_args "$TESTDIR"/root.ext3 root 0 1
-#   qemu_add_drive disk_index disk_args "$TESTDIR"/client.img client
-#   qemu_add_drive disk_index disk_args "$TESTDIR"/iscsidisk2.img iscsidisk2
-#   qemu_add_drive disk_index disk_args "$TESTDIR"/iscsidisk3.img iscsidisk3
+#   qemu_add_drive disk_args "$TESTDIR"/root.ext3 root 0 1
+#   qemu_add_drive disk_args "$TESTDIR"/client.img client
+#   qemu_add_drive disk_args "$TESTDIR"/iscsidisk2.img iscsidisk2
+#   qemu_add_drive disk_args "$TESTDIR"/iscsidisk3.img iscsidisk3
 #   qemu "${disk_args[@]}"
 # ```
 qemu_add_drive() {
-    local index=${!1}
     # shellcheck disable=SC2178  # args is a nameref to an array
-    local -n args=$2
-    local file=$3
-    local name=$4
-    local size=${5:-0}
-    local bootindex=${6-}
+    local -n args=$1
+    local file=$2
+    local name=$3
+    local size=${4:-0}
+    local bootindex=${5-}
+
+    local index=0
+    while [[ ${args[*]} == *id=scsi${index}* ]]; do
+        index=$((index + 1))
+    done
 
     if [ "${size}" -ne 0 ]; then
         if [[ ${name} =~ "marker" ]]; then
@@ -244,8 +246,6 @@ qemu_add_drive() {
         -drive "if=none,format=raw,file=${file},id=drive-data${index}"
         -device "scsi-hd,bus=scsi${index}.0,drive=drive-data${index},id=data${index},${bootindex:+bootindex=$bootindex,}serial=${name}"
     )
-
-    : $(("${1}++"))
 }
 
 test_marker_reset() {

--- a/test/test-functions
+++ b/test/test-functions
@@ -221,6 +221,8 @@ inst_init() {
 # ```
 qemu_add_drive() {
     local index=${!1}
+    # shellcheck disable=SC2178  # args is a nameref to an array
+    local -n args=$2
     local file=$3
     local name=$4
     local size=${5:-0}
@@ -237,11 +239,11 @@ qemu_add_drive() {
         truncate -s "${size}M" "$file"
     fi
 
-    eval "${2}"'+=(' \
-        -device "virtio-scsi-pci,id=scsi${index}" \
-        -drive "if=none,format=raw,file=${file},id=drive-data${index}" \
-        -device "scsi-hd,bus=scsi${index}.0,drive=drive-data${index},id=data${index},${bootindex:+bootindex=$bootindex,}serial=${name}" \
-        ')'
+    args+=(
+        -device "virtio-scsi-pci,id=scsi${index}"
+        -drive "if=none,format=raw,file=${file},id=drive-data${index}"
+        -device "scsi-hd,bus=scsi${index}.0,drive=drive-data${index},id=data${index},${bootindex:+bootindex=$bootindex,}serial=${name}"
+    )
 
     : $(("${1}++"))
 }


### PR DESCRIPTION
Simplify `qemu_add_drive` by dropping the `index` parameter. Determine the index dynamically from the content of `args`.

That way declaring `disk_index` is not needed any more and shellcheck is happy.

### Checklist
- [ ] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it
