### PR TITLE
ci: increase test timeout

### DIFF
--- a/.github/workflows/daily-basic.yml
+++ b/.github/workflows/daily-basic.yml
@@ -16,7 +16,7 @@ jobs:
     basic:
         name: ${{ matrix.test }} on ${{ matrix.container }} on ${{ matrix.architecture.tag }}
         runs-on: ${{ matrix.architecture.runner }}
-        timeout-minutes: 30
+        timeout-minutes: 60
         concurrency:
             group: >
                 daily-basic-${{ github.workflow }}-${{ github.ref }}

--- a/test/run-qemu
+++ b/test/run-qemu
@@ -5,7 +5,7 @@ set -eu
 
 export PATH=/usr/sbin:/usr/bin:/sbin:/bin
 ARCH="${ARCH-$(uname -m)}"
-default_qemu_timeout=600 # 10 min (default might be increased based on the architecture)
+default_qemu_timeout=1200 # 20 min (default might be increased based on the architecture)
 if [ -z "${QEMU_CPU-}" ]; then
     case "$ARCH" in
         aarch64 | arm64)
@@ -158,8 +158,8 @@ case "$ARCH" in
     aarch64 | arm64)
         ARGS+=(-M "virt,gic-version=max")
         console=ttyAMA0
-        # Increase timeout to 30 min
-        default_qemu_timeout=1800
+        # Increase timeout to 60 min
+        default_qemu_timeout=3600
         ;;
     amd64 | i?86 | x86_64)
         ARGS+=(-M q35)
@@ -167,8 +167,8 @@ case "$ARCH" in
     arm | armhf | armv7l)
         ARGS+=(-M virt)
         console=ttyAMA0
-        # Increase timeout to 30 min
-        default_qemu_timeout=1800
+        # Increase timeout to 60 min
+        default_qemu_timeout=3600
         ;;
     ppc64el | ppc64le)
         ARGS+=(-M "cap-ccf-assist=off,cap-cfpc=broken,cap-ibs=broken,cap-sbbc=broken")
@@ -177,8 +177,8 @@ case "$ARCH" in
     riscv64)
         ARGS+=(-M virt)
         rng_device=virtio-rng-device
-        # Increase timeout to 30 min
-        default_qemu_timeout=1800
+        # Increase timeout to 60 min
+        default_qemu_timeout=3600
         ;;
     s390x)
         console=hvc0


### PR DESCRIPTION
Test 26 on ubuntu:devel on ARM needs more than 30 minutes.

Set the timeout to 40 min to allow the test to run to its conclusion.

Follow-up to f378df5 .

<!-- This pull request changes... -->

<!-- Fixes: https://github.com/dracut-ng/dracut-ng/issues/<number> -->

### Checklist
- [ ] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it
