### PR TITLE
Remove dracut-live dependency from Dockerfile-fedora

### DIFF
--- a/test/container/Dockerfile-fedora
+++ b/test/container/Dockerfile-fedora
@@ -55,7 +55,6 @@ RUN dnf -y install --setopt=install_weak_deps=False \
     device-mapper-multipath \
     diffutils \
     dnsmasq \
-    dracut-live \
     e2fsprogs \
     erofs-utils \
     fcoe-utils \


### PR DESCRIPTION
Attempt to fix https://github.com/dracut-ng/dracut-ng/issues/2277

This really should not be there anyway. Had nothing to do with FIPS (stated in the original commit) and brings dracut itself  (from the OS/distro) into the dnf transaction.

### Checklist
- [ ] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it
