### PR TITLE
nvmf: dynamic subsystem configuration and default interface naming

### DIFF
--- a/dracut.sh
+++ b/dracut.sh
@@ -1186,6 +1186,7 @@ drivers_dir="${drivers_dir%"${drivers_dir##*[!/]}"}"
 [[ $kernel_image_l ]] && kernel_image=$(path_rel_to_abs "$kernel_image_l")
 [[ $sbat_l ]] && sbat="$sbat_l"
 [[ $machine_id_l ]] && machine_id="$machine_id_l"
+[[ $nvmf_nbft_mode ]] || nvmf_nbft_mode=match
 
 # shellcheck source=./dracut-functions.sh
 . "$dracutbasedir"/dracut-functions.sh
@@ -2055,6 +2056,14 @@ else
     unset enhanced_cpio
 fi
 unset threecpio_help_output
+
+case $nvmf_nbft_mode in
+    nbft | match | static) ;;
+    *)
+        dwarn "Invalid value \"$nvmf_nbft_mode\" for nvmf_nbft_mode. Assuming \"match\"."
+        nvmf_nbft_mode=match
+        ;;
+esac
 
 if [[ $no_kernel != yes ]] && ! [[ -d $srcmods ]]; then
     dfatal "Cannot find module directory $srcmods"

--- a/dracut.sh
+++ b/dracut.sh
@@ -1194,6 +1194,7 @@ drivers_dir="${drivers_dir%"${drivers_dir##*[!/]}"}"
 [[ $kernel_image_l ]] && kernel_image=$(path_rel_to_abs "$kernel_image_l")
 [[ $sbat_l ]] && sbat="$sbat_l"
 [[ $machine_id_l ]] && machine_id="$machine_id_l"
+[[ $nvmf_nbft_mode ]] || nvmf_nbft_mode=match
 
 TMPDIR="$(realpath -e "$tmpdir")"
 readonly TMPDIR
@@ -2063,6 +2064,14 @@ else
     unset enhanced_cpio
 fi
 unset threecpio_help_output
+
+case $nvmf_nbft_mode in
+    nbft | match | static) ;;
+    *)
+        derror "Invalid value \"$nvmf_nbft_mode\" for nvmf_nbft_mode. Assuming \"match\"."
+        nvmf_nbft_mode=match
+        ;;
+esac
 
 if [[ $no_kernel != yes ]] && ! [[ -d $srcmods ]]; then
     dfatal "Cannot find module directory $srcmods"

--- a/man/dracut.cmdline.7.adoc
+++ b/man/dracut.cmdline.7.adoc
@@ -946,6 +946,13 @@ Requires the dracut 'nvmf' module.
     the initramfs was built. Targets specified with rd.nvmf.discover on the
     kernel command line will still be tried.
 
+**rd.nvmf.nm**::
+    Rely on NetworkManagers nm-initrd-generator tool to set up network
+    interfaces from the NVMe Boot Firmware Table (NBFT). This has the effect
+    that the network interfaces generated from the NBFT will have regular
+    interface names rather than ++nbft0++ etc. *This requires NetworkManager
+    1.54.0 or higher*.
+
 **rd.nvmf.hostnqn=**__<hostNQN>__::
     NVMe host NQN to use
 

--- a/man/dracut.conf.5.adoc
+++ b/man/dracut.conf.5.adoc
@@ -400,6 +400,21 @@ Defaults to _initramfs-$\{kernel\}.img_.
 Let kernel-install create a rescue image (default=no).
 This configuration option applies only to kernel-install.
 
+*nvmf_nbft_mode*="__{match|nbft|static}__"::
+For systems that use the ++nvmf++ module for booting from NVMe over Fabrics
+(NVMeoF), specify how to set command line options for NVMe subsystems that are
+listed in the NVMe Boot Firmware Table (NBFT). This option only has an effect
+if ++hostonly_cmdline++ is set to ++yes++.  If set to ++static++, generate
+cmdline entries for all NVMe subsystems detected while the initramfs was
+built. If set to ++nbft++, don't generate any entries for NVMe subsystems using
+the ++tcp++ transport (i.e. rely on NBFT parsing for detecting NVMe subsystems
+at boot time). If set to ++match++ (default), only add cmdline entries for
+++tcp++ subsystems that do not match any entry in the NBFT, comparing subsystem
+IP address (traddr) and port (trsvcid).  Use ++nbft++ or ++match++ if you want
+the system to adapt if the content of the NBFT changes between reboots. Use
+++static++ if you want connect to the same subsystems, always, no matter what
+the content of the NBFT is.  The default is ++match++.
+
 == Files
 _/etc/dracut.conf_::
 Old configuration file. It is recommended to use individual files in

