### PR TITLE
ci: add overlayfs-crypt to labeler

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -343,6 +343,10 @@ overlayfs:
     - changed-files:
           - any-glob-to-any-file: 'modules.d/[0-9][0-9]overlayfs/*'
 
+overlayfs-crypt:
+    - changed-files:
+          - any-glob-to-any-file: 'modules.d/[0-9][0-9]overlayfs-crypt/*'
+
 pcmcia:
     - changed-files:
           - any-glob-to-any-file: 'modules.d/[0-9][0-9]pcmcia/*'


### PR DESCRIPTION
Fixes: c74f8ac20500 ("feat(overlayfs-crypt): add new encrypted persistent overlay support")

Such mistakes will be prevented by https://github.com/dracut-ng/dracut-ng/pull/2387 in the future.

### Checklist
- [ ] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it
