### PR TITLE
test: use "set -eu" in server rootfs test scripts

### DIFF
--- a/test/TEST-60-NFS/server-init.sh
+++ b/test/TEST-60-NFS/server-init.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+set -eu
 
 export PATH=/usr/sbin:/usr/bin:/sbin:/bin
 

--- a/test/TEST-70-ISCSI/server-init.sh
+++ b/test/TEST-70-ISCSI/server-init.sh
@@ -1,4 +1,5 @@
 #!/bin/sh
+set -eu
 
 # required binaries: dnsmasq ip mount pidof poweroff sleep tgtadm tgtd
 

--- a/test/TEST-71-ISCSI-MULTI/server-init.sh
+++ b/test/TEST-71-ISCSI-MULTI/server-init.sh
@@ -1,4 +1,5 @@
 #!/bin/sh
+set -eu
 
 # required binaries: dnsmasq ip mount pidof poweroff sleep tgtadm tgtd
 

--- a/test/TEST-72-NBD/server-init.sh
+++ b/test/TEST-72-NBD/server-init.sh
@@ -1,4 +1,5 @@
 #!/bin/sh
+set -eu
 
 # required binaries: dnsmasq ip mount nbd-server pidof poweroff sleep
 


### PR DESCRIPTION
Use an EXIT trap in `server-init.sh` to poweroff on exit to make the code similar to the client init scripts. This will allow to run those scripts with `set -e`.

Use `set -eu` in server rootfs test scripts to make them more robust against failures.

### Checklist
- [ ] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it
