### PR TITLE
fix(systemd-cryptsetup): load libcryptsetup via dlopen

### DIFF
--- a/modules.d/71systemd-cryptsetup/module-setup.sh
+++ b/modules.d/71systemd-cryptsetup/module-setup.sh
@@ -46,6 +46,11 @@ depends() {
 }
 
 # called by dracut
+config() {
+    add_dlopen_features+=" libsystemd-shared-*.so:cryptsetup "
+}
+
+# called by dracut
 install() {
     # the cryptsetup targets are already pulled in by 00systemd, but not
     # the enablement symlinks
@@ -58,6 +63,12 @@ install() {
         "$systemdsystemunitdir"/sysinit.target.wants/cryptsetup.target \
         "$systemdsystemunitdir"/remote-cryptsetup.target \
         "$systemdsystemunitdir"/initrd-root-device.target.wants/remote-cryptsetup.target
+
+    # Install required libraries.
+    if [[ ! $USE_SYSTEMD_DLOPEN_DEPS ]]; then
+        inst_libdir_file \
+            {"tls/$DRACUT_ARCH/",tls/,"$DRACUT_ARCH/",}"libcryptsetup.so.*"
+    fi
 
     if [[ $hostonly ]] && [[ -f $initdir/etc/crypttab ]]; then
         # for each entry in /etc/crypttab check if the key file is backed by a socket unit and if so,


### PR DESCRIPTION
The `systemd-cryptsetup` binary no longer depends on `libcryptsetup`, and there is no other binary installed with the `systemd-cryptsetup` or `crypt` modules that installs it.

```
switch_root:/root# systemd-cryptsetup --version | head -1
systemd 261 (261~devel+git20260423.43dab5ea8)
switch_root:/root# systemd-cryptsetup help
Shared library 'libcryptsetup.so.12' is not available: libcryptsetup.so.12: cannot open shared object file: No such file or directory
switch_root:/root# echo $?
1
```

Required since https://github.com/systemd/systemd/commit/43dab5ea8797e45e0702f8ee89cdf25e577a652b

### Checklist
- [X] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it
