### PR TITLE
fix(dracut-logger): do not export maxloglvl and syslogfacility

### DIFF
--- a/dracut-logger.sh
+++ b/dracut-logger.sh
@@ -166,7 +166,6 @@ dlog_init() {
         else
             readonly syslogfacility=daemon
         fi
-        export syslogfacility
     fi
 
     local lvl
@@ -175,7 +174,6 @@ dlog_init() {
         ((lvl > maxloglvl_l)) && maxloglvl_l=$lvl
     done
     readonly maxloglvl=$maxloglvl_l
-    export maxloglvl
 
     if ((stdloglvl < 6)) && ((kmsgloglvl < 6)) && ((fileloglvl < 6)) && ((sysloglvl < 6)); then
         unset dtrace


### PR DESCRIPTION
Commit 46265a9d3e0a ("dracut-logger: make $maxloglvl public") exports the `maxloglvl` variable, but this is not needed. Exporting variables is only needed when subprocesses need to access those variables.

`maxloglvl` is only used in `dracut-logger.sh` and `dracut.sh`. `dracut.sh` sources `dracut-logger.sh`. So exporting `maxloglvl` is not needed. `syslogfacility` is only used in `dracut-logger.sh`.

So do not export `maxloglvl` and `syslogfacility`.

<!-- This pull request changes... -->

<!-- Fixes: https://github.com/dracut-ng/dracut-ng/issues/<number> -->

### Checklist
- [ ] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it
