### PR TITLE
test: do not use the same IP for different MAC addresses

### DIFF
--- a/test/TEST-60-NFS/dhcpd.conf
+++ b/test/TEST-60-NFS/dhcpd.conf
@@ -20,7 +20,7 @@ option domain-name "other.com";
 
                 host nfs3-0 {
                         hardware ethernet 52:54:00:12:34:00;
-                        fixed-address 192.168.50.101;
+                        fixed-address 192.168.50.100;
                 }
         }
 
@@ -40,7 +40,7 @@ option domain-name "other.com";
 
                 host nfs3-2 {
                         hardware ethernet 52:54:00:12:34:02;
-                        fixed-address 192.168.50.101;
+                        fixed-address 192.168.50.102;
                 }
         }
 
@@ -50,7 +50,7 @@ option domain-name "other.com";
 
                 host nfs3-3 {
                         hardware ethernet 52:54:00:12:34:03;
-                        fixed-address 192.168.50.101;
+                        fixed-address 192.168.50.103;
                 }
         }
 
@@ -59,7 +59,7 @@ option domain-name "other.com";
 
                 host nfs3-4 {
                         hardware ethernet 52:54:00:12:34:04;
-                        fixed-address 192.168.50.101;
+                        fixed-address 192.168.50.104;
                 }
         }
 
@@ -69,7 +69,7 @@ option domain-name "other.com";
 
                 host nfs3-5 {
                         hardware ethernet 52:54:00:12:34:05;
-                        fixed-address 192.168.50.101;
+                        fixed-address 192.168.50.105;
                 }
         }
 
@@ -79,7 +79,7 @@ option domain-name "other.com";
 
                 host nfs3-6 {
                         hardware ethernet 52:54:00:12:34:06;
-                        fixed-address 192.168.50.101;
+                        fixed-address 192.168.50.106;
                 }
         }
 
@@ -89,7 +89,7 @@ option domain-name "other.com";
 
                 host nfs3-7 {
                         hardware ethernet 52:54:00:12:34:07;
-                        fixed-address 192.168.50.101;
+                        fixed-address 192.168.50.107;
                 }
         }
 
@@ -102,7 +102,7 @@ option domain-name "other.com";
 
                 host nfs4-0 {
                         hardware ethernet 52:54:00:12:34:80;
-                        fixed-address 192.168.50.101;
+                        fixed-address 192.168.50.180;
                 }
         }
 
@@ -112,7 +112,7 @@ option domain-name "other.com";
 
                 host nfs4-1 {
                         hardware ethernet 52:54:00:12:34:81;
-                        fixed-address 192.168.50.101;
+                        fixed-address 192.168.50.181;
                 }
         }
 
@@ -122,7 +122,7 @@ option domain-name "other.com";
 
                 host nfs4-2 {
                         hardware ethernet 52:54:00:12:34:82;
-                        fixed-address 192.168.50.101;
+                        fixed-address 192.168.50.182;
                 }
         }
 
@@ -132,7 +132,7 @@ option domain-name "other.com";
 
                 host nfs4-3 {
                         hardware ethernet 52:54:00:12:34:83;
-                        fixed-address 192.168.50.101;
+                        fixed-address 192.168.50.183;
                 }
         }
 
@@ -140,7 +140,7 @@ option domain-name "other.com";
                 # NFSv3 root=nfs4, nfsroot=/path and nfsroot=IP:/path testing
                 host nfs4-4 {
                         hardware ethernet 52:54:00:12:34:84;
-                        fixed-address 192.168.50.101;
+                        fixed-address 192.168.50.184;
                 }
         }
 
@@ -150,7 +150,7 @@ option domain-name "other.com";
 
                 host nfs4-5 {
                         hardware ethernet 52:54:00:12:34:85;
-                        fixed-address 192.168.50.101;
+                        fixed-address 192.168.50.185;
                 }
         }
 
@@ -160,7 +160,7 @@ option domain-name "other.com";
 
                 host nfs4-6 {
                         hardware ethernet 52:54:00:12:34:86;
-                        fixed-address 192.168.50.101;
+                        fixed-address 192.168.50.186;
                 }
         }
 
@@ -170,7 +170,7 @@ option domain-name "other.com";
 
                 host nfs4-7 {
                         hardware ethernet 52:54:00:12:34:87;
-                        fixed-address 192.168.50.101;
+                        fixed-address 192.168.50.187;
                 }
         }
 

--- a/test/TEST-72-NBD/dhcpd.conf
+++ b/test/TEST-72-NBD/dhcpd.conf
@@ -14,7 +14,7 @@ subnet 192.168.50.0 netmask 255.255.255.0 {
 	group {
 		host nbd-0 {
 			hardware ethernet 52:54:00:12:34:00;
-			fixed-address 192.168.50.101;
+			fixed-address 192.168.50.100;
 		}
 	}
 
@@ -32,7 +32,7 @@ subnet 192.168.50.0 netmask 255.255.255.0 {
 			option root-path "nbd:192.168.50.1:raw:ext2";
 
 			hardware ethernet 52:54:00:12:34:02;
-			fixed-address 192.168.50.101;
+			fixed-address 192.168.50.102;
 		}
 	}
 
@@ -41,7 +41,7 @@ subnet 192.168.50.0 netmask 255.255.255.0 {
 			option root-path "nbd:192.168.50.1:raw::errors=panic";
 
 			hardware ethernet 52:54:00:12:34:03;
-			fixed-address 192.168.50.101;
+			fixed-address 192.168.50.103;
 		}
 	}
 
@@ -50,7 +50,7 @@ subnet 192.168.50.0 netmask 255.255.255.0 {
 			option root-path "nbd:192.168.50.1:raw:ext2:errors=panic";
 
 			hardware ethernet 52:54:00:12:34:04;
-			fixed-address 192.168.50.101;
+			fixed-address 192.168.50.104;
 		}
 	}
 
@@ -60,7 +60,7 @@ subnet 192.168.50.0 netmask 255.255.255.0 {
 			option root-path "nbd:192.168.50.1:encrypted:ext2:errors=panic";
 
 			hardware ethernet 52:54:00:12:34:05;
-			fixed-address 192.168.50.101;
+			fixed-address 192.168.50.105;
 		}
 	}
 }


### PR DESCRIPTION
dnsmasq will complain when different MAC addresses are mapped to the same IP address.

<!-- This pull request changes... -->

<!-- Fixes: https://github.com/dracut-ng/dracut-ng/issues/<number> -->

### Checklist
- [ ] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it
