### PR TITLE
test/run-qemu: force cpu to neoverse-n1 for arm64 when QEMU_CPU not set

### DIFF
--- a/test/run-qemu
+++ b/test/run-qemu
@@ -5,7 +5,16 @@ set -eu
 
 export PATH=/usr/sbin:/usr/bin:/sbin:/bin
 ARCH="${ARCH-$(uname -m)}"
-QEMU_CPU="${QEMU_CPU:-max}"
+if [ -z "${QEMU_CPU-}" ]; then
+    case "$ARCH" in
+        aarch64 | arm64)
+            QEMU_CPU="neoverse-n1"
+            ;;
+        *)
+            QEMU_CPU="max"
+            ;;
+    esac
+fi
 
 add_to_append() {
     local extra="$1"


### PR DESCRIPTION
using cpu=max might expose new unstable features with qemu/edk2 upgrades, this unstability might cause test failures to happen , we are experiencing that in Debian/Ubuntu with edk2 latest version that enables LPA2 that is still unstable.

since using cpu=max is not required for dracut tests, using a named model will offer a better stability for the tests for future qemu/edk2 upgrades. the choosen cpu model for arm64 is neoverse-n1 since it is one of the most stable and proven CPU model from a virtualization standpoint.

### Checklist
- [x] I have tested it locally
- [x] I am providing new code and test(s) for it
