### PR TITLE
fix(kernel-modules): add Mediatek MTU3 USB controller

### DIFF
--- a/modules.d/70kernel-modules/module-setup.sh
+++ b/modules.d/70kernel-modules/module-setup.sh
@@ -100,6 +100,7 @@ installkernel() {
                 "=drivers/usb/host" \
                 "=drivers/usb/isp1760" \
                 "=drivers/usb/misc" \
+                "=drivers/usb/mtu3" \
                 "=drivers/usb/musb" \
                 "=drivers/usb/phy" \
                 "=drivers/scsi/hisi_sas" \


### PR DESCRIPTION
This is the USB dual-role controller used by some MediaTek SoCs.

Adding it fixes booting from USB storage on Lenovo Chromebook Duet EDU G2 (mt8188-geralt-ciri). That device does not have any SD slot, so USB storage is the only usable external storage.

<!-- This pull request changes... -->

<!-- Fixes: https://github.com/dracut-ng/dracut-ng/issues/<number> -->

### Checklist
- [x] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it
