### PR TITLE
Switch to /usr/lib from /lib for hooks

### DIFF
--- a/doc_site/modules/ROOT/pages/developer/modules.adoc
+++ b/doc_site/modules/ROOT/pages/developer/modules.adoc
@@ -125,8 +125,8 @@ You are encouraged to provide a `README` that describes what the module is for.
 
 Dracut init looks for custom hook scripts in the following locations
 (`HOOKDIR` below): `/var/lib/dracut/hooks`, `/etc/dracut/hooks`, and
-`/lib/dracut/hooks`. The intended use of these locations is: standard,
-distribution shipped scripts are put to `/lib/dracut/hooks`;
+`/usr/lib/dracut/hooks`. The intended use of these locations is: standard,
+distribution shipped scripts are put to `/usr/lib/dracut/hooks`;
 `/etc/dracut/hooks` is used as a local override; dracut modules create
 (and remove) scripts in runtime in `/var/lib/dracut/hooks` (and `$hookdir`
 variable is provided). The following hook points to inject scripts are

--- a/man/dracut.modules.7.adoc
+++ b/man/dracut.modules.7.adoc
@@ -50,13 +50,13 @@ Common used functions are in _dracut-lib.sh_, which can be sourced by any script
 dracut looks for custom hook scripts in subdirectories (cmdline, pre-udev,
 pre-trigger, initqueue, pre-mount, mount, pre-pivot, cleanup) of the following
 locations:  _/var/lib/dracut/hooks_, _/etc/dracut/hooks_, and
-_/lib/dracut/hooks_. The intended use of these locations is: standard,
-distribution shipped scripts are put to _/lib/dracut/hooks_; _/etc/dracut/hooks_
-is used as a local override; dracut modules create (and remove) scripts in
-runtime in _/var/lib/dracut/hooks_. If a hook with the same name exists in
-multiple locations simultaneously, the most privileged location
+_/usr/lib/dracut/hooks_. The intended use of these locations is: standard,
+distribution shipped scripts are put to _/usr/lib/dracut/hooks_;
+_/etc/dracut/hooks_ is used as a local override; dracut modules create (and
+remove) scripts in runtime in _/var/lib/dracut/hooks_. If a hook with the same
+name exists in multiple locations simultaneously, the most privileged location
 (_/var/lib/dracut/hooks_, then _/etc/dracut/hooks_, and then
-_/lib/dracut/hooks_) wins and only one instance of the hook is executed.
+_/usr/lib/dracut/hooks_) wins and only one instance of the hook is executed.
 
 === Hook: cmdline
 

