### PR TITLE
ci: skip void:latest due to dash 0.5.13.1 bug

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -40,7 +40,8 @@ jobs:
                     - gentoo:latest
                     - opensuse:latest
                     - ubuntu:devel
-                    - void:latest
+                    # Fails due escaping bug in dash 0.5.13.1: https://github.com/dracut-ng/dracut-ng/issues/2280
+                    # - void:latest
                 test:
                     - "10"
         container:
@@ -85,7 +86,8 @@ jobs:
                     - gentoo:latest
                     - opensuse:latest
                     - ubuntu:devel
-                    - void:latest
+                    # Fails due escaping bug in dash 0.5.13.1: https://github.com/dracut-ng/dracut-ng/issues/2280
+                    # - void:latest
                 test:
                     - "11"
                     - "12"
@@ -280,7 +282,8 @@ jobs:
                     - debian:latest
                     - opensuse:latest
                     - ubuntu:rolling
-                    - void:latest
+                    # Fails due escaping bug in dash 0.5.13.1: https://github.com/dracut-ng/dracut-ng/issues/2280
+                    # - void:latest
                 test:
                     - "10"
         container:


### PR DESCRIPTION
The tests on `void:latest` started to fail after updating dash to version 0.5.13.1. This is caused by an escaping bug in dash:

```

str_replace() {
    local in="$1"
    local s="$2"
    local r="$3"
    local out=''

    while [ "${in##*"$s"*}" != "$in" ]; do
        chop="${in%%"$s"*}"
        out="${out}${chop}$r"
        in="${in#*"$s"}"
    done
    printf -- '%s' "${out}${in}"
}

str_replace "/dev/disk/by-label/dracut" '/' '\x2f'
echo
_name=$(str_replace "/dev/disk/by-label/dracut" '/' '\x2f')
echo "_name=$_name"
```

```
bash-5.3# bash /z/bug
\x2fdev\x2fdisk\x2fby-label\x2fdracut
_name=\x2fdev\x2fdisk\x2fby-label\x2fdracut
bash-5.3# sh /z/bug
\x2fdev\x2fdisk\x2fby-label\x2fdracut
_name=/dev/disk/by-label/dracut
```

Skip the failing test cases on `void:latest` to unblock merge requests.

<!-- This pull request changes... -->

<!-- Fixes: https://github.com/dracut-ng/dracut-ng/issues/<number> -->

### Checklist
- [ ] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it
