### PR TITLE
chore: remove udevconfdir configuration option

### DIFF
--- a/dracut.sh
+++ b/dracut.sh
@@ -2157,7 +2157,6 @@ set_global_var "dbus" "dbussystemservices" "${dbus}/system-services"
 
 # udev global variables
 set_global_var "udev" "udevdir" "/lib/udev:/lib/udev/ata_id" "/usr/lib/udev:/usr/lib/udev/ata_id"
-[[ $hostonly ]] && set_global_var "udev" "udevconfdir" "/etc/udev"
 set_global_var "udev" "udevrulesdir" "${udevdir}/rules.d"
 
 # systemd global variables

--- a/modules.d/74hwdb/module-setup.sh
+++ b/modules.d/74hwdb/module-setup.sh
@@ -18,6 +18,6 @@ install() {
     # Install the hosts local user configurations if enabled.
     if [[ $hostonly ]]; then
         inst_multiple -H -o \
-            "$udevconfdir"/hwdb.bin
+            /etc/udev/hwdb.bin
     fi
 }

--- a/modules.d/74udev-rules/module-setup.sh
+++ b/modules.d/74udev-rules/module-setup.sh
@@ -97,10 +97,10 @@ install() {
 
     # Install the hosts local user configurations if enabled.
     if [[ $hostonly ]]; then
-        inst_dir "$udevconfdir"
+        inst_dir /etc/udev
         inst_multiple -H -o \
-            "$udevconfdir"/udev.conf \
-            "$udevconfdir/udev.conf.d/*.conf" \
-            "$udevconfdir/rules.d/*.rules"
+            /etc/udev/udev.conf \
+            "/etc/udev/udev.conf.d/*.conf" \
+            "/etc/udev/rules.d/*.rules"
     fi
 }


### PR DESCRIPTION
`udevconfdir` is not really configurable and is always expected to set to `/etc/udev`.

Follow-up to d867f00.

Fixes (partially): https://github.com/dracut-ng/dracut-ng/issues/2250

<!-- This pull request changes... -->

<!-- Fixes: https://github.com/dracut-ng/dracut-ng/issues/<number> -->

### Checklist
- [ ] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it
