### PR TITLE
fix: remove dirname calls

### DIFF
--- a/dracut-functions.sh
+++ b/dracut-functions.sh
@@ -654,7 +654,7 @@ get_blockdev_drv_through_sys() {
             _mod=$(basename "$_mod")
             _block_mods="$_block_mods $_mod"
         fi
-        _path=$(dirname "$_path")
+        _path="${_path%/*}"
         if [[ $_path == '/sys/devices' ]] || [[ $_path == '/' ]]; then
             break
         fi

--- a/dracut.sh
+++ b/dracut.sh
@@ -3601,9 +3601,9 @@ if [[ -d ${dracutsysrootdir-}/run/systemd/system ]]; then
 
     # use fsfreeze only if we're not writing to /
     if [[ "$(stat -c %m -- "$outfile")" != "/" ]] && freeze_ok_for_fstype "$outfile"; then
-        FSFROZEN="$(dirname "$outfile")"
+        FSFROZEN="${outfile%/*}"
         if ! (fsfreeze -f "${FSFROZEN}" 2> /dev/null && fsfreeze -u "${FSFROZEN}" 2> /dev/null); then
-            dwarn "Could not fsfreeze $(dirname "$outfile")"
+            dwarn "Could not fsfreeze ${FSFROZEN}"
         fi
         unset FSFROZEN
     fi


### PR DESCRIPTION
https://dracut-ng.github.io/dracut/developer/bash.html says that `dirname` should not be used.

So replace the usage of `dirname` by variable expansion instead.

<!-- This pull request changes... -->

<!-- Fixes: https://github.com/dracut-ng/dracut/issues/<number> -->

### Checklist
- [ ] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it