--- a/modules.d/77dracut-systemd/dracut-cmdline.service
+++ b/modules.d/77dracut-systemd/dracut-cmdline.service
@@ -11,7 +11,7 @@ ConditionPathExists=/usr/lib/initrd-release
 ConditionPathExistsGlob=|/etc/cmdline.d/*.conf
 ConditionDirectoryNotEmpty=|/var/lib/dracut/hooks/cmdline
 ConditionDirectoryNotEmpty=|/etc/dracut/hooks/cmdline
-ConditionDirectoryNotEmpty=|/lib/dracut/hooks/cmdline
+ConditionDirectoryNotEmpty=|/usr/lib/dracut/hooks/cmdline
 ConditionKernelCommandLine=|rd.break=cmdline
 Conflicts=shutdown.target emergency.target
 

--- a/modules.d/77dracut-systemd/dracut-mount.service
+++ b/modules.d/77dracut-systemd/dracut-mount.service
@@ -8,7 +8,7 @@ After=dracut-initqueue.service dracut-pre-mount.service
 ConditionPathExists=/usr/lib/initrd-release
 ConditionDirectoryNotEmpty=|/var/lib/dracut/hooks/mount
 ConditionDirectoryNotEmpty=|/etc/dracut/hooks/mount
-ConditionDirectoryNotEmpty=|/lib/dracut/hooks/mount
+ConditionDirectoryNotEmpty=|/usr/lib/dracut/hooks/mount
 ConditionKernelCommandLine=|rd.break=mount
 DefaultDependencies=no
 Conflicts=shutdown.target emergency.target

--- a/modules.d/77dracut-systemd/dracut-pre-mount.service
+++ b/modules.d/77dracut-systemd/dracut-pre-mount.service
@@ -9,7 +9,7 @@ After=dracut-initqueue.service cryptsetup.target
 ConditionPathExists=/usr/lib/initrd-release
 ConditionDirectoryNotEmpty=|/var/lib/dracut/hooks/pre-mount
 ConditionDirectoryNotEmpty=|/etc/dracut/hooks/pre-mount
-ConditionDirectoryNotEmpty=|/lib/dracut/hooks/pre-mount
+ConditionDirectoryNotEmpty=|/usr/lib/dracut/hooks/pre-mount
 ConditionKernelCommandLine=|rd.break=pre-mount
 Conflicts=shutdown.target emergency.target
 

--- a/modules.d/77dracut-systemd/dracut-pre-pivot.service
+++ b/modules.d/77dracut-systemd/dracut-pre-pivot.service
@@ -12,10 +12,10 @@ After=remote-fs.target
 ConditionPathExists=/usr/lib/initrd-release
 ConditionDirectoryNotEmpty=|/var/lib/dracut/hooks/pre-pivot
 ConditionDirectoryNotEmpty=|/etc/dracut/hooks/pre-pivot
-ConditionDirectoryNotEmpty=|/lib/dracut/hooks/pre-pivot
+ConditionDirectoryNotEmpty=|/usr/lib/dracut/hooks/pre-pivot
 ConditionDirectoryNotEmpty=|/var/lib/dracut/hooks/cleanup
 ConditionDirectoryNotEmpty=|/etc/dracut/hooks/cleanup
-ConditionDirectoryNotEmpty=|/lib/dracut/hooks/cleanup
+ConditionDirectoryNotEmpty=|/usr/lib/dracut/hooks/cleanup
 ConditionKernelCommandLine=|rd.break=pre-pivot
 ConditionKernelCommandLine=|rd.break=cleanup
 ConditionKernelCommandLine=|rd.break

--- a/modules.d/77dracut-systemd/dracut-pre-trigger.service
+++ b/modules.d/77dracut-systemd/dracut-pre-trigger.service
@@ -10,7 +10,7 @@ Wants=dracut-pre-udev.service systemd-udevd.service
 ConditionPathExists=/usr/lib/initrd-release
 ConditionDirectoryNotEmpty=|/var/lib/dracut/hooks/pre-trigger
 ConditionDirectoryNotEmpty=|/etc/dracut/hooks/pre-trigger
-ConditionDirectoryNotEmpty=|/lib/dracut/hooks/pre-trigger
+ConditionDirectoryNotEmpty=|/usr/lib/dracut/hooks/pre-trigger
 ConditionKernelCommandLine=|rd.break=pre-trigger
 Conflicts=shutdown.target emergency.target
 

--- a/modules.d/77dracut-systemd/dracut-pre-udev.service
+++ b/modules.d/77dracut-systemd/dracut-pre-udev.service
@@ -10,7 +10,7 @@ Wants=dracut-cmdline.service
 ConditionPathExists=/usr/lib/initrd-release
 ConditionDirectoryNotEmpty=|/var/lib/dracut/hooks/pre-udev
 ConditionDirectoryNotEmpty=|/etc/dracut/hooks/pre-udev
-ConditionDirectoryNotEmpty=|/lib/dracut/hooks/pre-udev
+ConditionDirectoryNotEmpty=|/usr/lib/dracut/hooks/pre-udev
 ConditionKernelCommandLine=|rd.break=pre-udev
 ConditionKernelCommandLine=|rd.driver.blacklist
 ConditionKernelCommandLine=|rd.driver.pre

--- a/modules.d/80base/dracut-lib.sh
+++ b/modules.d/80base/dracut-lib.sh
@@ -375,7 +375,7 @@ list_hooks() {
 
     # It is allowed to override hooks by creating a file with the same name
     # in a directory which has higher priority. '/var/lib/dracut/hooks' gets top
-    # priority, '/etc/dracut/hooks' comes after and '/lib/dracut/hooks' is the
+    # priority, '/etc/dracut/hooks' comes after and '/usr/lib/dracut/hooks' is the
     # least priviliged location.
     for hook in "/var/lib/dracut/hooks/$dir/"$pattern; do
         [ -f "$hook" ] && echo "$hook"
@@ -383,7 +383,7 @@ list_hooks() {
     for hook in "/etc/dracut/hooks/$dir/"$pattern; do
         [ -f "$hook" ] && [ ! -f "/var/lib/dracut/hooks/$dir/${hook##*/}" ] && echo "$hook"
     done
