### PR TITLE
fix: avoid leading spaces in systemd units

### DIFF
--- a/modules.d/16dbus-broker/module-setup.sh
+++ b/modules.d/16dbus-broker/module-setup.sh
@@ -55,9 +55,7 @@ install() {
 
     # Adjusting dependencies for initramfs in the dbus socket unit.
     sed -i -e \
-        '/^\[Unit\]/aDefaultDependencies=no\
-        Conflicts=shutdown.target\
-        Before=shutdown.target
+        '/^\[Unit\]/aDefaultDependencies=no\nConflicts=shutdown.target\nBefore=shutdown.target
         /^\[Socket\]/aRemoveOnStop=yes' \
         "$initdir$systemdsystemunitdir/dbus.socket"
 

--- a/modules.d/16dbus-daemon/module-setup.sh
+++ b/modules.d/16dbus-daemon/module-setup.sh
@@ -52,16 +52,12 @@ install() {
 
     # Adjusting dependencies for initramfs in the dbus service unit.
     sed -i -e \
-        '/^\[Unit\]/aDefaultDependencies=no\
-        Conflicts=shutdown.target\
-        Before=shutdown.target' \
+        '/^\[Unit\]/aDefaultDependencies=no\nConflicts=shutdown.target\nBefore=shutdown.target' \
         "$initdir$systemdsystemunitdir/dbus.service"
 
     # Adjusting dependencies for initramfs in the dbus socket unit.
     sed -i -e \
-        '/^\[Unit\]/aDefaultDependencies=no\
-        Conflicts=shutdown.target\
-        Before=shutdown.target
+        '/^\[Unit\]/aDefaultDependencies=no\nConflicts=shutdown.target\nBefore=shutdown.target
         /^\[Socket\]/aRemoveOnStop=yes' \
         "$initdir$systemdsystemunitdir/dbus.socket"
 

--- a/modules.d/70bluetooth/module-setup.sh
+++ b/modules.d/70bluetooth/module-setup.sh
@@ -82,10 +82,7 @@ install() {
     inst_rules 69-btattach-bcm.rules 60-persistent-input.rules
 
     sed -i -e \
-        '/^\[Unit\]/aDefaultDependencies=no\
-        Conflicts=shutdown.target\
-        Before=shutdown.target\
-        After=dbus.service' \
+        '/^\[Unit\]/aDefaultDependencies=no\nConflicts=shutdown.target\nBefore=shutdown.target\nAfter=dbus.service' \
         "${initdir}/${systemdsystemunitdir}/bluetooth.service"
 
     $SYSTEMCTL -q --root "$initdir" enable bluetooth.service


### PR DESCRIPTION
Some `sed` commands insert multiple lines into systemd units. Using backslash followed by a newline and spaces (for indentation) will include those spaces in the systemd unit.

Use `\n` instead to remove those leading spaces.

<!-- This pull request changes... -->

<!-- Fixes: https://github.com/dracut-ng/dracut-ng/issues/<number> -->

### Checklist
- [x] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it
