### PR TITLE
test: run all tests with --no-hostonly-cmdline

### DIFF
--- a/dracut.conf.d/test/test.conf
+++ b/dracut.conf.d/test/test.conf
@@ -1,4 +1,5 @@
 add_dracutmodules+=" qemu "
+hostonly_cmdline="no"
 
 # test the dlopen dependencies support
 add_dlopen_features+=" libsystemd-shared-*.so:fido2 "

--- a/test/TEST-13-SYSROOT/test.sh
+++ b/test/TEST-13-SYSROOT/test.sh
@@ -23,7 +23,7 @@ test_setup() {
     build_ext4_image "$TESTDIR/rootfs" "$TESTDIR"/root.img dracut
 
     ln -s / "$TESTDIR"/sysroot
-    test_dracut --keep --hostonly --no-hostonly-cmdline --sysroot "$TESTDIR"/sysroot
+    test_dracut --keep --hostonly --sysroot "$TESTDIR"/sysroot
 
     if grep -q '^root:' /etc/shadow; then
         if ! grep -q '^root:' "$TESTDIR"/initrd/dracut.*/initramfs/etc/shadow; then

--- a/test/TEST-40-SYSTEMD/test.sh
+++ b/test/TEST-40-SYSTEMD/test.sh
@@ -38,7 +38,6 @@ test_setup() {
     #make sure --omit-drivers does not filter out drivers using regexp to test for an earlier regression (assuming there is no one letter linux kernel module needed to run the test)
 
     test_dracut \
-        --no-hostonly-cmdline \
         --omit "fido2 initqueue" \
         --omit-drivers 'a b c d e f g h i j k l m n o p q r s t u v w x y z' \
         -I systemd-analyze \

--- a/test/TEST-45-SYSTEMD-IMPORT/test.sh
+++ b/test/TEST-45-SYSTEMD-IMPORT/test.sh
@@ -120,7 +120,6 @@ test_setup() {
         network_handler="systemd-networkd"
     fi
     test_dracut \
-        --no-hostonly-cmdline \
         "${local_pubring[@]}" \
         -a "systemd-import $network_handler"
 }


### PR DESCRIPTION
Several tests fail in a Ubuntu VM after commit 04af3c097797 enabled `hostonly_cmdline` in hostonly mode again, because the host disks leak into the `cmdline` config stored in the initrd. See 8c70c5bf99ea ("test(sysroot): run with --no-hostonly-cmdline") for a more detailed explanation.

So run all tests with `--no-hostonly-cmdline`.

<!-- This pull request changes... -->

<!-- Fixes: https://github.com/dracut-ng/dracut-ng/issues/<number> -->

### Checklist
- [x] I have tested it locally
- [x] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it
