### PR TITLE
test(NETWORK): use POSIX shell for assertion.sh

### DIFF
--- a/test/TEST-50-NETWORK/assertion.sh
+++ b/test/TEST-50-NETWORK/assertion.sh
@@ -1,4 +1,4 @@
-#!/usr/bin/env bash
+#!/bin/sh
 
 # Get the output of 'ip addr show' and filter out lo interface
 ip_output=$(ip -o -4 addr show | grep -v ': lo')


### PR DESCRIPTION
Make the test 50 more flexible by only requiring a POSIX shell in `assertion.sh` in the client rootfs.

<!-- This pull request changes... -->

<!-- Fixes: https://github.com/dracut-ng/dracut-ng/issues/<number> -->

### Checklist
- [ ] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it
