### PR TITLE
fix(dracut): remove unused dracut_no_switch_root

### DIFF
--- a/dracut.sh
+++ b/dracut.sh
@@ -1477,11 +1477,6 @@ dracut_module_included() {
     [[ " $mods_to_load $modules_loaded " == *\ $*\ * ]]
 }
 
-# shellcheck disable=SC2317,SC2329
-dracut_no_switch_root() {
-    : > "$initdir/lib/dracut/no-switch-root"
-}
-
 dracut_module_path() {
     local _dir
 


### PR DESCRIPTION
Commit 19e575859086 ("squash: also squash systemctl if switch-root is not needed") added the function `dracut_no_switch_root` but never used it. https://codesearch.debian.net shows no user as well.

So remove the unused `dracut_no_switch_root` function.

https://codesearch.debian.net

<!-- This pull request changes... -->

<!-- Fixes: https://github.com/dracut-ng/dracut-ng/issues/<number> -->

### Checklist
- [ ] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it
