### PR TITLE
test(SYSROOT): correct path for build-parameter.txt

### DIFF
--- a/test/TEST-13-SYSROOT/test.sh
+++ b/test/TEST-13-SYSROOT/test.sh
@@ -26,7 +26,7 @@ test_setup() {
     # test DRACUT_EXTRA_ARGS
     DRACUT_EXTRA_ARGS="--keep --hostonly --sysroot '$TESTDIR/sysroot'" test_dracut
 
-    grep 'hostonly' "$TESTDIR"/initrd/dracut.*/initramfs/usr/lib/dracut/build-parameter.txt
+    grep 'hostonly' "$TESTDIR"/initrd/dracut.*/initramfs/lib/dracut/build-parameter.txt
 
     if grep -q '^root:' /etc/shadow; then
         if ! grep -q '^root:' "$TESTDIR"/initrd/dracut.*/initramfs/etc/shadow; then


### PR DESCRIPTION
`build-parameter.txt` is stored under /lib. In most cases /usr/lib is a symbolic link to /lib, but not always.

The canonical path for build-parameter.txt is under /lib/dracut/

Follow-up to 99738e5.

Fixes: https://github.com/dracut-ng/dracut-ng/issues/2407

<!-- This pull request changes... -->

<!-- Fixes: https://github.com/dracut-ng/dracut-ng/issues/<number> -->

### Checklist
- [ ] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it
