### PR TITLE
test(run-qemu): test if /dev/kvm is readable and writable

### DIFF
--- a/test/run-qemu
+++ b/test/run-qemu
@@ -129,7 +129,7 @@ set_vmlinux_env() {
 [[ -x /usr/bin/qemu ]] && BIN=/usr/bin/qemu && ARGS=(-cpu "$QEMU_CPU")
 (lsmod | grep -q '^kqemu ') && BIN=/usr/bin/qemu && ARGS=(-kernel-kqemu -cpu host)
 [[ -x "/usr/bin/qemu-system-${ARCH}" ]] && BIN="/usr/bin/qemu-system-${ARCH}" && ARGS=(-cpu "$QEMU_CPU")
-if [[ -z ${NO_KVM-} && -c /dev/kvm ]]; then
+if [[ -z ${NO_KVM-} && -c /dev/kvm && -r /dev/kvm && -w /dev/kvm ]]; then
     [[ -x /usr/bin/kvm ]] && BIN=/usr/bin/kvm && ARGS=(-cpu host)
     [[ -x /usr/bin/qemu-kvm ]] && BIN=/usr/bin/qemu-kvm && ARGS=(-cpu host)
     [[ -x /usr/libexec/qemu-kvm ]] && BIN=/usr/libexec/qemu-kvm && ARGS=(-cpu host)

--- a/test/run-qemu
+++ b/test/run-qemu
@@ -128,11 +128,13 @@ set_vmlinux_env() {
 
 [[ -x /usr/bin/qemu ]] && BIN=/usr/bin/qemu && ARGS=(-cpu "$QEMU_CPU")
 (lsmod | grep -q '^kqemu ') && BIN=/usr/bin/qemu && ARGS=(-kernel-kqemu -cpu host)
-[[ -z ${NO_KVM-} && -c /dev/kvm && -x /usr/bin/kvm ]] && BIN=/usr/bin/kvm && ARGS=(-cpu host)
-[[ -z ${NO_KVM-} && -c /dev/kvm && -x /usr/bin/qemu-kvm ]] && BIN=/usr/bin/qemu-kvm && ARGS=(-cpu host)
-[[ -z ${NO_KVM-} && -c /dev/kvm && -x /usr/libexec/qemu-kvm ]] && BIN=/usr/libexec/qemu-kvm && ARGS=(-cpu host)
 [[ -x "/usr/bin/qemu-system-${ARCH}" ]] && BIN="/usr/bin/qemu-system-${ARCH}" && ARGS=(-cpu "$QEMU_CPU")
-[[ -z ${NO_KVM-} && -c /dev/kvm && -x "/usr/bin/qemu-system-${ARCH}" ]] && BIN="/usr/bin/qemu-system-${ARCH}" && ARGS=(-enable-kvm -cpu host)
+if [[ -z ${NO_KVM-} && -c /dev/kvm ]]; then
+    [[ -x /usr/bin/kvm ]] && BIN=/usr/bin/kvm && ARGS=(-cpu host)
+    [[ -x /usr/bin/qemu-kvm ]] && BIN=/usr/bin/qemu-kvm && ARGS=(-cpu host)
+    [[ -x /usr/libexec/qemu-kvm ]] && BIN=/usr/libexec/qemu-kvm && ARGS=(-cpu host)
+    [[ -x "/usr/bin/qemu-system-${ARCH}" ]] && BIN="/usr/bin/qemu-system-${ARCH}" && ARGS=(-enable-kvm -cpu host)
+fi
 
 [[ ${BIN-} ]] || {
     echo "${0##*/}: Could not find a working KVM or QEMU to test with!" >&2


### PR DESCRIPTION
In case `/dev/kvm` is not readable or writable, enabling KVM will fail:

```
run-qemu: timeout --foreground 600 /usr/bin/qemu-system-aarch64 -enable-kvm -cpu host [...]
qemu-system-aarch64: Could not access KVM kernel module: Permission denied
qemu-system-aarch64: failed to initialize kvm: Permission denied
```

### Checklist
- [x] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it
