### PR TITLE
fix: remove basename calls

### DIFF
--- a/dracut-functions.sh
+++ b/dracut-functions.sh
@@ -651,7 +651,7 @@ get_blockdev_drv_through_sys() {
     while :; do
         if [[ -L "$_path"/driver/module ]]; then
             _mod=$(realpath "$_path"/driver/module)
-            _mod=$(basename "$_mod")
+            _mod="${_mod##*/}"
             _block_mods="$_block_mods $_mod"
         fi
         _path="${_path%/*}"
@@ -972,8 +972,8 @@ block_is_fcoe() {
     until [[ -d "$_dir/sys" ]]; do
         _dir="$_dir/.."
         if [[ -d "$_dir/subsystem" ]]; then
-            subsystem=$(basename "$(readlink "$_dir"/subsystem)")
-            [[ $subsystem == "fcoe" ]] && return 0
+            subsystem=$(readlink "$_dir"/subsystem)
+            [[ ${subsystem##*/} == "fcoe" ]] && return 0
         fi
     done
     return 1

--- a/modules.d/45drm/module-setup.sh
+++ b/modules.d/45drm/module-setup.sh
@@ -46,7 +46,7 @@ installkernel() {
         for i in /sys/class/drm/privacy_screen-*/device/driver/module; do
             [[ -L $i ]] || continue
             modlink=$(readlink "$i")
-            modname=$(basename "$modlink")
+            modname="${modlink##*/}"
             hostonly=$(optional_hostonly) instmods "$modname"
         done
     else

--- a/modules.d/45simpledrm/module-setup.sh
+++ b/modules.d/45simpledrm/module-setup.sh
@@ -17,7 +17,7 @@ installkernel() {
         for i in /sys/class/drm/privacy_screen-*/device/driver/module; do
             [[ -L $i ]] || continue
             modlink=$(readlink "$i")
-            modname=$(basename "$modlink")
+            modname="${modlink##*/}"
             hostonly='' instmods "$modname"
         done
     else

--- a/modules.d/45url-lib/url-lib.sh
+++ b/modules.d/45url-lib/url-lib.sh
@@ -160,7 +160,7 @@ nfs_fetch_url() {
         mntdir="$(mkuniqdir /run nfs_mnt)"
         mount_nfs "$nfs:$server:$filepath${options:+:$options}" "$mntdir"
         # lazy unmount during pre-pivot hook
-        inst_hook --hook pre-pivot --name 99url-lib-umount-nfs-"$(basename "$mntdir")" umount -l -- "$mntdir"
+        inst_hook --hook pre-pivot --name 99url-lib-umount-nfs-"${mntdir##*/}" umount -l -- "$mntdir"
     fi
 
     if [ -z "$outloc" ]; then

--- a/modules.d/71systemd-cryptsetup/module-setup.sh
+++ b/modules.d/71systemd-cryptsetup/module-setup.sh
@@ -121,7 +121,7 @@ install() {
                         "the service unit may encounter a deadlock due to a circular dependency"
                 fi
 
-                socket_unit_basename=$(basename "$socket_unit")
+                socket_unit_basename="${socket_unit##*/}"
                 inst_multiple -H -o \
                     "$systemdsystemunitdir"/sockets.target.wants/"$socket_unit_basename" \
                     "$systemdsystemconfdir"/sockets.target.wants/"$socket_unit_basename"


### PR DESCRIPTION
https://dracut-ng.github.io/dracut/developer/bash.html says that `basename` should not be used.

So replace the usage of `basename` by variable expansion instead.

<!-- This pull request changes... -->

<!-- Fixes: https://github.com/dracut-ng/dracut/issues/<number> -->

### Checklist
- [ ] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it
