### PR TITLE
fix(shutdown): warning printed unconditionally

### DIFF
--- a/modules.d/86shutdown/shutdown.sh
+++ b/modules.d/86shutdown/shutdown.sh
@@ -43,9 +43,10 @@ getargs 'rd.break=pre-shutdown' && emergency_shell --shutdown pre-shutdown "Brea
 
 source_hook pre-shutdown
 
-info "Killing all remaining processes"
-
-killall_proc_mountpoint /oldroot || sleep 0.2
+if ! killall_proc_mountpoint /oldroot; then
+    warn "Killed remaining processes using /oldroot"
+    sleep 0.2
+fi
 
 # Timeout for umount calls. The value can be set to 0 to wait forever.
 _umount_timeout=$(getarg rd.shutdown.timeout.umount)


### PR DESCRIPTION
The shutdown dracut module unconditionally warns
"Killing all remaining processes" on every shutdown, even when no processes need to be killed.

This produces unnecessary warning noise on the console during clean shutdowns.

The warning was introduced in commit 551c2dd (Jan 2013) and was historically invisible because older dracut versions (e.g. 048) had a less reliable console redirect. Since version 051,
the improved console redirect logic (echo </dev/console subshell check) makes the warning reliably visible.

Fixes: https://github.com/dracutdevs/dracut/issues/2725

CC @artskirk 

<!-- This pull request changes... -->

<!-- Fixes: https://github.com/dracut-ng/dracut-ng/issues/<number> -->

### Checklist
- [ ] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it
