### PR TITLE
test: print error in case root partition count mismatch

### DIFF
--- a/test/TEST-30-DMSQUASH/test.sh
+++ b/test/TEST-30-DMSQUASH/test.sh
@@ -43,7 +43,10 @@ client_run() {
 check_autooverlay_marker() {
     local rootPartitions part2_info part2_start part2_size
     rootPartitions=$(sfdisk -d "$TESTDIR"/root.img | grep -c 'root\.img[0-9]')
-    [ "$rootPartitions" -eq 2 ]
+    if [ "$rootPartitions" -ne 2 ]; then
+        echo >&2 "E: Expected two partitions on root.img, but got $rootPartitions."
+        return 1
+    fi
     part2_info=$(sfdisk -d "$TESTDIR"/root.img | grep 'root\.img2')
     part2_start=$(echo "$part2_info" | sed -n 's/.*start= *\([0-9]*\).*/\1/p')
     part2_size=$(echo "$part2_info" | sed -n 's/.*size= *\([0-9]*\).*/\1/p')


### PR DESCRIPTION
The dmsquash test case can fail by not creating an overlay partition. In this case the test fails with exit code 1 without printing an error. This is hard to debug.

So print an error message in case the root partition count mismatches.

<!-- This pull request changes... -->

<!-- Fixes: https://github.com/dracut-ng/dracut-ng/issues/<number> -->

### Checklist
- [ ] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it
