### PR TITLE
fix(usrmount): filter out subvolid option for btrfs

### DIFF
--- a/modules.d/77usrmount/mount-usr.sh
+++ b/modules.d/77usrmount/mount-usr.sh
@@ -13,6 +13,7 @@ filtersubvol() {
     while [ $# -gt 0 ]; do
         case $1 in
             'subvol='*) : ;;
+            'subvolid='*) : ;;
             *) printf '%s' "${1}," ;;
         esac
         shift


### PR DESCRIPTION
Currently if rootfs mount options contain subvolid, then /usr subvolume will fail to mount with the following error:

BTRFS error (device dm-0): subvol '/usr' does not match subvolid 5

Fix this by filtering out subvolid from rootfs options.

Bug: https://bugs.gentoo.org/961622

<!-- This pull request changes... -->

<!-- Fixes: https://github.com/dracut-ng/dracut/issues/<number> -->

### Checklist
- [x] I have tested it locally
- [x] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it
