### PR TITLE
fix(systemd-tmpfiles): do not include tmpfiles configured in /etc

### DIFF
--- a/modules.d/11systemd-tmpfiles/module-setup.sh
+++ b/modules.d/11systemd-tmpfiles/module-setup.sh
@@ -50,7 +50,6 @@ install() {
     # Install the hosts local user configurations if enabled.
     if [[ $hostonly ]]; then
         inst_multiple -H -o \
-            "$tmpfilesconfdir/*.conf" \
             "$systemdsystemconfdir"/systemd-tmpfiles-clean.service \
             "$systemdsystemconfdir/systemd-tmpfiles-clean.service.d/*.conf" \
             "$systemdsystemconfdir"/systemd-tmpfiles-setup.service \


### PR DESCRIPTION
Users may have tmpfiles configured in /etc to be created after switching root, always including this user configuration in the initrd may break their setups.

Fixes #1706

### Checklist
- [ ] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it
