### PR TITLE
ci: sort modules in labeler.yml

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -55,21 +55,153 @@ modules:
     - changed-files:
           - any-glob-to-any-file: ['modules.d/*', 'modules.d/**/*']
 
+test:
+    - changed-files:
+          - any-glob-to-any-file: ['test/*', 'test/**/*']
+
+base:
+    - changed-files:
+          - any-glob-to-any-file: 'modules.d/[0-9][0-9]base/*'
+
 bash:
     - changed-files:
           - any-glob-to-any-file: 'modules.d/[0-9][0-9]bash/*'
+
+biosdevname:
+    - changed-files:
+          - any-glob-to-any-file: 'modules.d/[0-9][0-9]biosdevname/*'
+
+bluetooth:
+    - changed-files:
+          - any-glob-to-any-file: 'modules.d/[0-9][0-9]bluetooth/*'
+
+btrfs:
+    - changed-files:
+          - any-glob-to-any-file: 'modules.d/[0-9][0-9]btrfs/*'
+
+busybox:
+    - changed-files:
+          - any-glob-to-any-file: 'modules.d/[0-9][0-9]busybox/*'
+
+caps:
+    - changed-files:
+          - any-glob-to-any-file: 'modules.d/[0-9][0-9]caps/*'
+
+cifs:
+    - changed-files:
+          - any-glob-to-any-file: 'modules.d/[0-9][0-9]cifs/*'
+
+cio_ignore:
+    - changed-files:
+          - any-glob-to-any-file: 'modules.d/[0-9][0-9]cio_ignore/*'
+
+cms:
+    - changed-files:
+          - any-glob-to-any-file: 'modules.d/[0-9][0-9]cms/*'
+
+connman:
+    - changed-files:
+          - any-glob-to-any-file: 'modules.d/[0-9][0-9]connman/*'
+
+convertfs:
+    - changed-files:
+          - any-glob-to-any-file: 'modules.d/[0-9][0-9]convertfs/*'
+
+crypt:
+    - changed-files:
+          - any-glob-to-any-file: 'modules.d/[0-9][0-9]crypt/*'
+
+crypt-gpg:
+    - changed-files:
+          - any-glob-to-any-file: 'modules.d/[0-9][0-9]crypt-gpg/*'
+
+crypt-lib:
+    - changed-files:
+          - any-glob-to-any-file: 'modules.d/[0-9][0-9]crypt-lib/*'
+
+crypt-loop:
+    - changed-files:
+          - any-glob-to-any-file: 'modules.d/[0-9][0-9]crypt-loop/*'
+
+dasd:
+    - changed-files:
+          - any-glob-to-any-file: 'modules.d/[0-9][0-9]dasd/*'
+
+dasd_mod:
+    - changed-files:
+          - any-glob-to-any-file: 'modules.d/[0-9][0-9]dasd_mod/*'
 
 dash:
     - changed-files:
           - any-glob-to-any-file: 'modules.d/[0-9][0-9]dash/*'
 
-systemd:
+dbus:
     - changed-files:
-          - any-glob-to-any-file: 'modules.d/[0-9][0-9]systemd/*'
+          - any-glob-to-any-file: 'modules.d/[0-9][0-9]dbus/*'
 
-warpclock:
+dbus-broker:
     - changed-files:
