### PR TITLE
ci: increase timeout for tests

### DIFF
--- a/.github/workflows/daily-basic.yml
+++ b/.github/workflows/daily-basic.yml
@@ -16,7 +16,7 @@ jobs:
     basic:
         name: ${{ matrix.test }} on ${{ matrix.container }} on ${{ matrix.architecture.tag }}
         runs-on: ${{ matrix.architecture.runner }}
-        timeout-minutes: 20
+        timeout-minutes: 30
         concurrency:
             group: >
                 daily-basic-${{ github.workflow }}-${{ github.ref }}
@@ -64,7 +64,7 @@ jobs:
     extended:
         name: ${{ matrix.test }} on ${{ matrix.container }} on ${{ matrix.architecture.tag }}
         runs-on: ${{ matrix.architecture.runner }}
-        timeout-minutes: 20
+        timeout-minutes: 30
         concurrency:
             group: >
                 daily-basic-extended-${{ github.workflow }}-${{ github.ref }}

--- a/.github/workflows/daily-busybox-x64.yml
+++ b/.github/workflows/daily-busybox-x64.yml
@@ -16,7 +16,7 @@ jobs:
     busybox:
         name: ${{ matrix.test }} on ${{ matrix.container }} with busybox
         runs-on: ubuntu-24.04
-        timeout-minutes: 20
+        timeout-minutes: 30
         concurrency:
             group: >
                 daily-busybox-${{ github.workflow }}-${{ github.ref }}

--- a/.github/workflows/daily-hostonlystrict.yml
+++ b/.github/workflows/daily-hostonlystrict.yml
@@ -16,7 +16,7 @@ jobs:
     hostonlystrict:
         name: ${{ matrix.test }} on ${{ matrix.container }} with hostonly-mode strict
         runs-on: ${{ matrix.architecture.runner }}
-        timeout-minutes: 20
+        timeout-minutes: 30
         concurrency:
             group: >
                 daily-hostonlystrict-${{ github.workflow }}-${{ github.ref }}

--- a/.github/workflows/daily-iscsi-x64.yml
+++ b/.github/workflows/daily-iscsi-x64.yml
@@ -16,7 +16,7 @@ jobs:
     iscsi:
         name: ${{ matrix.test }} on ${{ matrix.container }}
         runs-on: ubuntu-24.04
-        timeout-minutes: 20
+        timeout-minutes: 40
         concurrency:
             group: >
                 daily-iscsi-${{ github.workflow }}-${{ github.ref }}

--- a/.github/workflows/daily-kernel-install-x64.yml
+++ b/.github/workflows/daily-kernel-install-x64.yml
@@ -16,7 +16,7 @@ jobs:
     kernel-install:
         name: ${{ matrix.test }} on ${{ matrix.container }}
         runs-on: ubuntu-24.04
-        timeout-minutes: 20
+        timeout-minutes: 30
         concurrency:
             group: >
                 daily-kernel-install-${{ github.workflow }}-${{ github.ref }}

--- a/.github/workflows/daily-systemd.yml
+++ b/.github/workflows/daily-systemd.yml
@@ -16,7 +16,7 @@ jobs:
     systemd:
         name: ${{ matrix.test }} on ${{ matrix.container }} on ${{ matrix.architecture.tag }}
         runs-on: ${{ matrix.architecture.runner }}
-        timeout-minutes: 20
+        timeout-minutes: 30
         concurrency:
             group: >
                 daily-systemd-${{ github.workflow }}-${{ github.ref }}

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -22,7 +22,7 @@ jobs:
         # run this test on all containers
         name: ${{ matrix.test }} on ${{ matrix.container }}
         runs-on: ubuntu-24.04
-        timeout-minutes: 20
+        timeout-minutes: 30
         concurrency:
             group: >
                 basic-${{ github.workflow }}-${{ github.ref }}
@@ -70,7 +70,7 @@ jobs:
         needs: basic
         name: ${{ matrix.test }} on ${{ matrix.container }}
         runs-on: ubuntu-24.04
-        timeout-minutes: 20
+        timeout-minutes: 30
         concurrency:
             group: >
                 extended-${{ github.workflow }}-${{ github.ref }}
@@ -111,7 +111,7 @@ jobs:
         needs: basic
         name: ${{ matrix.test }} on ${{ matrix.container }}
         runs-on: ubuntu-24.04
-        timeout-minutes: 20
+        timeout-minutes: 30
         concurrency:
             group: >
                 extended-systemd-${{ github.workflow }}-${{ github.ref }}
@@ -150,7 +150,7 @@ jobs:
         needs: basic
         name: ${{ matrix.test }} on ${{ matrix.container }}
         runs-on: ubuntu-24.04
-        timeout-minutes: 20
+        timeout-minutes: 30
         concurrency:
             group: >
                 dracut-cpio-${{ github.workflow }}-${{ github.ref }}
@@ -176,7 +176,7 @@ jobs:
         # all nfs based on default networking
         name: ${{ matrix.test }} on ${{ matrix.container }}
         runs-on: ubuntu-24.04
-        timeout-minutes: 20
+        timeout-minutes: 40
         concurrency:
             group: >
                 network-${{ github.workflow }}-${{ github.ref }}
@@ -207,7 +207,7 @@ jobs:
         needs: basic
         name: ${{ matrix.test }} on ${{ matrix.container }}
         runs-on: ubuntu-24.04
-        timeout-minutes: 20
+        timeout-minutes: 40
         concurrency:
             group: >
                 network-iscsi-${{ github.workflow }}-${{ github.ref }}
@@ -238,7 +238,7 @@ jobs:
         needs: basic
         name: ${{ matrix.test }} on ${{ matrix.container }}
         runs-on: ubuntu-24.04
-        timeout-minutes: 20
+        timeout-minutes: 40
         concurrency:
             group: >
                 network-nbd-${{ github.workflow }}-${{ github.ref }}
@@ -267,7 +267,7 @@ jobs:
         needs: basic
         name: ${{ matrix.test }} on ${{ matrix.container }} on arm64
         runs-on: ubuntu-24.04-arm
-        timeout-minutes: 20
+        timeout-minutes: 30
         concurrency:
             group: >
                 arm64-${{ github.workflow }}-${{ github.ref }}

--- a/.github/workflows/manualtest.yml
+++ b/.github/workflows/manualtest.yml
@@ -58,7 +58,7 @@ jobs:
     test:
         needs: matrix
         runs-on: ubuntu-24.04
-        timeout-minutes: 20
+        timeout-minutes: 40
         concurrency:
             group: >
                 manual-${{ github.workflow }}-${{ github.ref }}


### PR DESCRIPTION
Tests seems to need more time to pass.

Give 30 min timeout for non-networking tests and 40 min for networked tests.

<!-- This pull request changes... -->

<!-- Fixes: https://github.com/dracut-ng/dracut-ng/issues/<number> -->

### Checklist
- [ ] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it
