### PR TITLE
ci: enable TEST-45-SYSTEMD-IMPORT in openSUSE

### DIFF
--- a/.github/workflows/daily-systemd.yml
+++ b/.github/workflows/daily-systemd.yml
@@ -82,9 +82,6 @@ jobs:
                     - container: debian:latest
                       test: "45"
                     # TEST-45-SYSTEMD-IMPORT requires systemd >= v258
-                    - container: opensuse:latest
-                      test: "45"
-                    # TEST-45-SYSTEMD-IMPORT requires systemd >= v258
                     - container: ubuntu:rolling
                       test: "45"
         container:

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -137,9 +137,6 @@ jobs:
                     # https://github.com/dracut-ng/dracut-ng/issues/1677
                     - container: arch:latest
                       test: "41"
-                    # TEST-45-SYSTEMD-IMPORT requires systemd >= v258
-                    - container: opensuse:latest
-                      test: "45"
         container:
             image: ghcr.io/dracut-ng/${{ matrix.container }}
             options: '--device=/dev/kvm --privileged'


### PR DESCRIPTION
openSUSE Tumbleweed ships systemd-v258 since snapshot 20260205.