-          - any-glob-to-any-file: 'modules.d/[0-9][0-9]warpclock/*'
+          - any-glob-to-any-file: 'modules.d/[0-9][0-9]dbus-broker/*'
+
+dbus-daemon:
+    - changed-files:
+          - any-glob-to-any-file: 'modules.d/[0-9][0-9]dbus-daemon/*'
+
+dcssblk:
+    - changed-files:
+          - any-glob-to-any-file: 'modules.d/[0-9][0-9]dcssblk/*'
+
+debug:
+    - changed-files:
+          - any-glob-to-any-file: 'modules.d/[0-9][0-9]debug/*'
+
+devicetree-firmware:
+    - changed-files:
+          - any-glob-to-any-file: 'modules.d/[0-9][0-9]devicetree-firmware/*'
+
+dm:
+    - changed-files:
+          - any-glob-to-any-file: 'modules.d/[0-9][0-9]dm/*'
+
+dmraid:
+    - changed-files:
+          - any-glob-to-any-file: 'modules.d/[0-9][0-9]dmraid/*'
+
+dmsquash-live:
+    - changed-files:
+          - any-glob-to-any-file: 'modules.d/[0-9][0-9]dmsquash-live/*'
+
+dmsquash-live-autooverlay:
+    - changed-files:
+          - any-glob-to-any-file: 'modules.d/[0-9][0-9]dmsquash-live-autooverlay/*'
+
+dmsquash-live-ntfs:
+    - changed-files:
+          - any-glob-to-any-file: 'modules.d/[0-9][0-9]dmsquash-live-ntfs/*'
+
+dracut-systemd:
+    - changed-files:
+          - any-glob-to-any-file: 'modules.d/[0-9][0-9]dracut-systemd/*'
+
+drm:
+    - changed-files:
+          - any-glob-to-any-file: 'modules.d/[0-9][0-9]drm/*'
+
+ecryptfs:
+    - changed-files:
+          - any-glob-to-any-file: 'modules.d/[0-9][0-9]ecryptfs/*'
+
+fcoe:
+    - changed-files:
+          - any-glob-to-any-file: 'modules.d/[0-9][0-9]fcoe/*'
+
+fcoe-uefi:
+    - changed-files:
+          - any-glob-to-any-file: 'modules.d/[0-9][0-9]fcoe-uefi/*'
+
+fido2:
+    - changed-files:
+          - any-glob-to-any-file: 'modules.d/[0-9][0-9]fido2/*'
 
 fips:
     - changed-files:
@@ -79,13 +211,237 @@ fips-crypto-policies:
     - changed-files:
           - any-glob-to-any-file: 'modules.d/[0-9][0-9]fips-crypto-policies/*'
 
+fs-lib:
+    - changed-files:
+          - any-glob-to-any-file: 'modules.d/[0-9][0-9]fs-lib/*'
+
+fstab-sys:
+    - changed-files:
+          - any-glob-to-any-file: 'modules.d/[0-9][0-9]fstab-sys/*'
+
+hwdb:
+    - changed-files:
+          - any-glob-to-any-file: 'modules.d/[0-9][0-9]hwdb/*'
+
+i18n:
+    - changed-files:
+          - any-glob-to-any-file: 'modules.d/[0-9][0-9]i18n/*'
+
+img-lib:
+    - changed-files:
+          - any-glob-to-any-file: 'modules.d/[0-9][0-9]img-lib/*'
+
 initqueue:
     - changed-files:
           - any-glob-to-any-file: 'modules.d/[0-9][0-9]initqueue/*'
 
-systemd-battery-check:
+integrity:
     - changed-files:
