### PR TITLE
docs: --remove/remove_items supports globbing

### DIFF
--- a/dracut.sh
+++ b/dracut.sh
@@ -227,7 +227,7 @@ Creates initial ramdisk images for preloading modules
   -I, --install [LIST]  Install the space separated list of files into the
                          initramfs.
   --remove      [LIST]  Remove a space-separated list of files and directories
-                        from the initramfs.
+                        from the initramfs (supports globbing).
   --install-optional [LIST]
                         Install the space separated list of files into the
                          initramfs, if they exist.

--- a/man/dracut.8.adoc
+++ b/man/dracut.8.adoc
@@ -476,6 +476,7 @@ example:
 
 **--remove** _<file/dir list>_::
     Remove a space-separated list of files and directories from the initramfs.
+    These __file/dir__ are shell wildcard patterns (see *glob*(7)).
 
 **--install-optional** _<file list>_::
     Install the space separated list of files into the initramfs, if they exist.

--- a/man/dracut.conf.5.adoc
+++ b/man/dracut.conf.5.adoc
@@ -110,6 +110,7 @@ Specify additional files to include in the initramfs, separated by spaces.
 *remove_items+=*" __<file/dir>__[ __<file/dir>__ ...] "::
 Specify additional files or directories to remove from the generated initramfs,
 separated by spaces.
+These __file/dir__ are shell wildcard patterns (see *glob*(7)).
 Warning: Avoid manually removing files or directories, as you may inadvertently
 remove essential ones that dracut won't detect or warn you about.
 Using this option is not recommended and is at your own risk.
@@ -117,7 +118,6 @@ Using this option is not recommended and is at your own risk.
 *install_optional_items+=*" __<file>__[ __<file>__ ...] "::
 Specify additional files to include in the initramfs, separated by spaces,
 if they exist.
-
 *compress=*"__{cat|bzip2|lzma|xz|gzip|lzop|lz4|zstd|<compressor [args ...]>}__"::
 Compress the generated initramfs using the passed compression program.
 +


### PR DESCRIPTION
The dracut option `--remove` and the corresponding config option `remove_items` support globbing (see https://launchpad.net/bugs/2139065 for a real-world usage example).

<!-- This pull request changes... -->

<!-- Fixes: https://github.com/dracut-ng/dracut-ng/issues/<number> -->

### Checklist
- [x] I have tested it locally
- [x] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it
