### PR TITLE
fix(dmsquash-live-autooverlay): fix GPT on disk of dd'd .iso file

### DIFF
--- a/modules.d/70dmsquash-live-autooverlay/create-overlay.sh
+++ b/modules.d/70dmsquash-live-autooverlay/create-overlay.sh
@@ -56,7 +56,7 @@ gatherData() {
     blockDevice="/dev/${fullDriveSysfsPath##*/}"
     currentPartitionCount=$(grep --count -E "${blockDevice#/dev/}[0-9]+" /proc/partitions)
 
-    freeSpaceStart=$(parted --script "${blockDevice}" unit % print free \
+    freeSpaceStart=$(parted --script "${blockDevice}" --fix unit % print free \
         | awk -v "x=${currentPartitionCount}" '$1 == x {getline; print $1}')
     if [ -z "$freeSpaceStart" ]; then
         info "Skipping overlay creation: there is no free space after the last partition"


### PR DESCRIPTION
Use parted option --fix to automatically answer 'fix' to exceptions in parted script mode on disks larger than a dd copied .iso file.

This fixes the failure when creating a new partition extending into the 'unused' free space.

Background:
Running this script: parted /dev/sdc -s -m unit B print free on a USB storage device loaded by the dd command with the Fedora-Workstation-Live-x86_64-41-1.4.iso image, yields the following:

Warning: Not all of the space available to /dev/sdc appears to be used, you can fix the GPT to use all of the space (an extra 245825418 blocks) or continue with the current setting?
BYT;
/dev/sdc:128320801792B:scsi:512:512:gpt:Samsung Flash Drive:; 1:32768B:2444607487B:2444574720B::ISO9660:hidden, msftdata; 2:2444607488B:2457847807B:13240320B:fat16:Appended2:boot, esp; 3:2457847808B:2458155007B:307200B::Gap1:hidden, msftdata; 1:2458155008B:128320769535B:125862614528B:free;

CC @FGrose 

<!-- This pull request changes... -->

<!-- Fixes: https://github.com/dracut-ng/dracut-ng/issues/<number> -->

### Checklist
- [ ] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it