-          - any-glob-to-any-file: 'modules.d/[0-9][0-9]systemd-battery-check/*'
+          - any-glob-to-any-file: 'modules.d/[0-9][0-9]integrity/*'
+
+iscsi:
+    - changed-files:
+          - any-glob-to-any-file: 'modules.d/[0-9][0-9]iscsi/*'
+
+kernel-modules:
+    - changed-files:
+          - any-glob-to-any-file: 'modules.d/[0-9][0-9]kernel-modules/*'
+
+kernel-modules-export:
+    - changed-files:
+          - any-glob-to-any-file: 'modules.d/[0-9][0-9]kernel-modules-export/*'
+
+kernel-modules-extra:
+    - changed-files:
+          - any-glob-to-any-file: 'modules.d/[0-9][0-9]kernel-modules-extra/*'
+
+kernel-network-modules:
+    - changed-files:
+          - any-glob-to-any-file: 'modules.d/[0-9][0-9]kernel-network-modules/*'
+
+livenet:
+    - changed-files:
+          - any-glob-to-any-file: 'modules.d/[0-9][0-9]livenet/*'
+
+lunmask:
+    - changed-files:
+          - any-glob-to-any-file: 'modules.d/[0-9][0-9]lunmask/*'
+
+lvm:
+    - changed-files:
+          - any-glob-to-any-file: 'modules.d/[0-9][0-9]lvm/*'
+
+lvmmerge:
+    - changed-files:
+          - any-glob-to-any-file: 'modules.d/[0-9][0-9]lvmmerge/*'
+
+lvmthinpool-monitor:
+    - changed-files:
+          - any-glob-to-any-file: 'modules.d/[0-9][0-9]lvmthinpool-monitor/*'
+
+masterkey:
+    - changed-files:
+          - any-glob-to-any-file: 'modules.d/[0-9][0-9]masterkey/*'
+
+mdraid:
+    - changed-files:
+          - any-glob-to-any-file: 'modules.d/[0-9][0-9]mdraid/*'
+
+memdisk:
+    - changed-files:
+          - any-glob-to-any-file: 'modules.d/[0-9][0-9]memdisk/*'
+
+memstrack:
+    - changed-files:
+          - any-glob-to-any-file: 'modules.d/[0-9][0-9]memstrack/*'
+
+modsign:
+    - changed-files:
+          - any-glob-to-any-file: 'modules.d/[0-9][0-9]modsign/*'
+
+multipath:
+    - changed-files:
+          - any-glob-to-any-file: 'modules.d/[0-9][0-9]multipath/*'
+
+nbd:
+    - changed-files:
+          - any-glob-to-any-file: 'modules.d/[0-9][0-9]nbd/*'
+
+net-lib:
+    - changed-files:
+          - any-glob-to-any-file: 'modules.d/[0-9][0-9]net-lib/*'
+
+network:
+    - changed-files:
+          - any-glob-to-any-file: 'modules.d/[0-9][0-9]network/*'
+
+network-legacy:
+    - changed-files:
+          - any-glob-to-any-file: 'modules.d/[0-9][0-9]network-legacy/*'
+
+network-manager:
+    - changed-files:
+          - any-glob-to-any-file: 'modules.d/[0-9][0-9]network-manager/*'
+
+nfs:
+    - changed-files:
+          - any-glob-to-any-file: 'modules.d/[0-9][0-9]nfs/*'
+
+numlock:
+    - changed-files:
+          - any-glob-to-any-file: 'modules.d/[0-9][0-9]numlock/*'
+
+nvdimm:
+    - changed-files:
+          - any-glob-to-any-file: 'modules.d/[0-9][0-9]nvdimm/*'
+
+nvmf:
+    - changed-files:
+          - any-glob-to-any-file: 'modules.d/[0-9][0-9]nvmf/*'
+
+overlayfs:
+    - changed-files:
+          - any-glob-to-any-file: 'modules.d/[0-9][0-9]overlayfs/*'
+
+pcmcia:
+    - changed-files:
+          - any-glob-to-any-file: 'modules.d/[0-9][0-9]pcmcia/*'
+
+pcsc:
+    - changed-files:
+          - any-glob-to-any-file: 'modules.d/[0-9][0-9]pcsc/*'
+
+pkcs11:
+    - changed-files:
+          - any-glob-to-any-file: 'modules.d/[0-9][0-9]pkcs11/*'
+
+plymouth:
+    - changed-files:
+          - any-glob-to-any-file: 'modules.d/[0-9][0-9]plymouth/*'
+
+pollcdrom:
+    - changed-files:
+          - any-glob-to-any-file: 'modules.d/[0-9][0-9]pollcdrom/*'
+
+ppcmac:
+    - changed-files:
+          - any-glob-to-any-file: 'modules.d/[0-9][0-9]ppcmac/*'
+
+qemu:
+    - changed-files:
+          - any-glob-to-any-file: 'modules.d/[0-9][0-9]qemu/*'
+
+qemu-net:
+    - changed-files:
+          - any-glob-to-any-file: 'modules.d/[0-9][0-9]qemu-net/*'
+
+rescue:
+    - changed-files:
+          - any-glob-to-any-file: 'modules.d/[0-9][0-9]rescue/*'
+
+resume:
+    - changed-files:
+          - any-glob-to-any-file: 'modules.d/[0-9][0-9]resume/*'
+
+rngd:
+    - changed-files:
+          - any-glob-to-any-file: 'modules.d/[0-9][0-9]rngd/*'
+
+rootfs-block:
+    - changed-files:
+          - any-glob-to-any-file: 'modules.d/[0-9][0-9]rootfs-block/*'
+
+rootfs-block-fallback:
+    - changed-files:
+          - any-glob-to-any-file: 'modules.d/[0-9][0-9]rootfs-block-fallback/*'
+
+securityfs:
+    - changed-files:
+          - any-glob-to-any-file: 'modules.d/[0-9][0-9]securityfs/*'
+
+selinux:
+    - changed-files:
+          - any-glob-to-any-file: 'modules.d/[0-9][0-9]selinux/*'
+
+shell-interpreter:
+    - changed-files:
+          - any-glob-to-any-file: 'modules.d/[0-9][0-9]shell-interpreter/*'
+
+shutdown:
+    - changed-files:
+          - any-glob-to-any-file: 'modules.d/[0-9][0-9]shutdown/*'
+
+simpledrm:
+    - changed-files:
+          - any-glob-to-any-file: 'modules.d/[0-9][0-9]simpledrm/*'
+
+squash:
+    - changed-files:
+          - any-glob-to-any-file: 'modules.d/[0-9][0-9]squash/*'
+
+squash-erofs:
+    - changed-files:
+          - any-glob-to-any-file: 'modules.d/[0-9][0-9]squash/*'
+
+squash-lib:
+    - changed-files:
+          - any-glob-to-any-file: 'modules.d/[0-9][0-9]squash-lib/*'
+
+squash-squashfs:
+    - changed-files:
+          - any-glob-to-any-file: 'modules.d/[0-9][0-9]squash/*'
+
+ssh-client:
+    - changed-files:
+          - any-glob-to-any-file: 'modules.d/[0-9][0-9]ssh-client/*'
+
+syslog:
+    - changed-files:
+          - any-glob-to-any-file: 'modules.d/[0-9][0-9]syslog/*'
+
+systemd:
+    - changed-files:
+          - any-glob-to-any-file: 'modules.d/[0-9][0-9]systemd/*'
 
 systemd-ac-power:
     - changed-files:
