### PR TITLE
ci: reenable test 41 for Arch

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -133,10 +133,6 @@ jobs:
                     - "43"
                     - "44"
                     - "45"
-                exclude:
-                    # https://github.com/dracut-ng/dracut-ng/issues/1677
-                    - container: arch:latest
-                      test: "41"
         container:
             image: ghcr.io/dracut-ng/${{ matrix.container }}
             options: '--device=/dev/kvm --privileged'


### PR DESCRIPTION
It looks like this systemd test has recovered on Arch, let's reenable it.

Fixes: #1677

<!-- This pull request changes... -->

<!-- Fixes: https://github.com/dracut-ng/dracut-ng/issues/<number> -->

### Checklist
- [ ] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it
