### PR TITLE
test(test.sh): pass through USE_NETWORK environment variable

### DIFF
--- a/test/test.sh
+++ b/test/test.sh
@@ -38,7 +38,7 @@ fi
 # clear previous test run
 TARGETS='clean all install check' "$PODMAN" run --rm -it \
     --device=/dev/kvm --privileged \
-    -e V -e NO_KVM -e TESTS -e TEST_RUN_ID -e TARGETS -e MAKEFLAGS -e TEST_DRACUT_ARGS ${TEST_FSTYPE:+-e TEST_FSTYPE} -e TEST_CONTAINER_COMMAND \
+    -e V -e NO_KVM -e TESTS -e TEST_RUN_ID -e TARGETS -e MAKEFLAGS -e USE_NETWORK -e TEST_DRACUT_ARGS ${TEST_FSTYPE:+-e TEST_FSTYPE} -e TEST_CONTAINER_COMMAND \
     -v "$PWD"/:/z \
     "$CONTAINER" \
     /z/test/test-container.sh


### PR DESCRIPTION
Allow setting the `USE_NETWORK` environment variable when running the tests locally with `test/test.sh`.

<!-- This pull request changes... -->

<!-- Fixes: https://github.com/dracut-ng/dracut-ng/issues/<number> -->

### Checklist
- [x] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it
