### PR TITLE
feat(chrony): introducing the chrony module

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -88,6 +88,10 @@ caps:
     - changed-files:
           - any-glob-to-any-file: 'modules.d/[0-9][0-9]caps/*'
 
+chrony:
+    - changed-files:
+          - any-glob-to-any-file: 'modules.d/[0-9][0-9]chrony/*'
+
 cifs:
     - changed-files:
           - any-glob-to-any-file: 'modules.d/[0-9][0-9]cifs/*'

--- a/.github/workflows/daily-network.yml
+++ b/.github/workflows/daily-network.yml
@@ -40,6 +40,7 @@ jobs:
                 test:
                     - "31"
                     - "60"
+                    - "61"
                 exclude:
                     - container: arch:latest
                       architecture: {runner: 'ubuntu-24.04-arm', tag: 'arm'}
@@ -50,6 +51,17 @@ jobs:
                     # https://github.com/dracut-ng/dracut/issues/1988
                     - container: debian:sid
                       architecture: {runner: 'ubuntu-24.04-arm', tag: 'arm'}
+                    # In Debian/Ubuntu both chrony and systemd-timesyncd provide
+                    # the virtual package time-daemon, so systemd-timesyncd
+                    # would have to be removed, breaking test 41.
+                    - container: debian:latest
+                      test: "61"
+                    - container: debian:sid
+                      test: "61"
+                    - container: ubuntu:devel
+                      test: "61"
+                    - container: ubuntu:rolling
+                      test: "61"
         container:
             image: ghcr.io/dracut-ng/${{ matrix.container }}
             options: '--device=/dev/kvm --privileged'

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -190,6 +190,13 @@ jobs:
                 test:
                     - "31"
                     - "60"
+                    - "61"
+                exclude:
+                    # In Debian/Ubuntu both chrony and systemd-timesyncd provide
+                    # the virtual package time-daemon, so systemd-timesyncd
+                    # would have to be removed, breaking test 41.
+                    - container: ubuntu:devel
+                      test: "61"
         container:
             image: ghcr.io/dracut-ng/${{ matrix.container }}
             options: '--device=/dev/kvm'

--- a/doc_site/modules/ROOT/pages/modules/network.adoc
+++ b/doc_site/modules/ROOT/pages/modules/network.adoc
@@ -6,6 +6,9 @@
 |===
 | Module | Description
 
+| chrony
+| Adds support for synchronizing the internal clock via Network Time Protocol (NTP)
+
 | cifs
 | https://docs.kernel.org/admin-guide/cifs/index.html[CIFS], https://repology.org/project/cifs-utils[cifs-utils]
 

--- a/man/dracut.cmdline.7.adoc
+++ b/man/dracut.cmdline.7.adoc
@@ -729,6 +729,27 @@ interface name. Better name it "bootnet" or "bluesocket".
     list of physical (ethernet) interfaces. Bridge without parameters assumes
     bridge=br0:eth0
 
+NTP
+~~~
+Requires the dracut 'chrony' module.
+
+**rd.ntp=**__{server|pool|peer}__:__<hostname-or-ip>__[:__<option>__[,<option>...]]::
+    This parameter can be specified multiple times.
+    IPv6 addresses have to be put in brackets.
+    See man:chrony.conf[5,external] for more information about server, pool and
+    peer options.
++
+[listing]
+.Examples
+--
+    rd.ntp=pool:2.europe.pool.ntp.org:iburst
+    rd.ntp=server:185.177.150.95:iburst,prefer
+    rd.ntp=server:[2600:1f18:631e:db00:363d:d9d7:5c80:d560]:iburst,maxdelay,0.3
+--
+
+**rd.ntp.nodhcp**::
+    Disable using NTP sources from DHCP.
+
 NFS
 ~~~
 Requires the dracut 'nfs' module.

