### PR TITLE
ci: no need to explicitly add qemu-net anymore

### DIFF
--- a/test/TEST-30-DMSQUASH/test.sh
+++ b/test/TEST-30-DMSQUASH/test.sh
@@ -134,7 +134,7 @@ EOF
         mkfs.ext4 -q -L dracut_iso -d "$TESTDIR"/iso/ "$TESTDIR"/root_iso.img
     fi
 
-    local dracut_modules="dmsquash-live-autooverlay convertfs pollcdrom kernel-modules kernel-modules-extra qemu qemu-net"
+    local dracut_modules="dmsquash-live-autooverlay convertfs pollcdrom kernel-modules kernel-modules-extra qemu"
 
     if type -p ntfs-3g &> /dev/null; then
         dracut_modules="$dracut_modules dmsquash-live-ntfs"

--- a/test/TEST-60-NFS/test.sh
+++ b/test/TEST-60-NFS/test.sh
@@ -260,11 +260,11 @@ test_setup() {
     test_dracut \
         --no-hostonly \
         --include ./client.link /etc/systemd/network/01-client.link \
-        -a "watchdog dmsquash-live qemu-net ${USE_NETWORK}"
+        -a "watchdog dmsquash-live ${USE_NETWORK}"
 
     # Make server's dracut image
     call_dracut \
-        -a "bash qemu-net $USE_NETWORK ${SERVER_DEBUG:+debug}" \
+        -a "bash $USE_NETWORK ${SERVER_DEBUG:+debug}" \
         --include ./server.link /etc/systemd/network/01-server.link \
         --include ./wait-if-server.sh /lib/dracut/hooks/pre-mount/99-wait-if-server.sh \
         -N \

--- a/test/TEST-70-ISCSI/test.sh
+++ b/test/TEST-70-ISCSI/test.sh
@@ -174,7 +174,7 @@ test_setup() {
 
     # Make server's dracut image
     call_dracut \
-        -a "qemu-net $USE_NETWORK" \
+        -a "$USE_NETWORK" \
         --add-confdir test \
         -i "./server.link" "/etc/systemd/network/01-server.link" \
         -i ./wait-if-server.sh /lib/dracut/hooks/pre-mount/99-wait-if-server.sh \
@@ -184,7 +184,7 @@ test_setup() {
     # Make client's dracut image
     test_dracut \
         --no-hostonly \
-        --add "watchdog qemu-net $USE_NETWORK" \
+        --add "watchdog $USE_NETWORK" \
         --include "./client-persistent-lan0.link" "/etc/systemd/network/01-persistent-lan0.link" \
         --include "./client-persistent-lan1.link" "/etc/systemd/network/01-persistent-lan1.link" \
         --kernel-cmdline "rw rd.auto"

--- a/test/TEST-71-ISCSI-MULTI/test.sh
+++ b/test/TEST-71-ISCSI-MULTI/test.sh
@@ -186,14 +186,14 @@ test_setup() {
     # Make client's dracut image
     test_dracut \
         --no-hostonly \
-        --add "watchdog qemu-net $USE_NETWORK" \
+        --add "watchdog $USE_NETWORK" \
         -i ./client-persistent-lan0.link /etc/systemd/network/01-persistent-lan0.link \
         -i ./client-persistent-lan1.link /etc/systemd/network/01-persistent-lan1.link
 
     # Make server's dracut image
     call_dracut \
         --add-confdir test \
-        -a "qemu-net $USE_NETWORK ${SERVER_DEBUG:+debug}" \
+        -a "$USE_NETWORK ${SERVER_DEBUG:+debug}" \
         -i "./server.link" "/etc/systemd/network/01-server.link" \
         -i "./wait-if-server.sh" "/lib/dracut/hooks/pre-mount/99-wait-if-server.sh" \
         -N \

--- a/test/TEST-72-NBD/test.sh
+++ b/test/TEST-72-NBD/test.sh
@@ -263,14 +263,14 @@ test_setup() {
 
     test_dracut \
         --no-hostonly \
-        -a "watchdog qemu-net ${USE_NETWORK}" \
+        -a "watchdog ${USE_NETWORK}" \
         -i "./client.link" "/etc/systemd/network/01-client.link" \
         -i "/tmp/crypttab" "/etc/crypttab" \
         -i "/tmp/key" "/etc/key"
 
     call_dracut -N \
         --add-confdir test \
-        -a "qemu-net $USE_NETWORK ${SERVER_DEBUG:+debug}" \
+        -a "$USE_NETWORK ${SERVER_DEBUG:+debug}" \
         -i "./server.link" "/etc/systemd/network/01-server.link" \
         -i "./wait-if-server.sh" "/lib/dracut/hooks/pre-mount/99-wait-if-server.sh" \
         -f "$TESTDIR"/initramfs.server


### PR DESCRIPTION
Commit 94b21ab enables dracut to automatically detect when qemu-net is required.

Ensure this condition is covered by CI by removing qemu-net from the dracut module lists.

<!-- This pull request changes... -->

<!-- Fixes: https://github.com/dracut-ng/dracut-ng/issues/<number> -->

### Checklist
- [ ] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it
