### PR TITLE
test: rename overlay directory to rootfs

### DIFF
--- a/test/TEST-44-DRIVERS/test.sh
+++ b/test/TEST-44-DRIVERS/test.sh
@@ -38,18 +38,18 @@ test_setup() {
         --mount "/dev/disk/by-id/scsi-0QEMU_QEMU_HARDDISK_mnt /mnt xfs rw" \
         --add-confdir test-root \
         -f "$TESTDIR"/initramfs.root
-    mkdir -p "$TESTDIR"/overlay/source
-    mv "$TESTDIR"/dracut.*/initramfs/* "$TESTDIR"/overlay/source
+    mkdir -p "$TESTDIR"/rootfs
+    mv "$TESTDIR"/dracut.*/initramfs/* "$TESTDIR"/rootfs
     rm -rf "$TESTDIR"/dracut.*
 
     # make sure no linux kernel driver is included in the rootfs
-    rm -rf "$TESTDIR"/overlay/source/lib/modules/*
+    rm -rf "$TESTDIR"/rootfs/lib/modules/*
 
     # make sure /lib/modules directory exists inside the rootfs
-    mkdir -p "$TESTDIR"/overlay/source/lib/modules "$TESTDIR"/overlay/source/mnt
+    mkdir -p "$TESTDIR"/rootfs/lib/modules "$TESTDIR"/rootfs/mnt
 
-    build_ext4_image "$TESTDIR/overlay/source" "$TESTDIR"/root.img dracut
-    rm -rf "$TESTDIR"/overlay
+    build_ext4_image "$TESTDIR/rootfs" "$TESTDIR"/root.img dracut
+    rm -rf "$TESTDIR"/rootfs
 
     rm -f "$TESTDIR/mnt.img"
     truncate -s 512M "$TESTDIR/mnt.img"

--- a/test/TEST-60-NFS/test.sh
+++ b/test/TEST-60-NFS/test.sh
@@ -234,11 +234,11 @@ test_setup() {
         -i "./dhcpd.conf" "/etc/dhcpd.conf" \
         -f "$TESTDIR"/initramfs.root
 
-    mkdir -p "$TESTDIR"/server/overlay/source
-    mv "$TESTDIR"/server/overlay/dracut.*/initramfs/* "$TESTDIR"/server/overlay/source
+    mkdir -p "$TESTDIR"/server-rootfs
+    mv "$TESTDIR"/server/overlay/dracut.*/initramfs/* "$TESTDIR"/server-rootfs
     rm -rf "$TESTDIR"/server/overlay/dracut.*
 
-    export initdir=$TESTDIR/server/overlay/source
+    export initdir=$TESTDIR/server-rootfs
     mkdir -p "$initdir"/var/lib/{dhcpd,rpcbind} "$initdir"/var/lib/nfs/{v4recovery,rpc_pipefs}
     chmod 777 "$initdir"/var/lib/{dhcpd,rpcbind}
     inst_init ./server-init.sh "$initdir"
@@ -247,14 +247,14 @@ test_setup() {
 
     # Make client root inside server root
     # shellcheck disable=SC2031
-    export initdir=$TESTDIR/server/overlay/source/nfs/client
+    export initdir=$TESTDIR/server-rootfs/nfs/client
     mkdir -p "$initdir"
     mv "$TESTDIR"/dracut.*/initramfs/* "$initdir"
     rm -rf "$TESTDIR"/dracut.*
     echo "TEST FETCH FILE" > "$initdir"/root/fetchfile
     inst_init ./client-init.sh "$initdir"
 
-    build_ext4_image "$TESTDIR/server/overlay/source" "$TESTDIR"/server.img dracut
+    build_ext4_image "$TESTDIR/server-rootfs" "$TESTDIR"/server.img dracut
 
     # Make client's dracut image
     test_dracut \

--- a/test/TEST-70-ISCSI/test.sh
+++ b/test/TEST-70-ISCSI/test.sh
@@ -163,15 +163,15 @@ test_setup() {
         --install-optional "/etc/netconfig dhcpd /etc/group /etc/nsswitch.conf /etc/rpc /etc/protocols /etc/services /usr/etc/nsswitch.conf /usr/etc/rpc /usr/etc/protocols /usr/etc/services" \
         -i "./dhcpd.conf" "/etc/dhcpd.conf" \
         -f "$TESTDIR"/initramfs.root
-    mkdir -p "$TESTDIR"/overlay/source
-    mv "$TESTDIR"/dracut.*/initramfs/* "$TESTDIR"/overlay/source
+    mkdir -p "$TESTDIR"/server-rootfs
+    mv "$TESTDIR"/dracut.*/initramfs/* "$TESTDIR"/server-rootfs
     rm -rf "$TESTDIR"/dracut.*
 
-    mkdir -p "$TESTDIR"/overlay/source/var/lib/dhcpd
-    inst_init ./server-init.sh "$TESTDIR"/overlay/source
+    mkdir -p "$TESTDIR"/server-rootfs/var/lib/dhcpd
+    inst_init ./server-init.sh "$TESTDIR"/server-rootfs
 
-    build_ext4_image "$TESTDIR/overlay/source" "$TESTDIR"/server.img dracut
-    rm -rf "$TESTDIR"/overlay
+    build_ext4_image "$TESTDIR/server-rootfs" "$TESTDIR"/server.img dracut
+    rm -rf "$TESTDIR"/server-rootfs
 
     # Make server's dracut image
     call_dracut \

--- a/test/TEST-71-ISCSI-MULTI/test.sh
+++ b/test/TEST-71-ISCSI-MULTI/test.sh
@@ -173,15 +173,15 @@ test_setup() {
         -i /tmp/config /etc/nbd-server/config \
         -i "./dhcpd.conf" "/etc/dhcpd.conf" \
         -f "$TESTDIR"/initramfs.root
-    mkdir -p "$TESTDIR"/overlay/source
-    mv "$TESTDIR"/dracut.*/initramfs/* "$TESTDIR"/overlay/source
+    mkdir -p "$TESTDIR"/server-rootfs
+    mv "$TESTDIR"/dracut.*/initramfs/* "$TESTDIR"/server-rootfs
     rm -rf "$TESTDIR"/dracut.*
 
-    mkdir -p -- "$TESTDIR"/overlay/source/var/lib/dhcpd "$TESTDIR"/overlay/source/etc/iscsi
-    inst_init ./server-init.sh "$TESTDIR"/overlay/source
+    mkdir -p -- "$TESTDIR"/server-rootfs/var/lib/dhcpd "$TESTDIR"/server-rootfs/etc/iscsi
+    inst_init ./server-init.sh "$TESTDIR"/server-rootfs
 
-    build_ext4_image "$TESTDIR/overlay/source" "$TESTDIR"/server.img dracut
-    rm -rf "$TESTDIR"/overlay
+    build_ext4_image "$TESTDIR/server-rootfs" "$TESTDIR"/server.img dracut
+    rm -rf "$TESTDIR"/server-rootfs
 
     # Make client's dracut image
     test_dracut \

--- a/test/TEST-72-NBD/test.sh
+++ b/test/TEST-72-NBD/test.sh
@@ -203,16 +203,16 @@ make_encrypted_root() {
 }
 
 make_client_root() {
-    build_client_rootfs "$TESTDIR/overlay/source"
+    build_client_rootfs "$TESTDIR/client-rootfs"
     inst_multiple ip
-    inst_init ./client-init.sh "$TESTDIR"/overlay/source
+    inst_init ./client-init.sh "$TESTDIR"/client-rootfs
 
-    build_ext4_image "$TESTDIR/overlay/source" "$TESTDIR"/unencrypted.img dracut
-    rm -fr "$TESTDIR"/overlay
+    build_ext4_image "$TESTDIR/client-rootfs" "$TESTDIR"/unencrypted.img dracut
+    rm -fr "$TESTDIR"/client-rootfs
 }
 
 make_server_root() {
-    rm -fr "$TESTDIR"/overlay
+    rm -fr "$TESTDIR"/server-rootfs
 
     cat > /tmp/config << EOF
 [generic]
@@ -235,15 +235,15 @@ EOF
         -i "./dhcpd.conf" "/etc/dhcpd.conf" \
         --no-hostonly \
         -f "$TESTDIR"/initramfs.root
-    mkdir -p "$TESTDIR"/overlay/source
-    mv "$TESTDIR"/dracut.*/initramfs/* "$TESTDIR"/overlay/source
+    mkdir -p "$TESTDIR"/server-rootfs
+    mv "$TESTDIR"/dracut.*/initramfs/* "$TESTDIR"/server-rootfs
     rm -rf "$TESTDIR"/dracut.*
 
-    mkdir -p -- "$TESTDIR"/overlay/source/var/lib/dhcpd "$TESTDIR"/overlay/source/etc/nbd-server
-    inst_init ./server-init.sh "$TESTDIR"/overlay/source
+    mkdir -p -- "$TESTDIR"/server-rootfs/var/lib/dhcpd "$TESTDIR"/server-rootfs/etc/nbd-server
+    inst_init ./server-init.sh "$TESTDIR"/server-rootfs
 
-    build_ext4_image "$TESTDIR/overlay/source" "$TESTDIR"/server.img dracut
-    rm -fr "$TESTDIR"/overlay
+    build_ext4_image "$TESTDIR/server-rootfs" "$TESTDIR"/server.img dracut
+    rm -fr "$TESTDIR"/server-rootfs
 }
 
 test_setup() {


### PR DESCRIPTION
Several tests use `build_ext4_image` to generate a rootfs and do not rely on `test-makeroot` any more (where the `overlay` directory name was used).

To make the test code more readable, rename the `overlay` directory to `rootfs`. In case there are client and server rootfs, use `client-rootfs` and `server-rootfs`.

<!-- This pull request changes... -->

<!-- Fixes: https://github.com/dracut-ng/dracut-ng/issues/<number> -->

### Checklist
- [ ] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it
