### PR TITLE
fix(dracut-functions): do not initialize the logger if sourced from tests

### DIFF
--- a/dracut-functions.sh
+++ b/dracut-functions.sh
@@ -1533,9 +1533,21 @@ _detect_library_directories() {
 }
 
 if ! is_func dinfo > /dev/null 2>&1; then
-    # shellcheck source=./dracut-logger.sh
-    . "${BASH_SOURCE[0]%/*}/dracut-logger.sh"
-    dlog_init
+    # If dracut-functions.sh is sourced from tests, the logger initialization is
+    # borked, with some readonly variables wrongly set and others unset.
+    if ! [[ "${dracut_cmd-}" ]]; then
+        dtrace() { :; }
+        ddebug() { :; }
+        dinfo() { :; }
+        dwarn() { :; }
+        dwarning() { :; }
+        derror() { :; }
+        dfatal() { :; }
+    else
+        # shellcheck source=./dracut-logger.sh
+        . "${BASH_SOURCE[0]%/*}/dracut-logger.sh"
+        dlog_init
+    fi
 fi
 
 DRACUT_LDCONFIG=${DRACUT_LDCONFIG:-ldconfig}


### PR DESCRIPTION
After 7679b3d8b9e8da0a03efe38f4b30066925d19af1, `dracut-functions.sh` is sourced to build the rootfs. `dracut-functions.sh` also sources `dracut-logger.sh`, which in this case sets some readonly variables without taking care of dracut configuration. This causes subsequent actual calls to dracut within the tests to not correctly initialize the logger, because it thinks it's already initialized, and every call to a log function issues the message:

`logger: unknown facility name:`

Follow-up for 7679b3d8b9e8da0a03efe38f4b30066925d19af1

### Checklist
- [X] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it

E.g., seen in the CI:

```
2026-01-30T11:43:15.7489620Z TEST: download and import disk images at boot with systemd-import  [0;32m [STARTED] [0;39m
2026-01-30T11:43:16.2315275Z Calling dracut --confdir /var/tmp/dracut-test.4SgO1n/dracut.conf.d --add-confdir test --tmpdir /var/tmp/dracut-test.4SgO1n/initrd --no-hostonly-cmdline -a systemd-import /var/tmp/dracut-test.4SgO1n/initramfs.testing
2026-01-30T11:43:16.3737659Z logger: unknown facility name: 
2026-01-30T11:43:16.3786747Z logger: unknown facility name: 
2026-01-30T11:43:17.2429953Z logger: unknown facility name: 
2026-01-30T11:43:17.2532846Z logger: unknown facility name: 
2026-01-30T11:43:17.2631602Z logger: unknown facility name: 
2026-01-30T11:43:17.2715713Z logger: unknown facility name: 
2026-01-30T11:43:17.4185118Z logger: unknown facility name: 
2026-01-30T11:43:17.6745421Z logger: unknown facility name: 
2026-01-30T11:43:17.6841431Z logger: unknown facility name: 
2026-01-30T11:43:17.7086663Z logger: unknown facility name: 
2026-01-30T11:43:17.7166827Z logger: unknown facility name: 
2026-01-30T11:43:17.8615481Z logger: unknown facility name: 
2026-01-30T11:43:17.8789237Z logger: unknown facility name: 
2026-01-30T11:43:17.9110223Z logger: unknown facility name: 
2026-01-30T11:43:17.9456066Z logger: unknown facility name: 
2026-01-30T11:43:17.9530889Z logger: unknown facility name: 
2026-01-30T11:43:17.9765294Z logger: unknown facility name: 
2026-01-30T11:43:17.9983403Z logger: unknown facility name: 
2026-01-30T11:43:18.0338315Z logger: unknown facility name: 
2026-01-30T11:43:18.0931356Z logger: unknown facility name: 
2026-01-30T11:43:18.1120212Z logger: unknown facility name: 
2026-01-30T11:43:18.1150580Z logger: unknown facility name: 
2026-01-30T11:43:18.2500076Z logger: unknown facility name: 
2026-01-30T11:43:18.3818953Z logger: unknown facility name: 
2026-01-30T11:43:18.3850043Z logger: unknown facility name: 
2026-01-30T11:43:18.4605462Z logger: unknown facility name: 
2026-01-30T11:43:18.5316373Z logger: unknown facility name: 
2026-01-30T11:43:19.5549096Z logger: unknown facility name: 
2026-01-30T11:43:19.7027142Z logger: unknown facility name: 
2026-01-30T11:43:20.9888468Z logger: unknown facility name: 
2026-01-30T11:43:20.9997060Z logger: unknown facility name: 
2026-01-30T11:43:22.3294842Z logger: unknown facility name: 
2026-01-30T11:43:22.3574967Z logger: unknown facility name: 
2026-01-30T11:43:22.4711125Z logger: unknown facility name: 
2026-01-30T11:43:22.5045708Z logger: unknown facility name: 
2026-01-30T11:43:22.5173196Z logger: unknown facility name: 
2026-01-30T11:43:22.9836629Z logger: unknown facility name: 
2026-01-30T11:43:23.1101228Z logger: unknown facility name: 
2026-01-30T11:43:23.1339320Z logger: unknown facility name: 
2026-01-30T11:43:23.1370454Z logger: unknown facility name: 
2026-01-30T11:43:23.1546732Z logger: unknown facility name: 
2026-01-30T11:43:23.2291419Z logger: unknown facility name: 
2026-01-30T11:43:23.2583660Z logger: unknown facility name: 
2026-01-30T11:43:23.2617676Z logger: unknown facility name: 
2026-01-30T11:43:23.3008543Z logger: unknown facility name: 
2026-01-30T11:43:23.3096125Z logger: unknown facility name: 
2026-01-30T11:43:24.7433960Z logger: unknown facility name: 
2026-01-30T11:43:24.7485721Z logger: unknown facility name: 
2026-01-30T11:43:25.1201649Z logger: unknown facility name: 
2026-01-30T11:43:25.1282578Z logger: unknown facility name: 
2026-01-30T11:43:25.1386758Z logger: unknown facility name: 
2026-01-30T11:43:25.1719804Z logger: unknown facility name: 
2026-01-30T11:43:25.1750740Z logger: unknown facility name: 
2026-01-30T11:43:25.2065425Z logger: unknown facility name: 
2026-01-30T11:43:25.2108902Z logger: unknown facility name: 
2026-01-30T11:43:35.6193290Z logger: unknown facility name: 
2026-01-30T11:43:35.7447085Z Starting HTTP server...
```
