### PR TITLE
fix(resolved): install libssl

### DIFF
--- a/modules.d/11systemd-resolved/module-setup.sh
+++ b/modules.d/11systemd-resolved/module-setup.sh
@@ -33,6 +33,8 @@ install() {
 
     inst_sysusers systemd-resolve.conf
 
+    inst_libdir_file "libssl.so*"
+
     inst_multiple -o \
         "$dbussystem"/org.freedesktop.resolve1.conf \
         "$dbussystemservices"/org.freedesktop.resolve1.service \


### PR DESCRIPTION
systemd-resolved from v261 dlopens libssl, so it is not pulled in by dracut, so it fails to start in a dracut initrd:

```
[    2.857336] systemd-resolved[311]: Shared library 'libssl.so.3' is not available: libssl.so.3: cannot open shared object file: No such file or directory
[    2.861594] systemd-resolved[311]: Could not create manager: Operation not supported
[    2.869073] systemd[1]: systemd-resolved.service: Main process exited, code=exited, status=1/FAILURE
```

Pull it in from the module script.

### Checklist
- [x] I have tested it locally
- [x] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it