@@ -94,6 +450,10 @@ systemd-ac-power:
 systemd-ask-password:
     - changed-files:
           - any-glob-to-any-file: 'modules.d/[0-9][0-9]systemd-ask-password/*'
+
+systemd-battery-check:
+    - changed-files:
+          - any-glob-to-any-file: 'modules.d/[0-9][0-9]systemd-battery-check/*'
 
 systemd-bsod:
     - changed-files:
@@ -106,6 +466,14 @@ systemd-coredump:
 systemd-creds:
     - changed-files:
           - any-glob-to-any-file: 'modules.d/[0-9][0-9]systemd-creds/*'
+
+systemd-cryptsetup:
+    - changed-files:
+          - any-glob-to-any-file: 'modules.d/[0-9][0-9]systemd-cryptsetup/*'
+
+systemd-emergency:
+    - changed-files:
+          - any-glob-to-any-file: 'modules.d/[0-9][0-9]systemd-emergency/*'
 
 systemd-hostnamed:
     - changed-files:
@@ -135,13 +503,13 @@ systemd-modules-load:
     - changed-files:
           - any-glob-to-any-file: 'modules.d/[0-9][0-9]systemd-modules-load/*'
 
-systemd-networkd:
-    - changed-files:
-          - any-glob-to-any-file: 'modules.d/[0-9][0-9]systemd-networkd/*'
-
 systemd-network-management:
     - changed-files:
           - any-glob-to-any-file: 'modules.d/[0-9][0-9]systemd-network-management/*'
+
+systemd-networkd:
+    - changed-files:
+          - any-glob-to-any-file: 'modules.d/[0-9][0-9]systemd-networkd/*'
 
 systemd-pcrextend:
     - changed-files:
@@ -195,309 +563,29 @@ systemd-veritysetup:
     - changed-files:
           - any-glob-to-any-file: 'modules.d/[0-9][0-9]systemd-veritysetup/*'
 
-systemd-emergency:
+terminfo:
     - changed-files:
