### PR TITLE
test: prevent overlay/source being added in test_dracut

### DIFF
--- a/test/TEST-11-USR-MOUNT/test.sh
+++ b/test/TEST-11-USR-MOUNT/test.sh
@@ -66,6 +66,7 @@ test_setup() {
         "${disk_args[@]}" \
         -append "root=/dev/dracut/root quiet" \
         -initrd "$TESTDIR"/initramfs.makeroot
+    rm -rf "$TESTDIR"/overlay
 
     if ! test_marker_check dracut-root-block-created; then
         echo "Could not create root filesystem"

--- a/test/TEST-20-STORAGE/test.sh
+++ b/test/TEST-20-STORAGE/test.sh
@@ -156,6 +156,8 @@ test_setup() {
         chmod 0600 /tmp/key
     fi
 
+    rm -rf "$TESTDIR"/overlay
+
     # shellcheck disable=SC2046
     test_dracut \
         -a "lvm" \

--- a/test/TEST-26-ENC-RAID-LVM/test.sh
+++ b/test/TEST-26-ENC-RAID-LVM/test.sh
@@ -72,6 +72,7 @@ test_setup() {
         -append "root=/dev/fakeroot quiet" \
         -initrd "$TESTDIR"/initramfs.makeroot
     test_marker_check dracut-root-block-created
+    rm -rf "$TESTDIR"/overlay
     cryptoUUIDS=$(grep -F -a -m 3 ID_FS_UUID "$TESTDIR"/marker.img)
     for uuid in $cryptoUUIDS; do
         eval "$uuid"

--- a/test/TEST-41-FULL-SYSTEMD/test.sh
+++ b/test/TEST-41-FULL-SYSTEMD/test.sh
@@ -88,6 +88,7 @@ test_setup() {
         -I "mkfs.btrfs cryptsetup" \
         -i ./create-root.sh /usr/lib/dracut/hooks/initqueue/01-create-root.sh \
         -f "$TESTDIR"/initramfs.makeroot
+    rm -rf "$TESTDIR"/overlay
 
     KVERSION=$(determine_kernel_version "$TESTDIR"/initramfs.makeroot)
 

--- a/test/TEST-44-DRIVERS/test.sh
+++ b/test/TEST-44-DRIVERS/test.sh
@@ -49,6 +49,7 @@ test_setup() {
     mkdir -p "$TESTDIR"/overlay/source/lib/modules "$TESTDIR"/overlay/source/mnt
 
     build_ext4_image "$TESTDIR/overlay/source" "$TESTDIR"/root.img dracut
+    rm -rf "$TESTDIR"/overlay
 
     rm -f "$TESTDIR/mnt.img"
     truncate -s 512M "$TESTDIR/mnt.img"

--- a/test/TEST-70-ISCSI/test.sh
+++ b/test/TEST-70-ISCSI/test.sh
@@ -171,6 +171,7 @@ test_setup() {
     inst_init ./server-init.sh "$TESTDIR"/overlay/source
 
     build_ext4_image "$TESTDIR/overlay/source" "$TESTDIR"/server.img dracut
+    rm -rf "$TESTDIR"/overlay
 
     # Make server's dracut image
     call_dracut \

--- a/test/TEST-71-ISCSI-MULTI/test.sh
+++ b/test/TEST-71-ISCSI-MULTI/test.sh
@@ -182,6 +182,7 @@ test_setup() {
     inst_init ./server-init.sh "$TESTDIR"/overlay/source
 
     build_ext4_image "$TESTDIR/overlay/source" "$TESTDIR"/server.img dracut
+    rm -rf "$TESTDIR"/overlay
 
     # Make client's dracut image
     test_dracut \


### PR DESCRIPTION
The function `test_dracut()` will include `$TESTDIR/overlay` into the test `initramfs.testing` if available. Several tests create `$TESTDIR/overlay/source` for creating rootfs using `test-makeroot`.

Delete `$TESTDIR/overlay` after being used by `test-makeroot` to avoid adding `$TESTDIR/overlay/source` to the client test initrd.

<!-- This pull request changes... -->

<!-- Fixes: https://github.com/dracut-ng/dracut-ng/issues/<number> -->

### Checklist
- [x] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it
