### PR TITLE
fix(release): only install clog-cli if it isn't already installed

### DIFF
--- a/tools/release.sh
+++ b/tools/release.sh
@@ -31,7 +31,9 @@ cat _CONTRIBUTORS >> CONTRIBUTORS.md
 make AUTHORS
 
 # Update the contributors list in NEWS.md
-cargo install clog-cli --version 0.9.3
+if ! type -p clog &> /dev/null; then
+    cargo install clog-cli --version 0.9.3
+fi
 head -2 NEWS.md > NEWS_header.md
 tail +2 NEWS.md > NEWS_body.md
 printf "dracut-ng-%s\n=============\n" "$NEW_VERSION" > NEWS_header_new.md


### PR DESCRIPTION
That way, it does not uselessly run when it is already present.

### Checklist
- [x] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it
