### PR TITLE
revert(ci): skip void:latest due to dash 0.5.13.1 bug

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -40,8 +40,7 @@ jobs:
                     - gentoo:latest
                     - opensuse:latest
                     - ubuntu:devel
-                    # Fails due escaping bug in dash 0.5.13.1: https://github.com/dracut-ng/dracut-ng/issues/2280
-                    # - void:latest
+                    - void:latest
                 test:
                     - "10"
         container:
@@ -86,8 +85,7 @@ jobs:
                     - gentoo:latest
                     - opensuse:latest
                     - ubuntu:devel
-                    # Fails due escaping bug in dash 0.5.13.1: https://github.com/dracut-ng/dracut-ng/issues/2280
-                    # - void:latest
+                    - void:latest
                 test:
                     - "11"
                     - "12"
@@ -282,8 +280,7 @@ jobs:
                     - debian:latest
                     - opensuse:latest
                     - ubuntu:rolling
-                    # Fails due escaping bug in dash 0.5.13.1: https://github.com/dracut-ng/dracut-ng/issues/2280
-                    # - void:latest
+                    - void:latest
                 test:
                     - "10"
         container:


### PR DESCRIPTION
As dash has not acknowledged the bug report yet, and more issues with that version of dash were reported, void have reverted to the previous version 0.5.12.

This reverts commit 96d8bb130d1f83f5902f3456dcdf9d35126ecc44.

Fixes: https://github.com/dracut-ng/dracut-ng/issues/2280

<!-- This pull request changes... -->

<!-- Fixes: https://github.com/dracut-ng/dracut-ng/issues/<number> -->

### Checklist
- [ ] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it
