### PR TITLE
test: unset DRACUT_NO_XATTR after build_client_rootfs

### DIFF
--- a/test/test-functions
+++ b/test/test-functions
@@ -164,6 +164,8 @@ build_client_rootfs() {
     if command -v hardlink > /dev/null; then
         hardlink -q "$rootdir"
     fi
+
+    unset DRACUT_NO_XATTR
 }
 
 # Call dracut and log its call in verbose mode


### PR DESCRIPTION
`build_client_rootfs` sets `DRACUT_NO_XATTR` to not require xattr support which is noot needed for the client rootfs. To not influence the test coverage for xattr support, unset `DRACUT_NO_XATTR` afterwards.

<!-- This pull request changes... -->

<!-- Fixes: https://github.com/dracut-ng/dracut-ng/issues/<number> -->

### Checklist
- [ ] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it
