### PR TITLE
01-gentoo.conf: disable hostonly_cmdline and improve documentation

### DIFF
--- a/dracut.conf.d/gentoo/01-gentoo.conf
+++ b/dracut.conf.d/gentoo/01-gentoo.conf
@@ -1,2 +1,22 @@
-# Gentoo specific Dracut configuration
+# Build an initramfs specific to this machine by default. This ensures
+# local configuration files (/etc/...) are included.
+hostonly="yes"
+hostonly_mode="sloppy"
+
+# Usage of ukify is controlled via sys-kernel/installkernel[+/-ukify].
+# Automatic delegation in sys-kernel/dracut is disabled here.
 ukify="no"
+# Building an UKI is toggled by sys-kernel/installkernel[+/-uki].
+# If the ukify USE flag is also enabled then ukify is used to build
+# the UKI. If not, then Dracut uses objcopy/objdump to build an UKI.
+# Automatic delegation to ukify is disabled, see also above.
+# By default we do not build an UKI (initramfs only).
+uefi="no"
+
+# Inclusion of CPU microcode is controlled via:
+#     sys-kernel/linux-firmware[+/-initramfs], and/or
+#     sys-firmware/intel-microcode[+/-initramfs]
+# The later takes precedence if both are installed. Disable the
+# inclusion by default here, the aforementioned packages override it.
+# If neither package is installed then no microcode can be included.
+early_microcode="no"

--- a/dracut.conf.d/gentoo/01-gentoo.conf
+++ b/dracut.conf.d/gentoo/01-gentoo.conf
@@ -2,6 +2,10 @@
 # local configuration files (/etc/...) are included.
 hostonly="yes"
 hostonly_mode="sloppy"
+# Delegate setting the cmdline to the bootloader or firmware. This
+# avoids setting an incorrect cmdline when building from a chroot. It
+# also avoids creating two distinct sources of truth for the cmdline.
+hostonly_cmdline="no"
 
 # Usage of ukify is controlled via sys-kernel/installkernel[+/-ukify].
 # Automatic delegation in sys-kernel/dracut is disabled here.


### PR DESCRIPTION
Our new users are stumbling over a check we added that prevents accidentally including a cmdline for the live system in the initramfs for the new install. Since the overall majority of our new users will be setting a cmdline via the bootloader or system firmware anyway this setting is not really useful for our users and only creates confusion because there are now two knobs which control the same thing.

For that reason we would like to disable the `hostonly_cmdline` by default (like Fedora does as well).

While I am touching this file anyway I added explicitly the other configuration settings that we have been controlling implicitly via other packages. By documenting this explicitly I hope that users reading this configuration file will have an (even) easier time finding "the Gentoo way" of doing things like including microcode or building an UKI. We control these things outside the scope of Dracut since optional external dependencies are required for these functions. (linux-firmware, intel-microcode systemd-stub, ukify, etc).

See-also: https://bugs.gentoo.org/971572
See-also: https://github.com/dracut-ng/dracut-ng/issues/1326

CC @thesamesam @immolo 

tl;dr The only effective change here is disabling `hostonly_cmdline`, the rest is just more verbosity from my side on things we are already doing.

### Checklist
- [ ] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it
