### PR TITLE
ci: increase timeout for test 60 on ARM to 60 minutes

### DIFF
--- a/.github/workflows/daily-network-legacy.yml
+++ b/.github/workflows/daily-network-legacy.yml
@@ -18,7 +18,7 @@ jobs:
             ${{ matrix.test }} on ${{ matrix.container }}
             ${{ matrix.network }} networking on ${{ matrix.architecture.tag }}
         runs-on: ${{ matrix.architecture.runner }}
-        timeout-minutes: 40
+        timeout-minutes: ${{ matrix.architecture.timeout }}
         concurrency:
             group: >
                 daily-network-legacy-${{ github.workflow }}-${{ github.ref }}
@@ -29,8 +29,8 @@ jobs:
             fail-fast: false
             matrix:
                 architecture:
-                    - {runner: 'ubuntu-24.04', tag: 'amd'}
-                    - {runner: 'ubuntu-24.04-arm', tag: 'arm'}
+                    - {runner: 'ubuntu-24.04', tag: 'amd', timeout: 20}
+                    - {runner: 'ubuntu-24.04-arm', tag: 'arm', timeout: 60}
                 network:
                     - network-legacy
                 container:

--- a/.github/workflows/daily-network.yml
+++ b/.github/workflows/daily-network.yml
@@ -16,7 +16,7 @@ jobs:
     network:
         name: ${{ matrix.test }} on ${{ matrix.container }} on ${{ matrix.architecture.tag }}
         runs-on: ${{ matrix.architecture.runner }}
-        timeout-minutes: 40
+        timeout-minutes: ${{ matrix.architecture.timeout }}
         concurrency:
             group: >
                 daily-network-${{ github.workflow }}-${{ github.ref }}
@@ -26,8 +26,8 @@ jobs:
             fail-fast: false
             matrix:
                 architecture:
-                    - {runner: 'ubuntu-24.04', tag: 'amd'}
-                    - {runner: 'ubuntu-24.04-arm', tag: 'arm'}
+                    - {runner: 'ubuntu-24.04', tag: 'amd', timeout: 20}
+                    - {runner: 'ubuntu-24.04-arm', tag: 'arm', timeout: 60}
                 container:
                     - arch:latest
                     - debian:latest

--- a/.github/workflows/daily-omitsystemd.yml
+++ b/.github/workflows/daily-omitsystemd.yml
@@ -16,7 +16,7 @@ jobs:
     omitsystemd:
         name: ${{ matrix.test }} on ${{ matrix.container }} on ${{ matrix.architecture.tag }} with no systemd
         runs-on: ${{ matrix.architecture.runner }}
-        timeout-minutes: 40
+        timeout-minutes: ${{ matrix.architecture.timeout }}
         concurrency:
             group: >
                 daily-omitsystemd-${{ github.workflow }}-${{ github.ref }}
@@ -26,8 +26,8 @@ jobs:
             fail-fast: false
             matrix:
                 architecture:
-                    - {runner: 'ubuntu-24.04', tag: 'amd'}
-                    - {runner: 'ubuntu-24.04-arm', tag: 'arm'}
+                    - {runner: 'ubuntu-24.04', tag: 'amd', timeout: 20}
+                    - {runner: 'ubuntu-24.04-arm', tag: 'arm', timeout: 60}
                 container:
                     - ubuntu:devel
                 test:


### PR DESCRIPTION
Test 60 can run into the 40 minutes timeout on ARM. So increase the timeout to 60 minutes only on ARM.

Test 60 took 36m here: https://github.com/dracut-ng/dracut-ng/actions/runs/22601284680/job/65483494467
and ran into the 40m timeout here: https://github.com/dracut-ng/dracut-ng/actions/runs/22621093296/job/65599347832

### Checklist
- [ ] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it
