### PR TITLE
test: use "set -eu" in client rootfs test scripts

### DIFF
--- a/test/TEST-21-OVERLAYFS/assertion.sh
+++ b/test/TEST-21-OVERLAYFS/assertion.sh
@@ -1,4 +1,5 @@
 #!/bin/sh
+set -eu
 
 # required binaries: cat grep
 

--- a/test/TEST-30-DMSQUASH/assertion.sh
+++ b/test/TEST-30-DMSQUASH/assertion.sh
@@ -1,4 +1,5 @@
 #!/bin/sh
+set -eu
 
 # required binaries: grep sync
 

--- a/test/TEST-50-NETWORK/assertion.sh
+++ b/test/TEST-50-NETWORK/assertion.sh
@@ -1,4 +1,5 @@
 #!/bin/sh
+set -eu
 
 # required binaries: grep ip
 

--- a/test/modules.d/70test-root/test-init.sh
+++ b/test/modules.d/70test-root/test-init.sh
@@ -1,4 +1,5 @@
 #!/bin/sh
+set -eu
 
 # required binaries: cat dd grep mkdir mount sync
 


### PR DESCRIPTION
Use `set -eu` in client rootfs test scripts to make them more robust against failures.

<!-- This pull request changes... -->

<!-- Fixes: https://github.com/dracut-ng/dracut-ng/issues/<number> -->

### Checklist
- [ ] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it
