### PR TITLE
fix(dmsquash-live): load kernel module before mount

### DIFF
--- a/modules.d/70dmsquash-live/dmsquash-live-root.sh
+++ b/modules.d/70dmsquash-live/dmsquash-live-root.sh
@@ -341,6 +341,8 @@ if [ -e "$SQUASHED" ]; then
     SQUASHED_LOOPDEV=$(losetup -f)
     losetup -r "$SQUASHED_LOOPDEV" "$SQUASHED"
     mkdir -m 0755 -p /run/initramfs/squashfs
+    fstype=$(det_img_fs "$SQUASHED_LOOPDEV")
+    load_fstype "$fstype"
     mount -n -o ro "$SQUASHED_LOOPDEV" /run/initramfs/squashfs
 
     if [ -d /run/initramfs/squashfs/LiveOS ]; then
@@ -426,6 +428,8 @@ if [ -n "$overlayfs" ]; then
         if [ "$FSIMG" = "$SQUASHED" ]; then
             mount --bind /run/initramfs/squashfs /run/rootfsbase
         else
+            fstype=$(det_img_fs "$FSIMG")
+            load_fstype "$fstype"
             mount -r "$FSIMG" /run/rootfsbase
         fi
     else


### PR DESCRIPTION
The mount call may require the kernel module for the filesystem type to be loaded in order to succeed.

Follow the already established sequence of calls for mounting.

```
det_img_fs
load_fstype
mount
```

<!-- This pull request changes... -->

<!-- Fixes: https://github.com/dracut-ng/dracut-ng/issues/<number> -->

### Checklist
- [ ] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it
