### PR TITLE
test: define test expectation in test.sh

### DIFF
--- a/test/TEST-21-OVERLAYFS/assertion.sh
+++ b/test/TEST-21-OVERLAYFS/assertion.sh
@@ -10,20 +10,13 @@ if ! echo > /test-overlay-write; then
     echo "overlay is not writable" >> /run/failed
 fi
 
-if grep -qE 'rd\.overlay=(LABEL|UUID|PARTUUID|PARTLABEL|/dev/)' /proc/cmdline; then
-    if grep -q "rd.overlay=LABEL=NONEXISTENT" /proc/cmdline; then
-        if grep -q "/run/overlayfs-backing" /proc/mounts; then
-            echo "non-existent device should have fallen back to tmpfs but backing is mounted" >> /run/failed
-        fi
-    else
-        if ! grep -q "/run/overlayfs-backing" /proc/mounts; then
-            echo "persistent overlay device not mounted at /run/overlayfs-backing" >> /run/failed
-        fi
+if grep -q 'test.expect=device' /proc/cmdline; then
+    if ! grep -q "/run/overlayfs-backing" /proc/mounts; then
+        echo "persistent overlay device not mounted at /run/overlayfs-backing" >> /run/failed
     fi
 else
-    # tmpfs mode - verify persistent backing is NOT mounted
     if grep -q "/run/overlayfs-backing" /proc/mounts; then
-        echo "tmpfs mode but persistent backing is mounted at /run/overlayfs-backing" >> /run/failed
+        echo "persistent overlay device is mounted at /run/overlayfs-backing" >> /run/failed
     fi
 fi
 

--- a/test/TEST-21-OVERLAYFS/test.sh
+++ b/test/TEST-21-OVERLAYFS/test.sh
@@ -27,12 +27,12 @@ test_run() {
     local overlay_uuid
     overlay_uuid=$(blkid -s UUID -o value "$TESTDIR"/overlay.img)
 
-    client_run "tmpfs overlay" "rd.overlayfs=1"
-    client_run "persistent device overlay (LABEL)" "rd.overlay=LABEL=OVERLAY"
-    client_run "persistent device overlay (UUID)" "rd.overlay=UUID=$overlay_uuid"
+    client_run "tmpfs overlay" "rd.overlayfs=1 test.expect=tmpfs"
+    client_run "persistent device overlay (LABEL)" "rd.overlay=LABEL=OVERLAY test.expect=device"
+    client_run "persistent device overlay (UUID)" "rd.overlay=UUID=$overlay_uuid test.expect=device"
     client_run "persistent device overlay (device path)" \
-        "rd.overlay=/dev/disk/by-id/scsi-0QEMU_QEMU_HARDDISK_overlay"
-    client_run "fallback to tmpfs (non-existent LABEL)" "rd.overlay=LABEL=NONEXISTENT"
+        "rd.overlay=/dev/disk/by-id/scsi-0QEMU_QEMU_HARDDISK_overlay test.expect=device"
+    client_run "fallback to tmpfs (non-existent LABEL)" "rd.overlay=LABEL=NONEXISTENT test.expect=tmpfs"
 }
 
 test_setup() {


### PR DESCRIPTION
Test 21 defines the test expectation in `assertion.sh` based on the boot parameters. Every time a new kind of subtest is added in `test.sh` the expectation in `assertion.sh` needs to be changed accordingly.

To avoid touching two places, define the test expectation in the kernel boot parameter `test.expect` and let `assertion.sh` operate on that.

<!-- This pull request changes... -->

<!-- Fixes: https://github.com/dracut-ng/dracut-ng/issues/<number> -->

### Checklist
- [x] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it
