### PR TITLE
fix(livenet): correct check for deprecated rd.live.overlay.overlayfs

### DIFF
--- a/modules.d/70livenet/livenet-generator.sh
+++ b/modules.d/70livenet/livenet-generator.sh
@@ -50,7 +50,7 @@ GENERATOR_DIR="$2"
 [ -d "$GENERATOR_DIR" ] || mkdir -p "$GENERATOR_DIR"
 
 getargbool 0 rd.overlay.readonly -d rd.live.overlay.readonly && readonly_overlay="--readonly" || readonly_overlay=""
-getargbool 0 rd.overlayfs -d rd.live.overlayfs.readonly && overlayfs="yes"
+getargbool 0 rd.overlayfs -d rd.live.overlay.overlayfs && overlayfs="yes"
 [ -e /xor_overlayfs ] && xor_overlayfs="yes"
 [ -e /xor_readonly ] && xor_readonly="--readonly"
 ROOTFLAGS="$(getarg rootflags)"


### PR DESCRIPTION
Commit b77ae7eb8523 ("feat: rename rd.live.overlay.overlayfs to rd.overlayfs") made a mistake and looks for `rd.live.overlayfs.readonly` instead of `rd.live.overlay.overlayfs` as deprecated option for `rd.overlayfs`.

<!-- This pull request changes... -->

<!-- Fixes: https://github.com/dracut-ng/dracut-ng/issues/<number> -->

### Checklist
- [ ] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it
