### PR TITLE
fix(crypt): use -d instead of -f to check for $NEWROOT/proc directory

### DIFF
--- a/modules.d/70crypt/cryptroot-ask.sh
+++ b/modules.d/70crypt/cryptroot-ask.sh
@@ -4,7 +4,7 @@ PATH=/usr/sbin:/usr/bin:/sbin:/bin
 NEWROOT=${NEWROOT:-"/sysroot"}
 
 # do not ask, if we already have root
-[ -f "$NEWROOT"/proc ] && exit 0
+[ -d "$NEWROOT"/proc ] && exit 0
 
 command -v getarg > /dev/null || . /lib/dracut-lib.sh
 


### PR DESCRIPTION
[All other instances](https://github.com/search?q=repo%3Adracut-ng%2Fdracut-ng+%2F%22*%5C%24NEWROOT%22*%5C%2Fproc%2F&type=code) of checks for the existence of `$NEWROOT/proc` use `-d` or at least `-e`, but incorrectly using `-f` to check for the existence of just a file at that path would fail to exit as it should if the directory exists.

### Fixes

Corrects logic introduced in [d0d1ea3](https://github.com/dracut-ng/dracut-ng/commit/d0d1ea3d875281774f7f455ad2bb2e0aa7b5c974#diff-f6aaa6e04fd6a2ced38eb4941e2173edfaca26a37c1064eb09551d6e837970ebR4) and copied to the `crypt` module in [5966b1b](https://github.com/dracut-ng/dracut-ng/commit/5966b1b15d6c56415994c55e77a4ef3276acbb09#diff-4c818a1f98f56ac87a7515fcf1476a6d2d6cc7944ffcdaa24efacdddabe07f42R4).

### Checklist
- [x] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it
