### PR TITLE
test: always call sync before poweroff -f

### DIFF
--- a/test/TEST-11-USR-MOUNT/create-root.sh
+++ b/test/TEST-11-USR-MOUNT/create-root.sh
@@ -16,5 +16,5 @@ btrfs filesystem sync /root
 btrfs subvolume snapshot -r /root /root/snapshot-root
 umount /root
 echo "dracut-root-block-created" | dd oflag=direct of=/dev/disk/by-id/scsi-0QEMU_QEMU_HARDDISK_marker status=none
-sync /dev/disk/by-id/scsi-0QEMU_QEMU_HARDDISK_marker
+sync
 poweroff -f

--- a/test/TEST-20-STORAGE/create-root.sh
+++ b/test/TEST-20-STORAGE/create-root.sh
@@ -86,5 +86,5 @@ fi
     echo "ID_FS_UUID=$ID_FS_UUID"
 } | dd oflag=direct of=/dev/disk/by-id/scsi-0QEMU_QEMU_HARDDISK_marker status=none
 
-sync /dev/disk/by-id/scsi-0QEMU_QEMU_HARDDISK_marker
+sync
 poweroff -f

--- a/test/TEST-26-ENC-RAID-LVM/create-root.sh
+++ b/test/TEST-26-ENC-RAID-LVM/create-root.sh
@@ -33,5 +33,5 @@ cryptsetup luksClose /dev/mapper/dracut_disk2
         udevadm info --query=property --name="$i" | grep -F 'ID_FS_UUID='
     done
 } | dd oflag=direct of=/dev/disk/by-id/scsi-0QEMU_QEMU_HARDDISK_marker status=none
-sync /dev/disk/by-id/scsi-0QEMU_QEMU_HARDDISK_marker
+sync
 poweroff -f

--- a/test/TEST-41-FULL-SYSTEMD/create-root.sh
+++ b/test/TEST-41-FULL-SYSTEMD/create-root.sh
@@ -38,5 +38,5 @@ eval "$(udevadm info --query=property --name=/dev/disk/by-id/scsi-0QEMU_QEMU_HAR
     echo "dracut-root-block-created"
     echo "ID_FS_UUID=$ID_FS_UUID"
 } | dd oflag=direct of=/dev/disk/by-id/scsi-0QEMU_QEMU_HARDDISK_marker status=none
-sync /dev/disk/by-id/scsi-0QEMU_QEMU_HARDDISK_marker
+sync
 poweroff -f

--- a/test/TEST-70-ISCSI/create-client-root.sh
+++ b/test/TEST-70-ISCSI/create-client-root.sh
@@ -17,5 +17,5 @@ lvm lvchange -a n /dev/dracut/root
 mdadm -W /dev/md0 || :
 mdadm --stop /dev/md0
 echo "dracut-root-block-created" | dd oflag=direct of=/dev/disk/by-id/scsi-0QEMU_QEMU_HARDDISK_marker status=none
-sync /dev/disk/by-id/scsi-0QEMU_QEMU_HARDDISK_marker
+sync
 poweroff -f

--- a/test/TEST-71-ISCSI-MULTI/create-client-root.sh
+++ b/test/TEST-71-ISCSI-MULTI/create-client-root.sh
@@ -17,5 +17,5 @@ lvm lvchange -a n /dev/dracut/root
 mdadm -W /dev/md0 || :
 mdadm --stop /dev/md0
 echo "dracut-root-block-created" | dd oflag=direct of=/dev/disk/by-id/scsi-0QEMU_QEMU_HARDDISK_marker status=none
-sync /dev/disk/by-id/scsi-0QEMU_QEMU_HARDDISK_marker
+sync
 poweroff -f

--- a/test/TEST-72-NBD/create-encrypted-root.sh
+++ b/test/TEST-72-NBD/create-encrypted-root.sh
@@ -28,5 +28,5 @@ eval "$(udevadm info --query=property --name=/dev/disk/by-id/scsi-0QEMU_QEMU_HAR
     echo "dracut-root-block-created"
     echo "ID_FS_UUID=$ID_FS_UUID"
 } | dd oflag=direct of=/dev/disk/by-id/scsi-0QEMU_QEMU_HARDDISK_marker status=none
-sync /dev/disk/by-id/scsi-0QEMU_QEMU_HARDDISK_marker
+sync
 poweroff -f


### PR DESCRIPTION
To be on the safe side, call `sync` before calling `poweroff -f` after creating client rootfs in a virtual machine.

<!-- This pull request changes... -->

<!-- Fixes: https://github.com/dracut-ng/dracut-ng/issues/<number> -->

### Checklist
- [ ] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it
