### PR TITLE
fix(systemd-*): add new dlopen dependencies to modules lists

### DIFF
--- a/modules.d/11systemd-creds/module-setup.sh
+++ b/modules.d/11systemd-creds/module-setup.sh
@@ -27,6 +27,11 @@ depends() {
 
 }
 
+# called by dracut
+config() {
+    add_dlopen_features+=" libsystemd-shared-*.so:libcrypto "
+}
+
 # Install the required file(s) and directories for the module in the initramfs.
 install() {
 

--- a/modules.d/11systemd-pcrextend/module-setup.sh
+++ b/modules.d/11systemd-pcrextend/module-setup.sh
@@ -34,6 +34,11 @@ depends() {
     return 0
 }
 
+# called by dracut
+config() {
+    add_dlopen_features+=" libsystemd-shared-*.so:libcrypto "
+}
+
 # Install the required file(s) and directories for the module in the initramfs.
 install() {
     inst_multiple -o \

--- a/modules.d/11systemd-repart/module-setup.sh
+++ b/modules.d/11systemd-repart/module-setup.sh
@@ -13,7 +13,7 @@ check() {
 
 # Config adjustments before installing anything.
 config() {
-    add_dlopen_features+=" libsystemd-shared-*.so:fdisk "
+    add_dlopen_features+=" libsystemd-shared-*.so:fdisk,libcrypto "
 }
 
 # Install the required file(s) for the module in the initramfs.

--- a/modules.d/11systemd-resolved/module-setup.sh
+++ b/modules.d/11systemd-resolved/module-setup.sh
@@ -26,6 +26,11 @@ depends() {
 
 }
 
+# called by dracut
+config() {
+    add_dlopen_features+=" libsystemd-shared-*.so:libcrypto,libssl "
+}
+
 # Install the required file(s) and directories for the module in the initramfs.
 install() {
 

--- a/modules.d/11systemd-veritysetup/module-setup.sh
+++ b/modules.d/11systemd-veritysetup/module-setup.sh
@@ -28,7 +28,7 @@ depends() {
 
 # Config adjustments before installing anything.
 config() {
-    add_dlopen_features+=" libsystemd-shared-*.so:cryptsetup "
+    add_dlopen_features+=" libsystemd-shared-*.so:cryptsetup,libcrypto "
 }
 
 # Install kernel module(s).

--- a/modules.d/45systemd-import/module-setup.sh
+++ b/modules.d/45systemd-import/module-setup.sh
@@ -16,7 +16,7 @@ depends() {
 }
 
 config() {
-    add_dlopen_features+=" libsystemd-shared-*.so:archive,lz4,lzma,zstd "
+    add_dlopen_features+=" libsystemd-shared-*.so:archive,curl,libcrypto,lz4,lzma,zstd "
 }
 
 installkernel() {

--- a/modules.d/71systemd-cryptsetup/module-setup.sh
+++ b/modules.d/71systemd-cryptsetup/module-setup.sh
@@ -47,7 +47,7 @@ depends() {
 
 # called by dracut
 config() {
-    add_dlopen_features+=" libsystemd-shared-*.so:cryptsetup "
+    add_dlopen_features+=" libsystemd-shared-*.so:cryptsetup,libcrypto "
 }
 
 # called by dracut


### PR DESCRIPTION
systemd v261 moved more dependencies to dlopen, including libssl which is required by various components, like resolved

```
[    2.857336] systemd-resolved[311]: Shared library 'libssl.so.3' is not available: libssl.so.3: cannot open shared object file: No such file or directory
[    2.861594] systemd-resolved[311]: Could not create manager: Operation not supported
[    2.869073] systemd[1]: systemd-resolved.service: Main process exited, code=exited, status=1/FAILURE
```

### Checklist
- [x] I have tested it locally
- [x] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it
