### PR TITLE
test: remove duplicate overlay removal

### DIFF
--- a/test/TEST-71-ISCSI-MULTI/test.sh
+++ b/test/TEST-71-ISCSI-MULTI/test.sh
@@ -164,7 +164,6 @@ test_setup() {
     rm -- "$TESTDIR"/marker.img
 
     # Create server root filesystem
-    rm -rf -- "$TESTDIR"/overlay
     call_dracut --tmpdir "$TESTDIR" \
         --add-confdir test-root \
         -a "$USE_NETWORK iscsi" \

--- a/test/TEST-72-NBD/test.sh
+++ b/test/TEST-72-NBD/test.sh
@@ -203,7 +203,6 @@ make_encrypted_root() {
 }
 
 make_client_root() {
-    rm -fr "$TESTDIR"/overlay
     build_client_rootfs "$TESTDIR/overlay/source"
     inst_multiple ip
     inst_init ./client-init.sh "$TESTDIR"/overlay/source
@@ -251,9 +250,6 @@ test_setup() {
     make_encrypted_root
     make_client_root
     make_server_root
-
-    rm -fr "$TESTDIR"/overlay
-    # Make the test image
 
     # shellcheck source=$TESTDIR/luks.uuid
     . "$TESTDIR"/luks.uuid


### PR DESCRIPTION
Removing `overlay` is done twice. Remove those duplicate calls.

<!-- This pull request changes... -->

<!-- Fixes: https://github.com/dracut-ng/dracut-ng/issues/<number> -->

### Checklist
- [ ] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it
