### PR TITLE
feat(systemd-sysusers-service): dracut module to include systemd-sysusers service

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -548,6 +548,10 @@ systemd-sysusers:
     - changed-files:
           - any-glob-to-any-file: 'modules.d/[0-9][0-9]systemd-sysusers/*'
 
+systemd-sysusers-service:
+    - changed-files:
+          - any-glob-to-any-file: 'modules.d/[0-9][0-9]systemd-sysusers-service/*'
+
 systemd-timedated:
     - changed-files:
           - any-glob-to-any-file: 'modules.d/[0-9][0-9]systemd-timedated/*'

--- a/doc_site/modules/ROOT/pages/modules/systemd.adoc
+++ b/doc_site/modules/ROOT/pages/modules/systemd.adoc
@@ -119,8 +119,11 @@ These modules would require including a version of systemd into initramfs.
 | systemd-sysext
 | https://www.freedesktop.org/software/systemd/man/systemd-sysext.html[systemd-sysext]
 
-| systemd-sysusers
+| systemd-sysusers initrd build-time
 | https://www.freedesktop.org/software/systemd/man/systemd-sysusers.html[systemd-sysusers]
+
+| systemd-sysusers-service initrd boot-time
+| https://www.freedesktop.org/software/systemd/man/latest/systemd-sysusers.html[systemd-sysusers-service]
 
 | systemd-timedated
 | https://www.freedesktop.org/software/systemd/man/systemd-timedated.html[systemd-timedated]

--- a/modules.d/11systemd-sysusers-service/module-setup.sh
+++ b/modules.d/11systemd-sysusers-service/module-setup.sh
@@ -1,0 +1,31 @@
+#!/bin/bash
+# This file is part of dracut.
+# SPDX-License-Identifier: GPL-2.0-or-later
+
+# Prerequisite check(s) for module.
+check() {
+    # If the binary(s) requirements are not fulfilled the module can't be installed.
+    require_binaries systemd-sysusers || return 1
+
+    # Return 255 to only include the module, if another module requires it.
+    return 255
+}
+
+# Install the required file(s) and directories for the module in the initramfs.
+install() {
+    inst_simple "$moddir/sysusers-dracut.conf" "$systemdsystemunitdir/systemd-sysusers.service.d/sysusers-dracut.conf"
+
+    inst_sysusers basic.conf
+
+    inst_multiple -o \
+        "$systemdsystemunitdir"/systemd-sysusers.service \
+        "$systemdsystemunitdir"/sysinit.target.wants/systemd-sysusers.service \
+        systemd-sysusers
+
+    # Install the hosts local user configurations if enabled.
+    if [[ $hostonly ]]; then
+        inst_multiple -H -o \
+            "$systemdsystemconfdir"/systemd-sysusers.service \
+            "$systemdsystemconfdir/systemd-sysusers.service.d/*.conf"
+    fi
+}

--- a/modules.d/11systemd-sysusers-service/sysusers-dracut.conf
+++ b/modules.d/11systemd-sysusers-service/sysusers-dracut.conf
@@ -1,0 +1,2 @@
+[Unit]
+ConditionNeedsUpdate=

--- a/test/TEST-41-FULL-SYSTEMD/test.sh
+++ b/test/TEST-41-FULL-SYSTEMD/test.sh
@@ -57,7 +57,7 @@ test_setup() {
     trap "$(shopt -p globstar)" RETURN
     shopt -q -s globstar
 
-    local dracut_modules="resume systemd-udevd systemd-journald systemd-tmpfiles systemd-cryptsetup systemd-emergency systemd-ac-power systemd-coredump systemd-creds systemd-integritysetup systemd-ldconfig systemd-pstore systemd-repart systemd-sysext systemd-veritysetup systemd-hostnamed systemd-timedated"
+    local dracut_modules="resume systemd-udevd systemd-journald systemd-tmpfiles systemd-cryptsetup systemd-emergency systemd-ac-power systemd-coredump systemd-creds systemd-integritysetup systemd-ldconfig systemd-pstore systemd-repart systemd-sysext systemd-sysusers-service systemd-veritysetup systemd-hostnamed systemd-timedated"
 
     if [ -f /usr/lib/systemd/systemd-networkd ]; then
         dracut_modules="$dracut_modules systemd-network-management"


### PR DESCRIPTION
This new dracut module allows to run systemd-sysusers as part of the initrd boot process.

Including this module is the preferred way for openSUSE.

<!-- This pull request changes... -->

<!-- Fixes: https://github.com/dracut-ng/dracut-ng/issues/<number> -->

### Checklist
- [ ] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it