--- a/modules.d/11systemd-networkd/module-setup.sh
+++ b/modules.d/11systemd-networkd/module-setup.sh
@@ -58,7 +58,7 @@ install() {
         "$systemdsystemunitdir"/systemd-networkd-wait-online.service \
         "$systemdsystemunitdir"/systemd-networkd-wait-online@.service \
         "$systemdsystemunitdir"/systemd-network-generator.service \
-        ip sed grep networkctl
+        ip sed grep networkctl tr
 
     inst_simple "$moddir"/99-wait-online-dracut.conf \
         "$systemdsystemunitdir"/systemd-networkd-wait-online.service.d/99-dracut.conf

--- a/modules.d/11systemd-networkd/networkd-run.sh
+++ b/modules.d/11systemd-networkd/networkd-run.sh
@@ -17,6 +17,27 @@ for ifpath in /sys/class/net/*; do
                 [ -n "$new_next_server" ] && printf "new_next_server='%s'\n" "$(escape "$new_next_server")"
                 new_root_path="$(sed -n 's/^ROOT_PATH=//p' "$leases_file")"
                 [ -n "$new_root_path" ] && printf "new_root_path='%s'\n" "$(escape "$new_root_path")"
+
+                # systemd-networkd mixes IPv4 and IPv6 addresses under
+                # the same NTP= property, but dhclient has two properties
+                # for that: new_ntp_servers and new_dhcp6_ntp_servers
+                ntp_ipv4=
+                ntp_ipv6=
+                ntp_servers=$(sed -n "s/^NTP=\(.*\)/\1/p" "$leases_file")
+                for i in $ntp_servers; do
+                    case "$i" in
+                        *.*.*.*)
+                            ntp_ipv4="$ntp_ipv4${ntp_ipv4:+ }$i"
+                            ;;
+                        *)
+                            # hostnames are only allowed in DHCPv6
+                            ntp_ipv6="$ntp_ipv6${ntp_ipv6:+ }$i"
+                            ;;
+                    esac
+                done
+                [ -n "$ntp_ipv4" ] && printf "new_ntp_servers=%s\n" "$(escape "$ntp_ipv4")"
+                [ -n "$ntp_ipv6" ] && printf "new_dhcp6_ntp_servers=%s\n" "$(escape "$ntp_ipv6")"
+
             } > "$dhcpopts_file"
         else
             # Since systemd v261 the DHCP lease is no longer serialized to /run/, use the new networkctl command.
@@ -28,6 +49,27 @@ for ifpath in /sys/class/net/*; do
                     # option 17 is the DHCP root-path; strip the leading "<code> <name> " columns
                     root_path=$(printf '%s\n' "$lease" | sed -n "s/^[[:space:]]*17[[:space:]].*[[:space:]]//p")
                     [ -n "$root_path" ] && printf "new_root_path='%s'\n" "$(escape "$root_path")"
+
+                    # DHCP options containing information about NTP servers:
+                    # - option 42: IPv4, no FQDN allowed. Parsing this option is
+                    #   tricky, because the first value is printed after the tag
+                    #   "NTP server", but the following values are indented
+                    #   below in new lines. E.g.:
+                    #
+                    #   28 broadcast address  192.168.122.255
+                    #   42 NTP server         185.103.119.60
+                    #                         216.239.35.0
+                    #   51 lease time         1h
+                    #
+                    # - option 56: IPv6, FQDN allowed. Since the dhcp-lease
+                    #   command of networkctl only reads IPv4 leases, we can
+                    #   omit parsing this option.
+                    ntp_servers=$(printf '%s\n' "$lease" \
+                        | sed -n "/^[[:space:]]*42 NTP server/{p; :a; n; /^[[:space:]]\+[0-9]/ {p; ba;};}" \
+                        | sed "s/^[[:space:]]*42 NTP server//; s/^[[:space:]]*//" \
+                        | tr '\n' ' ')
+                    [ -n "$ntp_servers" ] && printf "new_ntp_servers='%s'\n" "$(escape "$(trim "$ntp_servers")")"
+
                 } > "$dhcpopts_file" || :
             fi
         fi

