### PR TITLE
test: create /var/lib/nfs/rmtab in server rootfs

### DIFF
--- a/test/TEST-60-NFS/test.sh
+++ b/test/TEST-60-NFS/test.sh
@@ -239,7 +239,8 @@ make_server_rootfs() {
 
     export initdir=$TESTDIR/server-rootfs
     mkdir -p "$initdir"/var/lib/rpcbind "$initdir"/var/lib/nfs/{v4recovery,rpc_pipefs}
-    chmod 777 "$initdir"/var/lib/rpcbind
+    : > "$initdir"/var/lib/nfs/rmtab
+    chmod 777 "$initdir"/var/lib/{nfs/rmtab,rpcbind}
     inst_init ./server-init.sh "$initdir"
     cp ./exports "$initdir"/etc/exports
     cp ./dnsmasq.conf "$initdir"/etc/dnsmasq.conf


### PR DESCRIPTION
The server log shows this warning:

```
rpc.mountd[674]: can't open /var/lib/nfs/rmtab for writing
```

So create `/var/lib/nfs/rmtab` in the server rootfs.

<!-- This pull request changes... -->

<!-- Fixes: https://github.com/dracut-ng/dracut-ng/issues/<number> -->

### Checklist
- [ ] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it
