### PR TITLE
ci(gentoo): arm64 archtecture for openrc

### DIFF
--- a/.github/workflows/container-extra.yml
+++ b/.github/workflows/container-extra.yml
@@ -44,12 +44,15 @@ jobs:
                     - {dockerfile: 'Dockerfile-fedora', tag: 'centos:latest', registry: 'quay.io/centos'}
                     - {dockerfile: 'Dockerfile-debian', tag: 'debian:sid'}
                     - {dockerfile: 'Dockerfile-gentoo', tag: 'gentoo:amd64-openrc', option: 'amd64-openrc'}
+                    - {dockerfile: 'Dockerfile-gentoo', tag: 'gentoo:arm64-openrc', option: 'arm64-openrc'}
                     - {dockerfile: 'Dockerfile-gentoo', tag: 'gentoo:latest', option: 'systemd'}
                 exclude:
                     - config: {tag: 'arch:latest'}
                       architecture: {platform: 'linux/arm64'}
                     - config: {tag: 'gentoo:amd64-openrc'}
                       architecture: {platform: 'linux/arm64'}
+                    - config: {tag: 'gentoo:arm64-openrc'}
+                      architecture: {tag: 'amd'}
         steps:
             - name: Check out the repo
               uses: actions/checkout@v6


### PR DESCRIPTION
Enable Gentoo based OpenRC testing on arm64 as well.

<!-- This pull request changes... -->

<!-- Fixes: https://github.com/dracut-ng/dracut-ng/issues/<number> -->

### Checklist
- [ ] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it