--- a/modules.d/35network-manager/nm-run.sh
+++ b/modules.d/35network-manager/nm-run.sh
@@ -53,6 +53,8 @@ dhcpopts_create() {
     kf_parse root-path new_root_path < "$1"
     kf_parse next-server new_next_server < "$1"
     kf_parse dhcp-bootfile filename < "$1"
+    kf_parse dhcp4.ntp_servers new_ntp_servers < "$1"
+    kf_parse dhcp6.ntp_servers new_dhcp6_ntp_servers < "$1"
 }
 
 for _i in /sys/class/net/*; do

--- a/modules.d/74chrony/chrony-ntp-source.sh
+++ b/modules.d/74chrony/chrony-ntp-source.sh
@@ -1,0 +1,32 @@
+#!/bin/sh
+
+command -v getargbool > /dev/null || . /lib/dracut-lib.sh
+
+if getargbool 0 rd.ntp.nodhcp; then
+    info "rd.ntp.nodhcp=1: not adding NTP sources from DHCP."
+    return 0
+fi
+
+_ifname=$1
+[ -n "$_ifname" ] || return 0
+
+_dhcpopts_file="/tmp/dhclient.$_ifname.dhcpopts"
+[ -s "$_dhcpopts_file" ] || return 0
+
+(
+    # shellcheck disable=SC1090
+    . "$_dhcpopts_file"
+    [ -n "$new_ntp_servers" ] || [ -n "$new_dhcp6_ntp_servers" ] || return 0
+
+    info "Adding NTP sources from DHCP ($_ifname)."
+
+    [ -d /run/chrony-dhcp ] || mkdir -p /run/chrony-dhcp
+    for _srv in $new_ntp_servers $new_dhcp6_ntp_servers; do
+        echo "server $_srv iburst" >> "/run/chrony-dhcp/$_ifname.sources"
+    done
+
+    chronyc reload sources > /dev/null 2>&1 \
+        || warn "chronyc failed to reload NTP sources"
+)
+
+unset _ifname _dhcpopts_file

--- a/modules.d/74chrony/chrony-wait.service
+++ b/modules.d/74chrony/chrony-wait.service
@@ -1,0 +1,44 @@
+[Unit]
+Description=Wait for chrony to synchronize system clock (initrd)
+AssertPathExists=/etc/initrd-release
+DefaultDependencies=no
+After=chronyd.service
+Requires=chronyd.service
+Before=time-sync.target
+Wants=time-sync.target
+
+[Service]
+Type=oneshot
+# Wait for chronyd to update the clock and the remaining
+# correction to be less than 0.1 seconds
+ExecStart=/usr/bin/chronyc -h 127.0.0.1,::1 waitsync 0 0.1 0.0 1
+# Wait for at most 3 minutes
+TimeoutStartSec=180
+RemainAfterExit=yes
+StandardOutput=null
+
+CapabilityBoundingSet=
+DevicePolicy=closed
+DynamicUser=yes
+IPAddressAllow=localhost
+IPAddressDeny=any
+LockPersonality=yes
+MemoryDenyWriteExecute=yes
+PrivateDevices=yes
+PrivateUsers=yes
+ProtectClock=yes
+ProtectControlGroups=yes
+ProtectHome=yes
+ProtectHostname=yes
+ProtectKernelLogs=yes
+ProtectKernelModules=yes
+ProtectKernelTunables=yes
+ProtectProc=invisible
+ProtectSystem=strict
+RestrictAddressFamilies=AF_INET AF_INET6
+RestrictNamespaces=yes
+RestrictRealtime=yes
+SystemCallArchitectures=native
+SystemCallFilter=@system-service
+SystemCallFilter=~@privileged @resources
+UMask=0777

--- a/modules.d/74chrony/chrony.conf
+++ b/modules.d/74chrony/chrony.conf
@@ -1,0 +1,24 @@
+# This file is part of dracut chrony module.
+# SPDX-License-Identifier: GPL-2.0-or-later
+
+# Record the rate at which the system clock gains/losses time.
+driftfile /run/chrony/drift
+
+# Allow the system clock to be stepped in the first three updates
+# if its offset is larger than 1 second.
+makestep 1.0 3
+
+# Enable kernel synchronization of the real-time clock (RTC).
+rtcsync
+
+# Save NTS keys and cookies.
+ntsdumpdir /run/chrony
+
+# Specify directory for log files.
+logdir /run/chrony/log
+
+# First, use NTP sources parsed by dracut from the kernel command line.
+sourcedir /run/chrony/dracut.sources.d
+
+# Second, use NTP sources from DHCP.
+sourcedir /run/chrony-dhcp

--- a/modules.d/74chrony/chronyd.service
+++ b/modules.d/74chrony/chronyd.service
@@ -1,0 +1,46 @@
+[Unit]
+Description=NTP client/server (initrd)
+AssertPathExists=/etc/initrd-release
+DefaultDependencies=no
+After=dracut-cmdline.service network.target nss-lookup.target
+Before=time-sync.target
+Conflicts=ntpd.service systemd-timesyncd.service
+Wants=network.target time-sync.target
+ConditionCapability=CAP_SYS_TIME
+
+[Service]
+Type=notify
+PIDFile=/run/chrony/chronyd.pid
+Environment="OPTIONS="
+EnvironmentFile=-/etc/sysconfig/chronyd
+# The default location for chrony.conf can be set at build with the
+# --sysconfdir configuration option, so force /etc/chrony.conf with -f
+ExecStart=/usr/sbin/chronyd -f /etc/chrony.conf -n $OPTIONS
+
+CapabilityBoundingSet=~CAP_AUDIT_CONTROL CAP_AUDIT_READ CAP_AUDIT_WRITE
+CapabilityBoundingSet=~CAP_BLOCK_SUSPEND CAP_KILL CAP_LEASE CAP_LINUX_IMMUTABLE
+CapabilityBoundingSet=~CAP_MAC_ADMIN CAP_MAC_OVERRIDE CAP_MKNOD CAP_SYS_ADMIN
+CapabilityBoundingSet=~CAP_SYS_BOOT CAP_SYS_CHROOT CAP_SYS_MODULE CAP_SYS_PACCT
+CapabilityBoundingSet=~CAP_SYS_PTRACE CAP_SYS_RAWIO CAP_SYS_TTY_CONFIG CAP_WAKE_ALARM
+DeviceAllow=char-pps rw
+DeviceAllow=char-ptp rw
+DeviceAllow=char-rtc rw
+DevicePolicy=closed
+LockPersonality=yes
+MemoryDenyWriteExecute=yes
+NoNewPrivileges=yes
+PrivateTmp=yes
+ProtectControlGroups=yes
+ProtectHome=yes
+ProtectHostname=yes
+ProtectKernelLogs=yes
+ProtectKernelModules=yes
+ProtectKernelTunables=yes
+ProtectProc=invisible
+ProtectSystem=strict
+ReadWritePaths=/run
+RestrictAddressFamilies=AF_INET AF_INET6 AF_UNIX
+RestrictNamespaces=yes
+RestrictSUIDSGID=yes
+SystemCallArchitectures=native
+SystemCallFilter=~@cpu-emulation @debug @module @mount @obsolete @raw-io @reboot @swap

--- a/modules.d/74chrony/module-setup.sh
+++ b/modules.d/74chrony/module-setup.sh
@@ -1,0 +1,75 @@
+#!/bin/bash
+# SPDX-License-Identifier: GPL-2.0-or-later
+
+check() {
+    require_binaries \
+        chronyd \
+        || return 1
+
+    return 255
+}
+
+depends() {
+    echo systemd network
+    return 0
+}
+
+install() {
+    # openSUSE/Fedora: chrony
+    # Ubuntu: _chrony
+    grep -s -E '^(_chrony|chrony):' "${dracutsysrootdir-}"/etc/passwd \
+        | sed 's/\/var\/lib\/chrony/\/run\/chrony/' >> "$initdir/etc/passwd"
+    grep -s -E '^(_chrony|chrony):' "${dracutsysrootdir-}"/etc/group >> "$initdir/etc/group"
+
+    inst_hook cmdline 01 "$moddir/parse-ntp.sh"
+    inst_hook initqueue/online 01 "$moddir/chrony-ntp-source.sh"
+
+    inst_multiple -o \
+        "$systemdntpunits"/50-chronyd.list \
+        "$systemdsystemunitdir"/time-sync.target \
+        chronyd chronyc mkdir chown
+
+    inst_simple "$moddir/chrony.conf" /etc/chrony.conf
+
+    for i in \
+        chronyd.service \
+        chrony-wait.service; do
+        inst_simple "$moddir/$i" "$systemdsystemunitdir/$i"
+        $SYSTEMCTL -q --root "$initdir" add-wants initrd.target "$i"
+    done
+
+    if [[ $hostonly ]]; then
+        local _i _directives _keyfile _source_dirs=()
+
+        # Install the file pointed by the "keyfile" directive, used for NTP
+        # authentication. This directive is intended to be unique, chrony would
+        # end up using the last one processed.
+        readarray -t _directives < <(grep -r -h '^keyfile ' "${dracutsysrootdir-}"/etc/chrony*)
+        if ((${#_directives[@]})); then
+            printf "\n# Specify file containing keys for NTP authentication.\n%s\n" "${_directives[-1]}" >> "$initdir/etc/chrony.conf"
+            _keyfile="${_directives[-1]/#keyfile /}"
+        fi
+
+        # chrony allows to configure directories with .sources files using the
+        # "sourcedir" directive, used to specify NTP sources (server, pool, and
+        # peer directives).
+        readarray -t _directives < <(grep -r -h '^sourcedir /etc' "${dracutsysrootdir-}"/etc/chrony*)
+        if ((${#_directives[@]})); then
+            printf "\n# Use NTP sources configured on the host.\n" >> "$initdir/etc/chrony.conf"
+            for _i in "${_directives[@]}"; do
+                echo "$_i" >> "$initdir/etc/chrony.conf"
+                _source_dirs+=("$(echo "$_i" | sed -e 's/sourcedir //' -e 's/$/\/*.sources/')")
+            done
+        fi
+
+        # We do not want to include /etc/chrony.conf or ".conf" files specified
+        # with "include" or "confdir" directives from the host, because they
+        # can override "driftfile", "ntsdumpdir" or "logdir" directives,
+        # intended to point to /run in the initrd.
+
+        inst_multiple -H -o "$_keyfile" "${_source_dirs[@]}" \
+            /etc/sysconfig/chronyd \
+            "$systemdsystemconfdir"/time-sync.target \
+            "$systemdsystemconfdir/time-sync.target.wants/*.target"
+    fi
+}

--- a/modules.d/74chrony/parse-ntp.sh
+++ b/modules.d/74chrony/parse-ntp.sh
@@ -1,0 +1,65 @@
+#!/bin/sh
+
+command -v getargs > /dev/null || . /lib/dracut-lib.sh
+
+# format: rd.ntp={server|pool|peer}:<hostname-or-ip>[:<option>[,<option>...]]
+parse_ntp_source() {
+    local v="${1}":
+    local i
+    local src addr opts
+
+    set --
+    while [ -n "$v" ]; do
+        if [ "${v#\[*:*:*\]:}" != "$v" ]; then
+            # handle IPv6 address
+            i="${v%%\]:*}"
+            i="${i##\[}"
+            set -- "$@" "$i"
+            v=${v#\["$i"\]:}
+        else
+            set -- "$@" "${v%%:*}"
+            v=${v#*:}
+        fi
+    done
+
+    if [ $# -lt 2 ]; then
+        warn "Failed to parse NTP time source"
+        return 1
+    fi
+
+    case "$1" in
+        server | pool | peer)
+            src=$1
+            ;;
+        *)
+            warn "Invalid time source '$1'. Valid options: server, pool, peer"
+            return 1
+            ;;
+    esac
+
+    [ -n "$2" ] && addr=$2
+    [ -n "$3" ] && opts="$(str_replace "$3" "," " ")"
+
+    echo "${src} ${addr}${opts:+ $opts}"
+    return 0
+}
+
+mkdir -p -m 0750 /run/chrony
+chown chrony: /run/chrony
+mkdir /run/chrony/dracut.sources.d
+
+for _i in $(getargs rd.ntp); do
+    _src=$(parse_ntp_source "$_i")
+    if [ -n "$_src" ]; then
+        echo "$_src" >> /run/chrony/dracut.sources.d/dracut.sources
+    fi
+done
+
+if [ "$(ls -A /run/chrony/dracut.sources.d)" ] && ! getargbool 0 rd.neednet; then
+    echo "rd.neednet=1" > /etc/cmdline.d/01-chrony.conf
+    if ! getarg "ip="; then
+        echo "ip=dhcp" >> /etc/cmdline.d/01-chrony.conf
+    fi
+fi
+
+unset _i _src

--- a/test/TEST-61-CHRONY/Makefile
+++ b/test/TEST-61-CHRONY/Makefile
@@ -1,0 +1,1 @@
+-include ../Makefile.testdir

--- a/test/TEST-61-CHRONY/test.sh
+++ b/test/TEST-61-CHRONY/test.sh
@@ -1,0 +1,154 @@
+#!/usr/bin/env bash
+set -eu
+
+[ -z "${USE_NETWORK-}" ] && USE_NETWORK="network"
+
+# shellcheck disable=SC2034
+TEST_DESCRIPTION="NTP support with chrony, systemd and $USE_NETWORK"
+
+# Fake time way off in the future, so SSL certificates will appear to have
+# expired
+FAKE_TIME="2100-01-01T00:00:00"
+
+# Name of the SSL certificate
+SSL_CERT="webserver.pem"
+
+test_check() {
+    local binary
+
+    for binary in chronyd openssl; do
+        if ! type -p "$binary" &> /dev/null; then
+            echo "Test needs $binary... Skipping"
+            return 1
+        fi
+    done
+
+    command -v systemctl &> /dev/null
+}
+
+client_run() {
+    local nook="$1"
+    local test_name="$2"
+    local append="$3"
+
+    client_test_start "$test_name"
+
+    # Comments about some qemu options:
+    # - -rtc "base=...,clock=vm" allows to disconnect vm time from host time
+    # - initcall_blacklist=rtc_cmos_init (x86_64) / efi_rtc_init (aarch64)
+    #   instructs the kernel to avoid trying to sync the clock
+    "$testdir"/run-qemu \
+        "${disk_args[@]}" \
+        -rtc "base=$FAKE_TIME,clock=vm" \
+        -device "virtio-net-pci,netdev=lan0" \
+        -netdev "user,id=lan0,net=10.0.2.0/24,dhcpstart=10.0.2.15" \
+        -append "root=LABEL=dracut initcall_blacklist=rtc_cmos_init initcall_blacklist=efi_rtc_init $append $TEST_KERNEL_CMDLINE" \
+        -initrd "$TESTDIR/initramfs.testing"
+
+    # The "nook" variable controls whether a failed test is considered good
+    if [[ $nook != 1 ]]; then
+        check_qemu_log
+    else
+        check_qemu_log || :
+    fi
+
+    client_test_end
+}
+
+test_run() {
+    declare -a disk_args=()
+
+    qemu_add_drive disk_args "$TESTDIR"/root.img root
+
+    start_webserver "HTTPS" "$SSL_CERT"
+
+    client_run 1 \
+        "Fetch file from HTTPS with the system clock out of sync" \
+        "rd.neednet=1 ip=dhcp"
+
+    # 2606:4700:f1::1 should be Cloudflare
+    # "prefer" pool.ntp.org
+    client_run 0 \
+        "Fetch file from HTTPS after sync time via NTP" \
+        "rd.ntp=server:[2606:4700:f1::1]:iburst rd.ntp=pool:pool.ntp.org:iburst,prefer"
+}
+
+test_setup() {
+    # Create plain root filesystem
+    build_client_rootfs "$TESTDIR/rootfs"
+
+    # Create an ext4 image with the rootfs
+    build_ext4_image "$TESTDIR/rootfs" "$TESTDIR/root.img" dracut
+
+    # Create a file to be downloaded from the initrd
+    echo "dracut-chrony-success" > "$TESTDIR/remote-file.txt"
+
+    # We have to trick systemd to avoid taking its build time, see man
+    # systemd(1) for more details
+    touch -d "$FAKE_TIME" "$TESTDIR/clock-epoch"
+
+    # Create a certificate, we need to add it to the initrd, so we can call curl
+    # with the --cacert option, otherwise it fails with the error:
+    # "curl: (60) SSL certificate OpenSSL verify result: self-signed certificate (18)"
+    openssl req \
+        -quiet \
+        -new -x509 \
+        -keyout "$TESTDIR/$SSL_CERT" \
+        -subj "/CN=10.0.2.2/" \
+        -out "$TESTDIR/$SSL_CERT" \
+        -days 365 \
+        -nodes
+
+    # We will add a drop-in for dracut-pre-pivot.service, ordering it after
+    # time-sync.target, so it will wait until the system time is synchronized
+    {
+        echo "[Unit]"
+        echo "After=time-sync.target"
+    } > "$TESTDIR/dracut-wait.conf"
+
+    # Install a pre-pivot hook to fetch "remote-file.txt" using HTTPS, if the
+    # system clock is out of sync, curl will fail with the error:
+    # "curl: (60) SSL certificate OpenSSL verify result: certificate has expired (10)"
+    # and the script will unmount /sysroot, so the test should fail as well
+    # shellcheck disable=SC2016
+    {
+        echo "#!/bin/sh"
+        echo "command -v warn > /dev/null || . /lib/dracut-lib.sh"
+        echo 'warn "$(systemctl status chronyd.service)"'
+        echo "remote_file_content=\$(curl --cacert /etc/$SSL_CERT \"https://10.0.2.2:4443/remote-file.txt\")"
+        echo 'if [ "$remote_file_content" = "dracut-chrony-success" ]; then'
+        echo '    warn "$remote_file_content"'
+        echo "else"
+        echo '    warn "Failed to fetch remote-file.txt using HTTPS"'
+        echo "    umount /sysroot"
+        echo "fi"
+    } > "$TESTDIR/fetch-remote-file.sh"
+    chmod +x "$TESTDIR/fetch-remote-file.sh"
+
+    # Synchronizing the clock via NTP usually takes ~30s, if we want to test
+    # that fetching from HTTPS fails when the clock is out of sync, we would
+    # have to wait the default 3-minute timeout for a systemd service, so with
+    # the following drop-in we can reduce the time spent in the test
+    {
+        echo "[Service]"
+        echo "TimeoutSec=1min"
+    } > "$TESTDIR/chrony-less-timeout.conf"
+
+    # Build non-hostonly initrd to avoid adding local chrony configuration,
+    # pointing to a variety of NTP servers depending on the distribution
+    test_dracut \
+        --no-hostonly \
+        -i "$TESTDIR/clock-epoch" "/usr/lib/clock-epoch" \
+        -i "$TESTDIR/$SSL_CERT" "/etc/$SSL_CERT" \
+        -i "$TESTDIR/dracut-wait.conf" "/usr/lib/systemd/system/dracut-pre-pivot.service.d/dracut-wait.conf" \
+        -i "$TESTDIR/fetch-remote-file.sh" "/var/lib/dracut/hooks/pre-pivot/10-fetch-remote-file.sh" \
+        -i "$TESTDIR/chrony-less-timeout.conf" "/usr/lib/systemd/system/chrony-wait.service.d/chrony-less-timeout.conf" \
+        -a "chrony url-lib ${USE_NETWORK}"
+}
+
+test_cleanup() {
+    stop_webserver
+}
+
+# shellcheck disable=SC1090
+. "$testdir"/test-functions

--- a/test/test-functions
+++ b/test/test-functions
@@ -208,30 +208,58 @@ client_test_end() {
     rm "$TESTDIR/client_test_name.txt"
 }
 
-# Start a HTTP server that serves the content of TESTDIR
+# Start a HTTP/HTTPS server that serves the content of TESTDIR
 start_webserver() {
-    local pid port
+    local pid port type="${1-HTTP}" cert="${2-}"
 
-    echo "Starting HTTP server..." >&2
-    python3 -u -m http.server -d "$TESTDIR" 0 > "$TESTDIR/webserver.log" 2>&1 &
-    pid=$!
-    echo "$pid" > "$TESTDIR/webserver.pid"
+    echo "Starting $type server..." >&2
 
-    while ! grep -q 'Serving HTTP on' "$TESTDIR/webserver.log"; do
-        echo "sleeping..." >&2
-        sleep 0.05
-    done
+    case "$type" in
+        "HTTP")
+            python3 -u -m http.server -d "$TESTDIR" 0 > "$TESTDIR/webserver.log" 2>&1 &
+            pid=$!
+            echo "$pid" > "$TESTDIR/webserver.pid"
 
-    port=$(sed -n 's/.*port \([0-9]\+\).*/\1/p' "$TESTDIR/webserver.log")
-    echo "HTTP server running on port $port (pid $pid)" >&2
+            while ! grep -q 'Serving HTTP on' "$TESTDIR/webserver.log"; do
+                echo "sleeping..." >&2
+                sleep 0.05
+            done
+
+            port=$(sed -n 's/.*port \([0-9]\+\).*/\1/p' "$TESTDIR/webserver.log")
+            ;;
+
+        "HTTPS")
+            if [[ -z $cert ]]; then
+                echo "Missing certificate"
+                return 1
+            fi
+
+            # Set a fixed port
+            port=4443
+
+            # openssl does not have a specific parameter to set a working directory,
+            # so we have to change to TESTDIR before starting the server
+            (cd "$TESTDIR" && exec openssl s_server -accept "$port" -cert "$cert" -WWW > "$TESTDIR/webserver.log" 2>&1) &
+            pid=$!
+            echo "$pid" > "$TESTDIR/webserver.pid"
+            ;;
+
+        *)
+            echo "$type server not implemented"
+            return 1
+            ;;
+    esac
+
+    echo "$type server running on port $port (pid $pid)" >&2
     echo "$port"
