### PR TITLE
ci: disable running failing tests for daily network GA

### DIFF
--- a/.github/workflows/daily-network.yml
+++ b/.github/workflows/daily-network.yml
@@ -48,6 +48,12 @@ jobs:
                     # https://github.com/dracut-ng/dracut-ng/issues/1988
                     - container: debian:sid
                       architecture: {runner: 'ubuntu-24.04-arm', tag: 'arm'}
+                    - container: ubuntu:devel
+                      architecture: {runner: 'ubuntu-24.04-arm', tag: 'arm'}
+                      test: "72"
+                    - container: ubuntu:rolling
+                      architecture: {runner: 'ubuntu-24.04-arm', tag: 'arm'}
+                      test: "72"
         container:
             image: ghcr.io/dracut-ng/${{ matrix.container }}
             options: '--device=/dev/kvm --privileged'


### PR DESCRIPTION
`ubuntu:devel` and `ubuntu:rolling` needs over an hour to run test 72 and it times out. Other Linux distributions finish the test in less than 30 min.
    
<!-- This pull request changes... -->

<!-- Fixes: https://github.com/dracut-ng/dracut-ng/issues/<number> -->

### Checklist
- [ ] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it
