### PR TITLE
fix(SYSTEMD-IMPORT): remount /sysroot with dev and suid flags

### DIFF
--- a/modules.d/45systemd-import/dracut-remount-sysroot.service
+++ b/modules.d/45systemd-import/dracut-remount-sysroot.service
@@ -1,0 +1,14 @@
+[Unit]
+Description=Workaround for https://github.com/systemd/systemd/issues/41352
+After=imports.target sysroot.mount
+ConditionPathExists=/etc/initrd-release
+ConditionKernelCommandLine=rd.systemd.pull
+ConditionKernelCommandLine=root
+
+[Service]
+Type=oneshot
+RemainAfterExit=yes
+ExecStart=/usr/bin/mount -o remount,suid,dev /sysroot
+
+[Install]
+WantedBy=initrd.target

--- a/modules.d/45systemd-import/module-setup.sh
+++ b/modules.d/45systemd-import/module-setup.sh
@@ -52,6 +52,9 @@ install() {
         "$systemdsystemunitdir"/sysinit.target.wants/imports.target \
         gpg systemd-dissect
 
+    inst "$moddir/dracut-remount-sysroot.service" "$systemdsystemunitdir"/dracut-remount-sysroot.service
+    $SYSTEMCTL -q --root "$initdir" enable dracut-remount-sysroot.service
+
     # systemd < v259: requires the tar binary
     # See: https://github.com/systemd/systemd/commit/a7c8f92d1f937113a279adbe62399f6f0773473f
     if ((_systemd_version < 259)); then

--- a/test/TEST-45-SYSTEMD-IMPORT/assertion.sh
+++ b/test/TEST-45-SYSTEMD-IMPORT/assertion.sh
@@ -1,0 +1,21 @@
+#!/bin/sh
+set -eu
+
+# required binaries: cat grep
+
+if grep -Eq " / .*nodev" /proc/mounts; then
+    echo "Error: / mounted with nodev flag." >> /run/failed
+fi
+
+if grep -Eq " / .*nosuid" /proc/mounts; then
+    echo "Error: / mounted with nosuid flag." >> /run/failed
+fi
+
+# Dump /proc/mounts at the end if there were any failures for easier debugging
+if [ -s /run/failed ]; then
+    {
+        echo ">>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>> /proc/mounts >>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>"
+        cat /proc/mounts
+        echo "<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<< /proc/mounts <<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<"
+    } >> /run/failed
+fi

--- a/test/TEST-45-SYSTEMD-IMPORT/test.sh
+++ b/test/TEST-45-SYSTEMD-IMPORT/test.sh
@@ -66,7 +66,7 @@ test_setup() {
     local image images=() local_pubring=() network_handler
 
     # Create plain root filesystem
-    build_client_rootfs "$TESTDIR/rootfs"
+    build_client_rootfs "$TESTDIR/rootfs" ./assertion.sh
 
     # Create a compressed tarball with the plain rootfs
     tar -C "$TESTDIR/rootfs" --zstd -cf "$TESTDIR/root.tar.zst" .


### PR DESCRIPTION
When using `systemd-import` combined with a tarball, the resulting root filesystem retains the `nosuid` mount flag. This breaks any `setuid` binaries in the booted OS, causing critical utilities like sudo to fail with:

```
sudo: sudo must be owned by uid 0 and have the setuid bit set
```

Apply a workaround to remount `/sysroot` with the `dev` and `suid` flags. This workaround can be dropped when systemd is fixed or made conditional to only the affected systemd versions.

Fixes: https://github.com/dracut-ng/dracut-ng/issues/2318
Bug-Ubuntu: https://launchpad.net/bugs/2146342
Woraround for: https://github.com/systemd/systemd/issues/41352

<!-- This pull request changes... -->

<!-- Fixes: https://github.com/dracut-ng/dracut-ng/issues/<number> -->

### Checklist
- [ ] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it
