### PR TITLE
test: use verySecurePassword as cryptsetup password

### DIFF
--- a/test/TEST-20-STORAGE/create-root.sh
+++ b/test/TEST-20-STORAGE/create-root.sh
@@ -23,9 +23,9 @@ else
     fi
 
     if ! grep -qF 'rd.luks=0' /proc/cmdline && command -v cryptsetup > /dev/null; then
-        printf test > keyfile
+        printf verySecurePassword > keyfile
         cryptsetup --pbkdf pbkdf2 -q luksFormat /dev/md0 /keyfile
-        echo "The passphrase is test"
+        echo "The passphrase is verySecurePassword"
         cryptsetup luksOpen /dev/md0 dracut_crypt_test < /keyfile
         lvm pvcreate -ff -y /dev/mapper/dracut_crypt_test
         lvm vgcreate dracut /dev/mapper/dracut_crypt_test

--- a/test/TEST-20-STORAGE/test.sh
+++ b/test/TEST-20-STORAGE/test.sh
@@ -152,7 +152,7 @@ test_setup() {
         eval "$(grep -F -a -m 1 ID_FS_UUID "$TESTDIR"/marker.img)"
         echo "$ID_FS_UUID" > "$TESTDIR"/luksuuid
         echo "testluks UUID=$ID_FS_UUID /etc/key" > /tmp/crypttab
-        echo -n "test" > /tmp/key
+        echo -n "verySecurePassword" > /tmp/key
         chmod 0600 /tmp/key
     fi
 

--- a/test/TEST-26-ENC-RAID-LVM/create-root.sh
+++ b/test/TEST-26-ENC-RAID-LVM/create-root.sh
@@ -2,7 +2,7 @@
 
 trap 'poweroff -f' EXIT
 set -ex
-printf test > keyfile
+printf verySecurePassword > keyfile
 cryptsetup --pbkdf pbkdf2 -q luksFormat /dev/disk/by-id/scsi-0QEMU_QEMU_HARDDISK_disk1 /keyfile
 cryptsetup --pbkdf pbkdf2 -q luksFormat /dev/disk/by-id/scsi-0QEMU_QEMU_HARDDISK_disk2 /keyfile
 cryptsetup luksOpen /dev/disk/by-id/scsi-0QEMU_QEMU_HARDDISK_disk1 dracut_disk1 < /keyfile

--- a/test/TEST-26-ENC-RAID-LVM/test.sh
+++ b/test/TEST-26-ENC-RAID-LVM/test.sh
@@ -90,7 +90,7 @@ test_setup() {
         printf 'luks-%s /dev/disk/by-id/scsi-0QEMU_QEMU_HARDDISK_disk%s /etc/key timeout=0\n' "$ID_FS_UUID" $i
         ((i += 1))
     done > /tmp/crypttab
-    echo -n test > /tmp/key
+    echo -n verySecurePassword > /tmp/key
     chmod 0600 /tmp/key
 
     test_dracut \

--- a/test/TEST-41-FULL-SYSTEMD/create-root.sh
+++ b/test/TEST-41-FULL-SYSTEMD/create-root.sh
@@ -5,7 +5,7 @@ set -e
 
 modprobe btrfs || :
 mkfs.btrfs -q -L dracut /dev/disk/by-id/scsi-0QEMU_QEMU_HARDDISK_root
-printf test > keyfile
+printf verySecurePassword > keyfile
 cryptsetup --pbkdf pbkdf2 -q luksFormat /dev/disk/by-id/scsi-0QEMU_QEMU_HARDDISK_root_crypt /keyfile
 cryptsetup luksOpen /dev/disk/by-id/scsi-0QEMU_QEMU_HARDDISK_root_crypt dracut_crypt_test < /keyfile
 mkfs.btrfs -q -L dracut_crypt /dev/mapper/dracut_crypt_test

--- a/test/TEST-41-FULL-SYSTEMD/test.sh
+++ b/test/TEST-41-FULL-SYSTEMD/test.sh
@@ -107,7 +107,7 @@ test_setup() {
     test_marker_check dracut-root-block-created
 
     grep -F -a -m 1 ID_FS_UUID "$TESTDIR"/marker.img > "$TESTDIR"/luks.uuid
-    echo -n test > /tmp/key
+    echo -n verySecurePassword > /tmp/key
 
     # force add all available dracut modules that are dependent on systemd
     test_dracut --keep \

--- a/test/TEST-72-NBD/create-encrypted-root.sh
+++ b/test/TEST-72-NBD/create-encrypted-root.sh
@@ -3,9 +3,9 @@
 trap 'poweroff -f' EXIT
 set -ex
 
-printf test > keyfile
+printf verySecurePassword > keyfile
 cryptsetup --pbkdf pbkdf2 -q luksFormat /dev/disk/by-id/scsi-0QEMU_QEMU_HARDDISK_root /keyfile
-echo "The passphrase is test"
+echo "The passphrase is verySecurePassword"
 cryptsetup luksOpen /dev/disk/by-id/scsi-0QEMU_QEMU_HARDDISK_root dracut_crypt_test < /keyfile
 lvm pvcreate -ff -y /dev/mapper/dracut_crypt_test
 lvm vgcreate dracut /dev/mapper/dracut_crypt_test

--- a/test/TEST-72-NBD/test.sh
+++ b/test/TEST-72-NBD/test.sh
@@ -255,7 +255,7 @@ test_setup() {
     . "$TESTDIR"/luks.uuid
 
     echo "luks-$ID_FS_UUID /dev/nbd0 /etc/key" > /tmp/crypttab
-    echo -n test > /tmp/key
+    echo -n verySecurePassword > /tmp/key
 
     test_dracut \
         --no-hostonly \


### PR DESCRIPTION
The cryptsetup password `test` is not FIPS compliant. This causes test 20 to fail on Fedora:

```
systemd-cryptsetup[688]: Running in FIPS mode.
systemd-cryptsetup[688]: Set cipher aes, mode xts-plain64, key size 512 bits for device /dev/disk/by-uuid/aa12cc4c-b796-4c7f-a029-cf7f0120bb30.
systemd-cryptsetup[688]: Keyslot open failed.
systemd-cryptsetup[688]: Failed to activate with key file '/etc/key': Invalid argument
systemd[1]: systemd-cryptsetup@testluks.service: Main process exited, code=exited, status=1/FAILURE
```

So use `verySecurePassword` as password which makes FIPS happy.

Fixes: https://github.com/dracut-ng/dracut-ng/issues/2262

<!-- This pull request changes... -->

<!-- Fixes: https://github.com/dracut-ng/dracut-ng/issues/<number> -->

### Checklist
- [x] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it
