### PR TITLE
fix(systemd-ask-password): no graphical output in aarch64

### DIFF
--- a/modules.d/11systemd-ask-password/module-setup.sh
+++ b/modules.d/11systemd-ask-password/module-setup.sh
@@ -19,15 +19,15 @@ check() {
 # Module dependency requirements.
 depends() {
 
-    if [[ $hostonly ]]; then
+    if [[ ${DRACUT_ARCH} == arm* || ${DRACUT_ARCH} == aarch64 ]]; then
         # A password cannot be entered if there is no graphical output during boot,
         # as is the case in aarch64, where efifb does not work with qemu-system-aarch64:
         # - virtio-gpu-pci does not expose a linear framebuffer
         # - virtio-vga is not supported
         # - ramfb is not enough
         # Therefore, depend on the drm module if virtio_gpu is loaded on the system.
-        if [[ ${DRACUT_ARCH} == arm* || ${DRACUT_ARCH} == aarch64 ]] \
-            && grep -r -qs "virtio:d00000010v" /sys/bus/virtio/devices/*/modalias; then
+        if [[ ! $hostonly ]] \
+            || grep -r -qs "virtio:d00000010v" /sys/bus/virtio/devices/*/modalias; then
             echo drm
         fi
     fi


### PR DESCRIPTION
Depend on the drm module on aarch64 in non-hostonly (generic) mode.

Follow-up to 4cc962a .

Fixes: https://github.com/dracut-ng/dracut-ng/issues/2362

CC @bdrung @Rolv-Apneseth @cgwalters @aafeijoo-suse  @travier 

<!-- This pull request changes... -->

<!-- Fixes: https://github.com/dracut-ng/dracut-ng/issues/<number> -->

### Checklist
- [ ] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it
