### PR TITLE
ci(opensuse): install libarchive13 for TEST-45-SYSTEMD-IMPORT

### DIFF
--- a/test/container/Dockerfile-opensuse
+++ b/test/container/Dockerfile-opensuse
@@ -33,6 +33,7 @@ RUN zypper --non-interactive install --no-recommends \
     iscsiuio \
     kbd \
     kernel-vanilla \
+    libarchive13 \
     libfido2 \
     libkmod-devel \
     lvm2 \


### PR DESCRIPTION
This should fix the recent CI failure:

```
2026-03-12T13:16:04.1863272Z dracut-install: WARNING: could not locate dlopen dependency for archive feature requested by '/usr/lib64/systemd/libsystemd-shared-259.3-1.1.so'
```

### Checklist
- [X] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it
