### PR TITLE
ci(arch): ensure /etc/vconsole.conf exists

### DIFF
--- a/test/container/Dockerfile-arch
+++ b/test/container/Dockerfile-arch
@@ -19,6 +19,10 @@ FROM docker.io/archlinux
 # prefer running tests with btrfs
 ENV TEST_FSTYPE=btrfs
 
+# Ensure /etc/vconsole.conf exists
+RUN \
+touch /etc/vconsole.conf
+
 RUN pacman --noconfirm -Syu \
     3cpio \
     asciidoctor \


### PR DESCRIPTION
`/etc/vconsole.conf` no longer gets installed as part of package installation. 

See https://bbs.archlinux.org/viewtopic.php?id=310236

<!-- This pull request changes... -->

<!-- Fixes: https://github.com/dracut-ng/dracut-ng/issues/<number> -->

### Checklist
- [ ] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it
