### PR TITLE
test(FULL-SYSTEMD): make systemd-timesyncd optional

### DIFF
--- a/test/TEST-41-FULL-SYSTEMD/test.sh
+++ b/test/TEST-41-FULL-SYSTEMD/test.sh
@@ -60,7 +60,11 @@ test_setup() {
     local dracut_modules="resume systemd-udevd systemd-journald systemd-tmpfiles systemd-cryptsetup systemd-emergency systemd-ac-power systemd-coredump systemd-creds systemd-integritysetup systemd-ldconfig systemd-pstore systemd-repart systemd-sysext systemd-sysusers-service systemd-veritysetup systemd-hostnamed systemd-timedated"
 
     if [ -f /usr/lib/systemd/systemd-networkd ]; then
-        dracut_modules="$dracut_modules systemd-network-management"
+        dracut_modules="$dracut_modules systemd-networkd systemd-resolved"
+    fi
+
+    if [ -f /usr/lib/systemd/systemd-timesyncd ]; then
+        dracut_modules="$dracut_modules systemd-timesyncd"
     fi
 
     if [ -f /usr/lib/systemd/systemd-battery-check ]; then


### PR DESCRIPTION
Make it optional for this test to include systemd-timesyncd in the initramfs for the purpose of this test.

The motivation for this PR is to allow the CI to support other alternative NTP solution.

<!-- This pull request changes... -->

<!-- Fixes: https://github.com/dracut-ng/dracut-ng/issues/<number> -->

### Checklist
- [ ] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it
