### PR TITLE
test: make including assertion.sh explicitly

### DIFF
--- a/test/TEST-14-HOOKS/test.sh
+++ b/test/TEST-14-HOOKS/test.sh
@@ -62,7 +62,7 @@ test_setup() {
         )
     done
 
-    build_client_rootfs "$TESTDIR/rootfs"
+    build_client_rootfs "$TESTDIR/rootfs" ./assertion.sh
     for hook in "${expected_hooks_run[@]}"; do
         echo "$hook" >> "$TESTDIR/rootfs/expected_hooks_run"
     done

--- a/test/TEST-21-OVERLAYFS/test.sh
+++ b/test/TEST-21-OVERLAYFS/test.sh
@@ -41,7 +41,7 @@ test_run() {
 }
 
 test_setup() {
-    build_client_rootfs "$TESTDIR/rootfs"
+    build_client_rootfs "$TESTDIR/rootfs" ./assertion.sh
     build_ext4_image "$TESTDIR/rootfs" "$TESTDIR"/root.img dracut
 
     rm -f "$TESTDIR"/overlay.img

--- a/test/TEST-30-DMSQUASH/test.sh
+++ b/test/TEST-30-DMSQUASH/test.sh
@@ -94,7 +94,7 @@ test_run() {
 
 test_setup() {
     # Create what will eventually be our root filesystem onto an overlay
-    build_client_rootfs "$TESTDIR/rootfs"
+    build_client_rootfs "$TESTDIR/rootfs" ./assertion.sh
 
     # test to make sure /proc /sys and /dev is not needed inside the generated initrd
     rm -rf "$TESTDIR"/rootfs/proc "$TESTDIR"/rootfs/sys "$TESTDIR"/rootfs/dev

--- a/test/TEST-50-NETWORK/test.sh
+++ b/test/TEST-50-NETWORK/test.sh
@@ -24,7 +24,7 @@ test_run() {
 
 test_setup() {
     # create root filesystem
-    build_client_rootfs "$TESTDIR/rootfs"
+    build_client_rootfs "$TESTDIR/rootfs" ./assertion.sh
     build_ext4_image "$TESTDIR/rootfs" "$TESTDIR"/root.img dracut
 
     test_dracut --add-drivers "virtio_net" --add "qemu-net $USE_NETWORK"

--- a/test/test-functions
+++ b/test/test-functions
@@ -123,6 +123,7 @@ install_minimal_systemd() {
 # Create a minimal root file system to simulate a client
 build_client_rootfs() {
     local rootdir="$1"
+    local assertion_file="${2-}"
     local binaries
 
     build_rootfs_base "$rootdir"
@@ -154,9 +155,9 @@ build_client_rootfs() {
         inst poweroff
     fi
 
-    if [[ -x assertion.sh ]]; then
-        inst_script ./assertion.sh /assertion.sh
-        binaries=$(sed -n "s/^# required binaries: \(.*\)/\1/p" ./assertion.sh)
+    if [[ -n $assertion_file ]]; then
+        inst_script "$assertion_file" /assertion.sh
+        binaries=$(sed -n "s/^# required binaries: \(.*\)/\1/p" "$assertion_file")
         # shellcheck disable=SC2086
         inst_multiple $binaries
     fi


### PR DESCRIPTION
The function `build_client_rootfs` includes the `assertion.sh` file in case it can be found. This automatic behavior is fragile and a missing `assertion.sh` will not be noticed.

So explicitly specify the assertion file to include when calling `build_client_rootfs`.

<!-- This pull request changes... -->

<!-- Fixes: https://github.com/dracut-ng/dracut-ng/issues/<number> -->

### Checklist
- [ ] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it
