### PR TITLE
fix(iscsi): handle empty URI in firmware boot mode

### DIFF
--- a/modules.d/45net-lib/net-lib.sh
+++ b/modules.d/45net-lib/net-lib.sh
@@ -426,6 +426,7 @@ parse_iscsi_root() {
     set $v
     IFS="$OLDIFS"
 
+    [ $# -ge 2 ] || return 0
     iscsi_protocol=$1
     shift # ignored
     iscsi_target_port=$1

--- a/modules.d/74iscsi/iscsiroot.sh
+++ b/modules.d/74iscsi/iscsiroot.sh
@@ -301,7 +301,7 @@ if ! [ "$netif" = "online" ]; then
         for nroot in $(getargs netroot); do
             [ "${nroot%%:*}" = "iscsi" ] || continue
             nroot="${nroot##iscsi:}"
-            if [ -n "$nroot" ]; then
+            if [ -n "$nroot" ] && [ "$nroot" != "iscsi" ]; then
                 handle_netroot "$nroot"
                 ret=$((ret + $?))
             fi


### PR DESCRIPTION
When rd.iscsi.firmware=1 is set, netroot is either 'iscsi' or 'iscsi:'                                                                              
  with no real URI — the firmware handles the iSCSI target discovery.   
  However dracut still calls parse_iscsi_root() and handle_netroot() with                                                                             
  these bare values causing two issues:                                                                                                               
                                                                                                                                                      
  1. "shift count out of range" in parse_iscsi_root() in net-lib.sh                                                                                   
     When netroot=iscsi: (with colon), set $v produces $#=0.                                                                                          
     When netroot=iscsi (no colon), after the first shift $#=0.                                                                                       
     Both cases cause subsequent shift calls to fail.                                                                                                 
                                                                                                                                                      
     Fix: add two guards to return early when $#=0 — nothing to parse                                                                                 
     in firmware mode.                                                                                                                                
                                                                                                                                                      
  2. "iscsiadm: Cannot resolve host iscsi" in iscsiroot.sh                                                                                            
     The netroot loop strips the iscsi: prefix but when netroot=iscsi                                                                                 
     (no colon) the pattern doesn't match, leaving nroot="iscsi" —                                                                                    
     non-empty — so handle_netroot is called with "iscsi" as the target                                                                               
     IP causing a spurious DNS resolution attempt.                                                                                                    
                                                                                                                                                      
     Fix: skip handle_netroot when nroot="iscsi" after stripping.                                                                                     
                                                                                                                                                      
  Tested on: OCI VM.Standard.E5.Flex, RHEL 10.1, dracut-107-3.el10.x86_64                                                                           
                                                                                                                                                      
  Fixes #1701
