### PR TITLE
ci(labeler): fix glob for squash-erofs/squash-squashfs

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -421,7 +421,7 @@ squash:
 
 squash-erofs:
     - changed-files:
-          - any-glob-to-any-file: 'modules.d/[0-9][0-9]squash/*'
+          - any-glob-to-any-file: 'modules.d/[0-9][0-9]squash-erofs/*'
 
 squash-lib:
     - changed-files:
@@ -429,7 +429,7 @@ squash-lib:
 
 squash-squashfs:
     - changed-files:
-          - any-glob-to-any-file: 'modules.d/[0-9][0-9]squash/*'
+          - any-glob-to-any-file: 'modules.d/[0-9][0-9]squash-squashfs/*'
 
 ssh-client:
     - changed-files:


### PR DESCRIPTION
The glob rule for `squash-erofs` and `squash-squashfs` does not match the correct path.

Found by https://github.com/dracut-ng/dracut-ng/pull/2387

<!-- This pull request changes... -->

<!-- Fixes: https://github.com/dracut-ng/dracut-ng/issues/<number> -->

### Checklist
- [ ] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it
