### PR TITLE
ci(debian): dracut-squash and dracut-live packages are removed

### DIFF
--- a/test/container/Dockerfile-debian
+++ b/test/container/Dockerfile-debian
@@ -16,7 +16,7 @@ FROM docker.io/${DISTRIBUTION}
 ARG DISTRIBUTION
 
 # Install dracut as a linux-initramfs-tool provider so that the default initramfs-tool package does not get installed
-RUN apt-get update -y -qq && apt-get upgrade -y -qq && apt-get install -y -qq --install-recommends dracut dracut-network dracut-squash dracut-live dracut-test
+RUN apt-get update -y -qq && apt-get upgrade -y -qq && apt-get install -y -qq --install-recommends dracut dracut-network dracut-test
 
 # Install 3cpio where available
 RUN if [ "$DISTRIBUTION" != "debian:latest" ] ; then cpio=3cpio; else cpio=cpio; fi; \
@@ -39,6 +39,7 @@ RUN \
     console-data \
     cryptsetup \
     curl \
+    dmsetup \
     dnsmasq \
     docbook \
     docbook-xml \


### PR DESCRIPTION
Debian:sid remove dracut-squash and dracut-live packages.

Remove these packages from all Debian/Ubuntu versions.

See 
 - https://salsa.debian.org/kernel-team/dracut/-/merge_requests/42
 - https://salsa.debian.org/kernel-team/dracut/-/merge_requests/43

<!-- This pull request changes... -->

<!-- Fixes: https://github.com/dracut-ng/dracut-ng/issues/<number> -->

### Checklist
- [ ] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it
