### PR TITLE
chore(dracut-functions): make is_func non-public API

### DIFF
--- a/dracut-functions.sh
+++ b/dracut-functions.sh
@@ -27,9 +27,9 @@
 #
 export LC_MESSAGES=C
 
-# is_func <command>
+# _is_func <command>
 # Check whether $1 is a function.
-is_func() {
+_is_func() {
     [[ "$(type -t "$1")" == "function" ]]
 }
 
@@ -1532,7 +1532,7 @@ _detect_library_directories() {
     echo "${libdirs# }"
 }
 
-if ! is_func dinfo > /dev/null 2>&1; then
+if ! _is_func dinfo > /dev/null 2>&1; then
     # shellcheck source=./dracut-logger.sh
     . "${BASH_SOURCE[0]%/*}/dracut-logger.sh"
     dlog_init

--- a/dracut.sh
+++ b/dracut.sh
@@ -1609,7 +1609,7 @@ module_check() {
     check() { true; }
     # shellcheck disable=SC1090
     . "$_moddir"/module-setup.sh
-    is_func check || return 0
+    _is_func check || return 0
     [[ $_forced != 0 ]] && unset hostonly
     # don't quote $hostonly to leave argument empty
     # shellcheck disable=SC2086


### PR DESCRIPTION
is_func is not documented and it should not be in the public API.

Change the name to _is_func to make it explicit that it is not meant to be used by out-of-tree dracut modules.

<!-- This pull request changes... -->

<!-- Fixes: https://github.com/dracut-ng/dracut-ng/issues/<number> -->

### Checklist
- [ ] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it
