### PR TITLE
test: execute assertion.sh instead of sourcing it

### DIFF
--- a/test/modules.d/70test-root/test-init.sh
+++ b/test/modules.d/70test-root/test-init.sh
@@ -43,7 +43,7 @@ fi
 
 # run the test case specific test assertion if exists
 if [ -x "/assertion.sh" ]; then
-    . /assertion.sh
+    /assertion.sh
 fi
 
 if [ -s /run/failed ]; then


### PR DESCRIPTION
The `assertion.sh` files do not need to access from `test-init.sh`. So execute `assertion.sh` instead of sourcing it.

<!-- This pull request changes... -->

<!-- Fixes: https://github.com/dracut-ng/dracut-ng/issues/<number> -->

### Checklist
- [ ] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it
