### PR TITLE
chore(dracut): finalize transition to /var/lib/dracut/hooks

### DIFF
--- a/doc_site/modules/ROOT/pages/developer/modules.adoc
+++ b/doc_site/modules/ROOT/pages/developer/modules.adoc
@@ -125,16 +125,16 @@ You are encouraged to provide a `README` that describes what the module is for.
 
 init has the following hook points to inject scripts:
 
-`/lib/dracut/hooks/cmdline/*.sh`::
+`/var/lib/dracut/hooks/cmdline/*.sh`::
 scripts for command line parsing
 
-`/lib/dracut/hooks/pre-udev/*.sh`::
+`/var/lib/dracut/hooks/pre-udev/*.sh`::
 scripts to run before udev is started
 
-`/lib/dracut/hooks/pre-trigger/*.sh`::
+`/var/lib/dracut/hooks/pre-trigger/*.sh`::
 scripts to run before the main udev trigger is pulled
 
-`/lib/dracut/hooks/initqueue/*.sh`::
+`/var/lib/dracut/hooks/initqueue/*.sh`::
 runs in parallel to the udev trigger
 +
 Udev events can add scripts here with `/sbin/initqueue`.
@@ -142,7 +142,7 @@ Udev events can add scripts here with `/sbin/initqueue`.
 If `/sbin/initqueue` is called with the `--onetime` option, the script
 will be removed after it was run.
 +
-If `/lib/dracut/hooks/initqueue/work` is created then
+If `/var/lib/dracut/hooks/initqueue/work` is created then
 this loop can process the jobs in parallel to the udevtrigger.
 +
 If the udev queue is empty and no root device is found or no root
@@ -151,23 +151,23 @@ a timeout.
 +
 Scripts can remove themselves from the initqueue by `rm $job`.
 
-`/lib/dracut/hooks/pre-mount/*.sh`::
+`/var/lib/dracut/hooks/pre-mount/*.sh`::
 scripts to run before the root filesystem is mounted
 +
 Network filesystems like NFS that do not use device files are an
 exception. Root can be mounted already at this point.
 
-`/lib/dracut/hooks/mount/*.sh`::
+`/var/lib/dracut/hooks/mount/*.sh`::
 scripts to mount the root filesystem
 +
 If the udev queue is empty and no root device is found or no root
 filesystem was mounted, the user will be dropped to a shell after
 a timeout.
 
-`/lib/dracut/hooks/pre-pivot/*.sh`::
+`/var/lib/dracut/hooks/pre-pivot/*.sh`::
 scripts to run before latter initramfs cleanups
 
-`/lib/dracut/hooks/cleanup/*.sh`::
+`/var/lib/dracut/hooks/cleanup/*.sh`::
 scripts to run before the real init is executed and the initramfs
 disappears
 +

--- a/dracut.sh
+++ b/dracut.sh
@@ -2706,7 +2706,7 @@ if [[ $kernel_only != yes ]]; then
 
     for _d in $hookdirs; do
         # shellcheck disable=SC2174
-        mkdir -m 0755 -p "${initdir}/lib/dracut/hooks/$_d"
+        mkdir -m 0755 -p "${initdir}/var/lib/dracut/hooks/$_d"
     done
     if [[ $EUID == "0" ]] && ! [[ $DRACUT_NO_MKNOD ]]; then
         [[ -c ${initdir}/dev/null ]] || mknod "${initdir}"/dev/null c 1 3

--- a/modules.d/74resume/parse-resume.sh
+++ b/modules.d/74resume/parse-resume.sh
@@ -66,7 +66,7 @@ if ! getarg noresume; then
             printf -- ' cancel_wait_for_dev /dev/resume; rm -f -- "$job" "%s/initqueue/settled/resume.sh";\n' "$hookdir"
         } >> "$hookdir"/initqueue/timeout/resume.sh
 
