### PR TITLE
ci: fix wrong indentation in labeler YAML file

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -560,8 +560,8 @@ img-lib:
           - any-glob-to-any-file: 'modules.d/[0-9][0-9]img-lib/*'
 
 memdisk:
-  - changed-files:
-      - any-glob-to-any-file: 'modules.d/[0-9][0-9]memdisk/*'
+    - changed-files:
+          - any-glob-to-any-file: 'modules.d/[0-9][0-9]memdisk/*'
 
 memstrack:
     - changed-files:


### PR DESCRIPTION
```
$ yamllint .
./.github/labeler.yml
  563:3     error    wrong indentation: expected 4 but found 2  (indentation)
  564:7     error    wrong indentation: expected 8 but found 6  (indentation)
```

<!-- This pull request changes... -->

<!-- Fixes: https://github.com/dracut-ng/dracut-ng/issues/<number> -->

### Checklist
- [ ] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it
