### PR TITLE
fix: Avoid arguments for dot commands (SC2240)

### DIFF
--- a/modules.d/80base/dracut-lib.sh
+++ b/modules.d/80base/dracut-lib.sh
@@ -394,9 +394,9 @@ source_hook() {
     _dir=$1
     shift
     for f in $(list_hooks "$_dir"); do
+        set -- "$@"
         # shellcheck disable=SC1090
-        # shellcheck disable=SC2240
-        . "$f" "$@"
+        . "$f"
     done
 }
 

--- a/modules.d/86shutdown/shutdown.sh
+++ b/modules.d/86shutdown/shutdown.sh
@@ -131,8 +131,11 @@ _check_shutdown() {
     local __f
     local __s=0
     for __f in $(list_hooks "shutdown"); do
-        # shellcheck disable=SC1090 disable=SC2240
-        if (final="$1" . "$__f" "$1"); then
+        if (
+            set -- "$1"
+            # shellcheck disable=SC1090
+            final="$1" . "$__f"
+        ); then
             rm -f -- "$__f"
         else
             __s=1


### PR DESCRIPTION
Dot commands don't support arguments in Dash/ posix shell. Use 'set' instead.

Fixes: https://github.com/dracut-ng/dracut-ng/issues/346

### Checklist
- [X] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it