-          - any-glob-to-any-file: 'modules.d/[0-9][0-9]systemd-emergency/*'
-
-caps:
-    - changed-files:
-          - any-glob-to-any-file: 'modules.d/[0-9][0-9]caps/*'
-
-modsign:
-    - changed-files:
-          - any-glob-to-any-file: 'modules.d/[0-9][0-9]modsign/*'
-
-rescue:
-    - changed-files:
-          - any-glob-to-any-file: 'modules.d/[0-9][0-9]rescue/*'
-
-watchdog:
-    - changed-files:
-          - any-glob-to-any-file: 'modules.d/[0-9][0-9]watchdog/*'
-
-watchdog-modules:
-    - changed-files:
-          - any-glob-to-any-file: 'modules.d/[0-9][0-9]watchdog-modules/*'
-
-busybox:
-    - changed-files:
-          - any-glob-to-any-file: 'modules.d/[0-9][0-9]busybox/*'
-
-dbus-broker:
-    - changed-files:
-          - any-glob-to-any-file: 'modules.d/[0-9][0-9]dbus-broker/*'
-
-dbus-daemon:
-    - changed-files:
-          - any-glob-to-any-file: 'modules.d/[0-9][0-9]dbus-daemon/*'
-
-rngd:
-    - changed-files:
-          - any-glob-to-any-file: 'modules.d/[0-9][0-9]rngd/*'
-
-dbus:
-    - changed-files:
-          - any-glob-to-any-file: 'modules.d/[0-9][0-9]dbus/*'
-
-i18n:
-    - changed-files:
-          - any-glob-to-any-file: 'modules.d/[0-9][0-9]i18n/*'
-
-convertfs:
-    - changed-files:
-          - any-glob-to-any-file: 'modules.d/[0-9][0-9]convertfs/*'
-
-connman:
-    - changed-files:
-          - any-glob-to-any-file: 'modules.d/[0-9][0-9]connman/*'
-
-devicetree-firmware:
-    - changed-files:
-          - any-glob-to-any-file: 'modules.d/[0-9][0-9]devicetree-firmware/*'
-
-network-legacy:
-    - changed-files:
-          - any-glob-to-any-file: 'modules.d/[0-9][0-9]network-legacy/*'
-
-network-manager:
-    - changed-files:
-          - any-glob-to-any-file: 'modules.d/[0-9][0-9]network-manager/*'
-
-network:
-    - changed-files:
-          - any-glob-to-any-file: 'modules.d/[0-9][0-9]network/*'
-
-url-lib:
-    - changed-files:
-          - any-glob-to-any-file: 'modules.d/[0-9][0-9]url-lib/*'
-
-drm:
-    - changed-files:
-          - any-glob-to-any-file: 'modules.d/[0-9][0-9]drm/*'
-
-plymouth:
-    - changed-files:
-          - any-glob-to-any-file: 'modules.d/[0-9][0-9]plymouth/*'
-
-bluetooth:
-    - changed-files:
-          - any-glob-to-any-file: 'modules.d/[0-9][0-9]bluetooth/*'
-
-cms:
-    - changed-files:
-          - any-glob-to-any-file: 'modules.d/[0-9][0-9]cms/*'
-
-lvmmerge:
-    - changed-files:
-          - any-glob-to-any-file: 'modules.d/[0-9][0-9]lvmmerge/*'
-
-lvmthinpool-monitor:
-    - changed-files:
-          - any-glob-to-any-file: 'modules.d/[0-9][0-9]lvmthinpool-monitor/*'
-
-cio_ignore:
-    - changed-files:
-          - any-glob-to-any-file: 'modules.d/[0-9][0-9]cio_ignore/*'
-
-btrfs:
-    - changed-files:
-          - any-glob-to-any-file: 'modules.d/[0-9][0-9]btrfs/*'
-
-crypt:
-    - changed-files:
-          - any-glob-to-any-file: 'modules.d/[0-9][0-9]crypt/*'
-
-dm:
-    - changed-files:
-          - any-glob-to-any-file: 'modules.d/[0-9][0-9]dm/*'
-
-dmraid:
-    - changed-files:
-          - any-glob-to-any-file: 'modules.d/[0-9][0-9]dmraid/*'
-
-dmsquash-live:
-    - changed-files:
-          - any-glob-to-any-file: 'modules.d/[0-9][0-9]dmsquash-live/*'
-
-dmsquash-live-autooverlay:
-    - changed-files:
-          - any-glob-to-any-file: 'modules.d/[0-9][0-9]dmsquash-live-autooverlay/*'
-
-dmsquash-live-ntfs:
-    - changed-files:
-          - any-glob-to-any-file: 'modules.d/[0-9][0-9]dmsquash-live-ntfs/*'
-
-kernel-modules:
-    - changed-files:
-          - any-glob-to-any-file: 'modules.d/[0-9][0-9]kernel-modules/*'
-
-kernel-modules-export:
-    - changed-files:
-          - any-glob-to-any-file: 'modules.d/[0-9][0-9]kernel-modules-export/*'
-
-kernel-modules-extra:
-    - changed-files:
-          - any-glob-to-any-file: 'modules.d/[0-9][0-9]kernel-modules-extra/*'
-
-kernel-network-modules:
-    - changed-files:
-          - any-glob-to-any-file: 'modules.d/[0-9][0-9]kernel-network-modules/*'
-
-livenet:
-    - changed-files:
-          - any-glob-to-any-file: 'modules.d/[0-9][0-9]livenet/*'
-
-lvm:
-    - changed-files:
-          - any-glob-to-any-file: 'modules.d/[0-9][0-9]lvm/*'
-
-mdraid:
-    - changed-files:
-          - any-glob-to-any-file: 'modules.d/[0-9][0-9]mdraid/*'
-
-multipath:
-    - changed-files:
-          - any-glob-to-any-file: 'modules.d/[0-9][0-9]multipath/*'
-
-numlock:
-    - changed-files:
-          - any-glob-to-any-file: 'modules.d/[0-9][0-9]numlock/*'
-
-nvdimm:
-    - changed-files:
-          - any-glob-to-any-file: 'modules.d/[0-9][0-9]nvdimm/*'
-
-overlayfs:
-    - changed-files:
-          - any-glob-to-any-file: 'modules.d/[0-9][0-9]overlayfs/*'
-
-ppcmac:
-    - changed-files:
-          - any-glob-to-any-file: 'modules.d/[0-9][0-9]ppcmac/*'
-
-qemu:
-    - changed-files:
-          - any-glob-to-any-file: 'modules.d/[0-9][0-9]qemu/*'
-
-qemu-net:
-    - changed-files:
-          - any-glob-to-any-file: 'modules.d/[0-9][0-9]qemu-net/*'
-
-systemd-cryptsetup:
-    - changed-files:
-          - any-glob-to-any-file: 'modules.d/[0-9][0-9]systemd-cryptsetup/*'
-
-crypt-gpg:
-    - changed-files:
-          - any-glob-to-any-file: 'modules.d/[0-9][0-9]crypt-gpg/*'
-
-crypt-lib:
-    - changed-files:
-          - any-glob-to-any-file: 'modules.d/[0-9][0-9]crypt-lib/*'
-
-crypt-loop:
-    - changed-files:
-          - any-glob-to-any-file: 'modules.d/[0-9][0-9]crypt-loop/*'
-
-fido2:
-    - changed-files:
-          - any-glob-to-any-file: 'modules.d/[0-9][0-9]fido2/*'
-
-pcsc:
-    - changed-files:
-          - any-glob-to-any-file: 'modules.d/[0-9][0-9]pcsc/*'
-
-pkcs11:
-    - changed-files:
-          - any-glob-to-any-file: 'modules.d/[0-9][0-9]pkcs11/*'
+          - any-glob-to-any-file: 'modules.d/[0-9][0-9]terminfo/*'
 
 tpm2-tss:
     - changed-files:
           - any-glob-to-any-file: 'modules.d/[0-9][0-9]tpm2-tss/*'
 
