### PR TITLE
docs(dracut.conf): restore accidentally removed newline

### DIFF
--- a/man/dracut.conf.5.adoc
+++ b/man/dracut.conf.5.adoc
@@ -118,6 +118,7 @@ Using this option is not recommended and is at your own risk.
 *install_optional_items+=*" __<file>__[ __<file>__ ...] "::
 Specify additional files to include in the initramfs, separated by spaces,
 if they exist.
+
 *compress=*"__{cat|bzip2|lzma|xz|gzip|lzop|lz4|zstd|<compressor [args ...]>}__"::
 Compress the generated initramfs using the passed compression program.
 +


### PR DESCRIPTION
Commit 331a30a2dda9 ("docs: --remove/remove_items supports globbing") accidentally removed a newline. Restore it.

<!-- This pull request changes... -->

<!-- Fixes: https://github.com/dracut-ng/dracut-ng/issues/<number> -->

### Checklist
- [ ] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it
