### PR TITLE
fix(dracut.sh): use printf instead of echo in mark_hostonly

### DIFF
--- a/dracut.sh
+++ b/dracut.sh
@@ -1559,7 +1559,7 @@ inst_fsck_help() {
 # shellcheck disable=SC2317,SC2329
 mark_hostonly() {
     for i in "$@"; do
-        echo "$i" >> "$initdir/lib/dracut/hostonly-files"
+        printf "%s\n" "$i" >> "$initdir/lib/dracut/hostonly-files"
     done
 }
 


### PR DESCRIPTION
POSIX requires to interpreted escape sequences. The filenames passed to `mark_hostonly` might contain backslashes and therefore might be interpreted (dash 0.5.13.1 will do that).

So use `printf` instead to avoid escaping the filenames.

Fixes: https://github.com/dracut-ng/dracut-ng/issues/2280

<!-- This pull request changes... -->

<!-- Fixes: https://github.com/dracut-ng/dracut-ng/issues/<number> -->

### Checklist
- [ ] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it
