### PR TITLE
ci: temporary remove Fedora Rawhide CI

### DIFF
--- a/.github/workflows/container-extra.yml
+++ b/.github/workflows/container-extra.yml
@@ -43,7 +43,6 @@ jobs:
                     - {dockerfile: 'Dockerfile-azurelinux', tag: 'azurelinux:3.0', registry: 'mcr.microsoft.com'}
                     - {dockerfile: 'Dockerfile-fedora', tag: 'centos:latest', registry: 'quay.io/centos'}
                     - {dockerfile: 'Dockerfile-debian', tag: 'debian:sid'}
-                    - {dockerfile: 'Dockerfile-fedora', tag: 'fedora:rawhide', registry: 'registry.fedoraproject.org'}
                     - {dockerfile: 'Dockerfile-gentoo', tag: 'gentoo:amd64-openrc', option: 'amd64-openrc'}
                     - {dockerfile: 'Dockerfile-gentoo', tag: 'gentoo:latest', option: 'systemd'}
                 exclude:
@@ -89,7 +88,6 @@ jobs:
                     - {tag: 'azurelinux:3.0', platforms: ['amd', 'arm']}
                     - {tag: 'centos:latest', platforms: ['amd', 'arm']}
                     - {tag: 'debian:sid', platforms: ['amd', 'arm']}
-                    - {tag: 'fedora:rawhide', platforms: ['amd', 'arm']}
                     - {tag: 'gentoo:latest', platforms: ['amd', 'arm']}
                     - {tag: 'gentoo:amd64-openrc', platforms: ['amd']}
         steps:

--- a/.github/workflows/daily-basic.yml
+++ b/.github/workflows/daily-basic.yml
@@ -80,7 +80,6 @@ jobs:
                     - arch:latest
                     - azurelinux:3.0
                     - fedora:latest
-                    - fedora:rawhide
                     - centos:latest
                     - gentoo:amd64-openrc
                 test:

--- a/.github/workflows/daily-network.yml
+++ b/.github/workflows/daily-network.yml
@@ -33,7 +33,6 @@ jobs:
                     - debian:latest
                     - debian:sid
                     - fedora:latest
-                    - fedora:rawhide
                     - opensuse:latest
                     - ubuntu:devel
                     - ubuntu:rolling
@@ -45,8 +44,6 @@ jobs:
                     - container: arch:latest
                       architecture: {runner: 'ubuntu-24.04-arm', tag: 'arm'}
                     - container: fedora:latest
-                      architecture: {runner: 'ubuntu-24.04-arm', tag: 'arm'}
-                    - container: fedora:rawhide
                       architecture: {runner: 'ubuntu-24.04-arm', tag: 'arm'}
                     # https://github.com/dracut-ng/dracut-ng/issues/1988
                     - container: debian:sid

--- a/.github/workflows/manualtest.yml
+++ b/.github/workflows/manualtest.yml
@@ -17,7 +17,6 @@ on:  # yamllint disable-line rule:truthy
                     - "azurelinux:3.0"
                     - "centos:latest"
                     - "fedora:latest"
-                    - "fedora:rawhide"
                     - "arch:latest"
                     - "debian:latest"
                     - "debian:sid"


### PR DESCRIPTION
There is an acknoledged unresolved regression on the Fedora Rawhide CI container with no workaround.

Since this container generation fails, attempting to run this CI does not actually increases the code coverage for the dracut project and removing this container does not actually decreases the code coverage for dracut.

<!-- This pull request changes... -->

<!-- Fixes: https://github.com/dracut-ng/dracut-ng/issues/<number> -->

### Checklist
- [ ] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it
