### PR TITLE
fix(dracut): remove unused host_fs_all

### DIFF
--- a/dracut-functions.sh
+++ b/dracut-functions.sh
@@ -572,10 +572,6 @@ for_each_host_dev_fs() {
     return $_ret
 }
 
-host_fs_all() {
-    printf "%s\n" "${host_fs_types[@]}"
-}
-
 # Walk all the slave relationships for a given block device.
 # Stop when our helper function returns success
 # $1 = function to call on every found block device


### PR DESCRIPTION
host_fs_all function was never documented.

https://codesearch.debian.net shows no user as well.

So remove the unused host_fs_all function.

<!-- This pull request changes... -->

<!-- Fixes: https://github.com/dracut-ng/dracut-ng/issues/<number> -->

### Checklist
- [ ] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it
