### PR TITLE
fix(dracut-logger): disable kernel logging if /dev/kmsg is not writable

### DIFF
--- a/dracut-logger.sh
+++ b/dracut-logger.sh
@@ -153,11 +153,19 @@ dlog_init() {
             exec 15> "$_systemdcatfile"
         elif ! ([[ -S /dev/log ]] && [[ -w /dev/log ]] && command -v logger > /dev/null); then
             # We cannot log to syslog, so turn this facility off.
-            kmsgloglvl=$sysloglvl
+            if [[ -w /dev/kmsg ]]; then
+                kmsgloglvl=$sysloglvl
+            fi
             sysloglvl=0
             ret=1
             errmsgs+=("No '/dev/log' or 'logger' included for syslog logging")
         fi
+    fi
+
+    if ((kmsgloglvl > 0)) && [[ ! -w /dev/kmsg ]]; then
+        kmsgloglvl=0
+        ret=1
+        errmsgs+=("'/dev/kmsg' not writable. Disabling logging to kernel ring buffer.")
     fi
 
     if ((sysloglvl > 0)) || ((kmsgloglvl > 0)); then


### PR DESCRIPTION
`/dev/kmsg` is might not be writable (for example in a podman container). So disable trying to log to the kernel ring buffer in that case.

Note: With this change I get one step further:
```
$ test/test.sh opensuse:latest 10
TEST: root filesystem on ext4 filesystem   [STARTED] 
dracut[E]: '/dev/kmsg' not writable. Disabling logging to kernel ring buffer.
/z/dracut-logger.sh: line 554: debug: unbound variable
```

### Checklist
- [ ] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it
