### PR TITLE
ci: disable running failing tests for daily basic GA

### DIFF
--- a/.github/workflows/daily-basic.yml
+++ b/.github/workflows/daily-basic.yml
@@ -53,6 +53,10 @@ jobs:
                     # https://github.com/dracut-ng/dracut-ng/issues/1988
                     - container: debian:sid
                       architecture: {runner: 'ubuntu-24.04-arm', tag: 'arm'}
+                    # times out
+                    - container: ubuntu:devel
+                      architecture: {runner: 'ubuntu-24.04-arm', tag: 'arm'}
+                      test: "26"
         container:
             image: ghcr.io/dracut-ng/${{ matrix.container }}
             options: '--device=/dev/kvm --privileged'


### PR DESCRIPTION
ubuntu:devel and ubuntu:rolling needs over an hour to run test 26 and it times out. Other Linux distributions finish the test in less than 10 min.

<!-- This pull request changes... -->

<!-- Fixes: https://github.com/dracut-ng/dracut-ng/issues/<number> -->

### Checklist
- [ ] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it