+    return 0
 }
 
-# Stop HTTP server that was started by start_webserver
+# Stop HTTP/HTTPS server that was started by start_webserver
 stop_webserver() {
     if [[ -s "$TESTDIR/webserver.pid" ]]; then
         pid=$(cat "$TESTDIR/webserver.pid")
-        echo "Stopping HTTP server (pid $pid)..." >&2
+        echo "Stopping web server (pid $pid)..." >&2
         kill "$pid"
         rm "$TESTDIR/webserver.pid"
     fi


### PR DESCRIPTION
This new module relies on chrony to add support for NTP in the initrd. By default, it also uses NTP sources from DHCP.

It provides two new kernel command line options:
- `rd.ntp`: it can be used multiple times to specify server, pool and peer time sources.
- `rd.ntp.nodhcp`: it disables the use of NTP sources from DHCP.

In some environments, it's necessary to fetch live images from HTTPS URLs. The problem is that the hardware clock may be off, so the validation of the SSL certificates may fail if the time is out of sync. Also, some systems may not have access to DHCP for security reasons, that's why we need a way to configure them on the kernel command line.

Notes:
- chrony upstream only provides systemd services and configuration as [examples](https://gitlab.com/chrony/chrony/-/tree/master/examples?ref_type=heads), so there are many differences between the distributions.
- While it might make sense to use /var on the host, let's try to use /run in the initrd, so everything can persist after switching root.

### Checklist
- [X] I have tested it locally
- [X] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it
