### PR TITLE
test: switch QEMU network backend to dgram (UDP)

### DIFF
--- a/test/TEST-60-NFS/test.sh
+++ b/test/TEST-60-NFS/test.sh
@@ -28,8 +28,8 @@ run_server() {
 
     "$testdir"/run-qemu \
         "${disk_args[@]}" \
-        -net socket,listen=127.0.0.1:12320 \
-        -net nic,macaddr=52:54:00:12:34:56,model=virtio \
+        -device virtio-net-pci,netdev=lan0,mac=52:54:00:12:34:56 \
+        -netdev dgram,id=lan0,local.type=inet,local.host=localhost,local.port=60600,remote.type=inet,remote.host=localhost,remote.port=60601 \
         -serial "${SERIAL:-"file:./server${TEST_RUN_ID:+-$TEST_RUN_ID}.log"}" \
         -append "panic=1 oops=panic softlockup_panic=1 root=LABEL=dracut rootfstype=ext4 rw systemd.journald.forward_to_console=1 ${SERVER_DEBUG-}" \
         -pidfile "$TESTDIR"/server.pid -daemonize \
@@ -61,8 +61,8 @@ client_test() {
 
     "$testdir"/run-qemu \
         "${disk_args[@]}" \
-        -net nic,macaddr="$mac",model=virtio \
-        -net socket,connect=127.0.0.1:12320 \
+        -device virtio-net-pci,netdev=lan0,mac="$mac" \
+        -netdev dgram,id=lan0,local.type=inet,local.host=localhost,local.port=60601,remote.type=inet,remote.host=localhost,remote.port=60600 \
         -append "$TEST_KERNEL_CMDLINE $cmdline ro" \
         -initrd "$TESTDIR"/initramfs.testing
 

--- a/test/TEST-70-ISCSI/test.sh
+++ b/test/TEST-70-ISCSI/test.sh
@@ -24,9 +24,9 @@ run_server() {
         "${disk_args[@]}" \
         -serial "${SERIAL:-"file:./server${TEST_RUN_ID:+-$TEST_RUN_ID}.log"}" \
         -device virtio-net-pci,netdev=lan0,mac=52:54:00:12:34:56 \
-        -netdev socket,id=lan0,listen=127.0.0.1:60700 \
+        -netdev dgram,id=lan0,local.type=inet,local.host=localhost,local.port=60700,remote.type=inet,remote.host=localhost,remote.port=60701 \
         -device virtio-net-pci,netdev=lan1,mac=52:54:00:12:34:57 \
-        -netdev socket,id=lan1,listen=127.0.0.1:60701 \
+        -netdev dgram,id=lan1,local.type=inet,local.host=localhost,local.port=60702,remote.type=inet,remote.host=localhost,remote.port=60703 \
         -append "panic=1 oops=panic softlockup_panic=1 quiet root=/dev/disk/by-id/scsi-0QEMU_QEMU_HARDDISK_serverroot rw systemd.journald.forward_to_console=1 ${SERVER_DEBUG-}" \
         -pidfile "$TESTDIR"/server.pid -daemonize \
         -initrd "$TESTDIR"/initramfs.server
@@ -54,9 +54,9 @@ run_client() {
     "$testdir"/run-qemu \
         "${disk_args[@]}" \
         -device virtio-net-pci,netdev=lan0,mac=52:54:00:12:34:00 \
-        -netdev socket,id=lan0,connect=127.0.0.1:60700 \
+        -netdev dgram,id=lan0,local.type=inet,local.host=localhost,local.port=60701,remote.type=inet,remote.host=localhost,remote.port=60700 \
         -device virtio-net-pci,netdev=lan1,mac=52:54:00:12:34:01 \
-        -netdev socket,id=lan1,connect=127.0.0.1:60701 \
+        -netdev dgram,id=lan1,local.type=inet,local.host=localhost,local.port=60703,remote.type=inet,remote.host=localhost,remote.port=60702 \
         ${acpitable_file:+-acpitable "file=${acpitable_file}"} \
         -append "$TEST_KERNEL_CMDLINE $*" \
         -initrd "$TESTDIR"/initramfs.testing

--- a/test/TEST-71-ISCSI-MULTI/test.sh
+++ b/test/TEST-71-ISCSI-MULTI/test.sh
@@ -24,9 +24,9 @@ run_server() {
         "${disk_args[@]}" \
         -serial "${SERIAL:-"file:./server${TEST_RUN_ID:+-$TEST_RUN_ID}.log"}" \
         -device virtio-net-pci,netdev=lan0,mac=52:54:00:12:34:56 \
-        -netdev socket,id=lan0,listen=127.0.0.1:60710 \
+        -netdev dgram,id=lan0,local.type=inet,local.host=localhost,local.port=60710,remote.type=inet,remote.host=localhost,remote.port=60711 \
         -device virtio-net-pci,netdev=lan1,mac=52:54:00:12:34:57 \
-        -netdev socket,id=lan1,listen=127.0.0.1:60711 \
+        -netdev dgram,id=lan1,local.type=inet,local.host=localhost,local.port=60712,remote.type=inet,remote.host=localhost,remote.port=60713 \
         -append "panic=1 oops=panic softlockup_panic=1 systemd.crash_reboot root=/dev/disk/by-id/scsi-0QEMU_QEMU_HARDDISK_serverroot rootfstype=ext4 rw systemd.journald.forward_to_console=1 ${SERVER_DEBUG-}" \
         -pidfile "$TESTDIR"/server.pid -daemonize \
         -initrd "$TESTDIR"/initramfs.server
@@ -52,9 +52,9 @@ run_client() {
     "$testdir"/run-qemu \
         "${disk_args[@]}" \
         -device virtio-net-pci,netdev=lan0,mac=52:54:00:12:34:00 \
-        -netdev socket,id=lan0,connect=127.0.0.1:60710 \
+        -netdev dgram,id=lan0,local.type=inet,local.host=localhost,local.port=60711,remote.type=inet,remote.host=localhost,remote.port=60710 \
         -device virtio-net-pci,netdev=lan1,mac=52:54:00:12:34:01 \
-        -netdev socket,id=lan1,connect=127.0.0.1:60711 \
+        -netdev dgram,id=lan1,local.type=inet,local.host=localhost,local.port=60713,remote.type=inet,remote.host=localhost,remote.port=60712 \
         -append "$TEST_KERNEL_CMDLINE rw rd.auto $*" \
         -initrd "$TESTDIR"/initramfs.testing
     if ! test_marker_check iscsi-OK; then

--- a/test/TEST-72-NBD/test.sh
+++ b/test/TEST-72-NBD/test.sh
@@ -33,8 +33,8 @@ run_server() {
     "$testdir"/run-qemu \
         "${disk_args[@]}" \
         -serial "${SERIAL:-"file:./server${TEST_RUN_ID:+-$TEST_RUN_ID}.log"}" \
-        -net nic,macaddr=52:54:00:12:34:56,model=virtio \
-        -net socket,listen=127.0.0.1:12340 \
+        -device virtio-net-pci,netdev=lan0,mac=52:54:00:12:34:56 \
+        -netdev dgram,id=lan0,local.type=inet,local.host=localhost,local.port=60720,remote.type=inet,remote.host=localhost,remote.port=60721 \
         -append "panic=1 oops=panic softlockup_panic=1 rd.luks=0 systemd.crash_reboot quiet root=/dev/disk/by-id/scsi-0QEMU_QEMU_HARDDISK_serverroot rootfstype=ext4 rw systemd.journald.forward_to_console=1 ${SERVER_DEBUG-}" \
         -pidfile "$TESTDIR"/server.pid -daemonize \
         -initrd "$TESTDIR"/initramfs.server
@@ -64,8 +64,8 @@ client_test() {
     test_marker_reset
     "$testdir"/run-qemu \
         "${disk_args[@]}" \
-        -net nic,macaddr="$mac",model=virtio \
-        -net socket,connect=127.0.0.1:12340 \
+        -device virtio-net-pci,netdev=lan0,mac="$mac" \
+        -netdev dgram,id=lan0,local.type=inet,local.host=localhost,local.port=60721,remote.type=inet,remote.host=localhost,remote.port=60720 \
         -append "$cmdline rd.auto ro" \
         -initrd "$TESTDIR"/initramfs.testing
 


### PR DESCRIPTION
When replacing isc-dhcp-server by dnsmasq, test 60 starts to fail on some distributions. The second client test hangs for several seconds on shutdown and the third client test fails to get an IP adress. The client sends a DHCP discover packet, but that never reaches dnsmasq.

Adding tcpdump to `server-init.sh` let the tests succeed:
```
tcpdump -v -Z root -i enx525400123456 -n port 67 or port 68 &
```

Running the client tests individually let them succeed as well.

The assumption is that the host kernel keeps the QEMU netdev TCP socket in a TIME_WAIT or FIN_WAIT_2 state following a client shutdown which leads to a socket deadlock: the next client may successfully connect to the host socket, but the server QEMU process fails to re-initialize the virtual link correctly.

Switch to `-netdev dgram` (UDP) to eliminate the connection state management entirely.

See also https://github.com/dracut-ng/dracut-ng/pull/2271#issuecomment-3997945175

<!-- This pull request changes... -->

<!-- Fixes: https://github.com/dracut-ng/dracut-ng/issues/<number> -->

### Checklist
- [x] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it
