### PR TITLE
feat(overlayfs): support tmpfs size parameter in rd.overlay

### DIFF
--- a/man/dracut.cmdline.7.adoc
+++ b/man/dracut.cmdline.7.adoc
@@ -1109,6 +1109,29 @@ The **rd.overlay.readonly** option, which allows a persistent overlayfs to
 be mounted read-only through a higher level transient overlay directory, has
 been implemented through the multiple lower layers feature of OverlayFS.
 
+**rd.overlay=**__tmpfs:[size=<size>][,nr_blocks=<n>][,nr_inodes=<n>]__::
+Mounts a dedicated tmpfs with the specified options for the OverlayFS upper
+directory, instead of using the default `/run` tmpfs.  This allows controlling
+the size of the writable overlay at boot time, which is useful for deployments
+where the available RAM is known in advance (e.g. MAAS ephemeral environments).
++
+Supported options (comma-separated):
++
+--
+* _size=<size>_ - Maximum size of the tmpfs (e.g. `4G`, `512M`, `25%`).
+  Accepts the same values as the tmpfs `size=` mount option.
+* _nr_blocks=<n>_ - Maximum number of blocks allocated to the tmpfs.
+* _nr_inodes=<n>_ - Maximum number of inodes in the tmpfs.
+--
++
+[listing]
+.Examples
+----
+rd.overlay=tmpfs:size=4G
+rd.overlay=tmpfs:size=25%
+rd.overlay=tmpfs:size=512M,nr_inodes=100000
+----
+
 **rd.overlay=**__{LABEL=<label>|UUID=<uuid>|PARTUUID=<uuid>|PARTLABEL=<label>|/dev/<device>}__::
 Specifies the storage device for persistent overlay (for both live images and
 regular OverlayFS).  When a block device is specified, it will be mounted and

--- a/modules.d/70overlayfs/prepare-overlayfs.sh
+++ b/modules.d/70overlayfs/prepare-overlayfs.sh
@@ -10,6 +10,7 @@ overlay=$(get_rd_overlay)
 
 overlay_mode="tmpfs"
 overlay_device=""
+overlay_tmpfs_opts=""
 
 case "$overlay" in
     LABEL=* | UUID=* | PARTLABEL=* | PARTUUID=* | /dev/*)
@@ -19,6 +20,27 @@ case "$overlay" in
             warn "Failed to resolve device from '$overlay', falling back to tmpfs"
             overlay_mode="tmpfs"
         fi
+        ;;
+    tmpfs:*)
+        overlay_mode="tmpfs"
+        # Parse comma-separated key=value pairs from rd.overlay=tmpfs:key=val,
+        OLDIFS="$IFS"
+        IFS=,
+        set -f
+        for _param in ${overlay#tmpfs:}; do
+            _key="${_param%%=*}"
+            _val="${_param#*=}"
+            case "$_key" in
+                size | nr_blocks | nr_inodes)
+                    overlay_tmpfs_opts="${overlay_tmpfs_opts:+${overlay_tmpfs_opts},}${_key}=${_val}"
+                    ;;
+                *)
+                    warn "Unknown tmpfs option '${_key}', ignoring"
+                    ;;
+            esac
+        done
+        set +f
+        IFS="$OLDIFS"
         ;;
     *)
         # For dmsquash-live compatibility, any other format uses tmpfs
@@ -61,6 +83,13 @@ if [ "$overlay_mode" = "tmpfs" ]; then
     info "Using tmpfs overlay (changes will not persist across reboots)"
 
     [ -d /run/overlayfs ] || {
+        mkdir -m 0755 -p /run/initramfs/overlay
+        if [ -n "$overlay_tmpfs_opts" ]; then
+            info "Mounting tmpfs overlay with options: ${overlay_tmpfs_opts}"
+            if ! mount -t tmpfs -o "${overlay_tmpfs_opts}" tmpfs /run/initramfs/overlay; then
+                warn "Failed to mount tmpfs with options '${overlay_tmpfs_opts}', using default"
+            fi
+        fi
         mkdir -m 0755 -p /run/initramfs/overlay/overlayfs
         mkdir -m 0755 -p /run/initramfs/overlay/ovlwork
         ln -sf /run/initramfs/overlay/overlayfs /run/overlayfs

--- a/test/TEST-21-OVERLAYFS/assertion.sh
+++ b/test/TEST-21-OVERLAYFS/assertion.sh
@@ -27,6 +27,18 @@ else
     fi
 fi
 
+if grep -q 'test.expect=tmpfs-sized' /proc/cmdline; then
+    if ! grep -q "^tmpfs /run/initramfs/overlay tmpfs " /proc/mounts; then
+        echo "sized tmpfs not mounted at /run/initramfs/overlay" >> /run/failed
+    fi
+    if ! grep -q "^tmpfs /run/initramfs/overlay tmpfs .*size=32768k" /proc/mounts; then
+        echo "sized tmpfs does not have expected size (32M)" >> /run/failed
+    fi
+    if ! grep -q "^tmpfs /run/initramfs/overlay tmpfs .*nr_inodes=100000" /proc/mounts; then
+        echo "sized tmpfs does not have expected nr_inodes (100000)" >> /run/failed
+    fi
+fi
+
 # Dump /proc/mounts at the end if there were any failures for easier debugging
 if [ -s /run/failed ]; then
     {

--- a/test/TEST-21-OVERLAYFS/test.sh
+++ b/test/TEST-21-OVERLAYFS/test.sh
@@ -38,6 +38,8 @@ test_run() {
     client_run "persistent device overlay (device path)" \
         "rd.overlay=/dev/disk/by-id/scsi-0QEMU_QEMU_HARDDISK_overlay test.expect=device"
     client_run "fallback to tmpfs (non-existent LABEL)" "rd.overlay=LABEL=NONEXISTENT test.expect=tmpfs"
+    client_run "tmpfs overlay with size (rd.overlay=tmpfs:size=32M,nr_inodes=100000)" \
+        "rd.overlay=tmpfs:size=32M,nr_inodes=100000 test.expect=tmpfs-sized"
 }
 
 test_setup() {


### PR DESCRIPTION
When `rd.overlay=tmpfs:size=<size>` is passed on the kernel command line, mount a dedicated tmpfs with the specified options for the overlayfs upper directory, instead of using the default `/run` tmpfs.

Supported options (comma-separated after `tmpfs:`) are `size=`, `nr_blocks=` and `nr_inodes=`. If mounting fails, the script falls back gracefully to the default `/run` tmpfs overlay.

<!-- This pull request changes... -->

<!-- Fixes: https://github.com/dracut-ng/dracut-ng/issues/<number> -->

### Checklist
- [x] I have tested it locally
- [x] I have reviewed and updated any documentation if relevant
- [x] I am providing new code and test(s) for it