--- a/man/dracut.conf.5.adoc
+++ b/man/dracut.conf.5.adoc
@@ -192,6 +192,9 @@ in its current state will not be included, and modules may make additional
 efforts to save more space. Minor changes in hardware or environment can make
 the image unbootable.
 
+WARNING: If chrooted to another root other than the real root device, use
+`--fstab` and provide a valid _/etc/fstab_.
+
 *hostonly_cmdline=*"__{yes|no}__"::
 If set to "yes", store the kernel command line arguments needed in the
 initramfs. If **hostonly="yes"** and this option is not configured, it's
@@ -209,9 +212,6 @@ _<policy>_ can be any directory name found in /dev/disk (e.g. "by-uuid",
 *tmpdir=*"__<temporary directory>__"::
 Specify temporary directory to use.
 +
-WARNING: If chrooted to another root other than the real root device, use
-`--fstab` and provide a valid _/etc/fstab_.
-
 *use_fstab=*"__{yes|no}__"::
 Use _/etc/fstab_ instead of _/proc/self/mountinfo_ (default=no).
 

--- a/modules.d/74nvmf/module-setup.sh
+++ b/modules.d/74nvmf/module-setup.sh
@@ -98,6 +98,7 @@ cmdline() {
         local _address
         local -a _address_parts
         local nbft_entry
+        local -a version
 
         [[ -L "/sys/dev/block/$_dev" ]] || return 0
         cd -P "/sys/dev/block/$_dev" || return 0
@@ -150,6 +151,13 @@ cmdline() {
     if [ -f /etc/nvme/hostid ]; then
         read -r _hostid < /etc/nvme/hostid
         echo -n " rd.nvmf.hostid=${_hostid}"
+    fi
+
+    if dracut_module_included network-manager; then
+        mapfile -t -d . version < <(NetworkManager --version)
+        [[ ${#version[@]} == 3 &&
+            $((10000 * version[0] + 100 * version[1] + version[2])) -ge 15400 ]] \
+            && echo -n " rd.nvmf.nm=1 "
     fi
 
     [[ $hostonly ]] || [[ $mount_needs ]] && {

--- a/modules.d/74nvmf/module-setup.sh
+++ b/modules.d/74nvmf/module-setup.sh
@@ -102,6 +102,7 @@ cmdline() {
         local _address
         local -a _address_parts
         local nbft_entry
+        local -a version
 
         [[ -L "/sys/dev/block/$_dev" ]] || return 0
         cd -P "/sys/dev/block/$_dev" || return 0
@@ -154,6 +155,16 @@ cmdline() {
     if [ -f /etc/nvme/hostid ]; then
         read -r _hostid < /etc/nvme/hostid
         echo -n " rd.nvmf.hostid=${_hostid}"
+    fi
+
+    if dracut_module_included network-manager; then
+        # NetworkManager 1.54 and newer reads the NBFT natively.
+        # If this version is detected, set rd.nvmf.nm=1 in order to simplify
+        # the NBFT handling in the initrd
+        mapfile -t -d . version < <(NetworkManager --version)
+        [[ ${#version[@]} == 3 &&
+            $((10000 * version[0] + 100 * version[1] + version[2])) -ge 15400 ]] \
+            && echo -n " rd.nvmf.nm=1 "
     fi
 
     [[ $hostonly ]] || [[ $mount_needs ]] && {

--- a/modules.d/74nvmf/module-setup.sh
+++ b/modules.d/74nvmf/module-setup.sh
@@ -1,5 +1,15 @@
 #!/bin/bash
 
+__nvmf_has_nbft() {
+    local f found=
+    for f in /sys/firmware/acpi/tables/NBFT*; do
+        [ -f "$f" ] || continue
+        found=1
+        break
+    done
+    [[ $found ]]
+}
+
 # called by dracut
 check() {
     local -A nvmf_trtypes
@@ -32,16 +42,6 @@ check() {
         fi
     }
 
-    has_nbft() {
-        local f found=
-        for f in /sys/firmware/acpi/tables/NBFT*; do
-            [ -f "$f" ] || continue
-            found=1
-            break
-        done
-        [[ $found ]]
-    }
-
     [[ $hostonly ]] || [[ $mount_needs ]] && {
         [ -f /etc/nvme/hostnqn ] || return 255
         [ -f /etc/nvme/hostid ] || return 255
@@ -53,7 +53,7 @@ check() {
         require_kernel_modules "${!nvmf_trtypes[@]}" || return 1
         if [ ! -f /sys/class/fc/fc_udev_device/nvme_discovery ] \
             && [ ! -f /etc/nvme/discovery.conf ] \
-            && [ ! -f /etc/nvme/config.json ] && ! has_nbft; then
+            && [ ! -f /etc/nvme/config.json ] && ! __nvmf_has_nbft; then
             echo "No discovery arguments present"
             return 255
         fi
@@ -88,6 +88,10 @@ cmdline() {
     local _hostid
     local -a _nbft_subsystems
 
+    # Generate "rd.nvmf.discover=" cmdline parameters for NVMeoF devices found
+    # on the host (in hostonly mode).
+    # Depending on the value of $nvmf_nbft_mode, skip devices discovered
+    # from the NBFT.
     # shellcheck disable=SC2317,SC2329  # called later by for_each_host_dev_and_slaves
     gen_nvmf_cmdline() {
         local _dev=$1
@@ -125,12 +129,14 @@ cmdline() {
                 [[ $i =~ ^trsvcid= ]] && trsvcid="${i#trsvcid=}"
             done
             [[ -z $traddr && -z $host_traddr && -z $trsvcid ]] && continue
+            [[ $trtype == tcp && $nvmf_nbft_mode == nbft ]] \
+                && __nvmf_has_nbft && continue
             # _nbft_subsystems is set in cmdline() scope below.
             # It lists all subsystems found in the NBFT in the format
             # "traddr,trsvcid"
             # If the subsystem found is listed in the NBFT, don't add it
             # explicitly to the command line.
-            if [[ $trtype == tcp ]]; then
+            if [[ $trtype == tcp && $nvmf_nbft_mode == match ]]; then
                 for nbft_entry in "${_nbft_subsystems[@]}"; do
                     if [[ "$traddr,$trsvcid" == "$nbft_entry" ]]; then
                         continue 2

--- a/modules.d/74nvmf/parse-nvmf-boot-connections.sh
+++ b/modules.d/74nvmf/parse-nvmf-boot-connections.sh
@@ -203,6 +203,12 @@ nbft_parse() {
 
     nbft_json=$(nvme nbft show -H -o json) || return 0
     n_nbft=$(nbft_run_jq ". | length" "$nbft_json") || return 0
+    if [ "$n_nbft" -gt 0 ] && getargbool 0 rd.nvmf.nm; then
+        # nm-initrd-generator will take care of the interface setup.
+        # We set valid_nbft_entry_found to enable netroot (see below).
+        : > /tmp/valid_nbft_entry_found
+        return 0
+    fi
 
     while [ "$j" -lt "$n_nbft" ]; do
         all_hfi_json=$(nbft_run_jq ".[$j].hfi" "$nbft_json") || continue


### PR DESCRIPTION
This pull request contains enhancements to the nvmf module.

1. Instead of hard-coding the NVMe subsystems to connect to with `rd.nvmf.discover=` cmdline options, enable just reading the connections at boot time from the NBFT. The behavior can be customized at initramfs build time using the dracut.conf option `nvmf_nbft_mode={static,nbft,match}`.
2. Instead of always using the interface names `nbft0`, `nbft1` etc., allow using regular interface names as determined by the system's general interface naming policy. This requires NetworkManager 1.54.0 or newer. The feature can be enabled using the command line option `rd.nvmf.nm=1`, which is automatically enabled with `hostonly_cmdline` if NM 1.54.0 or newer is detected on the system.

The set also contains a minor man page fix.

### Checklist
- [x] I have tested it locally
- [x] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it

Cc: @aafeijoo-suse, @tbzatek, @johnmeneghini