### PR TITLE
fix(overlayfs): unmount NEWROOT before mounting overlay

### DIFF
--- a/modules.d/70overlayfs/mount-overlayfs.sh
+++ b/modules.d/70overlayfs/mount-overlayfs.sh
@@ -20,6 +20,9 @@ else
     ovlfs=lowerdir=/run/rootfsbase
 fi
 
-if ! strstr "$(cat /proc/mounts)" LiveOS_rootfs; then
-    mount -t overlay LiveOS_rootfs -o "$ovlfs",upperdir=/run/overlayfs,workdir=/run/ovlwork "$NEWROOT"
+if strstr "$(cat /proc/mounts)" LiveOS_rootfs; then
+    # LiveOS_rootfs already mounted
+    return 0
 fi
+
+mount -t overlay LiveOS_rootfs -o "$ovlfs",upperdir=/run/overlayfs,workdir=/run/ovlwork "$NEWROOT"

--- a/modules.d/70overlayfs/mount-overlayfs.sh
+++ b/modules.d/70overlayfs/mount-overlayfs.sh
@@ -25,4 +25,7 @@ if strstr "$(cat /proc/mounts)" LiveOS_rootfs; then
     return 0
 fi
 
+if incol2 /proc/mounts "$NEWROOT"; then
+    umount "$NEWROOT"
+fi
 mount -t overlay LiveOS_rootfs -o "$ovlfs",upperdir=/run/overlayfs,workdir=/run/ovlwork "$NEWROOT"

--- a/test/TEST-21-OVERLAYFS/assertion.sh
+++ b/test/TEST-21-OVERLAYFS/assertion.sh
@@ -1,7 +1,7 @@
 #!/bin/sh
 set -eu
 
-# required binaries: cat grep
+# required binaries: cat cut grep sort
 
 check_crypt_mounted() {
     if ! grep -q "^/dev/mapper/overlay-crypt /run/overlayfs-backing " /proc/mounts; then
@@ -24,6 +24,16 @@ check_crypt_passphrase() {
     if [ ! -f /run/initramfs/overlayfs.passwd ]; then
         echo "password file /run/initramfs/overlayfs.passwd not found" >> /run/failed
     fi
+}
+
+check_shadowed_mounts() {
+    local mount previous_mount=
+    cut -d ' ' -f 2 /proc/mounts | sort | while IFS= read -r mount; do
+        if [ "$mount" = "$previous_mount" ]; then
+            echo "Error: $mount found twice in /proc/mounts." >> /run/failed
+        fi
+        previous_mount="$mount"
+    done
 }
 
 if grep -q 'test.expect=none' /proc/cmdline; then
@@ -65,6 +75,8 @@ if grep -q 'test.expect=tmpfs-sized' /proc/cmdline; then
         echo "sized tmpfs does not have expected nr_inodes (100000)" >> /run/failed
     fi
 fi
+
+check_shadowed_mounts
 
 # Dump /proc/mounts at the end if there were any failures for easier debugging
 if [ -s /run/failed ]; then


### PR DESCRIPTION
When using `rd.overlay` the mount point `/run/rootfsbase` is not accessible any more, because `LiveOS_rootfs` is mounted over it. This is `/proc/mounts` from the `tmpfs overlay (rd.overlay)` test case:

```
tmpfs /run tmpfs rw,nosuid,nodev,size=194628k,nr_inodes=819200,mode=755,inode64 0 0
/dev/sda /run/rootfsbase ext4 ro,relatime 0 0
LiveOS_rootfs / overlay rw,relatime,lowerdir=/run/rootfsbase,upperdir=/run/overlayfs,workdir=/run/ovlwork,uuid=on,nouserxattr 0 0
LiveOS_rootfs /run/rootfsbase overlay rw,relatime,lowerdir=/run/rootfsbase,upperdir=/run/overlayfs,workdir=/run/ovlwork,uuid=on,nouserxattr 0 0
devtmpfs /dev devtmpfs rw,nosuid,size=159436k,nr_inodes=39859,mode=755,inode64 0 0
tmpfs /dev/shm tmpfs rw,nosuid,nodev,inode64,usrquota 0 0
devpts /dev/pts devpts rw,nosuid,noexec,relatime,gid=5,mode=600,ptmxmode=000 0 0
sysfs /sys sysfs rw,nosuid,nodev,noexec,relatime 0 0
securityfs /sys/kernel/security securityfs rw,nosuid,nodev,noexec,relatime 0 0
cgroup2 /sys/fs/cgroup cgroup2 rw,nosuid,nodev,noexec,relatime,nsdelegate,memory_recursiveprot,memory_hugetlb_accounting 0 0
none /sys/fs/pstore pstore rw,nosuid,nodev,noexec,relatime 0 0
efivarfs /sys/firmware/efi/efivars efivarfs rw,nosuid,nodev,noexec,relatime 0 0
bpf /sys/fs/bpf bpf rw,nosuid,nodev,noexec,relatime,mode=700 0 0
configfs /sys/kernel/config configfs rw,nosuid,nodev,noexec,relatime 0 0
proc /proc proc rw,nosuid,nodev,noexec,relatime 0 0
```

This breaks use cases where the underlying needs to be accessed.

Bug-Ubuntu: https://launchpad.net/bugs/2147471

### Checklist
- [x] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [x] I am providing new code and test(s) for it