-    for hook in "/lib/dracut/hooks/$dir/"$pattern; do
+    for hook in "/usr/lib/dracut/hooks/$dir/"$pattern; do
         [ -f "$hook" ] && [ ! -f "/var/lib/dracut/hooks/$dir/${hook##*/}" ] \
             && [ ! -f "/etc/dracut/hooks/$dir/${hook##*/}" ] && echo "$hook"
     done

--- a/test/TEST-11-USR-MOUNT/test.sh
+++ b/test/TEST-11-USR-MOUNT/test.sh
@@ -53,7 +53,7 @@ test_setup() {
     call_dracut -i "$TESTDIR"/overlay / \
         --add-confdir test-makeroot \
         -I "mkfs.btrfs" \
-        -i ./create-root.sh /lib/dracut/hooks/initqueue/01-create-root.sh \
+        -i ./create-root.sh /usr/lib/dracut/hooks/initqueue/01-create-root.sh \
         -f "$TESTDIR"/initramfs.makeroot
 
     # Create the blank file to use as a root filesystem

--- a/test/TEST-14-HOOKS/test.sh
+++ b/test/TEST-14-HOOKS/test.sh
@@ -33,32 +33,32 @@ test_setup() {
         # Create hooks with different names. All of them must execute.
         add_hook "/var/lib/dracut/hooks/$hookdir/testhook-difname-var.sh"
         add_hook "/etc/dracut/hooks/$hookdir/testhook-difname-etc.sh"
-        add_hook "/lib/dracut/hooks/$hookdir/testhook-difname-lib.sh"
+        add_hook "/usr/lib/dracut/hooks/$hookdir/testhook-difname-lib.sh"
         expected_hooks_run+=(
             "/var/lib/dracut/hooks/$hookdir/testhook-difname-var.sh"
             "/etc/dracut/hooks/$hookdir/testhook-difname-etc.sh"
-            "/lib/dracut/hooks/$hookdir/testhook-difname-lib.sh"
+            "/usr/lib/dracut/hooks/$hookdir/testhook-difname-lib.sh"
         )
 
         # Create hooks with the same name. Only the highest priority ones must execute.
         add_hook "/var/lib/dracut/hooks/$hookdir/testhook-samename3.sh"
         add_hook "/etc/dracut/hooks/$hookdir/testhook-samename3.sh"
-        add_hook "/lib/dracut/hooks/$hookdir/testhook-samename3.sh"
+        add_hook "/usr/lib/dracut/hooks/$hookdir/testhook-samename3.sh"
         expected_hooks_run+=(
             "/var/lib/dracut/hooks/$hookdir/testhook-samename3.sh"
         )
         expected_hooks_not_run+=(
             "/etc/dracut/hooks/$hookdir/testhook-samename3.sh"
-            "/lib/dracut/hooks/$hookdir/testhook-samename3.sh"
+            "/usr/lib/dracut/hooks/$hookdir/testhook-samename3.sh"
         )
 
         add_hook "/etc/dracut/hooks/$hookdir/testhook-samename2.sh"
-        add_hook "/lib/dracut/hooks/$hookdir/testhook-samename2.sh"
+        add_hook "/usr/lib/dracut/hooks/$hookdir/testhook-samename2.sh"
         expected_hooks_run+=(
             "/etc/dracut/hooks/$hookdir/testhook-samename2.sh"
         )
         expected_hooks_not_run+=(
-            "/lib/dracut/hooks/$hookdir/testhook-samename2.sh"
+            "/usr/lib/dracut/hooks/$hookdir/testhook-samename2.sh"
         )
     done
 

--- a/test/TEST-20-STORAGE/test.sh
+++ b/test/TEST-20-STORAGE/test.sh
@@ -127,7 +127,7 @@ test_setup() {
         $(if command -v mdadm > /dev/null; then echo "-a mdraid"; fi) \
         $(if command -v cryptsetup > /dev/null; then echo "-a crypt -I cryptsetup"; fi) \
         $(if [ "$TEST_FSTYPE" = "zfs" ]; then echo "-a zfs"; else echo "-I mkfs.${TEST_FSTYPE} --add-drivers ${TEST_FSTYPE}"; fi) \
-        -i ./create-root.sh /lib/dracut/hooks/initqueue/01-create-root.sh \
+        -i ./create-root.sh /usr/lib/dracut/hooks/initqueue/01-create-root.sh \
         -f "$TESTDIR"/initramfs.makeroot
 
     # LVM

--- a/test/TEST-26-ENC-RAID-LVM/test.sh
+++ b/test/TEST-26-ENC-RAID-LVM/test.sh
@@ -58,7 +58,7 @@ test_setup() {
         --add-confdir test-makeroot \
         -a "bash crypt lvm mdraid" \
         -I "grep cryptsetup" \
-        -i ./create-root.sh /lib/dracut/hooks/initqueue/01-create-root.sh \
+        -i ./create-root.sh /usr/lib/dracut/hooks/initqueue/01-create-root.sh \
         -f "$TESTDIR"/initramfs.makeroot
 
     # Create the blank files to use as a root filesystem

--- a/test/TEST-40-SYSTEMD/test.sh
+++ b/test/TEST-40-SYSTEMD/test.sh
@@ -34,7 +34,7 @@ test_setup() {
         --omit "fido2 initqueue" \
         --omit-drivers 'a b c d e f g h i j k l m n o p q r s t u v w x y z' \
         -I systemd-analyze \
-        -i ./systemd-analyze.sh /lib/dracut/hooks/pre-pivot/00-systemd-analyze.sh \
+        -i ./systemd-analyze.sh /usr/lib/dracut/hooks/pre-pivot/00-systemd-analyze.sh \
         -i "/bin/true" "/usr/bin/man"
 
     # shellcheck disable=SC2144 # We're not installing multilib libfido2, so

--- a/test/TEST-41-FULL-SYSTEMD/test.sh
+++ b/test/TEST-41-FULL-SYSTEMD/test.sh
@@ -86,7 +86,7 @@ test_setup() {
         --add-confdir test-makeroot \
         -a "btrfs crypt" \
         -I "mkfs.btrfs cryptsetup" \
-        -i ./create-root.sh /lib/dracut/hooks/initqueue/01-create-root.sh \
+        -i ./create-root.sh /usr/lib/dracut/hooks/initqueue/01-create-root.sh \
         -f "$TESTDIR"/initramfs.makeroot
 
     KVERSION=$(determine_kernel_version "$TESTDIR"/initramfs.makeroot)

--- a/test/TEST-60-NFS/test.sh
+++ b/test/TEST-60-NFS/test.sh
@@ -266,7 +266,7 @@ test_setup() {
     call_dracut \
         -a "bash qemu-net $USE_NETWORK ${SERVER_DEBUG:+debug}" \
         --include ./server.link /etc/systemd/network/01-server.link \
-        --include ./wait-if-server.sh /lib/dracut/hooks/pre-mount/99-wait-if-server.sh \
+        --include ./wait-if-server.sh /usr/lib/dracut/hooks/pre-mount/99-wait-if-server.sh \
         -N \
         -f "$TESTDIR"/initramfs.server
 }

--- a/test/TEST-70-ISCSI/test.sh
+++ b/test/TEST-70-ISCSI/test.sh
@@ -137,7 +137,7 @@ test_setup() {
         --add-confdir test-makeroot \
         -a "crypt lvm mdraid" \
         -I "setsid blockdev" \
-        -i ./create-client-root.sh /lib/dracut/hooks/initqueue/01-create-client-root.sh \
+        -i ./create-client-root.sh /usr/lib/dracut/hooks/initqueue/01-create-client-root.sh \
         -f "$TESTDIR"/initramfs.makeroot
     rm -rf -- "$TESTDIR"/overlay
 
@@ -177,7 +177,7 @@ test_setup() {
         -a "qemu-net $USE_NETWORK" \
         --add-confdir test \
         -i "./server.link" "/etc/systemd/network/01-server.link" \
-        -i ./wait-if-server.sh /lib/dracut/hooks/pre-mount/99-wait-if-server.sh \
+        -i ./wait-if-server.sh /usr/lib/dracut/hooks/pre-mount/99-wait-if-server.sh \
         -N \
         -f "$TESTDIR"/initramfs.server
 

--- a/test/TEST-71-ISCSI-MULTI/test.sh
+++ b/test/TEST-71-ISCSI-MULTI/test.sh
@@ -146,7 +146,7 @@ test_setup() {
         --add-confdir test-makeroot \
         -a "crypt lvm mdraid" \
         -I "setsid blockdev" \
-        -i ./create-client-root.sh /lib/dracut/hooks/initqueue/01-create-client-root.sh \
+        -i ./create-client-root.sh /usr/lib/dracut/hooks/initqueue/01-create-client-root.sh \
         -f "$TESTDIR"/initramfs.makeroot
     rm -rf -- "$TESTDIR"/overlay
 
@@ -195,7 +195,7 @@ test_setup() {
         --add-confdir test \
         -a "qemu-net $USE_NETWORK ${SERVER_DEBUG:+debug}" \
         -i "./server.link" "/etc/systemd/network/01-server.link" \
-        -i "./wait-if-server.sh" "/lib/dracut/hooks/pre-mount/99-wait-if-server.sh" \
+        -i "./wait-if-server.sh" "/usr/lib/dracut/hooks/pre-mount/99-wait-if-server.sh" \
         -N \
         -f "$TESTDIR"/initramfs.server
 }

--- a/test/TEST-72-NBD/test.sh
+++ b/test/TEST-72-NBD/test.sh
@@ -185,7 +185,7 @@ make_encrypted_root() {
         --add-confdir test-makeroot \
         -a "crypt lvm mdraid" \
         -I "cryptsetup" \
-        -i ./create-encrypted-root.sh /lib/dracut/hooks/initqueue/01-create-encrypted-root.sh \
+        -i ./create-encrypted-root.sh /usr/lib/dracut/hooks/initqueue/01-create-encrypted-root.sh \
         -f "$TESTDIR"/initramfs.makeroot
     rm -rf -- "$TESTDIR"/overlay
 
@@ -272,7 +272,7 @@ test_setup() {
         --add-confdir test \
         -a "qemu-net $USE_NETWORK ${SERVER_DEBUG:+debug}" \
         -i "./server.link" "/etc/systemd/network/01-server.link" \
-        -i "./wait-if-server.sh" "/lib/dracut/hooks/pre-mount/99-wait-if-server.sh" \
+        -i "./wait-if-server.sh" "/usr/lib/dracut/hooks/pre-mount/99-wait-if-server.sh" \
         -f "$TESTDIR"/initramfs.server
 }
 

--- a/test/TEST-82-DRACUT-CPIO/test.sh
+++ b/test/TEST-82-DRACUT-CPIO/test.sh
@@ -31,7 +31,7 @@ EOF
         --no-kernel --drivers "" \
         --add-confdir "test" \
         "${dracut_cpio_params[@]}" \
-        --include "$tdir/init.sh" /lib/dracut/hooks/emergency/00-init.sh \
+        --include "$tdir/init.sh" /usr/lib/dracut/hooks/emergency/00-init.sh \
         --install "poweroff" \
         "$tdir/initramfs"
 


### PR DESCRIPTION
As suggested by @Conan-Kudo on https://github.com/dracut-ng/dracut-ng/pull/1752 we
can use the opportunity and remove one more hardcoded /lib thing by moving distro shipped 
hooks location to /usr/lib.

### Checklist
- [X] I have tested it locally
- [X] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it
