### PR TITLE
test: rely on server initrd to load af_packet

### DIFF
--- a/test/TEST-60-NFS/server-init.sh
+++ b/test/TEST-60-NFS/server-init.sh
@@ -55,8 +55,6 @@ ip addr add 192.168.50.3/24 dev enx525400123456
 linkup enx525400123456
 
 : > /dev/watchdog
-modprobe af_packet
-: > /dev/watchdog
 mkdir /nfs/nfs3-4
 mount --bind /nfs/client /nfs/nfs3-4
 : > /dev/watchdog

--- a/test/TEST-70-ISCSI/server-init.sh
+++ b/test/TEST-70-ISCSI/server-init.sh
@@ -55,8 +55,6 @@ linkup enx525400123456
 ip addr add 192.168.51.1/24 dev enx525400123457
 linkup enx525400123457
 
-modprobe af_packet
-
 dnsmasq
 
 tgtd

--- a/test/TEST-71-ISCSI-MULTI/server-init.sh
+++ b/test/TEST-71-ISCSI-MULTI/server-init.sh
@@ -55,8 +55,6 @@ linkup enx525400123456
 ip addr add 192.168.51.1/24 dev enx525400123457
 linkup enx525400123457
 
-modprobe af_packet
-
 dnsmasq
 
 tgtd

--- a/test/TEST-72-NBD/server-init.sh
+++ b/test/TEST-72-NBD/server-init.sh
@@ -50,7 +50,6 @@ wait_for_if_link enx525400123456
 ip addr add 192.168.50.1/24 dev enx525400123456
 linkup enx525400123456
 
-modprobe af_packet
 nbd-server
 dnsmasq
 echo "Serving NBD disks"


### PR DESCRIPTION
To keep the server rootfs small, rely on the initrd to load `af_packet`.

<!-- This pull request changes... -->

<!-- Fixes: https://github.com/dracut-ng/dracut-ng/issues/<number> -->

### Checklist
- [ ] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it
