### PR TITLE
ci: install tcpdump in containers

### DIFF
--- a/test/container/Dockerfile-alpine
+++ b/test/container/Dockerfile-alpine
@@ -30,6 +30,7 @@ RUN apk add --no-cache \
     dnsmasq \
     dracut-tests \
     efistub \
+    tcpdump \
     ukify
 
 RUN \

--- a/test/container/Dockerfile-arch
+++ b/test/container/Dockerfile-arch
@@ -61,6 +61,7 @@ RUN pacman --noconfirm -Syu \
     swtpm \
     systemd-libs \
     systemd-ukify \
+    tcpdump \
     tgt \
     tpm2-tools \
     xfsprogs \

--- a/test/container/Dockerfile-azurelinux
+++ b/test/container/Dockerfile-azurelinux
@@ -52,6 +52,7 @@ RUN tdnf -y install --setopt=install_weak_deps=False \
     systemd-devel \
     systemd-resolved \
     tar \
+    tcpdump \
     tpm2-tools \
     xfsprogs \
     xorriso \

--- a/test/container/Dockerfile-debian
+++ b/test/container/Dockerfile-debian
@@ -98,6 +98,7 @@ RUN \
     systemd-sysv \
     systemd-timesyncd \
     systemd-ukify \
+    tcpdump \
     tgt \
     thin-provisioning-tools \
     tpm2-tools \

--- a/test/container/Dockerfile-fedora
+++ b/test/container/Dockerfile-fedora
@@ -97,6 +97,7 @@ RUN dnf -y install --setopt=install_weak_deps=False \
     systemd-resolved \
     systemd-ukify \
     tar \
+    tcpdump \
     tpm2-tools \
     xfsprogs \
     xorriso \

--- a/test/container/Dockerfile-gentoo
+++ b/test/container/Dockerfile-gentoo
@@ -55,6 +55,7 @@ emerge --quiet --deep --autounmask-continue=y --with-bdeps=n --noreplace \
     dev-libs/libxslt \
     dev-libs/openssl \
     dev-ruby/asciidoctor \
+    net-analyzer/tcpdump \
     net-dns/dnsmasq \
     net-fs/nfs-utils \
     net-misc/dhcp \

--- a/test/container/Dockerfile-opensuse
+++ b/test/container/Dockerfile-opensuse
@@ -56,6 +56,7 @@ RUN zypper --non-interactive install --no-recommends \
     systemd-devel \
     systemd-experimental \
     systemd-portable \
+    tcpdump \
     tgt \
     tpm2.0-tools \
     util-linux-systemd \

--- a/test/container/Dockerfile-void
+++ b/test/container/Dockerfile-void
@@ -59,6 +59,7 @@ RUN xbps-install -Syu xbps && xbps-install -yu \
     ruby-asciidoctor \
     squashfs-tools \
     systemd-boot-efistub \
+    tcpdump \
     ncurses-base \
     ukify \
     xorriso \


### PR DESCRIPTION
Test 60 fails with dnsmasq: no DHCP discover packet reached dsnmasq. The workaround is to run tcpdump on the server.

See https://github.com/dracut-ng/dracut-ng/issues/2283

<!-- This pull request changes... -->

<!-- Fixes: https://github.com/dracut-ng/dracut-ng/issues/<number> -->

### Checklist
- [ ] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it
