### PR TITLE
test: use mksquashfs -no-progress consistently

### DIFF
--- a/test/TEST-30-DMSQUASH/test.sh
+++ b/test/TEST-30-DMSQUASH/test.sh
@@ -100,7 +100,7 @@ test_setup() {
     rm -rf "$TESTDIR"/rootfs/proc "$TESTDIR"/rootfs/sys "$TESTDIR"/rootfs/dev
 
     mkdir -p "$TESTDIR"/live/LiveOS
-    mksquashfs "$TESTDIR"/rootfs/ "$TESTDIR"/live/LiveOS/rootfs.img -quiet
+    mksquashfs "$TESTDIR"/rootfs/ "$TESTDIR"/live/LiveOS/rootfs.img -quiet -no-progress
 
     # Create the blank file to use as a root filesystem
     declare -a disk_args=()

--- a/test/TEST-31-LIVENET/test.sh
+++ b/test/TEST-31-LIVENET/test.sh
@@ -42,7 +42,7 @@ test_run() {
 
 test_setup() {
     build_client_rootfs "$TESTDIR/rootfs"
-    mksquashfs "$TESTDIR/rootfs" "$TESTDIR/root.squashfs" -quiet
+    mksquashfs "$TESTDIR/rootfs" "$TESTDIR/root.squashfs" -quiet -no-progress
 
     test_dracut -a "livenet" --no-hostonly
 }


### PR DESCRIPTION
`mksquashfs` shows a progress bar by default. Test 12 calls `mksquashfs` with `-no-progress` to hide the progress bar.

Use this parameter for all test cases that call `mksquashfs`.

<!-- This pull request changes... -->

<!-- Fixes: https://github.com/dracut-ng/dracut-ng/issues/<number> -->

### Checklist
- [x] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it
