### PR TITLE
ci: install openssl to create a test for systemd-sysext

### DIFF
--- a/test/container/Dockerfile-arch
+++ b/test/container/Dockerfile-arch
@@ -48,6 +48,7 @@ RUN pacman --noconfirm -Syu \
     ntfs-3g \
     nvme-cli \
     open-iscsi \
+    openssl \
     parted \
     pciutils \
     pkgconf \

--- a/test/container/Dockerfile-debian
+++ b/test/container/Dockerfile-debian
@@ -75,6 +75,7 @@ RUN \
     ntfs-3g \
     nvme-cli \
     open-iscsi \
+    openssl \
     ovmf \
     parted \
     pcscd \

--- a/test/container/Dockerfile-fedora
+++ b/test/container/Dockerfile-fedora
@@ -81,6 +81,7 @@ RUN dnf -y install --setopt=install_weak_deps=False \
     NetworkManager \
     nfs-utils \
     nvme-cli \
+    openssl \
     parted \
     pcsc-lite \
     plymouth \

--- a/test/container/Dockerfile-opensuse
+++ b/test/container/Dockerfile-opensuse
@@ -42,6 +42,7 @@ RUN zypper --non-interactive install --no-recommends \
     NetworkManager \
     nfs-kernel-server \
     open-iscsi \
+    openssl \
     parted \
     pciutils \
     python3 \


### PR DESCRIPTION
The openssl binary is used to create a X.509 certificate to sign extensions.

### Checklist
- [ ] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it
