### PR TITLE
revert: systemd requires cryptsetup targets installed earlier

### DIFF
--- a/modules.d/10systemd/module-setup.sh
+++ b/modules.d/10systemd/module-setup.sh
@@ -47,6 +47,9 @@ install() {
         "$systemdutildir"/system-generators/systemd-gpt-auto-generator \
         "$systemdutildir"/system.conf \
         "$systemdutildir"/system.conf.d/*.conf \
+        "$systemdsystemunitdir"/cryptsetup-pre.target \
+        "$systemdsystemunitdir"/cryptsetup.target \
+        "$systemdsystemunitdir"/remote-cryptsetup.target \
         "$systemdsystemunitdir"/debug-shell.service \
         "$systemdsystemunitdir"/emergency.target \
         "$systemdsystemunitdir"/sysinit.target \

--- a/modules.d/71systemd-cryptsetup/module-setup.sh
+++ b/modules.d/71systemd-cryptsetup/module-setup.sh
@@ -53,10 +53,7 @@ install() {
         "$tmpfilesdir"/cryptsetup.conf \
         "$systemdutildir"/system-generators/systemd-cryptsetup-generator \
         "$systemdutildir"/systemd-cryptsetup \
-        "$systemdsystemunitdir"/cryptsetup-pre.target \
-        "$systemdsystemunitdir"/cryptsetup.target \
         "$systemdsystemunitdir"/sysinit.target.wants/cryptsetup.target \
-        "$systemdsystemunitdir"/remote-cryptsetup.target \
         "$systemdsystemunitdir"/initrd-root-device.target.wants/remote-cryptsetup.target
 
     if [[ $hostonly ]] && [[ -f $initdir/etc/crypttab ]]; then


### PR DESCRIPTION
This commit reverts ad52085 and 181e1f1 .

Fixes: https://github.com/dracut-ng/dracut-ng/issues/2395

<!-- This pull request changes... -->

<!-- Fixes: https://github.com/dracut-ng/dracut-ng/issues/<number> -->

### Checklist
- [ ] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it
