### PR TITLE
refactor(dracut): remove unnecessary 'realpath' call if '-k' is specified

### DIFF
--- a/dracut.sh
+++ b/dracut.sh
@@ -1468,11 +1468,11 @@ fi
 
 export LC_MESSAGES=C kernel
 
-srcmods="$(realpath -e "${dracutsysrootdir-}/lib/modules/$kernel")"
-
-[[ ${drivers_dir-} ]] && {
+if [[ ${drivers_dir-} ]]; then
     srcmods="$drivers_dir"
-}
+else
+    srcmods="$(realpath -e "${dracutsysrootdir-}/lib/modules/$kernel")"
+fi
 export srcmods
 
 # export standard hookdirs


### PR DESCRIPTION


No need to use 'realpath' to resolve a default directory to look for modules if one has already been specified. 'realpath' will complain if the directory doesn't exist which can lead a user to think that something went wrong.

<!-- This pull request changes... -->

<!-- Fixes: https://github.com/dracut-ng/dracut-ng/issues/<number> -->

### Checklist
- [x] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it
