### PR TITLE
test(container): install busybox in distro images

### DIFF
--- a/test/container/Dockerfile-arch
+++ b/test/container/Dockerfile-arch
@@ -9,7 +9,6 @@
 # - network: network-manager, systemd-networkd
 
 # Not installed
-# - busybox (no need, tested elsewhere)
 # - cifs-utils (no need, tested elsewhere)
 # - openssh (no need, tested elsewhere)
 # - rng-tools (does not start, https://github.com/dracut-ng/dracut/pull/290#issuecomment-2138184351)
@@ -28,6 +27,7 @@ RUN pacman --noconfirm -Syu \
     asciidoctor \
     bluez \
     btrfs-progs \
+    busybox \
     cargo \
     cpio \
     dhcp \

--- a/test/container/Dockerfile-debian
+++ b/test/container/Dockerfile-debian
@@ -30,6 +30,7 @@ RUN case $(dpkg --print-architecture) in \
     asciidoctor \
     bluez \
     btrfs-progs \
+    busybox \
     ca-certificates \
     cargo \
     console-data \

--- a/test/container/Dockerfile-fedora
+++ b/test/container/Dockerfile-fedora
@@ -48,6 +48,7 @@ RUN dnf -y install --setopt=install_weak_deps=False \
     asciidoctor \
     bash-completion \
     bluez \
+    busybox \
     cargo \
     cifs-utils \
     cryptsetup \

--- a/test/container/Dockerfile-gentoo
+++ b/test/container/Dockerfile-gentoo
@@ -7,7 +7,6 @@
 # - network (OpenRC): networkmanager
 
 # Not installed
-# - busybox (to increase coverage)
 # - dash (to increase coverage)
 # - rng-tools (to increase coverage)
 # - ntfs3g (to keep container small)
@@ -60,6 +59,7 @@ emerge --quiet --deep --autounmask-continue=y --with-bdeps=n --noreplace \
     net-fs/nfs-utils \
     net-misc/dhcp \
     net-wireless/bluez \
+    sys-apps/busybox \
     sys-apps/nvme-cli \
     sys-block/nbd \
     sys-block/open-iscsi \

--- a/test/container/Dockerfile-opensuse
+++ b/test/container/Dockerfile-opensuse
@@ -15,6 +15,7 @@ FROM registry.opensuse.org/opensuse/tumbleweed:latest
 RUN zypper --non-interactive install --no-recommends \
     bash-completion \
     btrfsprogs \
+    busybox \
     cargo \
     cpio \
     cryptsetup \

--- a/test/container/Dockerfile-void
+++ b/test/container/Dockerfile-void
@@ -25,6 +25,7 @@ RUN xbps-install -Syu xbps && xbps-install -yu \
     bash \
     binutils \
     btrfs-progs \
+    busybox \
     cargo \
     clang \
     cpio \


### PR DESCRIPTION
<!-- This pull request changes... -->

<!-- Fixes: https://github.com/dracut-ng/dracut/issues/<number> -->

Add the `busybox` package to the arch, fedora, opensuse, void, debian, and gentoo CI container images. This PR is needed for #2451 

### Checklist
- [x] I have tested it locally
- [x] I have reviewed and updated any documentation if relevant
- [x] I am providing new code and test(s) for it
