### PR TITLE
refactor(overlayfs): exit early in case overlayfs is not used

### DIFF
--- a/modules.d/70overlayfs/mount-overlayfs.sh
+++ b/modules.d/70overlayfs/mount-overlayfs.sh
@@ -5,14 +5,14 @@ command -v getarg > /dev/null || . /lib/dracut-lib.sh
 getargbool 0 rd.overlayfs -d rd.live.overlay.overlayfs && overlayfs="yes"
 getargbool 0 rd.overlay.readonly -d rd.live.overlayfs.readonly && readonly_overlay="--readonly" || readonly_overlay=""
 
-if [ -n "$overlayfs" ]; then
-    if [ -n "$readonly_overlay" ] && [ -h /run/overlayfs-r ]; then
-        ovlfs=lowerdir=/run/overlayfs-r:/run/rootfsbase
-    else
-        ovlfs=lowerdir=/run/rootfsbase
-    fi
+[ -n "$overlayfs" ] || return 0
 
-    if ! strstr "$(cat /proc/mounts)" LiveOS_rootfs; then
-        mount -t overlay LiveOS_rootfs -o "$ovlfs",upperdir=/run/overlayfs,workdir=/run/ovlwork "$NEWROOT"
-    fi
+if [ -n "$readonly_overlay" ] && [ -h /run/overlayfs-r ]; then
+    ovlfs=lowerdir=/run/overlayfs-r:/run/rootfsbase
+else
+    ovlfs=lowerdir=/run/rootfsbase
+fi
+
+if ! strstr "$(cat /proc/mounts)" LiveOS_rootfs; then
+    mount -t overlay LiveOS_rootfs -o "$ovlfs",upperdir=/run/overlayfs,workdir=/run/ovlwork "$NEWROOT"
 fi

--- a/modules.d/70overlayfs/prepare-overlayfs.sh
+++ b/modules.d/70overlayfs/prepare-overlayfs.sh
@@ -5,17 +5,17 @@ command -v getarg > /dev/null || . /lib/dracut-lib.sh
 getargbool 0 rd.overlayfs -d rd.live.overlay.overlayfs && overlayfs="yes"
 getargbool 0 rd.overlay.reset -d rd.live.overlay.reset && reset_overlay="yes"
 
-if [ -n "$overlayfs" ]; then
-    if ! [ -e /run/rootfsbase ]; then
-        mkdir -m 0755 -p /run/rootfsbase
-        mount --bind "$NEWROOT" /run/rootfsbase
-    fi
+[ -n "$overlayfs" ] || return 0
 
-    mkdir -m 0755 -p /run/overlayfs
-    mkdir -m 0755 -p /run/ovlwork
-    if [ -n "$reset_overlay" ] && [ -h /run/overlayfs ]; then
-        ovlfsdir=$(readlink /run/overlayfs)
-        info "Resetting the OverlayFS overlay directory."
-        rm -r -- "${ovlfsdir:?}"/* "${ovlfsdir:?}"/.* > /dev/null 2>&1
-    fi
+if ! [ -e /run/rootfsbase ]; then
+    mkdir -m 0755 -p /run/rootfsbase
+    mount --bind "$NEWROOT" /run/rootfsbase
+fi
+
+mkdir -m 0755 -p /run/overlayfs
+mkdir -m 0755 -p /run/ovlwork
+if [ -n "$reset_overlay" ] && [ -h /run/overlayfs ]; then
+    ovlfsdir=$(readlink /run/overlayfs)
+    info "Resetting the OverlayFS overlay directory."
+    rm -r -- "${ovlfsdir:?}"/* "${ovlfsdir:?}"/.* > /dev/null 2>&1
 fi


### PR DESCRIPTION
Increase the code readability by exiting early in case overlayfs is not enabled and therefore should do nothing.

<!-- This pull request changes... -->

<!-- Fixes: https://github.com/dracut-ng/dracut-ng/issues/<number> -->

### Checklist
- [ ] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it
