### PR TITLE
ci: do not force Void CI continer to test zfs

### DIFF
--- a/test/container/Dockerfile-void
+++ b/test/container/Dockerfile-void
@@ -5,7 +5,6 @@
 # - eudev (instead of systemd-udev)
 # - elogind (instead of logind)
 # - UEFI boot, UKI (without systemd)
-# - zfs and zfs out of tree dracut module
 # - gzip compression
 # - clang
 # - dbus-daemon
@@ -16,8 +15,7 @@
 
 FROM ghcr.io/void-linux/void-glibc-full
 
-# prefer running tests with zfs and clang
-ENV TEST_FSTYPE=zfs
+# prefer running tests with clang
 ENV CC=clang
 
 RUN xbps-install -Syu xbps && xbps-install -yu \


### PR DESCRIPTION
Running some tests with zfs enabled fails on Void. Disable testing with zfs until the issue is resolved.

<!-- This pull request changes... -->

<!-- Fixes: https://github.com/dracut-ng/dracut-ng/issues/<number> -->

### Checklist
- [ ] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it
