### PR TITLE
test: create server log in the test directory

### DIFF
--- a/test/TEST-60-NFS/test.sh
+++ b/test/TEST-60-NFS/test.sh
@@ -30,14 +30,14 @@ run_server() {
         "${disk_args[@]}" \
         -net socket,listen=127.0.0.1:12320 \
         -net nic,macaddr=52:54:00:12:34:56,model=virtio \
-        -serial "${SERIAL:-"file:$TESTDIR/server.log"}" \
+        -serial "${SERIAL:-"file:./server${TEST_RUN_ID:+-$TEST_RUN_ID}.log"}" \
         -append "panic=1 oops=panic softlockup_panic=1 root=LABEL=dracut rootfstype=ext4 rw systemd.journald.forward_to_console=1 ${SERVER_DEBUG-}" \
         -pidfile "$TESTDIR"/server.pid -daemonize \
         -initrd "$TESTDIR"/initramfs.server
     chmod 644 "$TESTDIR"/server.pid
 
     if ! [[ ${SERIAL-} ]]; then
-        wait_for_server_startup
+        wait_for_server_startup "./server${TEST_RUN_ID:+-$TEST_RUN_ID}.log"
     else
         echo Sleeping 10 seconds to give the server a head start
         sleep 10

--- a/test/TEST-70-ISCSI/test.sh
+++ b/test/TEST-70-ISCSI/test.sh
@@ -22,7 +22,7 @@ run_server() {
 
     "$testdir"/run-qemu \
         "${disk_args[@]}" \
-        -serial "${SERIAL:-"file:$TESTDIR/server.log"}" \
+        -serial "${SERIAL:-"file:./server${TEST_RUN_ID:+-$TEST_RUN_ID}.log"}" \
         -device virtio-net-pci,netdev=lan0,mac=52:54:00:12:34:56 \
         -netdev socket,id=lan0,listen=127.0.0.1:60700 \
         -device virtio-net-pci,netdev=lan1,mac=52:54:00:12:34:57 \
@@ -33,7 +33,7 @@ run_server() {
     chmod 644 "$TESTDIR"/server.pid
 
     if ! [[ ${SERIAL-} ]]; then
-        wait_for_server_startup
+        wait_for_server_startup "./server${TEST_RUN_ID:+-$TEST_RUN_ID}.log"
     else
         echo Sleeping 10 seconds to give the server a head start
         sleep 10

--- a/test/TEST-71-ISCSI-MULTI/test.sh
+++ b/test/TEST-71-ISCSI-MULTI/test.sh
@@ -22,7 +22,7 @@ run_server() {
 
     "$testdir"/run-qemu \
         "${disk_args[@]}" \
-        -serial "${SERIAL:-"file:$TESTDIR/server.log"}" \
+        -serial "${SERIAL:-"file:./server${TEST_RUN_ID:+-$TEST_RUN_ID}.log"}" \
         -device virtio-net-pci,netdev=lan0,mac=52:54:00:12:34:56 \
         -netdev socket,id=lan0,listen=127.0.0.1:60710 \
         -device virtio-net-pci,netdev=lan1,mac=52:54:00:12:34:57 \
@@ -33,7 +33,7 @@ run_server() {
     chmod 644 "$TESTDIR"/server.pid
 
     if ! [[ ${SERIAL-} ]]; then
-        wait_for_server_startup
+        wait_for_server_startup "./server${TEST_RUN_ID:+-$TEST_RUN_ID}.log"
     else
         echo Sleeping 10 seconds to give the server a head start
         sleep 10

--- a/test/TEST-72-NBD/test.sh
+++ b/test/TEST-72-NBD/test.sh
@@ -32,7 +32,7 @@ run_server() {
 
     "$testdir"/run-qemu \
         "${disk_args[@]}" \
-        -serial "${SERIAL:-"file:$TESTDIR/server.log"}" \
+        -serial "${SERIAL:-"file:./server${TEST_RUN_ID:+-$TEST_RUN_ID}.log"}" \
         -net nic,macaddr=52:54:00:12:34:56,model=virtio \
         -net socket,listen=127.0.0.1:12340 \
         -append "panic=1 oops=panic softlockup_panic=1 rd.luks=0 systemd.crash_reboot quiet root=/dev/disk/by-id/scsi-0QEMU_QEMU_HARDDISK_serverroot rootfstype=ext4 rw systemd.journald.forward_to_console=1 ${SERVER_DEBUG-}" \
@@ -41,7 +41,7 @@ run_server() {
     chmod 644 "$TESTDIR"/server.pid
 
     if ! [[ ${SERIAL-} ]]; then
-        wait_for_server_startup
+        wait_for_server_startup "./server${TEST_RUN_ID:+-$TEST_RUN_ID}.log"
     else
         echo Sleeping 10 seconds to give the server a head start
         sleep 10

--- a/test/test-functions
+++ b/test/test-functions
@@ -237,7 +237,7 @@ stop_webserver() {
 # Wait for the server QEMU has been started up.
 # It should print "Serving" in the server log in that case.
 wait_for_server_startup() {
-    local server_log="$TESTDIR"/server.log
+    local server_log="$1"
     local lines printed_lines=0 server_pid
     server_pid=$(cat "$TESTDIR"/server.pid)
 
@@ -393,9 +393,6 @@ print_test_result() {
     else
         client_test_end "FAILED"
         echo -e "TEST: $TEST_DESCRIPTION " "$COLOR_FAILURE" "[FAILED]" "$COLOR_NORMAL"
-        if [[ -f "$TESTDIR"/server.log ]]; then
-            mv "$TESTDIR"/server.log ./server${TEST_RUN_ID:+-$TEST_RUN_ID}.log
-        fi
         if [ "${V-}" == "2" ]; then
             tail -c 1048576 "$(pwd)/server${TEST_RUN_ID:+-$TEST_RUN_ID}.log" "$(pwd)/test${TEST_RUN_ID:+-$TEST_RUN_ID}.log"
             echo -e "TEST: $TEST_DESCRIPTION " "$COLOR_FAILURE" "[FAILED]" "$COLOR_NORMAL"


### PR DESCRIPTION
Store the server log in the test directory (similar to the test log) instead of putting the server log in `/var/tmp`. This makes it easier to access the server log in case of a failure.

### Checklist
- [x] I have tested it locally
- [x] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it
