### PR TITLE
ci: unify timeout to 10 min by default

### DIFF
--- a/.github/workflows/daily-basic.yml
+++ b/.github/workflows/daily-basic.yml
@@ -16,7 +16,7 @@ jobs:
     basic:
         name: ${{ matrix.test }} on ${{ matrix.container }} on ${{ matrix.architecture.tag }}
         runs-on: ${{ matrix.architecture.runner }}
-        timeout-minutes: 60
+        timeout-minutes: ${{ matrix.architecture.timeout }}
         concurrency:
             group: >
                 daily-basic-${{ github.workflow }}-${{ github.ref }}
@@ -26,8 +26,8 @@ jobs:
             fail-fast: false
             matrix:
                 architecture:
-                    - {runner: 'ubuntu-24.04', tag: 'amd'}
-                    - {runner: 'ubuntu-24.04-arm', tag: 'arm'}
+                    - {runner: 'ubuntu-24.04', tag: 'amd', timeout: 10}
+                    - {runner: 'ubuntu-24.04-arm', tag: 'arm', timeout: 40}
                 container:
                     - debian:latest
                     - debian:sid
@@ -68,7 +68,7 @@ jobs:
     extended:
         name: ${{ matrix.test }} on ${{ matrix.container }} on ${{ matrix.architecture.tag }}
         runs-on: ${{ matrix.architecture.runner }}
-        timeout-minutes: 30
+        timeout-minutes: ${{ matrix.architecture.timeout }}
         concurrency:
             group: >
                 daily-basic-extended-${{ github.workflow }}-${{ github.ref }}
@@ -78,7 +78,7 @@ jobs:
             fail-fast: false
             matrix:
                 architecture:
-                    - {runner: 'ubuntu-24.04', tag: 'amd'}
+                    - {runner: 'ubuntu-24.04', tag: 'amd', timeout: 10}
                 container:
                     - alpine:edge
                     - arch:latest
@@ -115,7 +115,7 @@ jobs:
     arm64-openrc:
         name: ${{ matrix.test }} on ${{ matrix.container }} on ${{ matrix.architecture.tag }}
         runs-on: ${{ matrix.architecture.runner }}
-        timeout-minutes: 60
+        timeout-minutes: ${{ matrix.architecture.timeout }}
         concurrency:
             group: >
                 daily-basic-${{ github.workflow }}-${{ github.ref }}
@@ -125,7 +125,7 @@ jobs:
             fail-fast: false
             matrix:
                 architecture:
-                    - {runner: 'ubuntu-24.04-arm', tag: 'arm'}
+                    - {runner: 'ubuntu-24.04-arm', tag: 'arm', timeout: 40}
                 container:
                     - gentoo:arm64-openrc
                 test:

--- a/.github/workflows/daily-busybox-x64.yml
+++ b/.github/workflows/daily-busybox-x64.yml
@@ -16,7 +16,7 @@ jobs:
     busybox:
         name: ${{ matrix.test }} on ${{ matrix.container }} with busybox
         runs-on: ubuntu-24.04
-        timeout-minutes: 30
+        timeout-minutes: 10
         concurrency:
             group: >
                 daily-busybox-${{ github.workflow }}-${{ github.ref }}

--- a/.github/workflows/daily-hostonlystrict.yml
+++ b/.github/workflows/daily-hostonlystrict.yml
@@ -16,7 +16,7 @@ jobs:
     hostonlystrict:
         name: ${{ matrix.test }} on ${{ matrix.container }} with hostonly-mode strict
         runs-on: ${{ matrix.architecture.runner }}
-        timeout-minutes: 30
+        timeout-minutes: ${{ matrix.architecture.timeout }}
         concurrency:
             group: >
                 daily-hostonlystrict-${{ github.workflow }}-${{ github.ref }}
@@ -26,8 +26,8 @@ jobs:
             fail-fast: false
             matrix:
                 architecture:
