### PR TITLE
ci(gentoo): arm64 archtecture for openrc

### DIFF
--- a/.github/workflows/container-extra.yml
+++ b/.github/workflows/container-extra.yml
@@ -93,6 +93,7 @@ jobs:
                     - {tag: 'debian:sid', platforms: ['amd', 'arm']}
                     - {tag: 'gentoo:latest', platforms: ['amd', 'arm']}
                     - {tag: 'gentoo:amd64-openrc', platforms: ['amd']}
+                    - {tag: 'gentoo:arm64-openrc', platforms: ['arm']}
         steps:
             - name: Login to GitHub Container Registry
               uses: docker/login-action@v4


### PR DESCRIPTION
Tag propely the newly created container image.

Follow-up to e775acc .

<!-- This pull request changes... -->

<!-- Fixes: https://github.com/dracut-ng/dracut-ng/issues/<number> -->

### Checklist
- [ ] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it
