### PR TITLE
feat(virtfs, virtiofs): auto-add dracut module if qemu included

### DIFF
--- a/modules.d/74virtfs/module-setup.sh
+++ b/modules.d/74virtfs/module-setup.sh
@@ -2,6 +2,10 @@
 
 # called by dracut
 check() {
+    if [[ $hostonly_mode != "strict" ]] && dracut_module_included "qemu"; then
+        return 0
+    fi
+
     [[ $hostonly ]] || [[ $mount_needs ]] && {
         for fs in "${host_fs_types[@]}"; do
             [[ $fs == "9p" ]] && return 0

--- a/modules.d/74virtiofs/module-setup.sh
+++ b/modules.d/74virtiofs/module-setup.sh
@@ -2,6 +2,10 @@
 
 # called by dracut
 check() {
+    if [[ $hostonly_mode != "strict" ]] && dracut_module_included "qemu"; then
+        return 0
+    fi
+
     [[ $hostonly ]] || [[ $mount_needs ]] && {
         is_qemu_virtualized && return 0
 


### PR DESCRIPTION
If qemu dracut module included than automatically include virtfs and virtiofs dracut-net dracut modules as well unless hostonly_mode is set to "strict".

Tested with the following dracut invocation (invoked from a non-virtualized host).

`dracut --hostonly-mode sloppy -add qemu`

<!-- This pull request changes... -->

<!-- Fixes: https://github.com/dracut-ng/dracut-ng/issues/<number> -->

### Checklist
- [ ] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it
