### PR TITLE
fix(dmsquash-live): correct det_img_fs implementation

### DIFF
--- a/modules.d/70dmsquash-live/dmsquash-live-root.sh
+++ b/modules.d/70dmsquash-live/dmsquash-live-root.sh
@@ -99,7 +99,7 @@ det_img_fs() {
     # avoid blkid options to maintain compatibility with busybox
     devicetype=$(blkid "$1")
     fstype="${devicetype#*TYPE=\"}"
-    echo "${fstype=%%\"*}"
+    echo "${fstype%%\"*}"
 }
 
 CMDLINE=$(getcmdline)


### PR DESCRIPTION
The `=` is being treated as an assignment operator, not part of a suffix-strip pattern, so the trimming never happens.

Fix it by separate them.

Follow-up for 7c0298a

<!-- This pull request changes... -->

<!-- Fixes: https://github.com/dracut-ng/dracut-ng/issues/<number> -->

### Checklist
- [ ] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it
