### PR TITLE
feat(dmsquash-live): add busybox blkid compatibility

### DIFF
--- a/modules.d/70dmsquash-live/dmsquash-live-root.sh
+++ b/modules.d/70dmsquash-live/dmsquash-live-root.sh
@@ -95,7 +95,11 @@ ln -s "$livedev" /run/initramfs/livedev
 # determine filesystem type for a filesystem image
 det_img_fs() {
     udevadm settle >&2
-    blkid -s TYPE -u noraid -o value "$1"
+
+    # avoid blkid options to maintain compatibility with busybox
+    devicetype=$(blkid "$1")
+    fstype="${devicetype#*TYPE=\"}"
+    echo "${fstype=%%\"*}"
 }
 
 CMDLINE=$(getcmdline)


### PR DESCRIPTION
busybox blkid does not support -s argument. Use POSIX shell to filter out the tags needed from the output of the blkid invocation.

Fixes https://github.com/dracut-ng/dracut-ng/issues/2207 for the dmsquash-live module.

<!-- This pull request changes... -->

<!-- Fixes: https://github.com/dracut-ng/dracut-ng/issues/<number> -->

### Checklist
- [ ] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it
