### PR TITLE
test: add commented DEBUGFAIL for debugging

### DIFF
--- a/test/TEST-10-BASIC/test.sh
+++ b/test/TEST-10-BASIC/test.sh
@@ -3,6 +3,9 @@ set -eu
 # shellcheck disable=SC2034
 TEST_DESCRIPTION="root filesystem on ext4 filesystem"
 
+# Uncomment this to debug failures
+#DEBUGFAIL="rd.debug rd.shell"
+
 test_run() {
     declare -a disk_args=()
     qemu_add_drive disk_args "$TESTDIR"/root.img root

--- a/test/TEST-12-UEFI/test.sh
+++ b/test/TEST-12-UEFI/test.sh
@@ -4,6 +4,9 @@ set -eu
 # shellcheck disable=SC2034
 TEST_DESCRIPTION="UEFI boot (ukify, kernel-install)"
 
+# Uncomment this to debug failures
+#DEBUGFAIL="rd.debug rd.shell"
+
 test_check() {
     if ! type -p mksquashfs &> /dev/null; then
         echo "Test needs mksquashfs... Skipping"

--- a/test/TEST-13-SYSROOT/test.sh
+++ b/test/TEST-13-SYSROOT/test.sh
@@ -3,6 +3,9 @@ set -eu
 # shellcheck disable=SC2034
 TEST_DESCRIPTION="initramfs created from sysroot"
 
+# Uncomment this to debug failures
+#DEBUGFAIL="rd.debug rd.shell"
+
 test_run() {
     declare -a disk_args=()
     qemu_add_drive disk_args "$TESTDIR"/root.img root

--- a/test/TEST-21-OVERLAYFS/test.sh
+++ b/test/TEST-21-OVERLAYFS/test.sh
@@ -3,6 +3,9 @@ set -eu
 # shellcheck disable=SC2034
 TEST_DESCRIPTION="Test overlayfs module with persistent device overlay"
 
+# Uncomment this to debug failures
+#DEBUGFAIL="rd.debug rd.shell"
+
 client_run() {
     local test_name="$1"
     shift

--- a/test/TEST-43-KERNEL-INSTALL/test.sh
+++ b/test/TEST-43-KERNEL-INSTALL/test.sh
@@ -3,6 +3,9 @@ set -eu
 # shellcheck disable=SC2034
 TEST_DESCRIPTION="kernel-install with root filesystem on ext4 filesystem"
 
+# Uncomment this to debug failures
+#DEBUGFAIL="rd.debug rd.shell"
+
 test_check() {
     if ! command -v kernel-install > /dev/null; then
         echo "This test needs kernel-install to run."

--- a/test/TEST-50-NETWORK/test.sh
+++ b/test/TEST-50-NETWORK/test.sh
@@ -6,6 +6,9 @@ set -e
 # shellcheck disable=SC2034
 TEST_DESCRIPTION="bring up network without netroot set with $USE_NETWORK"
 
+# Uncomment this to debug failures
+#DEBUGFAIL="rd.debug rd.shell"
+
 test_run() {
     declare -a disk_args=()
     qemu_add_drive disk_args "$TESTDIR"/root.img root


### PR DESCRIPTION
To ease debugging add a commented `DEBUGFAIL` to all test cases. Uncommenting `DEBUGFAIL` will be the first step of debugging in case the logs are not enough.

<!-- This pull request changes... -->

<!-- Fixes: https://github.com/dracut-ng/dracut-ng/issues/<number> -->

### Checklist
- [x] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it