-                    - {runner: 'ubuntu-24.04', tag: 'amd'}
-                    - {runner: 'ubuntu-24.04-arm', tag: 'arm'}
+                    - {runner: 'ubuntu-24.04', tag: 'amd', timeout: 10}
+                    - {runner: 'ubuntu-24.04-arm', tag: 'arm', timeout: 40}
                 container:
                     - ubuntu:rolling
                 test:

--- a/.github/workflows/daily-iscsi-x64.yml
+++ b/.github/workflows/daily-iscsi-x64.yml
@@ -16,7 +16,7 @@ jobs:
     iscsi:
         name: ${{ matrix.test }} on ${{ matrix.container }}
         runs-on: ubuntu-24.04
-        timeout-minutes: 40
+        timeout-minutes: 10
         concurrency:
             group: >
                 daily-iscsi-${{ github.workflow }}-${{ github.ref }}

--- a/.github/workflows/daily-kernel-install-x64.yml
+++ b/.github/workflows/daily-kernel-install-x64.yml
@@ -16,7 +16,7 @@ jobs:
     kernel-install:
         name: ${{ matrix.test }} on ${{ matrix.container }}
         runs-on: ubuntu-24.04
-        timeout-minutes: 30
+        timeout-minutes: 10
         concurrency:
             group: >
                 daily-kernel-install-${{ github.workflow }}-${{ github.ref }}

--- a/.github/workflows/daily-mkosi-x64.yml
+++ b/.github/workflows/daily-mkosi-x64.yml
@@ -16,7 +16,7 @@ jobs:
     mkosi:
         name: ${{ matrix.config.test }} on ${{ matrix.container }} with mkosi
         runs-on: ubuntu-24.04
-        timeout-minutes: 30
+        timeout-minutes: 10
         concurrency:
             group: >
                 daily-mkosi-${{ github.workflow }}-${{ github.ref }}

--- a/.github/workflows/daily-nbd.yml
+++ b/.github/workflows/daily-nbd.yml
@@ -26,8 +26,8 @@ jobs:
             fail-fast: false
             matrix:
                 architecture:
-                    - {runner: 'ubuntu-24.04', tag: 'amd', timeout: 20}
-                    - {runner: 'ubuntu-24.04-arm', tag: 'arm', timeout: 60}
+                    - {runner: 'ubuntu-24.04', tag: 'amd', timeout: 10}
+                    - {runner: 'ubuntu-24.04-arm', tag: 'arm', timeout: 40}
                 container:
                     - arch:latest
                     - debian:latest

--- a/.github/workflows/daily-network-legacy.yml
+++ b/.github/workflows/daily-network-legacy.yml
@@ -29,7 +29,7 @@ jobs:
             fail-fast: false
             matrix:
                 architecture:
-                    - {runner: 'ubuntu-24.04', tag: 'amd', timeout: 20}
+                    - {runner: 'ubuntu-24.04', tag: 'amd', timeout: 10}
                     - {runner: 'ubuntu-24.04-arm', tag: 'arm', timeout: 60}
                 network:
                     - network-legacy

--- a/.github/workflows/daily-network.yml
+++ b/.github/workflows/daily-network.yml
@@ -26,7 +26,7 @@ jobs:
             fail-fast: false
             matrix:
                 architecture:
-                    - {runner: 'ubuntu-24.04', tag: 'amd', timeout: 20}
+                    - {runner: 'ubuntu-24.04', tag: 'amd', timeout: 10}
                     - {runner: 'ubuntu-24.04-arm', tag: 'arm', timeout: 60}
                 container:
                     - arch:latest

--- a/.github/workflows/daily-omitsystemd.yml
+++ b/.github/workflows/daily-omitsystemd.yml
@@ -26,7 +26,7 @@ jobs:
             fail-fast: false
             matrix:
                 architecture:
-                    - {runner: 'ubuntu-24.04', tag: 'amd', timeout: 20}
+                    - {runner: 'ubuntu-24.04', tag: 'amd', timeout: 10}
                     - {runner: 'ubuntu-24.04-arm', tag: 'arm', timeout: 60}
                 container:
                     - ubuntu:rolling

