### PR TITLE
test: use different MAC addresses for all NFS client tests

### DIFF
--- a/test/TEST-60-NFS/dhcpd.conf
+++ b/test/TEST-60-NFS/dhcpd.conf
@@ -15,7 +15,7 @@ option domain-name "other.com";
 # NFSv3: last octet starts at 0x00 and works up
 
         group {
-                # NFSv3 root=dhcp or root={/dev/,}nfs, use server-id
+                # NFSv3 root=dhcp DHCP path only
                 option root-path "/nfs/client";
 
                 host nfs3-0 {
@@ -25,7 +25,7 @@ option domain-name "other.com";
         }
 
         group {
-                # NFSv3 root=dhcp or root={/dev/,}nfs, use given IP
+                # NFSv3 Legacy root=/dev/nfs nfsroot=IP:path
                 option root-path "192.168.50.2:/nfs/client";
 
                 host nfs3-1 {
@@ -35,8 +35,8 @@ option domain-name "other.com";
         }
 
         group {
-                # NFSv3 root=dhcp, use protocol from root-path
-                option root-path "nfs:192.168.50.3:/nfs/client";
+                # NFSv3 Legacy root=/dev/nfs DHCP path only
+                option root-path "/nfs/client";
 
                 host nfs3-2 {
                         hardware ethernet 52:54:00:12:34:02;
@@ -45,8 +45,8 @@ option domain-name "other.com";
         }
 
         group {
-                # NFSv3 root=dhcp, use protocol, options from root-path
-                option root-path "nfs:192.168.50.3:/nfs/client:wsize=4096";
+                # NFSv3 Legacy root=/dev/nfs DHCP IP:path
+                option root-path "192.168.50.2:/nfs/client";
 
                 host nfs3-3 {
                         hardware ethernet 52:54:00:12:34:03;
@@ -55,7 +55,8 @@ option domain-name "other.com";
         }
 
         group {
-                # NFSv3 root=dhcp, nfsroot=/path and nfsroot=IP:/path testing
+                # NFSv3 root=dhcp DHCP IP:path
+                option root-path "192.168.50.2:/nfs/client";
 
                 host nfs3-4 {
                         hardware ethernet 52:54:00:12:34:04;
@@ -64,8 +65,8 @@ option domain-name "other.com";
         }
 
         group {
-                # NFSv3 root=dhcp, use path, comma-separated options
-                option root-path "/nfs/client,wsize=4096";
+                # NFSv3 root=dhcp DHCP proto:IP:path
+                option root-path "nfs:192.168.50.3:/nfs/client";
 
                 host nfs3-5 {
                         hardware ethernet 52:54:00:12:34:05;
@@ -74,8 +75,8 @@ option domain-name "other.com";
         }
 
         group {
-                # NFSv3 root=dhcp, use IP, path, comma-separated options
-                option root-path "192.168.50.2:/nfs/client,wsize=4096";
+                # NFSv3 root=dhcp DHCP proto:IP:path:options
+                option root-path "nfs:192.168.50.3:/nfs/client:wsize=4096";
 
                 host nfs3-6 {
                         hardware ethernet 52:54:00:12:34:06;
@@ -84,8 +85,7 @@ option domain-name "other.com";
         }
 
         group {
-                # NFSv3 root=dhcp, use proto, IP, path, comma-separated options
-                option root-path "nfs:192.168.50.3:/nfs/client,wsize=4096";
+                # NFSv3 root=nfs:...
 
                 host nfs3-7 {
                         hardware ethernet 52:54:00:12:34:07;
@@ -93,12 +93,71 @@ option domain-name "other.com";
                 }
         }
 
+        group {
+                # NFSv3 Bridge root=nfs:...
+
+                host nfs3-8 {
+                        hardware ethernet 52:54:00:12:34:08;
+                        fixed-address 192.168.50.108;
+                }
+        }
+
+        group {
+                # NFSv3 Legacy root=IP:path
+
+                host nfs3-9 {
+                        hardware ethernet 52:54:00:12:34:09;
+                        fixed-address 192.168.50.109;
+                }
+        }
+
+        group {
+                # NFSv3 root=dhcp DHCP path,options
+                option root-path "/nfs/client,wsize=4096";
+
+                host nfs3-10 {
+                        hardware ethernet 52:54:00:12:34:10;
+                        fixed-address 192.168.50.110;
+                }
+        }
+
+        group {
+                # NFSv3 root=dhcp DHCP IP:path,options
+                option root-path "192.168.50.2:/nfs/client,wsize=4096";
+
+                host nfs3-11 {
+                        hardware ethernet 52:54:00:12:34:11;
+                        fixed-address 192.168.50.111;
+                }
+        }
+
+        group {
+                # NFSv3 root=dhcp DHCP proto:IP:path,options
+                option root-path "nfs:192.168.50.3:/nfs/client,wsize=4096";
+
+                host nfs3-12 {
+                        hardware ethernet 52:54:00:12:34:12;
+                        fixed-address 192.168.50.112;
+                }
+        }
+
+        group {
+                # NFSv3 Bridge Customized root=dhcp DHCP path,options
+                option root-path "/nfs/client,wsize=4096";
+
+                host nfs3-13 {
+                        hardware ethernet 52:54:00:12:34:13;
+                        fixed-address 192.168.50.113;
+                }
+        }
+
+
         # MAC numbering scheme:
         # NFSv4: last octet starts at 0x80 and works up
 
         group {
-                # NFSv4 root={/dev/,}nfs4, use server-id
-                option root-path "/client";
+                # NFSv4 root=dhcp DHCP proto:IP:path
+                option root-path "nfs4:192.168.50.3:/client";
 
                 host nfs4-0 {
                         hardware ethernet 52:54:00:12:34:80;
@@ -107,8 +166,8 @@ option domain-name "other.com";
         }
 
         group {
-                # NFSv4 root={/dev/,}nfs4, use given IP
-                option root-path "192.168.50.2:/client";
+                # NFSv4 root=dhcp DHCP proto:IP:path:options
+                option root-path "nfs4:192.168.50.3:/client:wsize=4096";
 
                 host nfs4-1 {
                         hardware ethernet 52:54:00:12:34:81;
@@ -117,9 +176,7 @@ option domain-name "other.com";
         }
 
         group {
-                # NFSv4 root=dhcp, use profocol from root-path
-                option root-path "nfs4:192.168.50.3:/client";
-
+                # NFSv4 root=nfs4:...
                 host nfs4-2 {
                         hardware ethernet 52:54:00:12:34:82;
                         fixed-address 192.168.50.182;
@@ -127,8 +184,8 @@ option domain-name "other.com";
         }
 
         group {
-                # NFSv4 root=dhcp, use profocol, options from root-path
-                option root-path "nfs4:192.168.50.3:/client:wsize=4096";
+                # NFSv4 root=dhcp DHCP proto:IP:path,options
+                option root-path "nfs4:192.168.50.3:/client,wsize=4096";
 
                 host nfs4-3 {
                         hardware ethernet 52:54:00:12:34:83;
@@ -137,7 +194,7 @@ option domain-name "other.com";
         }
 
         group {
-                # NFSv3 root=nfs4, nfsroot=/path and nfsroot=IP:/path testing
+                # NFSv4 Overlayfs root=nfs4:...
                 host nfs4-4 {
                         hardware ethernet 52:54:00:12:34:84;
                         fixed-address 192.168.50.184;
@@ -145,33 +202,10 @@ option domain-name "other.com";
         }
 
         group {
-                # NFSv4 root={/dev/,}nfs4, use server-id, comma-separated opts
-                option root-path "/client,wsize=4096";
-
+                # NFSv4 Live Overlayfs root=nfs4:...
                 host nfs4-5 {
                         hardware ethernet 52:54:00:12:34:85;
                         fixed-address 192.168.50.185;
                 }
         }
-
-        group {
-                # NFSv4 root={/dev/,}nfs4, use given IP, comma-separated opts
-                option root-path "192.168.50.2:/client,wsize=4096";
-
-                host nfs4-6 {
-                        hardware ethernet 52:54:00:12:34:86;
-                        fixed-address 192.168.50.186;
-                }
-        }
-
-        group {
-                # NFSv4 root=dhcp, use comma-separated opts
-                option root-path "nfs4:192.168.50.3:/client,wsize=4096";
-
-                host nfs4-7 {
-                        hardware ethernet 52:54:00:12:34:87;
-                        fixed-address 192.168.50.187;
-                }
-        }
-
 }

--- a/test/TEST-60-NFS/test.sh
+++ b/test/TEST-60-NFS/test.sh
@@ -129,41 +129,41 @@ test_nfsv3() {
     client_test "NFSv3 Legacy root=/dev/nfs nfsroot=IP:path" 52:54:00:12:34:01 \
         "root=/dev/nfs nfsroot=192.168.50.1:/nfs/client" 192.168.50.1 -wsize=4096
 
-    client_test "NFSv3 Legacy root=/dev/nfs DHCP path only" 52:54:00:12:34:00 \
+    client_test "NFSv3 Legacy root=/dev/nfs DHCP path only" 52:54:00:12:34:02 \
         "root=/dev/nfs" 192.168.50.1 -wsize=4096
 
-    client_test "NFSv3 Legacy root=/dev/nfs DHCP IP:path" 52:54:00:12:34:01 \
+    client_test "NFSv3 Legacy root=/dev/nfs DHCP IP:path" 52:54:00:12:34:03 \
         "root=/dev/nfs" 192.168.50.2 -wsize=4096
 
-    client_test "NFSv3 root=dhcp DHCP IP:path" 52:54:00:12:34:01 \
+    client_test "NFSv3 root=dhcp DHCP IP:path" 52:54:00:12:34:04 \
         "root=dhcp" 192.168.50.2 -wsize=4096
 
-    client_test "NFSv3 root=dhcp DHCP proto:IP:path" 52:54:00:12:34:02 \
+    client_test "NFSv3 root=dhcp DHCP proto:IP:path" 52:54:00:12:34:05 \
         "root=dhcp" 192.168.50.3 -wsize=4096
 
-    client_test "NFSv3 root=dhcp DHCP proto:IP:path:options" 52:54:00:12:34:03 \
+    client_test "NFSv3 root=dhcp DHCP proto:IP:path:options" 52:54:00:12:34:06 \
         "root=dhcp" 192.168.50.3 wsize=4096
 
-    client_test "NFSv3 root=nfs:..." 52:54:00:12:34:04 \
+    client_test "NFSv3 root=nfs:..." 52:54:00:12:34:07 \
         "root=nfs:192.168.50.1:/nfs/client" 192.168.50.1 -wsize=4096
 
-    client_test "NFSv3 Bridge root=nfs:..." 52:54:00:12:34:04 \
+    client_test "NFSv3 Bridge root=nfs:..." 52:54:00:12:34:08 \
         "root=nfs:192.168.50.1:/nfs/client bridge net.ifnames=0" 192.168.50.1 -wsize=4096
 
-    client_test "NFSv3 Legacy root=IP:path" 52:54:00:12:34:04 \
+    client_test "NFSv3 Legacy root=IP:path" 52:54:00:12:34:09 \
         "root=192.168.50.1:/nfs/client" 192.168.50.1 -wsize=4096
 
-    client_test "NFSv3 root=dhcp DHCP path,options" 52:54:00:12:34:05 \
+    client_test "NFSv3 root=dhcp DHCP path,options" 52:54:00:12:34:10 \
         "root=dhcp" 192.168.50.1 wsize=4096
 
-    client_test "NFSv3 root=dhcp DHCP IP:path,options" 52:54:00:12:34:06 \
+    client_test "NFSv3 root=dhcp DHCP IP:path,options" 52:54:00:12:34:11 \
         "root=dhcp" 192.168.50.2 wsize=4096
 
-    client_test "NFSv3 root=dhcp DHCP proto:IP:path,options" 52:54:00:12:34:07 \
+    client_test "NFSv3 root=dhcp DHCP proto:IP:path,options" 52:54:00:12:34:12 \
         "root=dhcp" 192.168.50.3 wsize=4096
 
     # TODO FIXME
-    #    client_test "NFSv3 Bridge Customized root=dhcp DHCP path,options" 52:54:00:12:34:05 \
+    #    client_test "NFSv3 Bridge Customized root=dhcp DHCP path,options" 52:54:00:12:34:13 \
     #        "root=dhcp bridge=foobr0:enp0s1" 192.168.50.1 wsize=4096
 
     return 0
@@ -174,22 +174,22 @@ test_nfsv4() {
     # server, so put these later in the list to avoid a pause when doing
     # switch_root
 
-    client_test "NFSv4 root=dhcp DHCP proto:IP:path" 52:54:00:12:34:82 \
+    client_test "NFSv4 root=dhcp DHCP proto:IP:path" 52:54:00:12:34:80 \
         "root=dhcp" 192.168.50.3 -wsize=4096
 
-    client_test "NFSv4 root=dhcp DHCP proto:IP:path:options" 52:54:00:12:34:83 \
+    client_test "NFSv4 root=dhcp DHCP proto:IP:path:options" 52:54:00:12:34:81 \
         "root=dhcp" 192.168.50.3 wsize=4096
 
-    client_test "NFSv4 root=nfs4:..." 52:54:00:12:34:84 \
+    client_test "NFSv4 root=nfs4:..." 52:54:00:12:34:82 \
         "root=nfs4:192.168.50.1:/client" 192.168.50.1 -wsize=4096
 
-    client_test "NFSv4 root=dhcp DHCP proto:IP:path,options" 52:54:00:12:34:87 \
+    client_test "NFSv4 root=dhcp DHCP proto:IP:path,options" 52:54:00:12:34:83 \
         "root=dhcp" 192.168.50.3 wsize=4096
 
     client_test "NFSv4 Overlayfs root=nfs4:..." 52:54:00:12:34:84 \
         "root=nfs4:192.168.50.1:/client rd.overlay " 192.168.50.1 -wsize=4096
 
-    client_test "NFSv4 Live Overlayfs root=nfs4:..." 52:54:00:12:34:84 \
+    client_test "NFSv4 Live Overlayfs root=nfs4:..." 52:54:00:12:34:85 \
         "root=nfs4:192.168.50.1:/client rd.live.image rd.overlay" 192.168.50.1 -wsize=4096
 
     return 0


### PR DESCRIPTION
Having two separate client tests use the same MAC address might not work with dnsmasq. To ease debugging use a separate MAC address for each client test. Update the DHCP config to reflect the test case name and make the numbering consecutive.

### Checklist
- [x] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it
