### PR TITLE
chore(dracut-logger): drop __DRACUT_LOGGER__

### DIFF
--- a/dracut-logger.sh
+++ b/dracut-logger.sh
@@ -17,8 +17,6 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-export __DRACUT_LOGGER__=1
-
 ## @brief Logging facility module for dracut both at build- and boot-time.
 #
 # @section intro Introduction


### PR DESCRIPTION
Commit d6d53f60b21e ("dracut-functions: use "type" to determine the need of sourcing dracut-logger") removed checking `__DRACUT_LOGGER__`. There is no code any more that checks this environment variable.

So drop setting `__DRACUT_LOGGER__`.

<!-- This pull request changes... -->

<!-- Fixes: https://github.com/dracut-ng/dracut-ng/issues/<number> -->

### Checklist
- [ ] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it
