### PR TITLE
fix(dracut): remove leading space from recorded arguments

### DIFF
--- a/dracut.sh
+++ b/dracut.sh
@@ -603,7 +603,7 @@ eval set -- "$TEMP"
 
 while :; do
     if [[ $1 != "--" ]] && [[ $1 != "--rebuild" ]]; then
-        PARMS_TO_STORE+=" $1"
+        PARMS_TO_STORE="${PARMS_TO_STORE:+$PARMS_TO_STORE }$1"
     fi
     case $1 in
         --kver)
@@ -941,7 +941,7 @@ while (($# > 0)); do
     if [ "${1%%=*}" == "++include" ]; then
         include_src+=("$2")
         include_target+=("$3")
-        PARMS_TO_STORE+=" --include '$2' '$3'"
+        PARMS_TO_STORE="${PARMS_TO_STORE:+$PARMS_TO_STORE }--include '$2' '$3'"
         shift 2
     fi
     shift


### PR DESCRIPTION
`/lib/dracut/build-parameter.txt` records the dracut arguments, but contains a leading space.

Remove the leading space when recording the arguments.

<!-- This pull request changes... -->

<!-- Fixes: https://github.com/dracut-ng/dracut-ng/issues/<number> -->

### Checklist
- [x] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it
