### PR TITLE
perf(dracut-systemd): drop ExecStart from oneshot shutdown service

### DIFF
--- a/modules.d/77dracut-systemd/dracut-shutdown.service
+++ b/modules.d/77dracut-systemd/dracut-shutdown.service
@@ -11,5 +11,4 @@ OnFailure=dracut-shutdown-onfailure.service
 [Service]
 RemainAfterExit=yes
 Type=oneshot
-ExecStart=/bin/true
 ExecStop=/usr/lib/dracut/dracut-initramfs-restore


### PR DESCRIPTION
Systemd oneshot services that set `RemainAfterExit=yes` do not need to specify `ExecStart` in case they define `ExecStop`.

So remove the useless `/bin/true` start command from `dracut-shutdown.service`.

<!-- This pull request changes... -->

<!-- Fixes: https://github.com/dracut-ng/dracut/issues/<number> -->

### Checklist
- [ ] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it
