### PR TITLE
ci: also run container manifest step for by workflow_dispatch

### DIFF
--- a/.github/workflows/container-extra.yml
+++ b/.github/workflows/container-extra.yml
@@ -77,7 +77,7 @@ jobs:
                       OPTION=${{ matrix.config.option }}
     manifest:
         needs: container-extra
-        if: github.event_name == 'push' || github.event_name == 'schedule'
+        if: github.event_name == 'push' || github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
         name: ${{ matrix.config.tag }}
         concurrency:
             group: manifest-${{ github.workflow }}-${{ github.ref }}-${{ matrix.config.tag }}

--- a/.github/workflows/container.yml
+++ b/.github/workflows/container.yml
@@ -75,7 +75,7 @@ jobs:
                       OPTION=${{ matrix.config.option }}
     manifest:
         needs: container
-        if: github.event_name == 'push' || github.event_name == 'schedule'
+        if: github.event_name == 'push' || github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
         name: ${{ matrix.config.tag }}
         concurrency:
             group: manifest-${{ github.workflow }}-${{ github.ref }}-${{ matrix.config.tag }}


### PR DESCRIPTION
The container CI jobs might be run manually (using the `workflow_dispatch` trigger). In this case the `manifest` step is skipped. This makes manually runnings the container job useless.

Also run the container manifest step for `workflow_dispatch`.

<!-- This pull request changes... -->

<!-- Fixes: https://github.com/dracut-ng/dracut-ng/issues/<number> -->

### Checklist
- [ ] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it
