### PR TITLE
ci: only run test 72 on arch as part of daily network test

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -248,7 +248,6 @@ jobs:
             fail-fast: false
             matrix:
                 container:
-                    - arch:latest
                     - debian:latest
                     - opensuse:latest
                 test:


### PR DESCRIPTION
Test 72 on Arch regressed today. To keep the main integration test runs green, disable running this test on arch.

<!-- This pull request changes... -->

<!-- Fixes: https://github.com/dracut-ng/dracut-ng/issues/<number> -->

### Checklist
- [ ] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it