--- a/.github/workflows/daily-systemd-networkd.yml
+++ b/.github/workflows/daily-systemd-networkd.yml
@@ -18,7 +18,7 @@ jobs:
             ${{ matrix.test }} on ${{ matrix.container }}
             ${{ matrix.network }} networking on ${{ matrix.architecture.tag }}
         runs-on: ${{ matrix.architecture.runner }}
-        timeout-minutes: 40
+        timeout-minutes: ${{ matrix.architecture.timeout }}
         concurrency:
             group: >
                 daily-systemd-networkd-${{ github.workflow }}-${{ github.ref }}
@@ -29,8 +29,8 @@ jobs:
             fail-fast: false
             matrix:
                 architecture:
-                    - {runner: 'ubuntu-24.04', tag: 'amd'}
-                    - {runner: 'ubuntu-24.04-arm', tag: 'arm'}
+                    - {runner: 'ubuntu-24.04', tag: 'amd', timeout: 10}
+                    - {runner: 'ubuntu-24.04-arm', tag: 'arm', timeout: 20}
                 network:
                     - systemd-networkd
                 container:

--- a/.github/workflows/daily-systemd.yml
+++ b/.github/workflows/daily-systemd.yml
@@ -16,7 +16,7 @@ jobs:
     systemd:
         name: ${{ matrix.test }} on ${{ matrix.container }} on ${{ matrix.architecture.tag }}
         runs-on: ${{ matrix.architecture.runner }}
-        timeout-minutes: 30
+        timeout-minutes: ${{ matrix.architecture.timeout }}
         concurrency:
             group: >
                 daily-systemd-${{ github.workflow }}-${{ github.ref }}
@@ -26,8 +26,8 @@ jobs:
             fail-fast: false
             matrix:
                 architecture:
-                    - {runner: 'ubuntu-24.04', tag: 'amd'}
-                    - {runner: 'ubuntu-24.04-arm', tag: 'arm'}
+                    - {runner: 'ubuntu-24.04', tag: 'amd', timeout: 10}
+                    - {runner: 'ubuntu-24.04-arm', tag: 'arm', timeout: 20}
                 container:
                     - arch:latest
                     - azurelinux:latest

--- a/.github/workflows/daily-zfs.yml
+++ b/.github/workflows/daily-zfs.yml
@@ -16,7 +16,7 @@ jobs:
     basic:
         name: ${{ matrix.test }} on ${{ matrix.container }} on ${{ matrix.architecture.tag }}
         runs-on: ${{ matrix.architecture.runner }}
-        timeout-minutes: 60
+        timeout-minutes: ${{ matrix.architecture.timeout }}
         concurrency:
             group: >
                 daily-basic-${{ github.workflow }}-${{ github.ref }}
@@ -26,8 +26,8 @@ jobs:
             fail-fast: false
             matrix:
                 architecture:
-                    - {runner: 'ubuntu-24.04', tag: 'amd'}
-                    - {runner: 'ubuntu-24.04-arm', tag: 'arm'}
+                    - {runner: 'ubuntu-24.04', tag: 'amd', timeout: 10}
+                    - {runner: 'ubuntu-24.04-arm', tag: 'arm', timeout: 40}
                 container:
                     - void:latest
                 test:

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -22,7 +22,7 @@ jobs:
         # run this test on all containers
         name: ${{ matrix.test }} on ${{ matrix.container }}
         runs-on: ubuntu-24.04
-        timeout-minutes: 30
+        timeout-minutes: 10
         concurrency:
             group: >
                 basic-${{ github.workflow }}-${{ github.ref }}
@@ -70,7 +70,7 @@ jobs:
         needs: basic
         name: ${{ matrix.test }} on ${{ matrix.container }}
         runs-on: ubuntu-24.04
-        timeout-minutes: 30
+        timeout-minutes: 10
         concurrency:
             group: >
                 extended-${{ github.workflow }}-${{ github.ref }}
