### PR TITLE
ci(void): fix zfs kernel module installation

### DIFF
--- a/test/container/Dockerfile-void
+++ b/test/container/Dockerfile-void
@@ -46,6 +46,7 @@ RUN xbps-install -Syu xbps && xbps-install -yu \
     kbd \
     libkmod-devel \
     linux \
+    linux-headers \
     lvm2 \
     make \
     mdadm \


### PR DESCRIPTION
To use DKMS on Void Linux, you must install the linux-headers package corresponding to your active kernel.

<!-- This pull request changes... -->

<!-- Fixes: https://github.com/dracut-ng/dracut-ng/issues/<number> -->

### Checklist
- [ ] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it
