### PR TITLE
test(SYSTEMD-INITRD): increase device timeout to infinity

### DIFF
--- a/test/TEST-42-SYSTEMD-INITRD/test.sh
+++ b/test/TEST-42-SYSTEMD-INITRD/test.sh
@@ -22,7 +22,7 @@ client_run() {
 
     "$testdir"/run-qemu \
         "${disk_args[@]}" \
-        -append "root=LABEL=dracut $TEST_KERNEL_CMDLINE $client_opts" \
+        -append "root=LABEL=dracut systemd.default_device_timeout_sec=0 $TEST_KERNEL_CMDLINE $client_opts" \
         -initrd "$TESTDIR"/initramfs.testing
     check_qemu_log
 


### PR DESCRIPTION
Test 42 fails to boot on very slow systems like an emulated nested VM with riscv64. `dev-disk-by\x2dlabel-dracut.device` runs into the 90 seconds timeout:

```
[ TIME ] Timed out waiting for device dev-d…device - /dev/disk/by-label/dracut.
[DEPEND] Dependency failed for sysroot.mount - /sysroot.
[  343.011821] systemd[1]: dev-disk-by\x2dlabel-dracut.device: Job dev-disk-by\x2dlabel-dracut.device/start timed out.
[DEPEND] Dependency failed for initrd-root-fs.target - Initrd Root File System.
[DEPEND] Dependency failed for initrd-parse…points Configured in the Real Root.
[  345.255798] systemd[1]: Timed out waiting for device dev-disk-by\x2dlabel-dracut.device - /dev/disk/by-label/dracut.
[  346.279436] systemd[1]: Dependency failed for sysroot.mount - /sysroot.
[  349.048942] systemd[1]: Dependency failed for initrd-root-fs.target - Initrd Root File System.
[DEPEND] Dependency failed for initrd-root-device.target - Initrd Root Device.
[  350.551967] systemd[1]: Dependency failed for initrd-parse-etc.service - Mountpoints Configured in the Real Root.
[  352.855207] systemd[1]: initrd-parse-etc.service: Job initrd-parse-etc.service/start failed with result 'dependency'.
[  354.805576] systemd[1]: initrd-parse-etc.service: Triggering OnFailure= dependencies.
[  356.883912] systemd[1]: initrd-parse-etc.service: Failed to enqueue OnFailure=emergency.target job, ignoring: Unit emergency.service not found.
[  359.654920] systemd[1]: initrd-root-fs.target: Job initrd-root-fs.target/start failed with result 'dependency'.
[  363.225631] systemd[1]: initrd-root-fs.target: Triggering OnFailure= dependencies.
[  365.516207] systemd[1]: initrd-root-fs.target: Failed to enqueue OnFailure=emergency.target job, ignoring: Unit emergency.service not found.
[  367.211266] systemd[1]: sysroot.mount: Job sysroot.mount/start failed with result 'dependency'.
[  369.327748] systemd[1]: Dependency failed for initrd-root-device.target - Initrd Root Device.
[  371.703782] systemd[1]: initrd-root-device.target: Job initrd-root-device.target/start failed with result 'dependency'.
```

Full log: https://ci.debian.net/packages/d/dracut/testing/riscv64/69536717/#L19714

So increase the device timeout to infinity to make the test succeed on slow systems.

<!-- This pull request changes... -->

<!-- Fixes: https://github.com/dracut-ng/dracut-ng/issues/<number> -->

### Checklist
- [ ] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it