-zipl:
-    - changed-files:
-          - any-glob-to-any-file: 'modules.d/[0-9][0-9]zipl/*'
-
-cifs:
-    - changed-files:
-          - any-glob-to-any-file: 'modules.d/[0-9][0-9]cifs/*'
-
-dasd:
-    - changed-files:
-          - any-glob-to-any-file: 'modules.d/[0-9][0-9]dasd/*'
-
-dasd_mod:
-    - changed-files:
-          - any-glob-to-any-file: 'modules.d/[0-9][0-9]dasd_mod/*'
-
-dcssblk:
-    - changed-files:
-          - any-glob-to-any-file: 'modules.d/[0-9][0-9]dcssblk/*'
-
-debug:
-    - changed-files:
-          - any-glob-to-any-file: 'modules.d/[0-9][0-9]debug/*'
-
-fcoe:
-    - changed-files:
-          - any-glob-to-any-file: 'modules.d/[0-9][0-9]fcoe/*'
-
-fcoe-uefi:
-    - changed-files:
-          - any-glob-to-any-file: 'modules.d/[0-9][0-9]fcoe-uefi/*'
-
-fstab-sys:
-    - changed-files:
-          - any-glob-to-any-file: 'modules.d/[0-9][0-9]fstab-sys/*'
-
-hwdb:
-    - changed-files:
-          - any-glob-to-any-file: 'modules.d/[0-9][0-9]hwdb/*'
-
-iscsi:
-    - changed-files:
-          - any-glob-to-any-file: 'modules.d/[0-9][0-9]iscsi/*'
-
-lunmask:
-    - changed-files:
-          - any-glob-to-any-file: 'modules.d/[0-9][0-9]lunmask/*'
-
-nbd:
-    - changed-files:
-          - any-glob-to-any-file: 'modules.d/[0-9][0-9]nbd/*'
-
-nfs:
-    - changed-files:
-          - any-glob-to-any-file: 'modules.d/[0-9][0-9]nfs/*'
-
-nvmf:
-    - changed-files:
-          - any-glob-to-any-file: 'modules.d/[0-9][0-9]nvmf/*'
-
-resume:
-    - changed-files:
-          - any-glob-to-any-file: 'modules.d/[0-9][0-9]resume/*'
-
-rootfs-block:
-    - changed-files:
-          - any-glob-to-any-file: 'modules.d/[0-9][0-9]rootfs-block/*'
-
-rootfs-block-fallback:
-    - changed-files:
-          - any-glob-to-any-file: 'modules.d/[0-9][0-9]rootfs-block-fallback/*'
-
-ssh-client:
-    - changed-files:
-          - any-glob-to-any-file: 'modules.d/[0-9][0-9]ssh-client/*'
-
-terminfo:
-    - changed-files:
-          - any-glob-to-any-file: 'modules.d/[0-9][0-9]terminfo/*'
-
 udev-rules:
     - changed-files:
           - any-glob-to-any-file: 'modules.d/[0-9][0-9]udev-rules/*'
