### PR TITLE
fix(dmsquash-live-autooverlay): check that parted is present

### DIFF
--- a/modules.d/70dmsquash-live-autooverlay/module-setup.sh
+++ b/modules.d/70dmsquash-live-autooverlay/module-setup.sh
@@ -1,6 +1,7 @@
 #!/bin/bash
 
 check() {
+    require_binaries parted || return 1
     # including a module dedicated to live environments in a host-only initrd doesn't make sense
     [[ $hostonly ]] && return 1
     return 255


### PR DESCRIPTION
The binary `parted` might not be installed. Then the `install` step of `dmsquash-live-autooverlay` will fail.

So better check that the required binary `parted` is present.

<!-- This pull request changes... -->

<!-- Fixes: https://github.com/dracut-ng/dracut-ng/issues/<number> -->

### Checklist
- [ ] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it
