### PR TITLE
test: do not require pkg-config

### DIFF
--- a/test/TEST-40-SYSTEMD/test.sh
+++ b/test/TEST-40-SYSTEMD/test.sh
@@ -20,6 +20,14 @@ test_run() {
     check_qemu_log
 }
 
+is_systemd_version_greater_or_equal() {
+    local version="$1"
+
+    command -v systemctl &> /dev/null
+    systemd_version=$(systemctl --version | awk 'NR==1 { print $2 }')
+    ((systemd_version >= "$version"))
+}
+
 test_setup() {
     build_client_rootfs "$TESTDIR/rootfs"
     build_ext4_image "$TESTDIR/rootfs" "$TESTDIR"/root.img '  rdinit=/bin/sh'
@@ -39,7 +47,7 @@ test_setup() {
 
     # shellcheck disable=SC2144 # We're not installing multilib libfido2, so
     # glob will only match once. More matches would break the test anyway.
-    if pkg-config --exists "libsystemd >= 257" && [ -e /usr/lib*/libfido2.so.1 ] \
+    if is_systemd_version_greater_or_equal 257 && [ -e /usr/lib*/libfido2.so.1 ] \
         && ! lsinitrd "$TESTDIR"/initramfs.testing | grep -E ' usr/lib[^/]*/libfido2\.so\.1\b' > /dev/null; then
         echo "Error: libfido2.so.1 should have been included in the initramfs" >&2
         return 1


### PR DESCRIPTION
The command `pkg-config` might not be installed in the test environment (for example on Debian autopkgest).

Replace calling `pkg-config` by calling `systemctl --version`.

<!-- This pull request changes... -->

<!-- Fixes: https://github.com/dracut-ng/dracut-ng/issues/<number> -->

### Checklist
- [x] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it
