### PR TITLE
fix(systemd-networkd): create /run/systemd/network if missing

### DIFF
--- a/modules.d/11systemd-networkd/networkd-config.sh
+++ b/modules.d/11systemd-networkd/networkd-config.sh
@@ -26,6 +26,7 @@ done
 
 # Add the default network if none was generated
 if [ "$generated" -eq "0" ]; then
+    mkdir -m 0755 -p /run/systemd/network
     cp -a /usr/lib/dracut/dracut-default.network /run/systemd/network/zzzz-dracut-default.network
 fi
 


### PR DESCRIPTION
During testing this error could be found in the logs:

```
[FAILED] Failed to start systemd-network-generator.service - Generate Network Units from Kernel Command Line.
[...]
[    3.034981] dracut-cmdline[198]: + cp -a /usr/lib/dracut/dracut-default.network /run/systemd/network/zzzz-dracut-default.network
[    3.038326] dracut-cmdline[301]: cp: cannot create regular file '/run/systemd/network/zzzz-dracut-default.network': No such file or directory
```

`systemd-network-generator` creates `/run/systemd/network` in `context_save` by calling `mkdir_p(p, 0755)`. In case `systemd-network-generator.service` fails this directory might not have been created.

So create `/run/systemd/network` if missing.

<!-- This pull request changes... -->

<!-- Fixes: https://github.com/dracut-ng/dracut-ng/issues/<number> -->

### Checklist
- [ ] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it
