### PR TITLE
fix(systemd-networkd): check if units exist before enabling them

### DIFF
--- a/modules.d/11systemd-networkd/module-setup.sh
+++ b/modules.d/11systemd-networkd/module-setup.sh
@@ -75,7 +75,9 @@ install() {
         systemd-networkd-resolve-hook.socket \
         systemd-network-generator.service \
         systemd-networkd-wait-online.service; do
-        $SYSTEMCTL -q --root "$initdir" enable "$i"
+        if [[ -e "$initdir$systemdsystemunitdir"/"$i" ]]; then
+            $SYSTEMCTL -q --root "$initdir" enable "$i"
+        fi
     done
 
     # Install the hosts local user configurations if enabled.


### PR DESCRIPTION
`systemd-networkd-resolve-hook.socket` was introduced in systemd-v259, so dracut throws an error with previous systemd versions:

```
dracut[I]: *** Including module: systemd-networkd ***
Failed to enable unit: Unit systemd-networkd-resolve-hook.socket does not exist
```

Follow-up for 84c05fc661fa2ec01cfb341e73569542d46938d7

### Checklist
- [X] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it
