### PR TITLE
man: document hookdir

### DIFF
--- a/man/dracut.modules.7.adoc
+++ b/man/dracut.modules.7.adoc
@@ -182,6 +182,7 @@ Module should only read (and not write) these variables.
  * `$hostonly_mode` (could be an empty string)
  * `$hostonly_cmdline` (not an empty string)
  * `$moddir` (not an empty string)
+ * `$hookdir` (not an empty string)
 
 First we create a check() function, which just exits with 0 indicating that this
 module should be included by default.


### PR DESCRIPTION
hookdir variable is the recommended way to refer to the path of the directory used for dracut hooks during boot.

This variable is part of the API for 3rd party dracut modules.

Follow-up to 04d5e29 .

CC @vittyvk 

<!-- This pull request changes... -->

<!-- Fixes: https://github.com/dracut-ng/dracut-ng/issues/<number> -->

### Checklist
- [ ] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it
