### PR TITLE
ci: add daily zfs test

### DIFF
--- a/.github/workflows/daily-zfs.yml
+++ b/.github/workflows/daily-zfs.yml
@@ -1,0 +1,44 @@
+---
+name: Daily Tests - zfs
+
+on:  # yamllint disable-line rule:truthy
+    schedule:
+        - cron: '30 23 * * *'   # every day at 23:30 UTC
+
+    # Allows you to run this workflow manually from the Actions tab
+    workflow_dispatch:
+
+    pull_request:
+        paths:
+            - '.github/workflows/daily-zfs.yml'
+
+jobs:
+    basic:
+        name: ${{ matrix.test }} on ${{ matrix.container }} on ${{ matrix.architecture.tag }}
+        runs-on: ${{ matrix.architecture.runner }}
+        timeout-minutes: 60
+        concurrency:
+            group: >
+                daily-basic-${{ github.workflow }}-${{ github.ref }}
+                -${{ matrix.container }}-${{ matrix.test }}-${{ matrix.architecture.tag }}
+            cancel-in-progress: true
+        strategy:
+            fail-fast: false
+            matrix:
+                architecture:
+                    - {runner: 'ubuntu-24.04', tag: 'amd'}
+                    - {runner: 'ubuntu-24.04-arm', tag: 'arm'}
+                container:
+                    - void:latest
+                test:
+                    - "20"
+        container:
+            image: ghcr.io/dracut-ng/${{ matrix.container }}
+            options: '--device=/dev/kvm --privileged'
+        steps:
+            - name: "Checkout Repository"
+              uses: actions/checkout@v6
+            - name: "${{ matrix.container }} TEST-${{ matrix.test }}"
+              run: >
+                TEST_CONTAINER_COMMAND="export TEST_FSTYPE=zfs"
+                ./test/test-container.sh "TEST-${{ matrix.test }}" ${{ matrix.test }}


### PR DESCRIPTION
Use the void CI container to run tests with the zfs dracut module.

<!-- This pull request changes... -->

<!-- Fixes: https://github.com/dracut-ng/dracut-ng/issues/<number> -->

### Checklist
- [ ] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it
