### PR TITLE
ci: switch from debian:latest to ubuntu:rolling

### DIFF
--- a/.github/workflows/daily-hostonlystrict.yml
+++ b/.github/workflows/daily-hostonlystrict.yml
@@ -29,7 +29,7 @@ jobs:
                     - {runner: 'ubuntu-24.04', tag: 'amd'}
                     - {runner: 'ubuntu-24.04-arm', tag: 'arm'}
                 container:
-                    - debian:latest
+                    - ubuntu:rolling
                 test:
                     - "10"
                     - "11"

--- a/.github/workflows/daily-omitsystemd.yml
+++ b/.github/workflows/daily-omitsystemd.yml
@@ -29,7 +29,7 @@ jobs:
                     - {runner: 'ubuntu-24.04', tag: 'amd', timeout: 20}
                     - {runner: 'ubuntu-24.04-arm', tag: 'arm', timeout: 60}
                 container:
-                    - debian:latest
+                    - ubuntu:rolling
                 test:
                     - "10"
                     - "11"


### PR DESCRIPTION
Commit 28323e6b769c ("ci: switch from ubuntu:devel to a more stable debian:latest") switched away from the Ubuntu devel release (which can be more unstable since it is a release in development) but also switched from Ubuntu to Debian.

Switch to `ubuntu:rolling` which is the latest Ubuntu release which should be stable enough for our purposes. Ubuntu gets a new release every six month in comparsion to Debian which cuts a new release around every two years.

<!-- This pull request changes... -->

<!-- Fixes: https://github.com/dracut-ng/dracut-ng/issues/<number> -->

### Checklist
- [ ] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it
