### PR TITLE
fix(dracut): properly detect kernel version with --sysroot

### DIFF
--- a/dracut.sh
+++ b/dracut.sh
@@ -974,11 +974,12 @@ export DRACUT_LOG_LEVEL=warning
 export add_dlopen_features="" omit_dlopen_features=""
 
 if ! [[ $kernel ]] && [[ $regenerate_all_l != "yes" ]]; then
-    if type -P systemd-detect-virt &> /dev/null && ! systemd-detect-virt -c &> /dev/null && ! systemd-detect-virt -r &> /dev/null; then
+    if [[ -z ${dracutsysrootdir-} ]] \
+        && type -P systemd-detect-virt &> /dev/null && ! systemd-detect-virt -c &> /dev/null && ! systemd-detect-virt -r &> /dev/null; then
         kernel="$(uname -r)"
     else
         # shellcheck disable=SC2012
-        kernel="$(cd /lib/modules && ls -1v | tail -1)"
+        kernel="$(cd "${dracutsysrootdir-}"/lib/modules && ls -1v | tail -1)"
     fi
 fi
 


### PR DESCRIPTION
Both `uname -r` and `cd /lib/modules` do not give the proper kernel version of the sysroot directory.

E.g. of the wrong behavior:

```
$ dracut -f --sysroot /srv/tw --no-kernel test.img
realpath: /srv/tw/lib/modules/6.19.6-1-default: No such file or directory
$ uname -r
6.19.6-1-default
$ ls -l /srv/tw/usr/lib/modules
total 0
drwxr-xr-x. 1 root root 630 Mar 25 16:30 6.19.8-1-default
```

Follow-up for 2b2debd7947b7d5a357c1a89691a75dfd3565747

### Checklist
- [X] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it
