### PR TITLE
chore(base): remove support for /dev/.initramfs

### DIFF
--- a/modules.d/80base/init.sh
+++ b/modules.d/80base/init.sh
@@ -361,11 +361,7 @@ else
 fi
 debug_on
 
-if ! [ -d "$NEWROOT"/run ]; then
-    NEWRUN=/dev/.initramfs
-    mkdir -m 0755 -p "$NEWRUN"
-    mount --rbind /run/initramfs "$NEWRUN"
-else
+if [ -d "$NEWROOT"/run ]; then
     mount --move /run "$NEWROOT"/run
 fi
 


### PR DESCRIPTION
/dev/.initramfs was a fallback when /run is not available.

This commit removes this legacy fallback support, which was only available in a non-systemd enviroment.

Follow-up to dbad9f466 .

<!-- This pull request changes... -->

<!-- Fixes: https://github.com/dracut-ng/dracut-ng/issues/<number> -->

### Checklist
- [ ] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it
