### PR TITLE
ci(void): prefer btrfs storage module

### DIFF
--- a/test/container/Dockerfile-void
+++ b/test/container/Dockerfile-void
@@ -18,6 +18,9 @@ FROM ghcr.io/void-linux/void-glibc-full
 # prefer running tests with clang
 ENV CC=clang
 
+# prefer running tests with btrfs
+ENV TEST_FSTYPE=btrfs
+
 RUN xbps-install -Syu xbps && xbps-install -yu \
     bash \
     binutils \


### PR DESCRIPTION
Disabling zfs lead to test 20 failing. Switch to btrfs (from the default ext4), to enable the test to pass.

Follow-up to 4d7a60d.

<!-- This pull request changes... -->

<!-- Fixes: https://github.com/dracut-ng/dracut-ng/issues/<number> -->

### Checklist
- [ ] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it
