### PR TITLE
test: drop setting up loop-back device

### DIFF
--- a/test/TEST-60-NFS/server-init.sh
+++ b/test/TEST-60-NFS/server-init.sh
@@ -49,8 +49,6 @@ linkup() {
 
 wait_for_if_link enx525400123456
 
-ip addr add 127.0.0.1/8 dev lo
-ip link set lo up
 ip addr add 192.168.50.1/24 dev enx525400123456
 ip addr add 192.168.50.2/24 dev enx525400123456
 ip addr add 192.168.50.3/24 dev enx525400123456

--- a/test/TEST-70-ISCSI/server-init.sh
+++ b/test/TEST-70-ISCSI/server-init.sh
@@ -49,9 +49,6 @@ linkup() {
 wait_for_if_link enx525400123456
 wait_for_if_link enx525400123457
 
-ip addr add 127.0.0.1/8 dev lo
-ip link set lo up
-
 ip addr add 192.168.50.1/24 dev enx525400123456
 linkup enx525400123456
 

--- a/test/TEST-71-ISCSI-MULTI/server-init.sh
+++ b/test/TEST-71-ISCSI-MULTI/server-init.sh
@@ -49,9 +49,6 @@ linkup() {
 wait_for_if_link enx525400123456
 wait_for_if_link enx525400123457
 
-ip addr add 127.0.0.1/8 dev lo
-ip link set lo up
-
 ip addr add 192.168.50.1/24 dev enx525400123456
 linkup enx525400123456
 

--- a/test/TEST-72-NBD/server-init.sh
+++ b/test/TEST-72-NBD/server-init.sh
@@ -46,9 +46,6 @@ linkup() {
     wait_for_if_link "$1" 2> /dev/null && ip link set "$1" up 2> /dev/null && wait_for_if_up "$1" 2> /dev/null
 }
 
-ip addr add 127.0.0.1/8 dev lo
-ip link set lo up
-
 wait_for_if_link enx525400123456
 ip addr add 192.168.50.1/24 dev enx525400123456
 linkup enx525400123456


### PR DESCRIPTION
The initrd already sets up `lo`. So setting it up on the server rootfs fails:

```
+ ip addr add 127.0.0.1/8 dev lo
Error: ipv4: Address already assigned.
```

<!-- This pull request changes... -->

<!-- Fixes: https://github.com/dracut-ng/dracut-ng/issues/<number> -->

### Checklist
- [ ] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it
