### PR TITLE
perf: export DRACUT_ARCH globally

### DIFF
--- a/dracut.sh
+++ b/dracut.sh
@@ -970,6 +970,8 @@ export DRACUT_LOG_LEVEL=warning
 
 [[ ${dracutbasedir-} ]] || dracutbasedir="${dracutsysrootdir-}"/usr/lib/dracut
 
+export DRACUT_ARCH=${DRACUT_ARCH:-$(uname -m)}
+
 # These config variables needs to be exported for dracut-install.
 export add_dlopen_features="" omit_dlopen_features=""
 
@@ -1953,19 +1955,19 @@ dracut_kernel_post() {
         # Using `rm -f' below as some distribution may not ship all firmware.
 
         # Non-x86 APU is not a thing (yet).
-        if [[ ${DRACUT_ARCH:-$(uname -m)} != x86_64 ]]; then
+        if [[ ${DRACUT_ARCH} != x86_64 ]]; then
             ddebug "Removing AMDGPU firmware unused by non-x86-64 systems ..."
             for _amdgpu_prefix in ${_apu_prefix}; do
                 rm -f "${_amdgpu_prefix}"*
             done
         fi
 
-        if [[ ${DRACUT_ARCH:-$(uname -m)} == arm64 ]]; then
+        if [[ ${DRACUT_ARCH} == arm64 ]]; then
             ddebug "Removing AMDGPU firmware unused by AArch64 systems ..."
             for _amdgpu_prefix in ${_mobile_prefix}; do
                 rm -f "${_amdgpu_prefix}"*
             done
-        elif [[ ${DRACUT_ARCH:-$(uname -m)} == mips64 ]]; then
+        elif [[ ${DRACUT_ARCH} == mips64 ]]; then
             # No post-GCN 4.0 support - crashes firmware.
             # Mobile AMD GPUs likely.
             ddebug "Removing AMDGPU firmware unused by MIPS64 (Loongson 3) systems ..."
@@ -2247,7 +2249,7 @@ if ! [[ $print_cmdline ]] && ! [[ $printconfig ]]; then
             exit 1
         fi
         unset EFI_MACHINE_TYPE_NAME
-        case "${DRACUT_ARCH:-$(uname -m)}" in
+        case "${DRACUT_ARCH}" in
             x86_64)
                 EFI_MACHINE_TYPE_NAME=x64
                 ;;
@@ -2264,7 +2266,7 @@ if ! [[ $print_cmdline ]] && ! [[ $printconfig ]]; then
                 EFI_MACHINE_TYPE_NAME=loongarch64
                 ;;
             *)
-                dfatal "Architecture '${DRACUT_ARCH:-$(uname -m)}' not supported to create a UEFI executable"
+                dfatal "Architecture '${DRACUT_ARCH}' not supported to create a UEFI executable"
                 exit 1
                 ;;
         esac
@@ -2306,7 +2308,7 @@ if [[ $early_microcode == yes ]]; then
             && unset early_microcode
     fi
     # Do not complain on non-x86 architectures as it makes no sense
-    case "${DRACUT_ARCH:-$(uname -m)}" in
+    case "${DRACUT_ARCH}" in
         x86_64 | i?86)
             [[ $early_microcode != yes ]] \
                 && dwarn "Disabling early microcode, because kernel does not support it. CONFIG_MICROCODE!=y"

--- a/man/dracut.modules.7.adoc
+++ b/man/dracut.modules.7.adoc
@@ -177,6 +177,7 @@ drauct modules. These shell variables are always declared and assigned
 values (the assigned value might be an empty string). There is a
 compatibility promise on these variables between dracut releases.
 Module should only read (and not write) these variables.
+ * `$DRACUT_ARCH` (not an empty string)
  * `$hostonly` (could be an empty string)
  * `$hostonly_mode` (could be an empty string)
  * `$hostonly_cmdline` (not an empty string)

--- a/modules.d/10systemd/module-setup.sh
+++ b/modules.d/10systemd/module-setup.sh
@@ -150,8 +150,7 @@ EOF
     unset _systemdbinary
 
     # Install library file(s)
-    _arch=${DRACUT_ARCH:-$(uname -m)}
     inst_libdir_file \
-        {"tls/$_arch/",tls/,"$_arch/",}"libbpf.so*" \
-        {"tls/$_arch/",tls/,"$_arch/",}"libnss_*"
+        {"tls/$DRACUT_ARCH/",tls/,"$DRACUT_ARCH/",}"libbpf.so*" \
+        {"tls/$DRACUT_ARCH/",tls/,"$DRACUT_ARCH/",}"libnss_*"
 }

