### PR TITLE
fix: set DRACUT_TMPDIR before using it in dlog_init()

### DIFF
--- a/dracut-logger.sh
+++ b/dracut-logger.sh
@@ -144,7 +144,7 @@ dlog_init() {
             && type -P systemd-cat &> /dev/null \
             && systemctl --quiet is-active systemd-journald.socket &> /dev/null \
             && { echo "dracut-$DRACUT_VERSION" | systemd-cat -t 'dracut' &> /dev/null; }; then
-            readonly _systemdcatfile="$DRACUT_TMPDIR/systemd-cat"
+            readonly _systemdcatfile="${DRACUT_TMPDIR:-${dracutsysrootdir-}/var/tmp}/systemd-cat"
             mkfifo "$_systemdcatfile"
             readonly _dlogfd=15
             systemd-cat -t 'dracut' --level-prefix=true < "$_systemdcatfile" &

--- a/dracut.sh
+++ b/dracut.sh
@@ -1189,6 +1189,20 @@ drivers_dir="${drivers_dir%"${drivers_dir##*[!/]}"}"
 [[ $sbat_l ]] && sbat="$sbat_l"
 [[ $machine_id_l ]] && machine_id="$machine_id_l"
 
+TMPDIR="$(realpath -e "$tmpdir")"
+readonly TMPDIR
+[ -d "$TMPDIR" ] || {
+    printf "%s\n" "dracut[F]: Invalid tmpdir '$tmpdir'." >&2
+    exit 1
+}
+
+DRACUT_TMPDIR="$(mktemp -p "$TMPDIR/" -d -t dracut.dXXXXXX)"
+readonly DRACUT_TMPDIR
+[ -d "$DRACUT_TMPDIR" ] || {
+    printf "%s\n" "dracut[F]: mktemp -p '$TMPDIR/' -d -t dracut.dXXXXXX failed." >&2
+    exit 1
+}
+
 # shellcheck source=./dracut-functions.sh
 . "$dracutbasedir"/dracut-functions.sh
 
@@ -1405,24 +1419,10 @@ if [[ -z $DRACUT_KMODDIR_OVERRIDE && -n $drivers_dir ]]; then
     fi
 fi
 
-TMPDIR="$(realpath -e "$tmpdir")"
-readonly TMPDIR
-[ -d "$TMPDIR" ] || {
-    dfatal "Invalid tmpdir '$tmpdir'."
-    exit 1
-}
-
 if findmnt --raw -n --target "$tmpdir" --output=options | grep -q noexec; then
     [[ $debug == yes ]] && ddebug "Tmpdir '$tmpdir' is mounted with 'noexec'."
     noexec=1
 fi
-
-DRACUT_TMPDIR="$(mktemp -p "$TMPDIR/" -d -t dracut.dXXXXXX)"
-readonly DRACUT_TMPDIR
-[ -d "$DRACUT_TMPDIR" ] || {
-    dfatal "mktemp -p '$TMPDIR/' -d -t dracut.dXXXXXX failed."
-    exit 1
-}
 
 # Cache file used to optimize get_maj_min()
 declare -x -r get_maj_min_cache_file="${DRACUT_TMPDIR}/majmin_cache"


### PR DESCRIPTION
Otherwise, dracut is performing mkfifo /systemd-cat on the host.

Fixes: 8552a0f
Fixes: https://github.com/dracut-ng/dracut-ng/issues/2291

<!-- This pull request changes... -->

<!-- Fixes: https://github.com/dracut-ng/dracut-ng/issues/<number> -->

### Checklist
- [ ] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it
