### PR TITLE
feat(dracut): add DRACUT_HOSTONLY environment variable

### DIFF
--- a/dracut.sh
+++ b/dracut.sh
@@ -1138,6 +1138,7 @@ drivers_dir="${drivers_dir%"${drivers_dir##*[!/]}"}"
 [[ $do_hardlink ]] || do_hardlink=yes
 [[ $prefix_l ]] && prefix=$prefix_l
 [[ $prefix == "/" ]] && unset prefix
+[[ ${DRACUT_HOSTONLY-} ]] && hostonly=$DRACUT_HOSTONLY
 [[ $hostonly_l ]] && hostonly=$hostonly_l
 [[ $hostonly_cmdline_l ]] && hostonly_cmdline=$hostonly_cmdline_l
 [[ $hostonly_mode_l ]] && hostonly_mode=$hostonly_mode_l

--- a/man/dracut.8.adoc
+++ b/man/dracut.8.adoc
@@ -731,6 +731,11 @@ _DRACUT_ARCH_::
 Default:
     _empty_ (the value of **uname -m** on the host system)
 
+_DRACUT_HOSTONLY_::
+    Enable/disable host-only mode.
+    Setting to _yes_ enables the host-only mode (see **--hostonly**).
+    Setting to _no_ disables the host-only mode (see **--no-hostonly**).
+
 _SYSTEMD_VERSION_::
     overrides systemd version. Used for **--sysroot**.
 


### PR DESCRIPTION
autopkgtest-build-qemu builds an image that should include a initrd that can boot this image. It uses the `chroot` command to build the image. Relevant log:

```
$ sudo autopkgtest-build-qemu --boot=efi unstable /tmp/unstable-amd64.img
[...]
Exec: ['chroot', '/tmp/tmpyajn1s9p', 'eatmydata', 'apt-get', '-y', '--no-show-progress', '', 'install', 'linux-image-amd64']
[...]
Processing triggers for dracut (110-9) ...
update-initramfs: Generating /boot/initrd.img-6.19.11+deb14-amd64
dracut[W]: Turning off host-only mode: /dev is not mounted!
[...]
Exec: ['mount', '--bind', '/dev', '/tmp/tmpyajn1s9p/dev']
Exec: ['mount', '--bind', '/sys', '/tmp/tmpyajn1s9p/sys']
Exec: ['mount', '--bind', '/proc', '/tmp/tmpyajn1s9p/proc']
Exec: ['parted', '-s', '/dev/loop15', 'set', '1', 'esp', 'on']
Exec: ['chroot', '/tmp/tmpyajn1s9p', 'apt-get', 'update']
Hit:1 http://deb.debian.org/debian unstable InRelease
Reading package lists...
Exec: ['chroot', '/tmp/tmpyajn1s9p', 'apt-get', '-y', '--no-show-progress', 'install', 'grub-efi-amd64']
[...]
Processing triggers for dracut (110-9) ...
update-initramfs: Generating /boot/initrd.img-6.19.11+deb14-amd64
[...]
```

Converting the resulting image to raw, mounting it and running `lsinitrd` on `/boot/initrd.img-6.19.11+deb14-amd64` shows:

```
dracut cmdline:
 root=/dev/mapper/loop15p2 rootfstype=ext4 rootflags=rw,relatime
```

This boot hangs then at:

> (1 of 2) Job dev-mapper-loop0p1.device/start running (3s / no limit)
> (2 of 2) Job dracut-initqueue.service/start running (8s / no limit)

When installing `linux-image-amd64`, `/dev` is not mounted and dracut turns off host-only mode. That's what we want for this image. But then `/dev` gets mounted and the initrd is regenerated (when installing `grub-efi-amd64`). This time the initrd is build in host-only mode.

To easily allow disabling the host-only mode, add an `DRACUT_HOSTONLY` ervironment variable.

Fixes: https://github.com/dracut-ng/dracut-ng/issues/2355

<!-- This pull request changes... -->

<!-- Fixes: https://github.com/dracut-ng/dracut-ng/issues/<number> -->

### Checklist
- [ ] I have tested it locally
- [x] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it
