### PR TITLE
fix(dracut): also check libraries when resolving lazy

### DIFF
--- a/dracut.sh
+++ b/dracut.sh
@@ -2860,15 +2860,15 @@ if [[ $kernel_only != yes ]]; then
     fi
 
     if [[ ${DRACUT_RESOLVE_LAZY-} ]] && [[ $DRACUT_INSTALL ]]; then
-        dinfo "*** Resolving executable dependencies ***"
+        dinfo "*** Resolving dependencies for executables and libraries ***"
         # shellcheck disable=SC2086
-        find "$initdir" -type f -perm /0111 -not -name '*.ko*' -print0 \
+        find "$initdir" -type f \( -perm /0111 -or -name '*.so*' \) -not -name '*.ko*' -print0 \
             | xargs -r -0 $DRACUT_INSTALL ${initdir:+-D "$initdir"} ${dracutsysrootdir:+-r "$dracutsysrootdir"} -R ${DRACUT_FIPS_MODE:+-f} --
         # shellcheck disable=SC2181
         if (($? == 0)); then
-            dinfo "*** Resolving executable dependencies done ***"
+            dinfo "*** Resolving dependencies for executables and libraries done ***"
         else
-            dfatal "Resolving executable dependencies failed"
+            dfatal "Resolving dependencies for executables and libraries failed"
             exit 1
         fi
     fi


### PR DESCRIPTION
Dracut might resolve executable dependencies lazy. In this case all libraries are installed without resolving their dependencies.

Later Dracut will resolve dependencies of the included executables, but it will not explicitly check libraries. This will miss resolving dependencies of libraries that are used via `dlopen()`.

Fixes: https://github.com/dracut-ng/dracut-ng/issues/2193

<!-- This pull request changes... -->

<!-- Fixes: https://github.com/dracut-ng/dracut-ng/issues/<number> -->

### Checklist
- [x] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it