-        mv /lib/dracut/resume.sh /lib/dracut/hooks/pre-mount/10-resume.sh
+        mv /lib/dracut/resume.sh /var/lib/dracut/hooks/pre-mount/10-resume.sh
     else
         {
             if [ -x /usr/sbin/resume ]; then

--- a/modules.d/77dracut-systemd/dracut-cmdline.service
+++ b/modules.d/77dracut-systemd/dracut-cmdline.service
@@ -9,7 +9,7 @@ After=systemd-journald.socket
 Wants=systemd-journald.socket
 ConditionPathExists=/usr/lib/initrd-release
 ConditionPathExistsGlob=|/etc/cmdline.d/*.conf
-ConditionDirectoryNotEmpty=|/lib/dracut/hooks/cmdline
+ConditionDirectoryNotEmpty=|/var/lib/dracut/hooks/cmdline
 ConditionKernelCommandLine=|rd.break=cmdline
 Conflicts=shutdown.target emergency.target
 

--- a/modules.d/77dracut-systemd/dracut-mount.service
+++ b/modules.d/77dracut-systemd/dracut-mount.service
@@ -6,7 +6,7 @@ Documentation=man:dracut-mount.service(8) man:dracut.bootup(7)
 After=initrd-root-fs.target initrd-parse-etc.service
 After=dracut-initqueue.service dracut-pre-mount.service
 ConditionPathExists=/usr/lib/initrd-release
-ConditionDirectoryNotEmpty=|/lib/dracut/hooks/mount
+ConditionDirectoryNotEmpty=|/var/lib/dracut/hooks/mount
 ConditionKernelCommandLine=|rd.break=mount
 DefaultDependencies=no
 Conflicts=shutdown.target emergency.target

--- a/modules.d/77dracut-systemd/dracut-pre-mount.service
+++ b/modules.d/77dracut-systemd/dracut-pre-mount.service
@@ -7,7 +7,7 @@ DefaultDependencies=no
 Before=initrd-root-fs.target sysroot.mount systemd-fsck-root.service
 After=dracut-initqueue.service cryptsetup.target
 ConditionPathExists=/usr/lib/initrd-release
-ConditionDirectoryNotEmpty=|/lib/dracut/hooks/pre-mount
+ConditionDirectoryNotEmpty=|/var/lib/dracut/hooks/pre-mount
 ConditionKernelCommandLine=|rd.break=pre-mount
 Conflicts=shutdown.target emergency.target
 

--- a/modules.d/77dracut-systemd/dracut-pre-pivot.service
+++ b/modules.d/77dracut-systemd/dracut-pre-pivot.service
@@ -10,8 +10,8 @@ Before=initrd-cleanup.service
 Wants=remote-fs.target
 After=remote-fs.target
 ConditionPathExists=/usr/lib/initrd-release
-ConditionDirectoryNotEmpty=|/lib/dracut/hooks/pre-pivot
-ConditionDirectoryNotEmpty=|/lib/dracut/hooks/cleanup
+ConditionDirectoryNotEmpty=|/var/lib/dracut/hooks/pre-pivot
+ConditionDirectoryNotEmpty=|/var/lib/dracut/hooks/cleanup
 ConditionKernelCommandLine=|rd.break=pre-pivot
 ConditionKernelCommandLine=|rd.break=cleanup
 ConditionKernelCommandLine=|rd.break

--- a/modules.d/77dracut-systemd/dracut-pre-trigger.service
+++ b/modules.d/77dracut-systemd/dracut-pre-trigger.service
@@ -8,7 +8,7 @@ Before=systemd-udev-trigger.service dracut-initqueue.service
 After=dracut-pre-udev.service systemd-udevd.service systemd-tmpfiles-setup-dev.service
 Wants=dracut-pre-udev.service systemd-udevd.service
 ConditionPathExists=/usr/lib/initrd-release
-ConditionDirectoryNotEmpty=|/lib/dracut/hooks/pre-trigger
+ConditionDirectoryNotEmpty=|/var/lib/dracut/hooks/pre-trigger
 ConditionKernelCommandLine=|rd.break=pre-trigger
 Conflicts=shutdown.target emergency.target
 

--- a/modules.d/77dracut-systemd/dracut-pre-udev.service
+++ b/modules.d/77dracut-systemd/dracut-pre-udev.service
@@ -8,7 +8,7 @@ Before=systemd-udevd.service dracut-pre-trigger.service
 After=dracut-cmdline.service
 Wants=dracut-cmdline.service
 ConditionPathExists=/usr/lib/initrd-release
-ConditionDirectoryNotEmpty=|/lib/dracut/hooks/pre-udev
+ConditionDirectoryNotEmpty=|/var/lib/dracut/hooks/pre-udev
 ConditionKernelCommandLine=|rd.break=pre-udev
 ConditionKernelCommandLine=|rd.driver.blacklist
 ConditionKernelCommandLine=|rd.driver.pre

--- a/modules.d/80base/dracut-lib.sh
+++ b/modules.d/80base/dracut-lib.sh
@@ -371,14 +371,14 @@ source_all() {
     done
 }
 
-hookdir=/lib/dracut/hooks
+hookdir=/var/lib/dracut/hooks
 export hookdir
 
 source_hook() {
     local _dir
     _dir=$1
     shift
-    source_all "/lib/dracut/hooks/$_dir" "$@"
+    source_all "/var/lib/dracut/hooks/$_dir" "$@"
 }
 
 check_finished() {

--- a/modules.d/80base/module-setup.sh
+++ b/modules.d/80base/module-setup.sh
@@ -135,7 +135,7 @@ install() {
                     export DRACUT_SYSTEMD=1
                 fi
                 export PREFIX="$initdir"
-                export hookdir=/lib/dracut/hooks
+                export hookdir=/var/lib/dracut/hooks
 
                 # shellcheck source=dracut-dev-lib.sh
                 . "$moddir/dracut-dev-lib.sh"

--- a/modules.d/86shutdown/module-setup.sh
+++ b/modules.d/86shutdown/module-setup.sh
@@ -18,6 +18,6 @@ install() {
     ln_r /var/lib/dracut/hooks /lib/dracut/hooks
 
     for _d in $hookdirs shutdown shutdown-emergency; do
-        mkdir -m 0755 -p "${initdir}"/lib/dracut/hooks/"$_d"
+        mkdir -m 0755 -p "${initdir}"/var/lib/dracut/hooks/"$_d"
     done
 }


### PR DESCRIPTION
As requested by @bdrung , I'm separating this commit from https://github.com/dracut-ng/dracut-ng/pull/1752 to simplify the review/merge process.

Commit a45048b80c ("move hooks directory from /usr/lib to /var/lib") moved hooks to /var/lib/dracut/hooks and created a symlink from /lib to avoid the code churn. In preparation to supporting additional hooks locations, finalize the transition and use /var/lib/dracut/hooks everywhere.

No functional change intended.

### Checklist
- [X] I have tested it locally
- [X] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it
