### PR TITLE
fix(systemd-repart): load libfdisk via dlopen

### DIFF
--- a/modules.d/11systemd-repart/module-setup.sh
+++ b/modules.d/11systemd-repart/module-setup.sh
@@ -11,6 +11,11 @@ check() {
     return 255
 }
 
+# Config adjustments before installing anything.
+config() {
+    add_dlopen_features+=" libsystemd-shared-*.so:fdisk "
+}
+
 # Install the required file(s) for the module in the initramfs.
 install() {
     inst_multiple -o \
@@ -29,6 +34,12 @@ install() {
         "mkfs.vfat" \
         "mkfs.erofs" \
         "mksquashfs"
+
+    # Install library file(s)
+    if [[ ! $USE_SYSTEMD_DLOPEN_DEPS ]]; then
+        inst_libdir_file \
+            {"tls/$DRACUT_ARCH/",tls/,"$DRACUT_ARCH/",}"libfdisk.so.*"
+    fi
 
     # Install the hosts local user configurations if enabled.
     if [[ $hostonly ]]; then


### PR DESCRIPTION
Required since https://github.com/systemd/systemd/commit/a066396fbc72d06e503acaf38899f949edf16c4c

### Checklist
- [X] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it
