### PR TITLE
fix(dracut): determine hostonly_cmdline after hostonly setting

### DIFF
--- a/dracut.sh
+++ b/dracut.sh
@@ -1141,7 +1141,6 @@ drivers_dir="${drivers_dir%"${drivers_dir##*[!/]}"}"
 [[ $hostonly_l ]] && hostonly=$hostonly_l
 [[ $hostonly_cmdline_l ]] && hostonly_cmdline=$hostonly_cmdline_l
 [[ $hostonly_mode_l ]] && hostonly_mode=$hostonly_mode_l
-[[ ${hostonly-} != "no" ]] && ! [[ $hostonly_cmdline ]] && hostonly_cmdline="yes"
 # shellcheck disable=SC2034
 [[ $i18n_install_all_l ]] && i18n_install_all=$i18n_install_all_l
 # shellcheck disable=SC2034
@@ -1355,6 +1354,11 @@ if [[ ${hostonly-} ]]; then
     elif ! findmnt --target "/sys" &> /dev/null; then
         dwarning "Hostonly mode with no /sys mounted!"
     fi
+fi
+
+if [[ ${hostonly-} ]] && ! [[ $hostonly_cmdline ]]; then
+    # Enable hostonly-cmdline by default in hostonly mode
+    hostonly_cmdline="yes"
 fi
 
 case $hostonly_mode in


### PR DESCRIPTION
Commit 04af3c097797 enabled `hostonly_cmdline` in host-only mode again, but determining that was done too early. In case `/dev` is not mounted, the host-only mode is turned off. At that point `hostonly_cmdline` has already be enabled.

So determine the default for `hostonly_cmdline` after the final check for `hostonly`.

Bug-Debian: https://bugs.debian.org/1132794
Fixes: 04af3c097797 ("fix(dracut): enable hostonly_cmdline in hostonly mode again")

<!-- This pull request changes... -->

<!-- Fixes: https://github.com/dracut-ng/dracut-ng/issues/<number> -->

### Checklist
- [ ] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it
