### PR TITLE
fix(bluetooth): skip warning when module is explicitly requested

### DIFF
--- a/modules.d/70bluetooth/module-setup.sh
+++ b/modules.d/70bluetooth/module-setup.sh
@@ -14,6 +14,7 @@ check() {
         #  * Keyboard/pointing (0xC0)
         # and if Appearance is set to the value defined for keyboard (0x03C1)
         [ -d "/sys/class/bluetooth" ] && grep -qsiE -e 'Class=0x[0-9a-f]{3}5[4c]0' -e 'Appearance=0x03c1' /var/lib/bluetooth/*/*/info \
+            && [[ " $dracutmodules $add_dracutmodules $force_add_dracutmodules " != *\ bluetooth\ * ]] \
             && dwarn "If you need to use bluetooth, please include it explicitly."
     fi
 


### PR DESCRIPTION
When a bluetooth keyboard is paired and the bluetooth module is
explicitly added via `add_dracutmodules` or `force_add_dracutmodules`,
the warning

"If you need to use bluetooth, please include it explicitly."

was still printed during initramfs generation.

This happens because `check()` is called with `forced=0` for
`add_dracutmodules`, preserving hostonly and allowing the warning block
to execute even when the module was explicitly requested.

Check `dracutmodules`, `add_dracutmodules`, and
`force_add_dracutmodules` before printing the warning, and skip it if
`bluetooth` is already present in any of them.

Fixes: #2253 

### Checklist
- [x] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it
