### PR TITLE
ci(debian): drop --quiet from apt-get calls

### DIFF
--- a/test/container/Dockerfile-debian
+++ b/test/container/Dockerfile-debian
@@ -26,8 +26,8 @@ RUN case $(dpkg --print-architecture) in \
     if [ "$DISTRIBUTION" = "ubuntu:rolling" ]; then \
         coreutils="coreutils-from-gnu coreutils-from-uutils- --allow-remove-essential"; \
     fi; \
-    apt-get update -y -qq && DEBIAN_FRONTEND=noninteractive apt-get upgrade -y -qq && \
-    DEBIAN_FRONTEND=noninteractive apt-get install -y -qq --no-install-recommends -o Dpkg::Use-Pty=0 \
+    apt-get update && DEBIAN_FRONTEND=noninteractive apt-get upgrade -y && \
+    DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends -o Dpkg::Use-Pty=0 \
     $arch_pkgs \
     $cpio \
     $coreutils \


### PR DESCRIPTION
Make the Debian/Ubuntu container build logs more verbose and easier to debug by dropping the `--quiet` flag.

<!-- This pull request changes... -->

<!-- Fixes: https://github.com/dracut-ng/dracut-ng/issues/<number> -->

### Checklist
- [ ] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it
