### PR TITLE
test: exit after create-root.sh has been run

### DIFF
--- a/test/TEST-11-USR-MOUNT/create-root.sh
+++ b/test/TEST-11-USR-MOUNT/create-root.sh
@@ -17,3 +17,4 @@ btrfs subvolume snapshot -r /root /root/snapshot-root
 umount /root
 echo "dracut-root-block-created" | dd oflag=direct of=/dev/disk/by-id/scsi-0QEMU_QEMU_HARDDISK_marker status=none
 sync
+exit 0

--- a/test/TEST-20-STORAGE/create-root.sh
+++ b/test/TEST-20-STORAGE/create-root.sh
@@ -87,3 +87,4 @@ fi
 } | dd oflag=direct of=/dev/disk/by-id/scsi-0QEMU_QEMU_HARDDISK_marker status=none
 
 sync
+exit 0

--- a/test/TEST-26-ENC-RAID-LVM/create-root.sh
+++ b/test/TEST-26-ENC-RAID-LVM/create-root.sh
@@ -34,3 +34,4 @@ cryptsetup luksClose /dev/mapper/dracut_disk2
     done
 } | dd oflag=direct of=/dev/disk/by-id/scsi-0QEMU_QEMU_HARDDISK_marker status=none
 sync
+exit 0

--- a/test/TEST-41-FULL-SYSTEMD/create-root.sh
+++ b/test/TEST-41-FULL-SYSTEMD/create-root.sh
@@ -39,3 +39,4 @@ eval "$(udevadm info --query=property --name=/dev/disk/by-id/scsi-0QEMU_QEMU_HAR
     echo "ID_FS_UUID=$ID_FS_UUID"
 } | dd oflag=direct of=/dev/disk/by-id/scsi-0QEMU_QEMU_HARDDISK_marker status=none
 sync
+exit 0

--- a/test/TEST-70-ISCSI/create-client-root.sh
+++ b/test/TEST-70-ISCSI/create-client-root.sh
@@ -18,3 +18,4 @@ mdadm -W /dev/md0 || :
 mdadm --stop /dev/md0
 echo "dracut-root-block-created" | dd oflag=direct of=/dev/disk/by-id/scsi-0QEMU_QEMU_HARDDISK_marker status=none
 sync
+exit 0

--- a/test/TEST-71-ISCSI-MULTI/create-client-root.sh
+++ b/test/TEST-71-ISCSI-MULTI/create-client-root.sh
@@ -18,3 +18,4 @@ mdadm -W /dev/md0 || :
 mdadm --stop /dev/md0
 echo "dracut-root-block-created" | dd oflag=direct of=/dev/disk/by-id/scsi-0QEMU_QEMU_HARDDISK_marker status=none
 sync
+exit 0

--- a/test/TEST-72-NBD/create-encrypted-root.sh
+++ b/test/TEST-72-NBD/create-encrypted-root.sh
@@ -29,3 +29,4 @@ eval "$(udevadm info --query=property --name=/dev/disk/by-id/scsi-0QEMU_QEMU_HAR
     echo "ID_FS_UUID=$ID_FS_UUID"
 } | dd oflag=direct of=/dev/disk/by-id/scsi-0QEMU_QEMU_HARDDISK_marker status=none
 sync
+exit 0


### PR DESCRIPTION
The `create-root.sh` scripts are installed as initqueue hook and soured by it. So just having an exit hook is not enough. The script needs to exit explicitly to shutdown the boot.

Fixes: 39e4b0a37bb5 ("test: drop poweroff call where poweroff is called by EXIT trap")

<!-- This pull request changes... -->

<!-- Fixes: https://github.com/dracut-ng/dracut-ng/issues/<number> -->

### Checklist
- [ ] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it
