### PR TITLE
ci(debian): install ipxe-qemu

### DIFF
--- a/test/container/Dockerfile-debian
+++ b/test/container/Dockerfile-debian
@@ -56,6 +56,7 @@ RUN case $(dpkg --print-architecture) in \
     iputils-arping \
     iputils-ping \
     iproute2 \
+    ipxe-qemu \
     isc-dhcp-server \
     iscsiuio \
     jq \


### PR DESCRIPTION
Test 50 fails on ubuntu:rolling on arm with:

```
qemu-system-aarch64: -device virtio-net-pci,netdev=lan0: failed to find romfile "efi-virtio.rom"
```

So install ipxe-qemu explicitly.

<!-- This pull request changes... -->

<!-- Fixes: https://github.com/dracut-ng/dracut-ng/issues/<number> -->

### Checklist
- [ ] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it
