### PR TITLE
fix(zipl): Fix parsing rd.zipl=LABEL|UUID|...=

### DIFF
--- a/modules.d/73zipl/parse-zipl.sh
+++ b/modules.d/73zipl/parse-zipl.sh
@@ -9,22 +9,22 @@ if [ -n "$zipl_arg" ]; then
         LABEL=*)
             zipl_env="ENV{ID_FS_LABEL}"
             zipl_val=${zipl_arg#LABEL=}
-            zipl_arg="$(label_uuid_to_dev "${zipl_val}")"
+            zipl_arg="$(label_uuid_to_dev "${zipl_arg}")"
             ;;
         UUID=*)
             zipl_env="ENV{ID_FS_UUID}"
             zipl_val=${zipl_arg#UUID=}
-            zipl_arg="$(label_uuid_to_dev "${zipl_val}")"
+            zipl_arg="$(label_uuid_to_dev "${zipl_arg}")"
             ;;
         PARTLABEL=*)
             zipl_env="ENV{ID_FS_PARTLABEL}"
             zipl_val=${zipl_arg#PARTLABEL=}
-            zipl_arg="$(label_uuid_to_dev "${zipl_val}")"
+            zipl_arg="$(label_uuid_to_dev "${zipl_arg}")"
             ;;
         PARTUUID=*)
             zipl_env="ENV{ID_FS_PARTUUID}"
             zipl_val=${zipl_arg#PARTUUID=}
-            zipl_arg="$(label_uuid_to_dev "${zipl_val}")"
+            zipl_arg="$(label_uuid_to_dev "${zipl_arg}")"
             ;;
         /dev/mapper/*)
             zipl_env="ENV{DM_NAME}"


### PR DESCRIPTION
label_uuid_to_dev needs the LABEL=|UUID=|... prefix as well to determine the full path.

Without this fix it hangs waiting for just the UUID/LABEL/... without the /dev path, breaking boot, e.g.:

Warning: 200c78bc-7099-3c44-f3b5-6adf477ffd15 does not exist

<!-- This pull request changes... -->

Downstream bug: https://bugzilla.opensuse.org/show_bug.cgi?id=1259587

### Checklist
- [X] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it
