### PR TITLE
feat: merge rd.overlayfs into rd.overlay

### DIFF
--- a/man/dracut.cmdline.7.adoc
+++ b/man/dracut.cmdline.7.adoc
@@ -1090,7 +1090,7 @@ OverlayFS
 ~~~~~~~~~
 Requires the dracut 'overlayfs' module.
 
-**rd.overlayfs=**1::
+**rd.overlay**::
 Enables the use of the *OverlayFS* kernel module, if available, to provide a
 copy-on-write union directory for the root filesystem.  OverlayFS overlays are
 directories of the files that have changed on the read-only base (lower)
@@ -1177,7 +1177,7 @@ filesystem, which often provide only a small number of gigabytes of free space.
 This shortage could be remedied by building the root filesystem with more
 allocated free space, or the OverlayFS based overlay mount method can be used.
 
-When the _rd.overlayfs_ option is specified or when
+When the _rd.overlay_ option is specified or when
 _rd.overlay=_ points to an appropriate directory with a sister at
 `/../ovlwork`, then an OverlayFS based overlay mount is employed.  Such a
 persistent OverlayFS overlay can extend the available root filesystem storage
@@ -1354,7 +1354,7 @@ where _<label>_ and _<uuid>_ are the LABEL and UUID of the filesystem specified
 by the **root=**live:__<path|url>__ device.
 
 If a persistent overlay __is detected__ at the standard LiveOS path,