+
+uefi-lib:
+    - changed-files:
+          - any-glob-to-any-file: 'modules.d/[0-9][0-9]uefi-lib/*'
+
+url-lib:
+    - changed-files:
+          - any-glob-to-any-file: 'modules.d/[0-9][0-9]url-lib/*'
+
+usrmount:
+    - changed-files:
+          - any-glob-to-any-file: 'modules.d/[0-9][0-9]usrmount/*'
 
 virtfs:
     - changed-files:
@@ -507,114 +595,26 @@ virtiofs:
     - changed-files:
           - any-glob-to-any-file: 'modules.d/[0-9][0-9]virtiofs/*'
 
+warpclock:
+    - changed-files:
+          - any-glob-to-any-file: 'modules.d/[0-9][0-9]warpclock/*'
+
+watchdog:
+    - changed-files:
+          - any-glob-to-any-file: 'modules.d/[0-9][0-9]watchdog/*'
+
+watchdog-modules:
+    - changed-files:
+          - any-glob-to-any-file: 'modules.d/[0-9][0-9]watchdog-modules/*'
+
 zfcp:
     - changed-files:
           - any-glob-to-any-file: 'modules.d/[0-9][0-9]zfcp/*'
 
+zipl:
+    - changed-files:
+          - any-glob-to-any-file: 'modules.d/[0-9][0-9]zipl/*'
+
 znet:
     - changed-files:
           - any-glob-to-any-file: 'modules.d/[0-9][0-9]znet/*'
