### PR TITLE
test: use TEST_KERNEL_CMDLINE in test 72 as well

### DIFF
--- a/test/TEST-72-NBD/test.sh
+++ b/test/TEST-72-NBD/test.sh
@@ -66,7 +66,7 @@ client_test() {
         "${disk_args[@]}" \
         -device virtio-net-pci,netdev=lan0,mac="$mac" \
         -netdev dgram,id=lan0,local.type=inet,local.host=localhost,local.port=60721,remote.type=inet,remote.host=localhost,remote.port=60720 \
-        -append "$cmdline rd.auto ro" \
+        -append "$TEST_KERNEL_CMDLINE $cmdline rd.auto ro" \
         -initrd "$TESTDIR"/initramfs.testing
 
     if ! test_marker_check nbd-OK; then


### PR DESCRIPTION
All tests add `TEST_KERNEL_CMDLINE` to their kernel command line options except for test 72. Setting `DEBUGFAIL` in test 72 has no effect, because this will only be added to `TEST_KERNEL_CMDLINE`.

So use `TEST_KERNEL_CMDLINE` in test 72 as well.

<!-- This pull request changes... -->

<!-- Fixes: https://github.com/dracut-ng/dracut-ng/issues/<number> -->

### Checklist
- [x] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it
