### PR TITLE
ci: switch from ubuntu:devel to a more stable debian:latest

### DIFF
--- a/.github/workflows/daily-hostonlystrict.yml
+++ b/.github/workflows/daily-hostonlystrict.yml
@@ -29,7 +29,7 @@ jobs:
                     - {runner: 'ubuntu-24.04', tag: 'amd'}
                     - {runner: 'ubuntu-24.04-arm', tag: 'arm'}
                 container:
-                    - ubuntu:devel
+                    - debian:latest
                 test:
                     - "10"
                     - "11"

--- a/.github/workflows/daily-omitsystemd.yml
+++ b/.github/workflows/daily-omitsystemd.yml
@@ -29,7 +29,7 @@ jobs:
                     - {runner: 'ubuntu-24.04', tag: 'amd', timeout: 20}
                     - {runner: 'ubuntu-24.04-arm', tag: 'arm', timeout: 60}
                 container:
-                    - ubuntu:devel
+                    - debian:latest
                 test:
                     - "10"
                     - "11"


### PR DESCRIPTION
Switch some of the daily runners over to a mores table container to avoid running into non-dracut related issues and regressions.

<!-- This pull request changes... -->

<!-- Fixes: https://github.com/dracut-ng/dracut-ng/issues/<number> -->

### Checklist
- [ ] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it