-
-securityfs:
-    - changed-files:
-          - any-glob-to-any-file: 'modules.d/[0-9][0-9]securityfs/*'
-
-biosdevname:
-    - changed-files:
-          - any-glob-to-any-file: 'modules.d/[0-9][0-9]biosdevname/*'
-
-masterkey:
-    - changed-files:
-          - any-glob-to-any-file: 'modules.d/[0-9][0-9]masterkey/*'
-
-dracut-systemd:
-    - changed-files:
-          - any-glob-to-any-file: 'modules.d/[0-9][0-9]dracut-systemd/*'
-
-ecryptfs:
-    - changed-files:
-          - any-glob-to-any-file: 'modules.d/[0-9][0-9]ecryptfs/*'
-
-integrity:
-    - changed-files:
-          - any-glob-to-any-file: 'modules.d/[0-9][0-9]integrity/*'
-
-pollcdrom:
-    - changed-files:
-          - any-glob-to-any-file: 'modules.d/[0-9][0-9]pollcdrom/*'
-
-selinux:
-    - changed-files:
-          - any-glob-to-any-file: 'modules.d/[0-9][0-9]selinux/*'
-
-syslog:
-    - changed-files:
-          - any-glob-to-any-file: 'modules.d/[0-9][0-9]syslog/*'
-
-usrmount:
-    - changed-files:
-          - any-glob-to-any-file: 'modules.d/[0-9][0-9]usrmount/*'
-
-base:
-    - changed-files:
-          - any-glob-to-any-file: 'modules.d/[0-9][0-9]base/*'
-
-fs-lib:
-    - changed-files:
-          - any-glob-to-any-file: 'modules.d/[0-9][0-9]fs-lib/*'
-
-img-lib:
-    - changed-files:
-          - any-glob-to-any-file: 'modules.d/[0-9][0-9]img-lib/*'
-
-memdisk:
-    - changed-files:
-          - any-glob-to-any-file: 'modules.d/[0-9][0-9]memdisk/*'
-
-memstrack:
-    - changed-files:
-          - any-glob-to-any-file: 'modules.d/[0-9][0-9]memstrack/*'
-
-shutdown:
-    - changed-files:
-          - any-glob-to-any-file: 'modules.d/[0-9][0-9]shutdown/*'
-
-simpledrm:
-    - changed-files:
-          - any-glob-to-any-file: 'modules.d/[0-9][0-9]simpledrm/*'
-
-squash:
-    - changed-files:
-          - any-glob-to-any-file: 'modules.d/[0-9][0-9]squash/*'
-
-squash-lib:
-    - changed-files:
-          - any-glob-to-any-file: 'modules.d/[0-9][0-9]squash-lib/*'
-
-squash-erofs:
-    - changed-files:
-          - any-glob-to-any-file: 'modules.d/[0-9][0-9]squash/*'
-
-squash-squashfs:
-    - changed-files:
-          - any-glob-to-any-file: 'modules.d/[0-9][0-9]squash/*'
-
-uefi-lib:
-    - changed-files:
-          - any-glob-to-any-file: 'modules.d/[0-9][0-9]uefi-lib/*'
-
-net-lib:
-    - changed-files:
-          - any-glob-to-any-file: 'modules.d/[0-9][0-9]net-lib/*'
-
-pcmcia:
-    - changed-files:
-          - any-glob-to-any-file: 'modules.d/[0-9][0-9]pcmcia/*'
-
-shell-interpreter:
-    - changed-files:
-          - any-glob-to-any-file: 'modules.d/[0-9][0-9]shell-interpreter/*'
-
-test:
-    - changed-files:
-          - any-glob-to-any-file: ['test/*', 'test/**/*']


### PR DESCRIPTION
Sort modules in `labeler.yml` and keep them last. This is done in preparation to generate this part of `labeler.yml` with a script.

<!-- This pull request changes... -->

<!-- Fixes: https://github.com/dracut-ng/dracut-ng/issues/<number> -->

### Checklist
- [ ] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it
