### PR TITLE
fix(kernel-modules): install mmc drivers on all architectures

### DIFF
--- a/modules.d/70kernel-modules/module-setup.sh
+++ b/modules.d/70kernel-modules/module-setup.sh
@@ -52,6 +52,8 @@ installkernel() {
             "=drivers/tty/serial" \
             "=drivers/input/serio" \
             "=drivers/input/keyboard" \
+            "=drivers/mmc/core" \
+            "=drivers/mmc/host" \
             "=drivers/pci/host" \
             "=drivers/pci/controller" \
             "=drivers/pinctrl" \
@@ -80,8 +82,6 @@ installkernel() {
                 "=drivers/mailbox" \
                 "=drivers/memory" \
                 "=drivers/mfd" \
-                "=drivers/mmc/core" \
-                "=drivers/mmc/host" \
                 "=drivers/nvmem" \
                 "=drivers/phy" \
                 "=drivers/platform/chrome" \


### PR DESCRIPTION
Some systems with Intel Atom CPUs (like Amston Lake, Alder Lake-N, Twin Lake) have onboard eMMC as a default storage. These eMMC drivers are missing in the initrd.

On Ubuntu 26.04 "resolute" with linux 7.0.0-7.7 on amd64 the generic images increases by 0.5 MB (increase from 30.8 MB to 31.3 MB):

```
$ dracut --force -H
$ 3cpio -t /boot/initrd.img > before
$ 3cpio -e /boot/initrd.img
Start     End       Size      Compr.   Extracted
0 B       92.0 kB   92.0 kB   cpio     91.1 kB
92.0 kB   30.8 MB   30.7 MB   zstd     58.4 MB
$ # apply patch
$ dracut --force -H
$ 3cpio -t /boot/initrd.img > after
$ 3cpio -e /boot/initrd.img
Start     End       Size      Compr.   Extracted
0 B       92.0 kB   92.0 kB   cpio     91.1 kB
92.0 kB   31.3 MB   31.2 MB   zstd     59.0 MB
$ diff -u before after | grep '^[-+]usr'
+usr/lib/modules/7.0.0-7-generic/kernel/drivers/misc/cardreader
+usr/lib/modules/7.0.0-7-generic/kernel/drivers/misc/cardreader/alcor_pci.ko.zst
+usr/lib/modules/7.0.0-7-generic/kernel/drivers/misc/cardreader/rtsx_pci.ko.zst
+usr/lib/modules/7.0.0-7-generic/kernel/drivers/misc/cardreader/rtsx_usb.ko.zst
+usr/lib/modules/7.0.0-7-generic/kernel/drivers/misc/cb710
+usr/lib/modules/7.0.0-7-generic/kernel/drivers/misc/cb710/cb710.ko.zst
+usr/lib/modules/7.0.0-7-generic/kernel/drivers/misc/tifm_core.ko.zst
+usr/lib/modules/7.0.0-7-generic/kernel/drivers/mmc
+usr/lib/modules/7.0.0-7-generic/kernel/drivers/mmc/core
+usr/lib/modules/7.0.0-7-generic/kernel/drivers/mmc/core/mmc_block.ko.zst
+usr/lib/modules/7.0.0-7-generic/kernel/drivers/mmc/core/sdio_uart.ko.zst
+usr/lib/modules/7.0.0-7-generic/kernel/drivers/mmc/host
+usr/lib/modules/7.0.0-7-generic/kernel/drivers/mmc/host/alcor.ko.zst
+usr/lib/modules/7.0.0-7-generic/kernel/drivers/mmc/host/cb710-mmc.ko.zst
+usr/lib/modules/7.0.0-7-generic/kernel/drivers/mmc/host/cqhci.ko.zst
+usr/lib/modules/7.0.0-7-generic/kernel/drivers/mmc/host/mmc_hsq.ko.zst
+usr/lib/modules/7.0.0-7-generic/kernel/drivers/mmc/host/mmc_spi.ko.zst
+usr/lib/modules/7.0.0-7-generic/kernel/drivers/mmc/host/mtk-sd.ko.zst
+usr/lib/modules/7.0.0-7-generic/kernel/drivers/mmc/host/of_mmc_spi.ko.zst
+usr/lib/modules/7.0.0-7-generic/kernel/drivers/mmc/host/rtsx_pci_sdmmc.ko.zst
+usr/lib/modules/7.0.0-7-generic/kernel/drivers/mmc/host/rtsx_usb_sdmmc.ko.zst
+usr/lib/modules/7.0.0-7-generic/kernel/drivers/mmc/host/sdhci-acpi.ko.zst
+usr/lib/modules/7.0.0-7-generic/kernel/drivers/mmc/host/sdhci-pci.ko.zst
+usr/lib/modules/7.0.0-7-generic/kernel/drivers/mmc/host/sdhci-pltfm.ko.zst
+usr/lib/modules/7.0.0-7-generic/kernel/drivers/mmc/host/sdhci-uhs2.ko.zst
+usr/lib/modules/7.0.0-7-generic/kernel/drivers/mmc/host/sdhci-xenon-driver.ko.zst
+usr/lib/modules/7.0.0-7-generic/kernel/drivers/mmc/host/sdhci.ko.zst
+usr/lib/modules/7.0.0-7-generic/kernel/drivers/mmc/host/sdhci_f_sdh30.ko.zst
+usr/lib/modules/7.0.0-7-generic/kernel/drivers/mmc/host/sdricoh_cs.ko.zst
+usr/lib/modules/7.0.0-7-generic/kernel/drivers/mmc/host/tifm_sd.ko.zst
+usr/lib/modules/7.0.0-7-generic/kernel/drivers/mmc/host/toshsd.ko.zst
+usr/lib/modules/7.0.0-7-generic/kernel/drivers/mmc/host/usdhi6rol0.ko.zst
+usr/lib/modules/7.0.0-7-generic/kernel/drivers/mmc/host/ushc.ko.zst
+usr/lib/modules/7.0.0-7-generic/kernel/drivers/mmc/host/via-sdmmc.ko.zst
+usr/lib/modules/7.0.0-7-generic/kernel/drivers/mmc/host/vub300.ko.zst
+usr/lib/modules/7.0.0-7-generic/kernel/drivers/mmc/host/wbsd.ko.zst
+usr/lib/modules/7.0.0-7-generic/kernel/lib/crc/crc7.ko.zst
```

Bug-Ubuntu: https://launchpad.net/bugs/2143030

<!-- This pull request changes... -->

<!-- Fixes: https://github.com/dracut-ng/dracut-ng/issues/<number> -->

### Checklist
- [ ] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it
