### PR TITLE
test: check if /dev/disk/by-id exists before trying to write the disk marker

### DIFF
--- a/test/modules.d/70test-root/test-init.sh
+++ b/test/modules.d/70test-root/test-init.sh
@@ -54,7 +54,11 @@ if [ -s /run/failed ]; then
     cat /run/failed
     echo "**************************FAILED**************************"
 else
-    echo "dracut-root-block-success" | dd oflag=direct status=none of=/dev/disk/by-id/scsi-0QEMU_QEMU_HARDDISK_marker
-    sync /dev/disk/by-id/scsi-0QEMU_QEMU_HARDDISK_marker
+    # writing a marker is not necessary for all tests, but only for those that
+    # verify it using test_marker_check()
+    if [ -e /dev/disk/by-id ]; then
+        echo "dracut-root-block-success" | dd oflag=direct status=none of=/dev/disk/by-id/scsi-0QEMU_QEMU_HARDDISK_marker
+        sync /dev/disk/by-id/scsi-0QEMU_QEMU_HARDDISK_marker
+    fi
     echo "All OK"
 fi


### PR DESCRIPTION
Not all the tests require a disk marker, so verify that /dev/disk/by-id exists before attempting to write it. E.g., on a successful run of TEST-45-SYSTEMD-IMPORT the following error messages are always printed:

```
2026-02-13T00:12:28.5241893Z made it to the test rootfs!
2026-02-13T00:12:28.5358768Z dd: failed to open '/dev/disk/by-id/scsi-0QEMU_QEMU_HARDDISK_marker': No such file or directory
2026-02-13T00:12:28.5410929Z sync: error opening '/dev/disk/by-id/scsi-0QEMU_QEMU_HARDDISK_marker': No such file or directory
2026-02-13T00:12:28.5417101Z All OK
```

However, the wrong sync operation sometimes seems to affect the "All OK" print and the final verification of the test result. E.g.:

```
2026-02-13T00:16:40.5815187Z made it to the test rootfs!
2026-02-13T00:16:40.5913208Z dd: failed to open '/dev/disk/by-id/scsi-0QEMU_QEMU_HARDDISK_marker': No such file or directory
2026-02-13T00:16:40.5932999Z /sbin/test-init: 57: echo: echo: I/O error
```

Hopefully fixes #2233

<!-- This pull request changes... -->

<!-- Fixes: https://github.com/dracut-ng/dracut-ng/issues/<number> -->

### Checklist
- [ ] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it
