### PR TITLE
fix(rngd): install rngd service dependency files

### DIFF
--- a/modules.d/16rngd/module-setup.sh
+++ b/modules.d/16rngd/module-setup.sh
@@ -39,6 +39,12 @@ install() {
         inst_simple "${moddir}/sysconfig" "/etc/sysconfig/rngd"
     fi
 
+    # Install the hosts local configurations
+    if [[ $hostonly ]]; then
+        inst_multiple -H -o \
+            /etc/conf.d/rngd
+    fi
+
     # make sure dependent libs are installed too
     inst_libdir_file opensc-pkcs11.so
 


### PR DESCRIPTION
Arch package requires the service configuration file.

Fixes: https://gitlab.archlinux.org/archlinux/packaging/packages/dracut/-/issues/12

<!-- This pull request changes... -->

<!-- Fixes: https://github.com/dracut-ng/dracut-ng/issues/<number> -->

### Checklist
- [ ] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it


CC @killermoehre @nhorman @mtorromeo 

Reference: https://gitlab.archlinux.org/archlinux/packaging/packages/rng-tools/-/blob/main/rngd.service?ref_type=heads