### PR TITLE
test(SYSROOT): properly fail test in case of password mismatch

### DIFF
--- a/test/TEST-13-SYSROOT/test.sh
+++ b/test/TEST-13-SYSROOT/test.sh
@@ -39,7 +39,7 @@ test_setup() {
 
         if [ "$root_password" != "$initramfs_root_password" ]; then
             echo "The password for root does not match, failing the test."
-            rm "$TESTDIR"/initramfs.testing
+            return 1
         fi
     fi
 }


### PR DESCRIPTION
In case the password mismatches in the sysroot test, the test should fail. So return with code 1 instead of removing `initramfs.testing` (which will cause the test to fail later). This eases debugging.

<!-- This pull request changes... -->

<!-- Fixes: https://github.com/dracut-ng/dracut/issues/<number> -->

### Checklist
- [x] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it
