### PR TITLE
fix(systemd-pcrextend): add NVPCR definition files

### DIFF
--- a/modules.d/11systemd-pcrextend/module-setup.sh
+++ b/modules.d/11systemd-pcrextend/module-setup.sh
@@ -41,7 +41,8 @@ install() {
         "$systemdutildir"/systemd-pcrextend \
         "$systemdsystemunitdir"/systemd-pcrphase-initrd.service \
         "$systemdsystemunitdir/systemd-pcrphase-initrd.service.d/*.conf" \
-        "$systemdsystemunitdir"/initrd.target.wants/systemd-pcrphase-initrd.service
+        "$systemdsystemunitdir"/initrd.target.wants/systemd-pcrphase-initrd.service \
+        "/usr/lib/nvpcr/*.nvpcr"
 
     # Install the hosts local user configurations if enabled.
     if [[ $hostonly ]]; then


### PR DESCRIPTION
According to https://github.com/systemd/systemd/issues/40159#issuecomment-3760597003 the initramfs is expected to include the nvpcr definition files from systemd for v259 compatibility.

<!-- This pull request changes... -->

<!-- Fixes: https://github.com/dracut-ng/dracut-ng/issues/<number> -->

### Checklist
- [ ] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it
