### PR TITLE
ci: run nbd test on debian:sid again

### DIFF
--- a/.github/workflows/daily-nbd.yml
+++ b/.github/workflows/daily-nbd.yml
@@ -31,6 +31,7 @@ jobs:
                 container:
                     - arch:latest
                     - debian:latest
+                    - debian:sid
                     - fedora:latest
                     - opensuse:latest
                     - ubuntu:devel


### PR DESCRIPTION
The nbd 1:3.27.1-1 Debian package broke the nbd tests. nbd 1:3.27.1-2 fixed that regression.

So run the nbd test on `debian:sid` again.

Fixes: https://github.com/dracut-ng/dracut-ng/issues/2381

<!-- This pull request changes... -->

<!-- Fixes: https://github.com/dracut-ng/dracut-ng/issues/<number> -->

### Checklist
- [ ] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it
