### PR TITLE
fix(man): inst_libdir_file() does not have a -o option

### DIFF
--- a/man/dracut.modules.7.adoc
+++ b/man/dracut.modules.7.adoc
@@ -344,15 +344,13 @@ is reported, but does not let dracut fail.
 installs multiple directories (but not their content) located on a library
 directory to the initramfs image.
 
-==== inst_libdir_file [-n <pattern>] [-o] <file> [<file>...]
+==== inst_libdir_file [-n <pattern>] <file> [<file>...]
 
 installs multiple files located on a library directory to the initramfs image.
 
 options:
 
 -n <pattern>:: install all library files matching a pattern.
-
--o:: optional, a missing library does not lead to an error.
 
 ==== instmods [-c] [-s] <kernelmodule> [ <kernelmodule> ... ]
 


### PR DESCRIPTION
Fixes a04c26583f82f5b8bc272bb4938b3aafb90a7fbc

### Checklist
- [ ] I have tested it locally
- [X] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it
