### PR TITLE
ci(gentoo): enable daily network-legacy testing for Gentoo

### DIFF
--- a/.github/workflows/daily-network-legacy.yml
+++ b/.github/workflows/daily-network-legacy.yml
@@ -35,10 +35,14 @@ jobs:
                     - network-legacy
                 container:
                     - opensuse:latest
+                    - gentoo:latest
                 test:
                     - "50"
                     - "60"
                     - "72"
+                exclude:
+                    - container: gentoo:latest
+                      test: "72"
         container:
             image: ghcr.io/dracut-ng/${{ matrix.container }}
             options: '--device=/dev/kvm --privileged'


### PR DESCRIPTION
It seems Gentoo community is interested in helping to maintain network-legacy, see
https://github.com/gentoo/gentoo/commit/edce3a9b8cba345ad645502ec3c534b86060030c.

CC @Nowa-Ammerlaan 

<!-- This pull request changes... -->

<!-- Fixes: https://github.com/dracut-ng/dracut-ng/issues/<number> -->

### Checklist
- [ ] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it
