### PR TITLE
ci: install diffutils on openSUSE container

### DIFF
--- a/test/container/Dockerfile-opensuse
+++ b/test/container/Dockerfile-opensuse
@@ -20,6 +20,7 @@ RUN zypper --non-interactive install --no-recommends \
     cryptsetup \
     dhcp-client \
     dhcp-server \
+    diffutils \
     dnsmasq \
     distribution-gpg-keys \
     e2fsprogs \


### PR DESCRIPTION
The test 81 needs the `diff` command and a recent openSUSE container does not include it any more.

So explicitly install `diffutils`.

<!-- This pull request changes... -->

<!-- Fixes: https://github.com/dracut-ng/dracut-ng/issues/<number> -->

### Checklist
- [ ] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it
