### PR TITLE
fix(functions): prevent find_binary from dropping last PATH element

### DIFF
--- a/dracut-functions.sh
+++ b/dracut-functions.sh
@@ -94,7 +94,7 @@ find_binary() {
             printf "%s\n" "${_path}"
             return 0
         fi
-    done <<< "$PATH"
+    done <<< "${PATH}:"
 
     [[ -n ${dracutsysrootdir-} ]] && return 1
     type -P "${1##*/}"


### PR DESCRIPTION
When `read` encounters EOF before the delimiter, it returns a non-zero exit status, causing the while loop to terminate immediately. As a result, if the PATH string doesn't end with a colon, the very last directory in PATH is ignored by find_binary().

This caused regressions on split-usr architectures where critical binaries reside exclusively in /bin, and /bin happens to be appended at the very end of the PATH by dracut.sh.

Appending a virtual colon to the Here-String ensures the loop processes all directories correctly.

Fixes : https://github.com/dracut-ng/dracut-ng/issues/1467