### PR TITLE
test: drop poweroff call where poweroff is called by EXIT trap

### DIFF
--- a/test/TEST-11-USR-MOUNT/create-root.sh
+++ b/test/TEST-11-USR-MOUNT/create-root.sh
@@ -17,4 +17,3 @@ btrfs subvolume snapshot -r /root /root/snapshot-root
 umount /root
 echo "dracut-root-block-created" | dd oflag=direct of=/dev/disk/by-id/scsi-0QEMU_QEMU_HARDDISK_marker status=none
 sync
-poweroff -f

--- a/test/TEST-20-STORAGE/create-root.sh
+++ b/test/TEST-20-STORAGE/create-root.sh
@@ -87,4 +87,3 @@ fi
 } | dd oflag=direct of=/dev/disk/by-id/scsi-0QEMU_QEMU_HARDDISK_marker status=none
 
 sync
-poweroff -f

--- a/test/TEST-26-ENC-RAID-LVM/create-root.sh
+++ b/test/TEST-26-ENC-RAID-LVM/create-root.sh
@@ -34,4 +34,3 @@ cryptsetup luksClose /dev/mapper/dracut_disk2
     done
 } | dd oflag=direct of=/dev/disk/by-id/scsi-0QEMU_QEMU_HARDDISK_marker status=none
 sync
-poweroff -f

--- a/test/TEST-41-FULL-SYSTEMD/create-root.sh
+++ b/test/TEST-41-FULL-SYSTEMD/create-root.sh
@@ -39,4 +39,3 @@ eval "$(udevadm info --query=property --name=/dev/disk/by-id/scsi-0QEMU_QEMU_HAR
     echo "ID_FS_UUID=$ID_FS_UUID"
 } | dd oflag=direct of=/dev/disk/by-id/scsi-0QEMU_QEMU_HARDDISK_marker status=none
 sync
-poweroff -f

--- a/test/TEST-70-ISCSI/create-client-root.sh
+++ b/test/TEST-70-ISCSI/create-client-root.sh
@@ -18,4 +18,3 @@ mdadm -W /dev/md0 || :
 mdadm --stop /dev/md0
 echo "dracut-root-block-created" | dd oflag=direct of=/dev/disk/by-id/scsi-0QEMU_QEMU_HARDDISK_marker status=none
 sync
-poweroff -f

--- a/test/TEST-71-ISCSI-MULTI/create-client-root.sh
+++ b/test/TEST-71-ISCSI-MULTI/create-client-root.sh
@@ -18,4 +18,3 @@ mdadm -W /dev/md0 || :
 mdadm --stop /dev/md0
 echo "dracut-root-block-created" | dd oflag=direct of=/dev/disk/by-id/scsi-0QEMU_QEMU_HARDDISK_marker status=none
 sync
-poweroff -f

--- a/test/TEST-72-NBD/create-encrypted-root.sh
+++ b/test/TEST-72-NBD/create-encrypted-root.sh
@@ -29,4 +29,3 @@ eval "$(udevadm info --query=property --name=/dev/disk/by-id/scsi-0QEMU_QEMU_HAR
     echo "ID_FS_UUID=$ID_FS_UUID"
 } | dd oflag=direct of=/dev/disk/by-id/scsi-0QEMU_QEMU_HARDDISK_marker status=none
 sync
-poweroff -f


### PR DESCRIPTION
Several scripts set an EXIT trap to call `poweroff -f`. So these scripts do not need to call `poweroff -f` at the end any more. They can just rely on the EXIT trap.

<!-- This pull request changes... -->

<!-- Fixes: https://github.com/dracut-ng/dracut-ng/issues/<number> -->

### Checklist
- [ ] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it
