### PR TITLE
fix(base): use printf instead of echo for hook variable

### DIFF
--- a/modules.d/80base/dracut-lib.sh
+++ b/modules.d/80base/dracut-lib.sh
@@ -378,14 +378,14 @@ list_hooks() {
     # priority, '/etc/dracut/hooks' comes after and '/usr/lib/dracut/hooks' is the
     # least priviliged location.
     for hook in "/var/lib/dracut/hooks/$dir/"$pattern; do
-        [ -f "$hook" ] && echo "$hook"
+        [ -f "$hook" ] && printf '%s\n' "$hook"
     done
     for hook in "/etc/dracut/hooks/$dir/"$pattern; do
-        [ -f "$hook" ] && [ ! -f "/var/lib/dracut/hooks/$dir/${hook##*/}" ] && echo "$hook"
+        [ -f "$hook" ] && [ ! -f "/var/lib/dracut/hooks/$dir/${hook##*/}" ] && printf '%s\n' "$hook"
     done
     for hook in "/usr/lib/dracut/hooks/$dir/"$pattern; do
         [ -f "$hook" ] && [ ! -f "/var/lib/dracut/hooks/$dir/${hook##*/}" ] \
-            && [ ! -f "/etc/dracut/hooks/$dir/${hook##*/}" ] && echo "$hook"
+            && [ ! -f "/etc/dracut/hooks/$dir/${hook##*/}" ] && printf '%s\n' "$hook"
     done
 }
 


### PR DESCRIPTION
… due to `echo` translation of `\x2f` character

Without this fix, boot was delayed around 5 minutes and a bunch of errors popped-up, like:

```
dracut-initqueue[349]: Warning: /var/lib/dracut/hooks/initqueue/finished/devexists-/dev/disk/by-uuid/734eed01-7ac0-4200-bdb7-2c91aa668d30.sh: ""
```
```
dracut-initqueue[2341]: cat: /var/lib/dracut/hooks/initqueue/finished/devexists-/dev/disk/by-uuid/734eed01-7ac0-4200-bdb7-2c91aa668d30.sh: No such file or directory
```

1.  `parse-root.sh` creates a "devexis ts" hook file to wait for the root device (/dev/disk/by-uuid/...). The / in the device path is escaped to \x2f in the filename via str_replace(), producing a file named devexis ts-\x2fdev\x2fdisk\x2fby-uuid\x2f....sh.

2. list_hooks() finds this file via glob ([ -f "$hook" ] succeeds), but then outputs it with echo "$hook".

3. Dash's echo interprets \x2f as a hex escape for / (0x2f = 47 = /), corrupting the path. The caller (check_finished(), source_hook()) receives a path with literal / instead of \x2f, which doesn't point to a real file.

4. check_finished() can never find the real hook → returns "not finished" → initqueue loops for 3.5 minutes until timeout.

<!-- This pull request changes... -->

<!-- Fixes: https://github.com/dracut-ng/dracut/issues/<number> -->

### Checklist
- [x] I have tested it locally
- [x] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it