@@ -111,7 +111,7 @@ jobs:
         needs: basic
         name: ${{ matrix.test }} on ${{ matrix.container }}
         runs-on: ubuntu-24.04
-        timeout-minutes: 30
+        timeout-minutes: 10
         concurrency:
             group: >
                 extended-systemd-${{ github.workflow }}-${{ github.ref }}
@@ -147,7 +147,7 @@ jobs:
         needs: basic
         name: ${{ matrix.test }} on ${{ matrix.container }}
         runs-on: ubuntu-24.04
-        timeout-minutes: 30
+        timeout-minutes: 10
         concurrency:
             group: >
                 dracut-cpio-${{ github.workflow }}-${{ github.ref }}
@@ -173,7 +173,7 @@ jobs:
         # all nfs based on default networking
         name: ${{ matrix.test }} on ${{ matrix.container }}
         runs-on: ubuntu-24.04
-        timeout-minutes: 40
+        timeout-minutes: 10
         concurrency:
             group: >
                 network-${{ github.workflow }}-${{ github.ref }}
@@ -204,7 +204,7 @@ jobs:
         needs: basic
         name: ${{ matrix.test }} on ${{ matrix.container }}
         runs-on: ubuntu-24.04
-        timeout-minutes: 40
+        timeout-minutes: 10
         concurrency:
             group: >
                 network-iscsi-${{ github.workflow }}-${{ github.ref }}
@@ -235,7 +235,7 @@ jobs:
         needs: basic
         name: ${{ matrix.test }} on ${{ matrix.container }}
         runs-on: ubuntu-24.04
-        timeout-minutes: 40
+        timeout-minutes: 10
         concurrency:
             group: >
                 network-nbd-${{ github.workflow }}-${{ github.ref }}
@@ -263,7 +263,7 @@ jobs:
         needs: basic
         name: ${{ matrix.test }} on ${{ matrix.container }} on arm64
         runs-on: ubuntu-24.04-arm
-        timeout-minutes: 30
+        timeout-minutes: 10
         concurrency:
             group: >
                 arm64-${{ github.workflow }}-${{ github.ref }}

--- a/.github/workflows/manualtest.yml
+++ b/.github/workflows/manualtest.yml
@@ -59,7 +59,7 @@ jobs:
     test:
         needs: matrix
         runs-on: ubuntu-24.04
-        timeout-minutes: 40
+        timeout-minutes: 10
         concurrency:
             group: >
                 manual-${{ github.workflow }}-${{ github.ref }}


### PR DESCRIPTION
Most tests take only a few seconds or minutes on AMD. The tests on ARM are two to four times slower than their AMD counterparts (due to not using KVM).

All tests finish in under five minutes except test 60-NFS on AMD (which can take six to seven minutes) and following tests on ARM:

| Test              | Duration  | Timeout |
| ----------------- | --------- | ------- |
| 11-USR-MOUNT      | 5-10 min  | 20 min  |
| 20-STORAGE        | 9-22 min  | 40 min  |
| 21-OVERLAYFS      | 5-11 min  | 20 min  |
| 26-ENC-RAID-LVM   | 9-21 min  | 40 min  |
| 30-DMSQUASH       | 5-10 min  | 20 min  |
| 41-FULL-SYSTEMD   | 5-9 min   | 20 min  |
| 45-SYSTEMD-IMPORT | 7 min     | 20 min  |
| 60-NFS            | 19-49 min | 60 min  |
| 71-ISCSI          | 9 min     | 20 min  |
| 72-ISCSI-MULTI    | 9-20 min  | 40 min  |

So use a 10 min timeout on all AMD tests and most ARM tests, but increase the timeout for ARM for those test mentioned above. So use 20 min timeout for several ARM tests, 40 min timeout for 20-STORAGE, 26-ENC-RAID-LVM, 72-ISCSI-MULTI on ARM, and 60 min timeout for 60-NFS on ARM.

<!-- This pull request changes... -->

<!-- Fixes: https://github.com/dracut-ng/dracut-ng/issues/<number> -->

### Checklist
- [ ] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it
