### PR TITLE
test: run mkfs.erofs with --quiet

### DIFF
--- a/test/TEST-30-DMSQUASH/test.sh
+++ b/test/TEST-30-DMSQUASH/test.sh
@@ -121,7 +121,7 @@ EOF
 
     # Write the erofs compressed filesystem to the partition
     if command -v mkfs.erofs &> /dev/null; then
-        mkfs.erofs "$TESTDIR"/root_erofs.img "$TESTDIR"/rootfs/
+        mkfs.erofs --quiet "$TESTDIR"/root_erofs.img "$TESTDIR"/rootfs/
     fi
 
     # iso drive

--- a/test/TEST-45-SYSTEMD-IMPORT/test.sh
+++ b/test/TEST-45-SYSTEMD-IMPORT/test.sh
@@ -86,7 +86,7 @@ test_setup() {
     # (e.g., in openSUSE distributions)
     if command -v mkfs.erofs &> /dev/null \
         && ! grep -q -r -w "blacklist erofs" /{etc,usr/lib}/modprobe.d; then
-        mkfs.erofs "$TESTDIR/root_erofs.img" "$TESTDIR/rootfs"
+        mkfs.erofs --quiet "$TESTDIR/root_erofs.img" "$TESTDIR/rootfs"
         images+=("root_erofs.img")
     fi
 


### PR DESCRIPTION
The test calls `mkfs.ext4` with `-q`. Do the same for `mkfs.erofs`. `mkfs.erofs` has only the long form `--quiet`.

<!-- This pull request changes... -->

<!-- Fixes: https://github.com/dracut-ng/dracut-ng/issues/<number> -->

### Checklist
- [ ] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it
