### PR TITLE
test(FULL-SYSTEMD): increase device timeout to infinity

### DIFF
--- a/test/TEST-41-FULL-SYSTEMD/test.sh
+++ b/test/TEST-41-FULL-SYSTEMD/test.sh
@@ -30,7 +30,7 @@ client_run() {
 
     "$testdir"/run-qemu \
         "${disk_args[@]}" \
-        -append "root=LABEL=dracut $TEST_KERNEL_CMDLINE mount.usr=LABEL=dracutusr mount.usrflags=subvol=usr $client_opts ${DEBUGOUT-}" \
+        -append "root=LABEL=dracut systemd.default_device_timeout_sec=0 $TEST_KERNEL_CMDLINE mount.usr=LABEL=dracutusr mount.usrflags=subvol=usr $client_opts ${DEBUGOUT-}" \
         -initrd "$TESTDIR"/initramfs.testing
     check_qemu_log
 


### PR DESCRIPTION
Test 41 fails to boot on arm64 on Debian in the autopkgtest because the service waiting for `/dev/disk/by-label/dracutusr` times out after 90 seconds. This is just caused by the arm64 runner being slow.

So increase the device timeout to infinity to make the test succeed on slow systems.

See also: d62de66d35d ("test(SYSTEMD-INITRD): increase device timeout to infinity")

<!-- This pull request changes... -->

<!-- Fixes: https://github.com/dracut-ng/dracut-ng/issues/<number> -->

### Checklist
- [ ] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it
