### PR TITLE
fix(dracut): enable hostonly_cmdline in hostonly mode again

### DIFF
--- a/dracut.sh
+++ b/dracut.sh
@@ -1138,7 +1138,7 @@ drivers_dir="${drivers_dir%"${drivers_dir##*[!/]}"}"
 [[ $hostonly_l ]] && hostonly=$hostonly_l
 [[ $hostonly_cmdline_l ]] && hostonly_cmdline=$hostonly_cmdline_l
 [[ $hostonly_mode_l ]] && hostonly_mode=$hostonly_mode_l
-[[ ${hostonly-} == "yes" ]] && ! [[ $hostonly_cmdline ]] && hostonly_cmdline="yes"
+[[ ${hostonly-} != "no" ]] && ! [[ $hostonly_cmdline ]] && hostonly_cmdline="yes"
 # shellcheck disable=SC2034
 [[ $i18n_install_all_l ]] && i18n_install_all=$i18n_install_all_l
 # shellcheck disable=SC2034


### PR DESCRIPTION
A fresh Ubuntu 26.04 installation with a RAID 1 fails to boot due to not assembling the RAID, because it neither sets `rd.auto` nor includes the cmdline (with `rd.md.uuid` set).

The documentation for `hostonly_cmdline` says:

> If **hostonly="yes"** and this option is not configured, it's automatically set to "yes".

When `hostonly=yes` was made the default, `hostonly_cmdline` was not set to `yes` any more in the default case.

Bug-Ubuntu: https://launchpad.net/bugs/2144948
Fixes: 24fb4c28538b ("feat(dracut): make hostonly the default")

<!-- This pull request changes... -->

<!-- Fixes: https://github.com/dracut-ng/dracut-ng/issues/<number> -->

### Checklist
- [x] I have tested it locally
- [x] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it
