### PR TITLE
fix(dracut-install): resolve dependencies even if not executable

### DIFF
--- a/src/install/dracut-install.c
+++ b/src/install/dracut-install.c
@@ -1392,7 +1392,6 @@ static int dracut_install(const char *orig_src, const char *orig_dst, bool isdir
         int ret;
         bool src_islink = false;
         bool src_isdir = false;
-        mode_t src_mode = 0;
         char *hash_path = NULL;
         const char *src, *dst;
 
@@ -1438,7 +1437,6 @@ static int dracut_install(const char *orig_src, const char *orig_dst, bool isdir
         } else {
                 src_islink = S_ISLNK(sb.st_mode);
                 src_isdir = S_ISDIR(sb.st_mode);
-                src_mode = sb.st_mode;
         }
 
         /* The install hasn't succeeded yet, but mark this item as successful
@@ -1461,7 +1459,7 @@ static int dracut_install(const char *orig_src, const char *orig_dst, bool isdir
                         return 1;
                 }
 
-                if (resolvedeps && S_ISREG(sb.st_mode) && (sb.st_mode & (S_IXUSR | S_IXGRP | S_IXOTH))) {
+                if (resolvedeps && S_ISREG(sb.st_mode)) {
                         log_debug("'%s' already exists, but checking for any deps", fulldstpath);
                         if (sysrootdirlen && (strncmp(fulldstpath, sysrootdir, sysrootdirlen) == 0))
                                 ret = resolve_deps(fulldstpath + sysrootdirlen, NULL);
@@ -1547,18 +1545,16 @@ static int dracut_install(const char *orig_src, const char *orig_dst, bool isdir
                         return 0;
                 }
 
-                if (src_mode & (S_IXUSR | S_IXGRP | S_IXOTH)) {
-                        if (resolvedeps) {
-                                /* ensure fullsrcpath contains sysrootdir */
-                                if (sysrootdirlen && (strncmp(fullsrcpath, sysrootdir, sysrootdirlen) == 0))
-                                        ret += resolve_deps(fullsrcpath + sysrootdirlen, NULL);
-                                else
-                                        ret += resolve_deps(fullsrcpath, NULL);
-                        }
-                        if (arg_hmac) {
-                                /* copy .hmac files also */
-                                hmac_install(src, dst, NULL);
-                        }
+                if (resolvedeps) {
+                        /* ensure fullsrcpath contains sysrootdir */
+                        if (sysrootdirlen && (strncmp(fullsrcpath, sysrootdir, sysrootdirlen) == 0))
+                                ret += resolve_deps(fullsrcpath + sysrootdirlen, NULL);
+                        else
+                                ret += resolve_deps(fullsrcpath, NULL);
+                }
+                if (arg_hmac) {
+                        /* copy .hmac files also */
+                        hmac_install(src, dst, NULL);
                 }
 
                 log_debug("dracut_install ret = %d", ret);


### PR DESCRIPTION
Library files on Debian/Ubuntu are not marked as executable. This causes `dracut-install` to not resolve dependencies:

```
$ ls -l /usr/lib/x86_64-linux-gnu/libarchive.so.13.7.7
-rw-r--r-- 1 root root 874648 Jun 25  2025 /usr/lib/x86_64-linux-gnu/libarchive.so.13.7.7
$ rm -rf foo && mkdir foo
$ ./dracut-install -D foo -l /usr/lib/x86_64-linux-gnu/libarchive.so.13
$ find foo
foo
foo/usr
foo/usr/lib
foo/usr/lib/x86_64-linux-gnu
foo/usr/lib/x86_64-linux-gnu/libarchive.so.13.7.7
foo/usr/lib/x86_64-linux-gnu/libarchive.so.13
```

There is no requirement for library files to be executable. So resolve dependencies all files. `resolve_deps()` will check if the file is either an ELF file or a script.

This will also resolve dependencies of scripts that are not marked executable, which might be an undesired side effect. In this case users are advised to either call `dracut-install` without `-l` or not include those files at all.

Fixes: https://github.com/dracut-ng/dracut-ng/issues/2193

<!-- This pull request changes... -->

<!-- Fixes: https://github.com/dracut-ng/dracut-ng/issues/<number> -->

### Checklist
- [x] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it
