### PR TITLE
fix(dracut): remove udevrulesconfdir variable

### DIFF
--- a/dracut.sh
+++ b/dracut.sh
@@ -2163,7 +2163,6 @@ set_global_var "dbus" "dbussystemservices" "${dbus}/system-services"
 set_global_var "udev" "udevdir" "/lib/udev:/lib/udev/ata_id" "/usr/lib/udev:/usr/lib/udev/ata_id"
 [[ $hostonly ]] && set_global_var "udev" "udevconfdir" "/etc/udev"
 set_global_var "udev" "udevrulesdir" "${udevdir}/rules.d"
-[[ $hostonly ]] && set_global_var "udev" "udevrulesconfdir" "${udevconfdir}/rules.d"
 
 # systemd global variables
 set_global_var "systemd" "prefix:systemdprefix" "/usr"

--- a/modules.d/74udev-rules/module-setup.sh
+++ b/modules.d/74udev-rules/module-setup.sh
@@ -101,6 +101,6 @@ install() {
         inst_multiple -H -o \
             "$udevconfdir"/udev.conf \
             "$udevconfdir/udev.conf.d/*.conf" \
-            "$udevrulesconfdir/*.rules"
+            "$udevconfdir/rules.d/*.rules"
     fi
 }


### PR DESCRIPTION
There is about 50 places in the dracut source code where the `/etc/udev/rules.d` path is hardcoded.

Having a `udevrulesconfdir` dracut variable gives an impression that dracut and dracut configuration files can configure and overwrite udevrulesconfdir variable, this functionality however never was supported and never worked.

Instead of making an attempt to fix the usage of udevrulesconfdir variable, let's just remove it and require that udevrulesconfdir always maps to /etc/udev/rules.d for dracut.

<!-- This pull request changes... -->

<!-- Fixes: https://github.com/dracut-ng/dracut-ng/issues/<number> -->

### Checklist
- [ ] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it
