### PR TITLE
docs: convert maintainer list into a table

### DIFF
--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -4,6 +4,8 @@ Maintainers
 The following are the Dracut maintainers who review and merge code and create releases.
 Release artifacts may be signed by one of their GPG keys.
 
-* Laszlo Gombos <dev@kontrol.dev> (46606b571322341e269fec8f1333764a8ff69d7f)
-* Neal Gompa <neal@gompa.dev> (2b6250c4dc6d13d85ae220fdc5ec6ef7e1ea6b86)
-* Benjamin Drung <bdrung@posteo.de> (a62d2cfbd50b9b5bf360d54b159eb5c4efc8774c)
+| Name           | GitHub Profile                              | Email Address      | GPG Key                                  |
+|----------------|---------------------------------------------|--------------------|------------------------------------------|
+| Laszlo Gombos  | [devkontrol](https://github.com/devkontrol) | <dev@kontrol.dev>  | 46606b571322341e269fec8f1333764a8ff69d7f |
+| Neal Gompa     | [Conan-Kudo](https://github.com/Conan-Kudo) | <neal@gompa.dev>   | 2b6250c4dc6d13d85ae220fdc5ec6ef7e1ea6b86 |
+| Benjamin Drung | [bdrung](https://github.com/bdrung/)        | <bdrung@posteo.de> | a62d2cfbd50b9b5bf360d54b159eb5c4efc8774c |


### PR DESCRIPTION
Convert maintainer list into a table and add a GitHub profile column.

<!-- This pull request changes... -->

<!-- Fixes: https://github.com/dracut-ng/dracut-ng/issues/<number> -->

### Checklist
- [ ] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it
