### PR TITLE
fix(dracut): inst_libdir_file() does not have a -o option

### DIFF
--- a/dracut.sh
+++ b/dracut.sh
@@ -3040,7 +3040,7 @@ if [[ $kernel_only != yes ]]; then
         for _dir in $libdirs; do
             for _f in "${dracutsysrootdir-}$_dir/libcrypto.so"*; do
                 [[ -e $_f ]] || continue
-                inst_libdir_file -o "libssl.so*"
+                inst_libdir_file "libssl.so*"
                 break 2
             done
         done


### PR DESCRIPTION
Follow-up for 5a4c3469338410b6aea9452994b4b0af1ba59be7

Spotted by https://github.com/dracut-ng/dracut-ng/pull/2354#issuecomment-4206443819

### Checklist
- [X] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it
