### PR TITLE
ci: reduce peak ci load

### DIFF
--- a/.github/workflows/container-extra.yml
+++ b/.github/workflows/container-extra.yml
@@ -5,7 +5,7 @@ name: Container (extra)
 
 on:  # yamllint disable-line rule:truthy
     schedule:
-        - cron: '30 11 * * *'   # every day at 11:30 UTC
+        - cron: '00 12 * * *'   # every day at 12:00 UTC
     push:
         branches: [main]
         paths:

--- a/.github/workflows/daily-basic.yml
+++ b/.github/workflows/daily-basic.yml
@@ -3,7 +3,7 @@ name: Daily Tests - basic
 
 on:  # yamllint disable-line rule:truthy
     schedule:
-        - cron: '30 23 * * *'   # every day at 23:30 UTC
+        - cron: '00 13 * * *'   # every day at 13:00 UTC
 
     # Allows you to run this workflow manually from the Actions tab
     workflow_dispatch:

--- a/.github/workflows/daily-busybox-x64.yml
+++ b/.github/workflows/daily-busybox-x64.yml
@@ -3,7 +3,7 @@ name: Daily Tests - busybox (x64)
 
 on:  # yamllint disable-line rule:truthy
     schedule:
-        - cron: '30 23 * * *'   # every day at 23:30 UTC
+        - cron: '00 15 * * *'   # every day at 15:00 UTC
 
     # Allows you to run this workflow manually from the Actions tab
     workflow_dispatch:

--- a/.github/workflows/daily-hostonlystrict.yml
+++ b/.github/workflows/daily-hostonlystrict.yml
@@ -3,7 +3,7 @@ name: Daily Tests - hostonlystrict
 
 on:  # yamllint disable-line rule:truthy
     schedule:
-        - cron: '30 23 * * *'   # every day at 23:30 UTC
+        - cron: '30 15 * * *'   # every day at 15:30 UTC
 
     # Allows you to run this workflow manually from the Actions tab
     workflow_dispatch:

--- a/.github/workflows/daily-iscsi-x64.yml
+++ b/.github/workflows/daily-iscsi-x64.yml
@@ -3,7 +3,7 @@ name: Daily Tests - iscsi (x64)
 
 on:  # yamllint disable-line rule:truthy
     schedule:
-        - cron: '30 23 * * *'   # every day at 23:30 UTC
+        - cron: '00 16 * * *'   # every day at 16:00 UTC
 
     # Allows you to run this workflow manually from the Actions tab
     workflow_dispatch:

--- a/.github/workflows/daily-kernel-install-x64.yml
+++ b/.github/workflows/daily-kernel-install-x64.yml
@@ -3,7 +3,7 @@ name: Daily Tests - kernel-install (x64)
 
 on:  # yamllint disable-line rule:truthy
     schedule:
-        - cron: '30 23 * * *'   # every day at 23:30 UTC
+        - cron: '30 16 * * *'   # every day at 16:30 UTC
 
     # Allows you to run this workflow manually from the Actions tab
     workflow_dispatch:

--- a/.github/workflows/daily-mkosi-x64.yml
+++ b/.github/workflows/daily-mkosi-x64.yml
@@ -3,7 +3,7 @@ name: Daily Tests - mkosi (x64)
 
 on:  # yamllint disable-line rule:truthy
     schedule:
-        - cron: '30 23 * * *'   # every day at 23:30 UTC
+        - cron: '00 17 * * *'   # every day at 17:00 UTC
 
     # Allows you to run this workflow manually from the Actions tab
     workflow_dispatch:

--- a/.github/workflows/daily-nbd.yml
+++ b/.github/workflows/daily-nbd.yml
@@ -3,7 +3,7 @@ name: Daily Tests - nbd
 
 on:  # yamllint disable-line rule:truthy
     schedule:
-        - cron: '30 23 * * *'   # every day at 23:30 UTC
+        - cron: '30 17 * * *'   # every day at 17:30 UTC
 
     # Allows you to run this workflow manually from the Actions tab
     workflow_dispatch:

--- a/.github/workflows/daily-network-legacy.yml
+++ b/.github/workflows/daily-network-legacy.yml
@@ -3,7 +3,7 @@ name: Daily Tests - network-legacy
 
 on:  # yamllint disable-line rule:truthy
     schedule:
-        - cron: '30 23 * * *'   # every day at 23:30 UTC
+        - cron: '30 22 * * *'   # every day at 22:30 UTC
 
     # Allows you to run this workflow manually from the Actions tab
     workflow_dispatch:

--- a/.github/workflows/daily-network.yml
+++ b/.github/workflows/daily-network.yml
@@ -3,7 +3,7 @@ name: Daily Tests - network
 
 on:  # yamllint disable-line rule:truthy
     schedule:
-        - cron: '30 23 * * *'   # every day at 23:30 UTC
+        - cron: '30 21 * * *'   # every day at 21:30 UTC
 
     # Allows you to run this workflow manually from the Actions tab
     workflow_dispatch:

--- a/.github/workflows/daily-omitsystemd.yml
+++ b/.github/workflows/daily-omitsystemd.yml
@@ -3,7 +3,7 @@ name: Daily Tests - omitsystemd
 
 on:  # yamllint disable-line rule:truthy
     schedule:
-        - cron: '30 23 * * *'   # every day at 23:30 UTC
+        - cron: '00 18 * * *'   # every day at 18:00 UTC
 
     # Allows you to run this workflow manually from the Actions tab
     workflow_dispatch:

--- a/.github/workflows/daily-systemd-networkd.yml
+++ b/.github/workflows/daily-systemd-networkd.yml
@@ -3,7 +3,7 @@ name: Daily Tests - systemd-networkd
 
 on:  # yamllint disable-line rule:truthy
     schedule:
-        - cron: '30 23 * * *'   # every day at 23:30 UTC
+        - cron: '00 20 * * *'   # every day at 20:00 UTC
 
     # Allows you to run this workflow manually from the Actions tab
     workflow_dispatch:

--- a/.github/workflows/daily-systemd.yml
+++ b/.github/workflows/daily-systemd.yml
@@ -3,7 +3,7 @@ name: Daily Tests - systemd
 
 on:  # yamllint disable-line rule:truthy
     schedule:
-        - cron: '30 23 * * *'   # every day at 23:30 UTC
+        - cron: '30 20 * * *'   # every day at 20:30 UTC
 
     # Allows you to run this workflow manually from the Actions tab
     workflow_dispatch:

--- a/.github/workflows/daily-zfs.yml
+++ b/.github/workflows/daily-zfs.yml
@@ -3,7 +3,7 @@ name: Daily Tests - zfs
 
 on:  # yamllint disable-line rule:truthy
     schedule:
-        - cron: '30 23 * * *'   # every day at 23:30 UTC
+        - cron: '00 19 * * *'   # every day at 19:00 UTC
 
     # Allows you to run this workflow manually from the Actions tab
     workflow_dispatch:


### PR DESCRIPTION
I noticed that running several GitHub Actions at the same time increases the chances of flakiness.

Spread out the daily jobs to reduce peak load and decrease the chances of jobs overlapping.

<!-- This pull request changes... -->

<!-- Fixes: https://github.com/dracut-ng/dracut-ng/issues/<number> -->

### Checklist
- [ ] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it
