### PR TITLE
refactor(crypt): use function in crypt-cleanup.sh

### DIFF
--- a/modules.d/70crypt/crypt-cleanup.sh
+++ b/modules.d/70crypt/crypt-cleanup.sh
@@ -3,7 +3,7 @@
 # close everything which is not busy
 rm -f -- /etc/udev/rules.d/70-luks.rules > /dev/null 2>&1
 
-if ! getarg rd.luks.uuid > /dev/null 2>&1 && getargbool 1 rd.luks > /dev/null 2>&1; then
+close_luks() {
     while :; do
         local do_break="y"
         for i in /dev/mapper/luks-*; do
@@ -11,4 +11,8 @@ if ! getarg rd.luks.uuid > /dev/null 2>&1 && getargbool 1 rd.luks > /dev/null 2>
         done
         [ "$do_break" = "y" ] && break
     done
+}
+
+if ! getarg rd.luks.uuid > /dev/null 2>&1 && getargbool 1 rd.luks > /dev/null 2>&1; then
+    close_luks
 fi


### PR DESCRIPTION
shellcheck will complain about crypt-cleanup.sh when checking for busybox:

```
In modules.d/70crypt/crypt-cleanup.sh line 8:
        local do_break="y"
        ^---^ SC2168 (error): 'local' is only valid in functions.
```

<!-- This pull request changes... -->

<!-- Fixes: https://github.com/dracut-ng/dracut/issues/<number> -->

### Checklist
- [ ] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it
