### PR TITLE
fix(release): use correct argument for head(1) to split header out

### DIFF
--- a/tools/release.sh
+++ b/tools/release.sh
@@ -34,7 +34,7 @@ make AUTHORS
 if ! type -p clog &> /dev/null; then
     cargo install clog-cli --version 0.9.3
 fi
-head --lines=-2 NEWS.md > NEWS_header.md
+head --lines=2 NEWS.md > NEWS_header.md
 tail --lines=+2 NEWS.md > NEWS_body.md
 printf "dracut-ng-%s\n=============\n" "$NEW_VERSION" > NEWS_header_new.md
 


### PR DESCRIPTION
We actually want it to take the top two lines for identifying the header.

Fixes: 77c0d5774b ("fix(release): use correct arguments for head(1) and tail(1) calls")

### Checklist
- [x] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it
