### PR TITLE
fix(squash-lib): inst_libdir_file() does not have a -o option

### DIFF
--- a/modules.d/88squash-lib/module-setup.sh
+++ b/modules.d/88squash-lib/module-setup.sh
@@ -53,10 +53,10 @@ squash_install() {
         DRACUT_RESOLVE_LAZY="" inst_multiple sh mount modprobe mkdir switch_root grep umount
 
         # libpthread workaround: pthread_cancel wants to dlopen libgcc_s.so
-        inst_libdir_file -o "libgcc_s.so*"
+        inst_libdir_file "libgcc_s.so*"
 
         # FIPS workaround for Fedora/RHEL: libcrypto needs libssl when FIPS is enabled
-        [[ $DRACUT_FIPS_MODE ]] && inst_libdir_file -o "libssl.so*"
+        [[ $DRACUT_FIPS_MODE ]] && inst_libdir_file "libssl.so*"
     fi
 
     hostonly="" instmods "loop" "overlay"


### PR DESCRIPTION
So it tries to find a file named "-o". Spotted while debugging:

```
/usr/lib/dracut/modules.d/88squash-lib/module-setup.sh@56(squash_install): inst_libdir_file -o 'libgcc_s.so*'
/usr/lib/dracut/dracut-functions.sh@1434(inst_libdir_file): _files=()
/usr/lib/dracut/dracut-functions.sh@1434(inst_libdir_file): local -a _files
/usr/lib/dracut/dracut-functions.sh@1435(inst_libdir_file): local _path
/usr/lib/dracut/dracut-functions.sh@1440(inst_libdir_file): declare -p _libdir_file_cache
/usr/lib/dracut/dracut-functions.sh@1440(inst_libdir_file): grep -q 'declare -A'
/usr/lib/dracut/dracut-functions.sh@1447(inst_libdir_file): [[ -o == \-n ]]
/usr/lib/dracut/dracut-functions.sh@1463(inst_libdir_file): for _dir in $libdirs
/usr/lib/dracut/dracut-functions.sh@1464(inst_libdir_file): for _i in "$@"
/usr/lib/dracut/dracut-functions.sh@1465(inst_libdir_file): for _f in "${dracutsysrootdir-}$_dir"/$_i
/usr/lib/dracut/dracut-functions.sh@1466(inst_libdir_file): _path=/lib64/-o
/usr/lib/dracut/dracut-functions.sh@1467(inst_libdir_file): [[ -e /lib64/-o ]]
/usr/lib/dracut/dracut-functions.sh@1464(inst_libdir_file): for _i in "$@"
/usr/lib/dracut/dracut-functions.sh@1465(inst_libdir_file): for _f in "${dracutsysrootdir-}$_dir"/$_i
/usr/lib/dracut/dracut-functions.sh@1466(inst_libdir_file): _path=/lib64/libgcc_s.so.1
/usr/lib/dracut/dracut-functions.sh@1467(inst_libdir_file): [[ -e /lib64/libgcc_s.so.1 ]]
/usr/lib/dracut/dracut-functions.sh@1467(inst_libdir_file): [[ '' != 1 ]]
/usr/lib/dracut/dracut-functions.sh@1468(inst_libdir_file): _files+=("$_path")
/usr/lib/dracut/dracut-functions.sh@1469(inst_libdir_file): _libdir_file_cache[$_path]=1
/usr/lib/dracut/dracut-functions.sh@1463(inst_libdir_file): for _dir in $libdirs
/usr/lib/dracut/dracut-functions.sh@1464(inst_libdir_file): for _i in "$@"
/usr/lib/dracut/dracut-functions.sh@1465(inst_libdir_file): for _f in "${dracutsysrootdir-}$_dir"/$_i
/usr/lib/dracut/dracut-functions.sh@1466(inst_libdir_file): _path=/usr/lib64/-o
/usr/lib/dracut/dracut-functions.sh@1467(inst_libdir_file): [[ -e /usr/lib64/-o ]]
/usr/lib/dracut/dracut-functions.sh@1464(inst_libdir_file): for _i in "$@"
/usr/lib/dracut/dracut-functions.sh@1465(inst_libdir_file): for _f in "${dracutsysrootdir-}$_dir"/$_i
/usr/lib/dracut/dracut-functions.sh@1466(inst_libdir_file): _path=/usr/lib64/libgcc_s.so.1
/usr/lib/dracut/dracut-functions.sh@1467(inst_libdir_file): [[ -e /usr/lib64/libgcc_s.so.1 ]]
/usr/lib/dracut/dracut-functions.sh@1467(inst_libdir_file): [[ '' != 1 ]]
/usr/lib/dracut/dracut-functions.sh@1468(inst_libdir_file): _files+=("$_path")
/usr/lib/dracut/dracut-functions.sh@1469(inst_libdir_file): _libdir_file_cache[$_path]=1
/usr/lib/dracut/dracut-functions.sh@1463(inst_libdir_file): for _dir in $libdirs
/usr/lib/dracut/dracut-functions.sh@1464(inst_libdir_file): for _i in "$@"
/usr/lib/dracut/dracut-functions.sh@1465(inst_libdir_file): for _f in "${dracutsysrootdir-}$_dir"/$_i
/usr/lib/dracut/dracut-functions.sh@1466(inst_libdir_file): _path=/lib/-o
/usr/lib/dracut/dracut-functions.sh@1467(inst_libdir_file): [[ -e /lib/-o ]]
/usr/lib/dracut/dracut-functions.sh@1464(inst_libdir_file): for _i in "$@"
/usr/lib/dracut/dracut-functions.sh@1465(inst_libdir_file): for _f in "${dracutsysrootdir-}$_dir"/$_i
/usr/lib/dracut/dracut-functions.sh@1466(inst_libdir_file): _path='/lib/libgcc_s.so*'
/usr/lib/dracut/dracut-functions.sh@1467(inst_libdir_file): [[ -e /lib/libgcc_s.so* ]]
/usr/lib/dracut/dracut-functions.sh@1463(inst_libdir_file): for _dir in $libdirs
/usr/lib/dracut/dracut-functions.sh@1464(inst_libdir_file): for _i in "$@"
/usr/lib/dracut/dracut-functions.sh@1465(inst_libdir_file): for _f in "${dracutsysrootdir-}$_dir"/$_i
/usr/lib/dracut/dracut-functions.sh@1466(inst_libdir_file): _path=/usr/lib/-o
/usr/lib/dracut/dracut-functions.sh@1467(inst_libdir_file): [[ -e /usr/lib/-o ]]
```

Follow-up for 5ab18dee996f0eeb2b0bfe354570e1b1af46d025

### Checklist
- [X] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it
