### PR TITLE
feat(dracut): add a DRACUT_EXTRA_ARGS environment variable

### DIFF
--- a/dracut.sh
+++ b/dracut.sh
@@ -601,6 +601,13 @@ PARMS_TO_STORE=""
 
 eval set -- "$TEMP"
 
+if [[ -n ${DRACUT_EXTRA_ARGS-} ]]; then
+    mapfile -d '' _extra_args < <(xargs printf '%s\0' <<< "$DRACUT_EXTRA_ARGS" 2> /dev/null \
+        || printf "%s\n" "dracut[W]: Ignoring malformed DRACUT_EXTRA_ARGS: $DRACUT_EXTRA_ARGS" >&2)
+    set -- "${_extra_args[@]}" "$@"
+    unset _extra_args
+fi
+
 while :; do
     case $1 in
         -h | --help)

--- a/man/dracut.8.adoc
+++ b/man/dracut.8.adoc
@@ -734,6 +734,18 @@ _DRACUT_ARCH_::
 Default:
     _empty_ (the value of **uname -m** on the host system)
 
+_DRACUT_EXTRA_ARGS_::
+    A string of additional _dracut_ command-line arguments.  The value is
+    word-split and prepended to the argument list before option parsing, so
+    explicit flags supplied directly on the command line will override the
+    values set here.
++
+Arguments that contain spaces must be shell-quoted within the value:
++
+----
+DRACUT_EXTRA_ARGS='--add "module1 module2"' dracut
+----
+
 _SYSTEMD_VERSION_::
     overrides systemd version. Used for **--sysroot**.
 

--- a/test/TEST-13-SYSROOT/test.sh
+++ b/test/TEST-13-SYSROOT/test.sh
@@ -23,7 +23,10 @@ test_setup() {
     build_ext4_image "$TESTDIR/rootfs" "$TESTDIR"/root.img dracut
 
     ln -s / "$TESTDIR"/sysroot
-    test_dracut --keep --hostonly --sysroot "$TESTDIR"/sysroot
+    # test DRACUT_EXTRA_ARGS
+    DRACUT_EXTRA_ARGS="--keep --hostonly --sysroot '$TESTDIR/sysroot'" test_dracut
+
+    grep 'hostonly' "$TESTDIR"/initrd/dracut.*/initramfs/usr/lib/dracut/build-parameter.txt
 
     if grep -q '^root:' /etc/shadow; then
         if ! grep -q '^root:' "$TESTDIR"/initrd/dracut.*/initramfs/etc/shadow; then


### PR DESCRIPTION
Some build tools (e.g. autopkgtest-build-qemu) invoke dracut indirectly through update-initramfs via dpkg triggers, making it impossible to pass extra flags directly on the command line.

Add a DRACUT_EXTRA_ARGS environment variable whose contents are word-split and prepended to the dracut argument list before option parsing.  This allows callers to inject arbitrary flags without modifying the configuration on disk:

  DRACUT_EXTRA_ARGS=--no-hostonly autopkgtest-build-qemu ...

The variable is intentionally word-split (like MAKEFLAGS), so arguments that themselves contain spaces must be shell-quoted within the value:

  DRACUT_EXTRA_ARGS='--add "mod1 mod2"' dracut
  
Changed test 13 to provide test coverage for DRACUT_EXTRA_ARGS variable.

<!-- This pull request changes... -->

<!-- Fixes: https://github.com/dracut-ng/dracut-ng/issues/<number> -->

### Checklist
- [ ] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it
