### PR TITLE
chore(dmsquash-live): remove support for ext3fs.img

### DIFF
--- a/modules.d/70dmsquash-live/dmsquash-live-root.sh
+++ b/modules.d/70dmsquash-live/dmsquash-live-root.sh
@@ -342,8 +342,6 @@ if [ -e "$SQUASHED" ]; then
     if [ -d /run/initramfs/squashfs/LiveOS ]; then
         if [ -f /run/initramfs/squashfs/LiveOS/rootfs.img ]; then
             FSIMG="/run/initramfs/squashfs/LiveOS/rootfs.img"
-        elif [ -f /run/initramfs/squashfs/LiveOS/ext3fs.img ]; then
-            FSIMG="/run/initramfs/squashfs/LiveOS/ext3fs.img"
         fi
     elif [ -d /run/initramfs/squashfs/usr ] || [ -d /run/initramfs/squashfs/ostree ]; then
         FSIMG=$SQUASHED
@@ -359,8 +357,6 @@ else
     # we might have an embedded fs image to use as rootfs (uncompressed live)
     if [ -e "/run/initramfs/live/${live_dir}/rootfs.img" ]; then
         FSIMG="/run/initramfs/live/${live_dir}/rootfs.img"
-    elif [ -e "/run/initramfs/live/${live_dir}/ext3fs.img" ]; then
-        FSIMG="/run/initramfs/live/${live_dir}/ext3fs.img"
     fi
     if [ -n "$live_ram" ]; then
         echo 'Copying live image to RAM...' > /dev/kmsg


### PR DESCRIPTION
All dracut based live iso use either squashfs.img (compressed live) or rootfs.img (uncompressed live).

Remove support for ext3fs.img. This feature was never documented.

Follow-up to fe17f4e (from 2011) .

<!-- This pull request changes... -->

<!-- Fixes: https://github.com/dracut-ng/dracut-ng/issues/<number> -->

### Checklist
- [ ] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it
