### PR TITLE
ci(debian): drop GNU coreutils workaround for Ubuntu 25.10

### DIFF
--- a/test/container/Dockerfile-debian
+++ b/test/container/Dockerfile-debian
@@ -17,15 +17,11 @@ ARG DISTRIBUTION
 
 # Install dracut as a linux-initramfs-tool provider so that the default initramfs-tool package does not get installed
 # Install 3cpio where available
-# use GNU coreutils on Ubuntu 25.10 instead of uutil's coreutils until https://github.com/uutils/coreutils/issues/9057 and https://launchpad.net/bugs/2129037 are fixed
 RUN case $(dpkg --print-architecture) in \
         amd64) arch_pkgs="qemu-system-x86" ;; \
         arm64) arch_pkgs="qemu-efi-aarch64 qemu-system-arm" ;; \
     esac; \
     if [ "$DISTRIBUTION" != "debian:latest" ]; then cpio=3cpio; else cpio=cpio; fi; \
-    if [ "$DISTRIBUTION" = "ubuntu:rolling" ]; then \
-        coreutils="coreutils-from-gnu coreutils-from-uutils- --allow-remove-essential"; \
-    fi; \
     apt-get update && DEBIAN_FRONTEND=noninteractive apt-get upgrade -y && \
     DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends -o Dpkg::Use-Pty=0 \
     $arch_pkgs \


### PR DESCRIPTION
The `ubuntu:rolling` points to Ubuntu 26.04 now. So the GNU coreutils workaround for Ubuntu 25.10 can be removed.

<!-- This pull request changes... -->

<!-- Fixes: https://github.com/dracut-ng/dracut-ng/issues/<number> -->

### Checklist
- [ ] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it