--- a/modules.d/10warpclock/module-setup.sh
+++ b/modules.d/10warpclock/module-setup.sh
@@ -5,8 +5,7 @@
 # Prerequisite check(s) for module.
 check() {
     # hwclock does not exist on S390(x), bail out silently then
-    local _arch=${DRACUT_ARCH:-$(uname -m)}
-    [ "$_arch" = "s390" ] || [ "$_arch" = "s390x" ] && return 1
+    [ "$DRACUT_ARCH" = "s390" ] || [ "$DRACUT_ARCH" = "s390x" ] && return 1
 
     # If the binary(s) requirements are not fulfilled the module can't be installed.
     require_binaries hwclock || return 1

--- a/modules.d/11systemd-ask-password/module-setup.sh
+++ b/modules.d/11systemd-ask-password/module-setup.sh
@@ -26,7 +26,7 @@ depends() {
         # - virtio-vga is not supported
         # - ramfb is not enough
         # Therefore, depend on the drm module if virtio_gpu is loaded on the system.
-        if [[ ${DRACUT_ARCH:-$(uname -m)} == arm* || ${DRACUT_ARCH:-$(uname -m)} == aarch64 ]] \
+        if [[ ${DRACUT_ARCH} == arm* || ${DRACUT_ARCH} == aarch64 ]] \
             && grep -r -qs "virtio:d00000010v" /sys/bus/virtio/devices/*/modalias; then
             echo drm
         fi

--- a/modules.d/11systemd-coredump/module-setup.sh
+++ b/modules.d/11systemd-coredump/module-setup.sh
@@ -48,12 +48,11 @@ install() {
         coredumpctl
 
     # Install library file(s)
-    _arch=${DRACUT_ARCH:-$(uname -m)}
     if [[ ! $USE_SYSTEMD_DLOPEN_DEPS ]]; then
         inst_libdir_file \
-            {"tls/$_arch/",tls/,"$_arch/",}"liblz4.so.*" \
-            {"tls/$_arch/",tls/,"$_arch/",}"liblzma.so.*" \
-            {"tls/$_arch/",tls/,"$_arch/",}"libzstd.so.*"
+            {"tls/$DRACUT_ARCH/",tls/,"$DRACUT_ARCH/",}"liblz4.so.*" \
+            {"tls/$DRACUT_ARCH/",tls/,"$DRACUT_ARCH/",}"liblzma.so.*" \
+            {"tls/$DRACUT_ARCH/",tls/,"$DRACUT_ARCH/",}"libzstd.so.*"
     fi
 
     # Install the hosts local user configurations if enabled.

--- a/modules.d/11systemd-integritysetup/module-setup.sh
+++ b/modules.d/11systemd-integritysetup/module-setup.sh
@@ -64,8 +64,7 @@ install() {
     fi
 
     # Install required libraries.
-    _arch=${DRACUT_ARCH:-$(uname -m)}
     if [[ ! $USE_SYSTEMD_DLOPEN_DEPS ]]; then
-        inst_libdir_file {"tls/$_arch/",tls/,"$_arch/",}"libcryptsetup.so.*"
+        inst_libdir_file {"tls/$DRACUT_ARCH/",tls/,"$DRACUT_ARCH/",}"libcryptsetup.so.*"
     fi
 }

--- a/modules.d/11systemd-journald/module-setup.sh
+++ b/modules.d/11systemd-journald/module-setup.sh
@@ -57,13 +57,12 @@ install() {
         journalctl
 
     # Install library file(s)
-    _arch=${DRACUT_ARCH:-$(uname -m)}
     if [[ ! $USE_SYSTEMD_DLOPEN_DEPS ]]; then
         inst_libdir_file \
-            {"tls/$_arch/",tls/,"$_arch/",}"libgcrypt.so*" \
-            {"tls/$_arch/",tls/,"$_arch/",}"liblz4.so.*" \
-            {"tls/$_arch/",tls/,"$_arch/",}"liblzma.so.*" \
-            {"tls/$_arch/",tls/,"$_arch/",}"libzstd.so.*"
+            {"tls/$DRACUT_ARCH/",tls/,"$DRACUT_ARCH/",}"libgcrypt.so*" \
+            {"tls/$DRACUT_ARCH/",tls/,"$DRACUT_ARCH/",}"liblz4.so.*" \
+            {"tls/$DRACUT_ARCH/",tls/,"$DRACUT_ARCH/",}"liblzma.so.*" \
+            {"tls/$DRACUT_ARCH/",tls/,"$DRACUT_ARCH/",}"libzstd.so.*"
     fi
 
     # Install the hosts local user configurations if enabled.

--- a/modules.d/11systemd-ldconfig/module-setup.sh
+++ b/modules.d/11systemd-ldconfig/module-setup.sh
@@ -37,8 +37,7 @@ install() {
         ldconfig.real
 
     # Install required libraries.
-    _arch=${DRACUT_ARCH:-$(uname -m)}
-    inst_libdir_file {"tls/$_arch/",tls/,"$_arch/",}"ld.so"
+    inst_libdir_file {"tls/$DRACUT_ARCH/",tls/,"$DRACUT_ARCH/",}"ld.so"
 
     # Install the hosts local user configurations if enabled.
     if [[ $hostonly ]]; then

--- a/modules.d/11systemd-udevd/module-setup.sh
+++ b/modules.d/11systemd-udevd/module-setup.sh
@@ -84,6 +84,5 @@ install() {
     ln_r "$(find_binary true)" "/bin/loginctl"
 
     # Install required libraries.
-    _arch=${DRACUT_ARCH:-$(uname -m)}
-    inst_libdir_file {"tls/$_arch/",tls/,"$_arch/",}"libudev.so.*"
+    inst_libdir_file {"tls/$DRACUT_ARCH/",tls/,"$DRACUT_ARCH/",}"libudev.so.*"
 }

--- a/modules.d/11systemd-veritysetup/module-setup.sh
+++ b/modules.d/11systemd-veritysetup/module-setup.sh
@@ -64,8 +64,7 @@ install() {
     fi
 
     # Install required libraries.
-    _arch=${DRACUT_ARCH:-$(uname -m)}
     if [[ ! $USE_SYSTEMD_DLOPEN_DEPS ]]; then
-        inst_libdir_file {"tls/$_arch/",tls/,"$_arch/",}"libcryptsetup.so.*"
+        inst_libdir_file {"tls/$DRACUT_ARCH/",tls/,"$DRACUT_ARCH/",}"libcryptsetup.so.*"
     fi
 }

--- a/modules.d/35network-legacy/module-setup.sh
+++ b/modules.d/35network-legacy/module-setup.sh
@@ -16,8 +16,6 @@ depends() {
 
 # called by dracut
 install() {
-    local _arch
-
     # Adding default link and (if exists) 98-default-mac-none.link
     if dracut_module_included "systemd"; then
         inst_multiple -o \
@@ -87,8 +85,6 @@ install() {
         )
     done
 
-    _arch=${DRACUT_ARCH:-$(uname -m)}
-
-    inst_libdir_file {"tls/$_arch/",tls/,"$_arch/",}"libnss_dns.so.*" \
-        {"tls/$_arch/",tls/,"$_arch/",}"libnss_mdns4_minimal.so.*"
+    inst_libdir_file {"tls/$DRACUT_ARCH/",tls/,"$DRACUT_ARCH/",}"libnss_dns.so.*" \
+        {"tls/$DRACUT_ARCH/",tls/,"$DRACUT_ARCH/",}"libnss_mdns4_minimal.so.*"
 }

--- a/modules.d/35network-manager/module-setup.sh
+++ b/modules.d/35network-manager/module-setup.sh
@@ -108,8 +108,6 @@ install() {
         echo "${UUID//-/}" > "$initdir/etc/machine-id"
     fi
 
-    _arch=${DRACUT_ARCH:-$(uname -m)}
-
-    inst_libdir_file {"tls/$_arch/",tls/,"$_arch/",}"libnss_dns.so.*" \
-        {"tls/$_arch/",tls/,"$_arch/",}"libnss_mdns4_minimal.so.*"
+    inst_libdir_file {"tls/$DRACUT_ARCH/",tls/,"$DRACUT_ARCH/",}"libnss_dns.so.*" \
+        {"tls/$DRACUT_ARCH/",tls/,"$DRACUT_ARCH/",}"libnss_mdns4_minimal.so.*"
 }

--- a/modules.d/45drm/module-setup.sh
+++ b/modules.d/45drm/module-setup.sh
@@ -9,7 +9,7 @@ check() {
 installkernel() {
     # Include KMS capable drm drivers
 
-    if [[ ${DRACUT_ARCH:-$(uname -m)} == arm* || ${DRACUT_ARCH:-$(uname -m)} == aarch64 ]]; then
+    if [[ ${DRACUT_ARCH} == arm* || ${DRACUT_ARCH} == aarch64 ]]; then
         # arm/aarch64 specific modules needed by drm
         hostonly=$(optional_hostonly) instmods \
             "=drivers/gpu/drm/i2c" \

--- a/modules.d/45systemd-import/module-setup.sh
+++ b/modules.d/45systemd-import/module-setup.sh
@@ -75,16 +75,15 @@ install() {
     fi
 
     # libcurl and libopenssl are not loaded via dlopen
-    _arch=${DRACUT_ARCH:-$(uname -m)}
     inst_libdir_file \
-        {"tls/$_arch/",tls/,"$_arch/",}"libcurl.so*" \
-        {"tls/$_arch/",tls/,"$_arch/",}"libssl.so*"
+        {"tls/$DRACUT_ARCH/",tls/,"$DRACUT_ARCH/",}"libcurl.so*" \
+        {"tls/$DRACUT_ARCH/",tls/,"$DRACUT_ARCH/",}"libssl.so*"
 
     if [[ ! $USE_SYSTEMD_DLOPEN_DEPS ]]; then
         inst_libdir_file \
-            {"tls/$_arch/",tls/,"$_arch/",}"libarchive.so*" \
-            {"tls/$_arch/",tls/,"$_arch/",}"liblz4.so*" \
-            {"tls/$_arch/",tls/,"$_arch/",}"liblzma.so*" \
-            {"tls/$_arch/",tls/,"$_arch/",}"libzstd.so*"
+            {"tls/$DRACUT_ARCH/",tls/,"$DRACUT_ARCH/",}"libarchive.so*" \
+            {"tls/$DRACUT_ARCH/",tls/,"$DRACUT_ARCH/",}"liblz4.so*" \
+            {"tls/$DRACUT_ARCH/",tls/,"$DRACUT_ARCH/",}"liblzma.so*" \
+            {"tls/$DRACUT_ARCH/",tls/,"$DRACUT_ARCH/",}"libzstd.so*"
     fi
 }

--- a/modules.d/68cms/module-setup.sh
+++ b/modules.d/68cms/module-setup.sh
@@ -2,16 +2,14 @@
 
 # called by dracut
 check() {
-    arch=${DRACUT_ARCH:-$(uname -m)}
-    [ "$arch" = "s390" ] || [ "$arch" = "s390x" ] || return 1
+    [ "$DRACUT_ARCH" = "s390" ] || [ "$DRACUT_ARCH" = "s390x" ] || return 1
     require_binaries chzdev lszdev || return 1
     return 255
 }
 
 # called by dracut
 depends() {
-    arch=${DRACUT_ARCH:-$(uname -m)}
-    [ "$arch" = "s390" ] || [ "$arch" = "s390x" ] || return 1
+    [ "$DRACUT_ARCH" = "s390" ] || [ "$DRACUT_ARCH" = "s390x" ] || return 1
     echo znet bash initqueue
     return 0
 }

--- a/modules.d/69cio_ignore/module-setup.sh
+++ b/modules.d/69cio_ignore/module-setup.sh
@@ -5,8 +5,7 @@
 # called by dracut
 check() {
     # do not add this module by default
-    local arch=${DRACUT_ARCH:-$(uname -m)}
-    [ "$arch" = "s390" ] || [ "$arch" = "s390x" ] || return 1
+    [ "$DRACUT_ARCH" = "s390" ] || [ "$DRACUT_ARCH" = "s390x" ] || return 1
     return 0
 }
 

--- a/modules.d/70crypt/module-setup.sh
+++ b/modules.d/70crypt/module-setup.sh
@@ -23,9 +23,8 @@ depends() {
 
 # called by dracut
 installkernel() {
-    local _arch=${DRACUT_ARCH:-$(uname -m)}
     local _s390drivers=
-    if [[ $_arch == "s390" ]] || [[ $_arch == "s390x" ]]; then
+    if [[ $DRACUT_ARCH == "s390" ]] || [[ $DRACUT_ARCH == "s390x" ]]; then
         _s390drivers="=drivers/s390/crypto"
     fi
 
@@ -158,8 +157,7 @@ install() {
     inst_script "$moddir/crypt-run-generator.sh" "/sbin/crypt-run-generator"
 
     # Install required libraries.
-    _arch=${DRACUT_ARCH:-$(uname -m)}
     inst_libdir_file \
-        {"tls/$_arch/",tls/,"$_arch/",}"/ossl-modules/fips.so" \
-        {"tls/$_arch/",tls/,"$_arch/",}"/ossl-modules/legacy.so"
+        {"tls/$DRACUT_ARCH/",tls/,"$DRACUT_ARCH/",}"/ossl-modules/fips.so" \
+        {"tls/$DRACUT_ARCH/",tls/,"$DRACUT_ARCH/",}"/ossl-modules/legacy.so"
 }

--- a/modules.d/70kernel-modules/module-setup.sh
+++ b/modules.d/70kernel-modules/module-setup.sh
@@ -66,7 +66,7 @@ installkernel() {
             virtio virtio_ring virtio_pci pci_hyperv \
             surface_aggregator_registry psmouse
 
-        if [[ ${DRACUT_ARCH:-$(uname -m)} == arm* || ${DRACUT_ARCH:-$(uname -m)} == aarch64 || ${DRACUT_ARCH:-$(uname -m)} == riscv* ]]; then
+        if [[ ${DRACUT_ARCH} == arm* || ${DRACUT_ARCH} == aarch64 || ${DRACUT_ARCH} == riscv* ]]; then
             # arm/aarch64 specific modules
             _blockfuncs+='|dw_mc_probe|dw_mci_pltfm_register|nvme_init_ctrl'
             hostonly=$(optional_hostonly) instmods \
@@ -131,7 +131,7 @@ installkernel() {
             hostonly='' instmods "${host_fs_types[@]}"
         fi
 
-        arch=${DRACUT_ARCH:-$(uname -m)}
+        local arch=${DRACUT_ARCH}
 
         # We don't want to play catch up with hash and encryption algorithms.
         # To be safe, just use the hammer and include all crypto.

--- a/modules.d/70kernel-network-modules/module-setup.sh
+++ b/modules.d/70kernel-network-modules/module-setup.sh
@@ -8,12 +8,11 @@ check() {
 # called by dracut
 installkernel() {
     # Include wired net drivers, excluding wireless
-    local _arch=${DRACUT_ARCH:-$(uname -m)}
     local _net_symbols='eth_type_trans|register_virtio_device|usbnet_open'
     local _unwanted_drivers='/(wireless|isdn|uwb|net/ethernet|net/phy|net/team)/'
     local _net_drivers
 
-    if [[ $_arch == "s390" ]] || [[ $_arch == "s390x" ]]; then
+    if [[ $DRACUT_ARCH == "s390" ]] || [[ $DRACUT_ARCH == "s390x" ]]; then
         dracut_instmods -o -P ".*${_unwanted_drivers}.*" -s "$_net_symbols" "=drivers/s390/net"
     fi
 

--- a/modules.d/70multipath/module-setup.sh
+++ b/modules.d/70multipath/module-setup.sh
@@ -48,10 +48,9 @@ cmdline() {
 
 # called by dracut
 installkernel() {
-    local _arch=${DRACUT_ARCH:-$(uname -m)}
     local _funcs='scsi_register_device_handler|dm_dirty_log_type_register|dm_register_path_selector|dm_register_target'
 
-    if [ "$_arch" = "s390" ] || [ "$_arch" = "s390x" ]; then
+    if [ "$DRACUT_ARCH" = "s390" ] || [ "$DRACUT_ARCH" = "s390x" ]; then
         _s390drivers="=drivers/s390/scsi"
     fi
 

--- a/modules.d/70ppcmac/module-setup.sh
+++ b/modules.d/70ppcmac/module-setup.sh
@@ -17,9 +17,8 @@
 
 # called by dracut
 check() {
-    local _arch=${DRACUT_ARCH:-$(uname -m)}
     # only for PowerPC Macs
-    [[ $_arch == ppc* && $_arch != ppc64le ]] || return 1
+    [[ $DRACUT_ARCH == ppc* && $DRACUT_ARCH != ppc64le ]] || return 1
     return 0
 }
 
@@ -32,7 +31,7 @@ installkernel() {
     }
 
     # only PowerMac3,6 has a module, special case
-    if [[ ${DRACUT_ARCH:-$(uname -m)} != ppc64* ]]; then
+    if [[ ${DRACUT_ARCH} != ppc64* ]]; then
         if [[ $hostonly_mode != "strict" ]] || [[ $hostonly && "$(pmac_model)" == "PowerMac3,6" ]]; then
             hostonly=$(optional_hostonly) instmods therm_windtunnel
         fi

--- a/modules.d/73fido2/module-setup.sh
+++ b/modules.d/73fido2/module-setup.sh
@@ -19,12 +19,11 @@ depends() {
 # Install the required file(s) and directories for the module in the initramfs.
 install() {
     # Install required libraries.
-    _arch=${DRACUT_ARCH:-$(uname -m)}
     inst_libdir_file \
-        {"tls/$_arch/",tls/,"$_arch/",}"libfido2.so.*" \
-        {"tls/$_arch/",tls/,"$_arch/",}"libz.so.*" \
-        {"tls/$_arch/",tls/,"$_arch/",}"libcryptsetup.so.*" \
-        {"tls/$_arch/",tls/,"$_arch/",}"/cryptsetup/libcryptsetup-token-systemd-fido2.so" \
-        {"tls/$_arch/",tls/,"$_arch/",}"libcbor.so.*" \
-        {"tls/$_arch/",tls/,"$_arch/",}"libhidapi-hidraw.so.*"
+        {"tls/$DRACUT_ARCH/",tls/,"$DRACUT_ARCH/",}"libfido2.so.*" \
+        {"tls/$DRACUT_ARCH/",tls/,"$DRACUT_ARCH/",}"libz.so.*" \
+        {"tls/$DRACUT_ARCH/",tls/,"$DRACUT_ARCH/",}"libcryptsetup.so.*" \
+        {"tls/$DRACUT_ARCH/",tls/,"$DRACUT_ARCH/",}"/cryptsetup/libcryptsetup-token-systemd-fido2.so" \
+        {"tls/$DRACUT_ARCH/",tls/,"$DRACUT_ARCH/",}"libcbor.so.*" \
+        {"tls/$DRACUT_ARCH/",tls/,"$DRACUT_ARCH/",}"libhidapi-hidraw.so.*"
 }

--- a/modules.d/73pcsc/module-setup.sh
+++ b/modules.d/73pcsc/module-setup.sh
@@ -42,20 +42,19 @@ install() {
     done
 
     # Install library file(s)
-    _arch=${DRACUT_ARCH:-$(uname -m)}
     inst_libdir_file \
-        {"tls/$_arch/",tls/,"$_arch/",}"libopensc.so.*" \
-        {"tls/$_arch/",tls/,"$_arch/",}"libsmm-local.so.*" \
-        {"tls/$_arch/",tls/,"$_arch/",}"opensc-pkcs11.so" \
-        {"tls/$_arch/",tls/,"$_arch/",}"onepin-opensc-pkcs11.so" \
-        {"tls/$_arch/",tls/,"$_arch/",}"pkcs11/opensc-pkcs11.so" \
-        {"tls/$_arch/",tls/,"$_arch/",}"pkcs11/onepin-opensc-pkcs11.so" \
-        {"tls/$_arch/",tls/,"$_arch/",}"pcsc/drivers/ifd-ccid.bundle/Contents/Info.plist" \
-        {"tls/$_arch/",tls/,"$_arch/",}"pcsc/drivers/ifd-ccid.bundle/Contents/Linux/libccid.so" \
-        {"tls/$_arch/",tls/,"$_arch/",}"pcsc/drivers/serial/libccidtwin.so" \
-        {"tls/$_arch/",tls/,"$_arch/",}"libeac.so*" \
-        {"tls/$_arch/",tls/,"$_arch/",}"libpcsclite.so.*" \
-        {"tls/$_arch/",tls/,"$_arch/",}"libpcsclite_real.so.*"
+        {"tls/$DRACUT_ARCH/",tls/,"$DRACUT_ARCH/",}"libopensc.so.*" \
+        {"tls/$DRACUT_ARCH/",tls/,"$DRACUT_ARCH/",}"libsmm-local.so.*" \
+        {"tls/$DRACUT_ARCH/",tls/,"$DRACUT_ARCH/",}"opensc-pkcs11.so" \
+        {"tls/$DRACUT_ARCH/",tls/,"$DRACUT_ARCH/",}"onepin-opensc-pkcs11.so" \
+        {"tls/$DRACUT_ARCH/",tls/,"$DRACUT_ARCH/",}"pkcs11/opensc-pkcs11.so" \
+        {"tls/$DRACUT_ARCH/",tls/,"$DRACUT_ARCH/",}"pkcs11/onepin-opensc-pkcs11.so" \
+        {"tls/$DRACUT_ARCH/",tls/,"$DRACUT_ARCH/",}"pcsc/drivers/ifd-ccid.bundle/Contents/Info.plist" \
+        {"tls/$DRACUT_ARCH/",tls/,"$DRACUT_ARCH/",}"pcsc/drivers/ifd-ccid.bundle/Contents/Linux/libccid.so" \
+        {"tls/$DRACUT_ARCH/",tls/,"$DRACUT_ARCH/",}"pcsc/drivers/serial/libccidtwin.so" \
+        {"tls/$DRACUT_ARCH/",tls/,"$DRACUT_ARCH/",}"libeac.so*" \
+        {"tls/$DRACUT_ARCH/",tls/,"$DRACUT_ARCH/",}"libpcsclite.so.*" \
+        {"tls/$DRACUT_ARCH/",tls/,"$DRACUT_ARCH/",}"libpcsclite_real.so.*"
 
     # Install the hosts local user configurations if enabled.
     if [[ $hostonly ]]; then

--- a/modules.d/73pkcs11/module-setup.sh
+++ b/modules.d/73pkcs11/module-setup.sh
@@ -24,12 +24,11 @@ depends() {
 install() {
 
     # Install library file(s)
-    _arch=${DRACUT_ARCH:-$(uname -m)}
     inst_libdir_file \
-        {"tls/$_arch/",tls/,"$_arch/",}"libtasn1.so.*" \
-        {"tls/$_arch/",tls/,"$_arch/",}"libffi.so.*" \
-        {"tls/$_arch/",tls/,"$_arch/",}"libp11-kit.so.*" \
-        {"tls/$_arch/",tls/,"$_arch/",}"libcryptsetup.so.*" \
-        {"tls/$_arch/",tls/,"$_arch/",}"/cryptsetup/libcryptsetup-token-systemd-pkcs11.so*"
+        {"tls/$DRACUT_ARCH/",tls/,"$DRACUT_ARCH/",}"libtasn1.so.*" \
+        {"tls/$DRACUT_ARCH/",tls/,"$DRACUT_ARCH/",}"libffi.so.*" \
+        {"tls/$DRACUT_ARCH/",tls/,"$DRACUT_ARCH/",}"libp11-kit.so.*" \
+        {"tls/$DRACUT_ARCH/",tls/,"$DRACUT_ARCH/",}"libcryptsetup.so.*" \
+        {"tls/$DRACUT_ARCH/",tls/,"$DRACUT_ARCH/",}"/cryptsetup/libcryptsetup-token-systemd-pkcs11.so*"
 
 }

--- a/modules.d/73tpm2-tss/module-setup.sh
+++ b/modules.d/73tpm2-tss/module-setup.sh
@@ -45,21 +45,20 @@ install() {
         tpm2_create tpm2_load tpm2_unseal tpm2
 
     # Install library file(s)
-    _arch=${DRACUT_ARCH:-$(uname -m)}
     inst_libdir_file \
-        {"tls/$_arch/",tls/,"$_arch/",}"libtss2-esys.so.*" \
-        {"tls/$_arch/",tls/,"$_arch/",}"libtss2-fapi.so.*" \
-        {"tls/$_arch/",tls/,"$_arch/",}"libtss2-mu.so.*" \
-        {"tls/$_arch/",tls/,"$_arch/",}"libtss2-rc.so.*" \
-        {"tls/$_arch/",tls/,"$_arch/",}"libtss2-sys.so.*" \
-        {"tls/$_arch/",tls/,"$_arch/",}"libtss2-tcti-cmd.so.*" \
-        {"tls/$_arch/",tls/,"$_arch/",}"libtss2-tcti-device.so.*" \
-        {"tls/$_arch/",tls/,"$_arch/",}"libtss2-tcti-mssim.so.*" \
-        {"tls/$_arch/",tls/,"$_arch/",}"libtss2-tcti-swtpm.so.*" \
-        {"tls/$_arch/",tls/,"$_arch/",}"libtss2-tctildr.so.*" \
-        {"tls/$_arch/",tls/,"$_arch/",}"libcryptsetup.so.*" \
-        {"tls/$_arch/",tls/,"$_arch/",}"/cryptsetup/libcryptsetup-token-systemd-tpm2.so" \
-        {"tls/$_arch/",tls/,"$_arch/",}"libcurl.so.*" \
-        {"tls/$_arch/",tls/,"$_arch/",}"libjson-c.so.*"
+        {"tls/$DRACUT_ARCH/",tls/,"$DRACUT_ARCH/",}"libtss2-esys.so.*" \
+        {"tls/$DRACUT_ARCH/",tls/,"$DRACUT_ARCH/",}"libtss2-fapi.so.*" \
+        {"tls/$DRACUT_ARCH/",tls/,"$DRACUT_ARCH/",}"libtss2-mu.so.*" \
+        {"tls/$DRACUT_ARCH/",tls/,"$DRACUT_ARCH/",}"libtss2-rc.so.*" \
+        {"tls/$DRACUT_ARCH/",tls/,"$DRACUT_ARCH/",}"libtss2-sys.so.*" \
+        {"tls/$DRACUT_ARCH/",tls/,"$DRACUT_ARCH/",}"libtss2-tcti-cmd.so.*" \
+        {"tls/$DRACUT_ARCH/",tls/,"$DRACUT_ARCH/",}"libtss2-tcti-device.so.*" \
+        {"tls/$DRACUT_ARCH/",tls/,"$DRACUT_ARCH/",}"libtss2-tcti-mssim.so.*" \
+        {"tls/$DRACUT_ARCH/",tls/,"$DRACUT_ARCH/",}"libtss2-tcti-swtpm.so.*" \
+        {"tls/$DRACUT_ARCH/",tls/,"$DRACUT_ARCH/",}"libtss2-tctildr.so.*" \
+        {"tls/$DRACUT_ARCH/",tls/,"$DRACUT_ARCH/",}"libcryptsetup.so.*" \
+        {"tls/$DRACUT_ARCH/",tls/,"$DRACUT_ARCH/",}"/cryptsetup/libcryptsetup-token-systemd-tpm2.so" \
+        {"tls/$DRACUT_ARCH/",tls/,"$DRACUT_ARCH/",}"libcurl.so.*" \
+        {"tls/$DRACUT_ARCH/",tls/,"$DRACUT_ARCH/",}"libjson-c.so.*"
 
 }

--- a/modules.d/73zipl/module-setup.sh
+++ b/modules.d/73zipl/module-setup.sh
@@ -10,9 +10,8 @@ get_boot_zipl_dev() {
 
 # called by dracut
 check() {
-    local _arch=${DRACUT_ARCH:-$(uname -m)}
     # Only for systems on s390 using indirect booting via userland grub
-    [ "$_arch" = "s390" ] || [ "$_arch" = "s390x" ] || return 1
+    [ "$DRACUT_ARCH" = "s390" ] || [ "$DRACUT_ARCH" = "s390x" ] || return 1
     # /boot/zipl contains a first stage kernel used to launch grub in initrd
     [ -d /boot/zipl ] || return 1
     return 0

--- a/modules.d/74dasd/module-setup.sh
+++ b/modules.d/74dasd/module-setup.sh
@@ -2,8 +2,7 @@
 
 # called by dracut
 check() {
-    local _arch=${DRACUT_ARCH:-$(uname -m)}
-    [ "$_arch" = "s390" ] || [ "$_arch" = "s390x" ] || return 1
+    [ "$DRACUT_ARCH" = "s390" ] || [ "$DRACUT_ARCH" = "s390x" ] || return 1
     require_binaries dasdconf.sh || return 1
     return 0
 }

--- a/modules.d/74dasd_mod/module-setup.sh
+++ b/modules.d/74dasd_mod/module-setup.sh
@@ -2,9 +2,7 @@
 
 # called by dracut
 check() {
-    local _arch=${DRACUT_ARCH:-$(uname -m)}
-    [ "$_arch" = "s390" ] || [ "$_arch" = "s390x" ] || return 1
-
+    [ "$DRACUT_ARCH" = "s390" ] || [ "$DRACUT_ARCH" = "s390x" ] || return 1
     return 0
 }
 

--- a/modules.d/74dcssblk/module-setup.sh
+++ b/modules.d/74dcssblk/module-setup.sh
@@ -4,8 +4,7 @@
 
 # called by dracut
 check() {
-    local _arch=${DRACUT_ARCH:-$(uname -m)}
-    [[ $_arch == "s390" ]] || [[ $_arch == "s390x" ]] || return 1
+    [[ $DRACUT_ARCH == "s390" ]] || [[ $DRACUT_ARCH == "s390x" ]] || return 1
     return 0
 }
 

--- a/modules.d/74iscsi/module-setup.sh
+++ b/modules.d/74iscsi/module-setup.sh
@@ -159,13 +159,12 @@ depends() {
 
 # called by dracut
 installkernel() {
-    local _arch=${DRACUT_ARCH:-$(uname -m)}
     local _funcs='iscsi_register_transport'
 
     hostonly=$(optional_hostonly) instmods bnx2i qla4xxx cxgb3i cxgb4i be2iscsi qedi
     hostonly="" instmods iscsi_tcp iscsi_ibft crc32c iscsi_boot_sysfs 8021q
 
-    if [ "$_arch" = "s390" ] || [ "$_arch" = "s390x" ]; then
+    if [ "$DRACUT_ARCH" = "s390" ] || [ "$DRACUT_ARCH" = "s390x" ]; then
         _s390drivers="=drivers/s390/scsi"
     fi
 

--- a/modules.d/74udev-rules/module-setup.sh
+++ b/modules.d/74udev-rules/module-setup.sh
@@ -90,10 +90,9 @@ install() {
         "${udevdir}"/udev.conf.d/*.conf
 
     # Install required libraries.
-    _arch=${DRACUT_ARCH:-$(uname -m)}
     inst_libdir_file \
-        {"tls/$_arch/",tls/,"$_arch/",}"libkmod.so*" \
-        {"tls/$_arch/",tls/,"$_arch/",}"libnss_files*"
+        {"tls/$DRACUT_ARCH/",tls/,"$DRACUT_ARCH/",}"libkmod.so*" \
+        {"tls/$DRACUT_ARCH/",tls/,"$DRACUT_ARCH/",}"libnss_files*"
 
     # Install the hosts local user configurations if enabled.
     if [[ $hostonly ]]; then

--- a/modules.d/74zfcp/module-setup.sh
+++ b/modules.d/74zfcp/module-setup.sh
@@ -2,8 +2,7 @@
 
 # called by dracut
 check() {
-    arch=${DRACUT_ARCH:-$(uname -m)}
-    [ "$arch" = "s390" ] || [ "$arch" = "s390x" ] || return 1
+    [ "$DRACUT_ARCH" = "s390" ] || [ "$DRACUT_ARCH" = "s390x" ] || return 1
 
     require_binaries zfcp_cio_free sed || return 1
 

--- a/modules.d/74znet/module-setup.sh
+++ b/modules.d/74znet/module-setup.sh
@@ -2,8 +2,7 @@
 
 # called by dracut
 check() {
-    arch=${DRACUT_ARCH:-$(uname -m)}
-    [ "$arch" = "s390" ] || [ "$arch" = "s390x" ] || return 1
+    [ "$DRACUT_ARCH" = "s390" ] || [ "$DRACUT_ARCH" = "s390x" ] || return 1
 
     require_binaries grep sed seq readlink chzdev || return 1
 


### PR DESCRIPTION
Usually `DRACUT_ARCH` is not set, so we are calling `uname -m` multiple times to get always the same value. Hence, get its external value at the beginning and export it globally, in the same way we do with other global variables.

### Checklist
- [X] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it