-and _rd.overlayfs_ is not set to 1, the overlay type (either
+and _rd.overlay_ is not set to 1, the overlay type (either
 Device-mapper or OverlayFS) will be detected and it will be used.
 --
 +
@@ -1547,7 +1547,7 @@ UNICODE:: vconsole.unicode (since version 008)
 
 EXT_KEYMAP:: vconsole.keymap.ext (since version 008)
 
-rd.live.overlay.overlayfs:: rd.overlayfs (since version 110)
+rd.live.overlay.overlayfs:: rd.overlay (since version 110)
 
 rd.live.overlay.readonly:: rd.overlay.readonly (since version 110)
 

--- a/modules.d/70dmsquash-live-autooverlay/create-overlay.sh
+++ b/modules.d/70dmsquash-live-autooverlay/create-overlay.sh
@@ -1,6 +1,7 @@
 #!/bin/sh
 
 command -v getarg > /dev/null || . /lib/dracut-lib.sh
+command -v get_rd_overlay > /dev/null || . /lib/overlayfs-lib.sh
 
 if getargbool 0 rd.live.debug; then
     exec > /tmp/create-overlay.$$.out
@@ -9,7 +10,7 @@ if getargbool 0 rd.live.debug; then
 fi
 
 gatherData() {
-    overlay=$(getarg rd.overlay -d rd.live.overlay)
+    overlay=$(get_rd_overlay)
     if [ -z "$overlay" ]; then
         info "Skipping overlay creation: kernel command line parameter 'rd.overlay' is not set"
         exit 0

--- a/modules.d/70dmsquash-live/dmsquash-generator.sh
+++ b/modules.d/70dmsquash-live/dmsquash-generator.sh
@@ -46,7 +46,7 @@ GENERATOR_DIR="$2"
 [ -d "$GENERATOR_DIR" ] || mkdir -p "$GENERATOR_DIR"
 
 getargbool 0 rd.overlay.readonly -d rd.live.overlayfs.readonly && readonly_overlay="--readonly" || readonly_overlay=""
-getargbool 0 rd.overlayfs -d rd.live.overlay.overlayfs && overlayfs="yes"
+getargbool 0 rd.overlay -d rd.live.overlay.overlayfs && overlayfs="yes"
 [ -e /xor_overlayfs ] && xor_overlayfs="yes"
 [ -e /xor_readonly ] && xor_readonly="--readonly"
 ROOTFLAGS="$(getarg rootflags)"

--- a/modules.d/70dmsquash-live/dmsquash-live-root.sh
+++ b/modules.d/70dmsquash-live/dmsquash-live-root.sh
@@ -3,6 +3,7 @@
 command -v getarg > /dev/null || . /lib/dracut-lib.sh
 command -v det_fs > /dev/null || . /lib/fs-lib.sh
 command -v unpack_archive > /dev/null || . /lib/img-lib.sh
+command -v get_rd_overlay > /dev/null || . /lib/overlayfs-lib.sh
 
 PATH=/usr/sbin:/usr/bin:/sbin:/bin
 
@@ -26,13 +27,13 @@ getargbool 0 rd.live.ram && live_ram="yes"
 getargbool 0 rd.overlay.reset -d rd.live.overlay.reset && reset_overlay="yes"
 getargbool 0 rd.overlay.readonly -d rd.live.overlay.readonly && readonly_overlay="--readonly" || readonly_overlay=""
 getargbool 0 rd.live.overlay.nouserconfirmprompt && overlay_no_user_confirm_prompt="--noprompt" || overlay_no_user_confirm_prompt=""
-overlay=$(getarg rd.overlay -d rd.live.overlay)
+overlay=$(get_rd_overlay)
 getargbool 0 rd.writable.fsimg && writable_fsimg="yes"
 overlay_size=$(getarg rd.live.overlay.size=)
 [ -z "$overlay_size" ] && overlay_size=32768
 
 getargbool 0 rd.live.overlay.thin && thin_snapshot="yes"
-getargbool 0 rd.overlayfs -d rd.live.overlay.overlayfs && overlayfs="yes"
+getargbool 0 rd.overlay -d rd.live.overlay.overlayfs && overlayfs="yes"
 
 # Take a path to a disk label and return the parent disk if it is a partition
 # Otherwise returns the original path
@@ -415,8 +416,8 @@ fi
 
 ROOTFLAGS="$(getarg rootflags)"
 
-if [ "$overlayfs" = required ]; then
-    echo "rd.overlayfs=1" > /etc/cmdline.d/20-dmsquash-need-overlay.conf
+if [ "$overlayfs" = required ] && ! getargbool 0 rd.overlay; then
+    echo "rd.overlay" > /etc/cmdline.d/20-dmsquash-need-overlay.conf
 fi
 
 if [ -n "$overlayfs" ]; then

--- a/modules.d/70livenet/livenet-generator.sh
+++ b/modules.d/70livenet/livenet-generator.sh
@@ -50,7 +50,7 @@ GENERATOR_DIR="$2"
 [ -d "$GENERATOR_DIR" ] || mkdir -p "$GENERATOR_DIR"
 
 getargbool 0 rd.overlay.readonly -d rd.live.overlay.readonly && readonly_overlay="--readonly" || readonly_overlay=""
-getargbool 0 rd.overlayfs -d rd.live.overlay.overlayfs && overlayfs="yes"
+getargbool 0 rd.overlay -d rd.live.overlay.overlayfs && overlayfs="yes"
 [ -e /xor_overlayfs ] && xor_overlayfs="yes"
 [ -e /xor_readonly ] && xor_readonly="--readonly"
 ROOTFLAGS="$(getarg rootflags)"

--- a/modules.d/70overlayfs/module-setup.sh
+++ b/modules.d/70overlayfs/module-setup.sh
@@ -18,4 +18,5 @@ install() {
     inst_hook mount 01 "$moddir/mount-overlayfs.sh"       # overlay on top of block device
     inst_hook pre-pivot 00 "$moddir/prepare-overlayfs.sh" # prepare for network root (e.g. nfs)
     inst_hook pre-pivot 10 "$moddir/mount-overlayfs.sh"   # overlay on top of network device
+    inst_simple "$moddir/overlayfs-lib.sh" "/lib/overlayfs-lib.sh"
 }

--- a/modules.d/70overlayfs/mount-overlayfs.sh
+++ b/modules.d/70overlayfs/mount-overlayfs.sh
@@ -1,10 +1,11 @@
 #!/bin/sh
 
 command -v getarg > /dev/null || . /lib/dracut-lib.sh
+command -v get_rd_overlay > /dev/null || . /lib/overlayfs-lib.sh
 
-getargbool 0 rd.overlayfs -d rd.live.overlay.overlayfs && overlayfs="yes"
+getargbool 0 rd.overlay -d rd.live.overlay.overlayfs && overlayfs="yes"
 getargbool 0 rd.overlay.readonly -d rd.live.overlayfs.readonly && readonly_overlay="--readonly" || readonly_overlay=""
-overlay=$(getarg rd.overlay -d rd.live.overlay)
+overlay=$(get_rd_overlay)
 
 [ -n "$overlayfs" ] || [ -n "$overlay" ] || return 0
 

--- a/modules.d/70overlayfs/overlayfs-lib.sh
+++ b/modules.d/70overlayfs/overlayfs-lib.sh
@@ -1,0 +1,17 @@
+#!/bin/sh
+
+command -v getarg > /dev/null || . /lib/dracut-lib.sh
+
+# Fetch non-boolean value for rd.overlay or fall back to rd.live.overlay
+get_rd_overlay() {
+    local overlay
+
+    overlay=$(getarg rd.overlay)
+    case $overlay in
+        0 | no | off | "" | 1)
+            overlay=$(getarg rd.live.overlay) || return 1
+            warn "Kernel command line option 'rd.live.overlay' is deprecated, use 'rd.overlay' instead."
+            ;;
+    esac
+    echo "$overlay"
+}

--- a/modules.d/70overlayfs/prepare-overlayfs.sh
+++ b/modules.d/70overlayfs/prepare-overlayfs.sh
@@ -1,12 +1,12 @@
 #!/bin/sh
 
 command -v getarg > /dev/null || . /lib/dracut-lib.sh
+command -v get_rd_overlay > /dev/null || . /lib/overlayfs-lib.sh
 
-getargbool 0 rd.overlayfs -d rd.live.overlay.overlayfs && overlayfs="yes"
+getargbool 0 rd.overlay -d rd.live.overlay.overlayfs || return 0
+
 getargbool 0 rd.overlay.reset -d rd.live.overlay.reset && reset_overlay="yes"
-overlay=$(getarg rd.overlay -d rd.live.overlay)
-
-[ -n "$overlayfs" ] || [ -n "$overlay" ] || return 0
+overlay=$(get_rd_overlay)
 
 overlay_mode="tmpfs"
 overlay_device=""

--- a/test/TEST-21-OVERLAYFS/assertion.sh
+++ b/test/TEST-21-OVERLAYFS/assertion.sh
@@ -2,12 +2,18 @@
 
 # required binaries: cat grep
 
-if ! grep -q " overlay " /proc/mounts; then
-    echo "overlay filesystem not found in /proc/mounts" >> /run/failed
-fi
+if grep -q 'test.expect=none' /proc/cmdline; then
+    if grep -q " overlay " /proc/mounts; then
+        echo "overlay filesystem found in /proc/mounts" >> /run/failed
+    fi
+else
+    if ! grep -q " overlay " /proc/mounts; then
+        echo "overlay filesystem not found in /proc/mounts" >> /run/failed
+    fi
 
-if ! echo > /test-overlay-write; then
-    echo "overlay is not writable" >> /run/failed
+    if ! echo > /test-overlay-write; then
+        echo "overlay is not writable" >> /run/failed
+    fi
 fi
 
 if grep -q 'test.expect=device' /proc/cmdline; then

--- a/test/TEST-21-OVERLAYFS/test.sh
+++ b/test/TEST-21-OVERLAYFS/test.sh
@@ -27,7 +27,9 @@ test_run() {
     local overlay_uuid
     overlay_uuid=$(blkid -s UUID -o value "$TESTDIR"/overlay.img)
 
-    client_run "tmpfs overlay" "rd.overlayfs=1 test.expect=tmpfs"
+    client_run "overlay disabled (rd.overlay=0)" "rd.overlay=0 test.expect=none"
+    client_run "tmpfs overlay (rd.overlay)" "rd.overlay test.expect=tmpfs"
+    client_run "tmpfs overlay (rd.overlay=1)" "rd.overlay=1 test.expect=tmpfs"
     client_run "persistent device overlay (LABEL)" "rd.overlay=LABEL=OVERLAY test.expect=device"
     client_run "persistent device overlay (UUID)" "rd.overlay=UUID=$overlay_uuid test.expect=device"
     client_run "persistent device overlay (device path)" \

--- a/test/TEST-30-DMSQUASH/test.sh
+++ b/test/TEST-30-DMSQUASH/test.sh
@@ -30,7 +30,7 @@ client_run() {
 
     "$testdir"/run-qemu \
         "${disk_args[@]}" \
-        -append "$TEST_KERNEL_CMDLINE rd.overlayfs=1 root=live:/dev/disk/by-label/dracut $client_opts" \
+        -append "$TEST_KERNEL_CMDLINE rd.overlay root=live:/dev/disk/by-label/dracut $client_opts" \
         -initrd "$TESTDIR"/initramfs.testing
     check_qemu_log
 

--- a/test/TEST-60-NFS/test.sh
+++ b/test/TEST-60-NFS/test.sh
@@ -187,10 +187,10 @@ test_nfsv4() {
         "root=dhcp" 192.168.50.3 wsize=4096
 
     client_test "NFSv4 Overlayfs root=nfs4:..." 52:54:00:12:34:84 \
-        "root=nfs4:192.168.50.1:/client rd.overlayfs=1 " 192.168.50.1 -wsize=4096
+        "root=nfs4:192.168.50.1:/client rd.overlay " 192.168.50.1 -wsize=4096
 
     client_test "NFSv4 Live Overlayfs root=nfs4:..." 52:54:00:12:34:84 \
-        "root=nfs4:192.168.50.1:/client rd.live.image rd.overlayfs=1" 192.168.50.1 -wsize=4096
+        "root=nfs4:192.168.50.1:/client rd.live.image rd.overlay" 192.168.50.1 -wsize=4096
 
     return 0
 }


### PR DESCRIPTION
Having both `rd.overlayfs` and `rd.overlay` is confusing.

Standardize on using `rd.overlay` for the overlayfs Dracut module. Merge `rd.overlayfs` into `rd.overlay`. `rd.overlay` can be a boolean or point to a storage device now.

Commit b77ae7eb8523 ("feat: rename rd.live.overlay.overlayfs to rd.overlayfs") introduced `rd.overlayfs` after the release 109. So no Dracut release included `rd.overlayfs` and therefore no backward compatility for `rd.overlayfs` is needed.

This PR depends on https://github.com/dracut-ng/dracut-ng/pull/2175.

### Checklist
- [x] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it
