### PR TITLE
fix(crypt-gpg): support missing /etc/dracut.conf.d

### DIFF
--- a/modules.d/73crypt-gpg/module-setup.sh
+++ b/modules.d/73crypt-gpg/module-setup.sh
@@ -38,6 +38,7 @@ install() {
 }
 
 sc_public_key() {
+    [ -d /etc/dracut.conf.d ] || return 0
     find /etc/dracut.conf.d -maxdepth 1 -type f -iname 'crypt-public-key*.gpg' -print0
 }
 


### PR DESCRIPTION
The directory `/etc/dracut.conf.d` might not exist. `crypt-gpg` will cause this error message (seen on `gentoo:latest` test 10):

```
find: '/etc/dracut.conf.d': No such file or directory
```

Support this case.

<!-- This pull request changes... -->

<!-- Fixes: https://github.com/dracut-ng/dracut-ng/issues/<number> -->

### Checklist
- [x] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it
