### PR TITLE
ci: re-run tests 20, 26, 70, and 71 on debian

### DIFF
--- a/.github/workflows/daily-basic.yml
+++ b/.github/workflows/daily-basic.yml
@@ -53,11 +53,6 @@ jobs:
                     # https://github.com/dracut-ng/dracut-ng/issues/1988
                     - container: debian:sid
                       architecture: {runner: 'ubuntu-24.04-arm', tag: 'arm'}
-                    # https://github.com/dracut-ng/dracut-ng/issues/2021
-                    - container: debian:sid
-                      test: "20"
-                    - container: debian:sid
-                      test: "26"
         container:
             image: ghcr.io/dracut-ng/${{ matrix.container }}
             options: '--device=/dev/kvm --privileged'

--- a/.github/workflows/daily-iscsi-x64.yml
+++ b/.github/workflows/daily-iscsi-x64.yml
@@ -26,6 +26,9 @@ jobs:
             fail-fast: false
             matrix:
                 container:
+                    - debian:latest
+                    # https://github.com/dracut-ng/dracut-ng/issues/2199
+                    # - debian:sid
                     - ubuntu:devel
                     - ubuntu:rolling
                 test:


### PR DESCRIPTION
mdadm 4.5-2 introduced a regression:

```
++ mdadm --create /dev/md0 --run --level=1 --metadata=0.90 --raid-devices=2 /dev/mapper/dracut_disk1 /dev/mapper/dracut_disk2
mdadm: Can't open /sys/module/md_mod/parameters/legacy_async_del_gendisk
mdadm: init md module parameters fail
```

This regression has been fixed in mdadm 4.5-3.

Fixes: https://github.com/dracut-ng/dracut-ng/issues/2021

<!-- This pull request changes... -->

<!-- Fixes: https://github.com/dracut-ng/dracut-ng/issues/<number> -->

### Checklist
- [ ] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it
