### PR TITLE
fix(systemd-networkd): get DHCP options values from networkctl

### DIFF
--- a/modules.d/11systemd-networkd/module-setup.sh
+++ b/modules.d/11systemd-networkd/module-setup.sh
@@ -58,7 +58,7 @@ install() {
         "$systemdsystemunitdir"/systemd-networkd-wait-online.service \
         "$systemdsystemunitdir"/systemd-networkd-wait-online@.service \
         "$systemdsystemunitdir"/systemd-network-generator.service \
-        ip sed grep
+        ip sed grep networkctl
 
     inst_simple "$moddir"/99-wait-online-dracut.conf \
         "$systemdsystemunitdir"/systemd-networkd-wait-online.service.d/99-dracut.conf

--- a/modules.d/11systemd-networkd/networkd-run.sh
+++ b/modules.d/11systemd-networkd/networkd-run.sh
@@ -16,6 +16,18 @@ for ifpath in /sys/class/net/*; do
                 | sed -e "s/NEXT_SERVER=/new_next_server='/" \
                     -e "s/ROOT_PATH=/new_root_path='/" \
                     -e "s/$/'/" > "$dhcpopts_file" || :
+        else
+            # Since systemd v261 the DHCP lease is no longer serialized to /run/, use the new networkctl command.
+            lease=$(networkctl --no-pager --no-legend --full dhcp-lease "$ifname" 2> /dev/null) || lease=""
+            if [ -n "$lease" ]; then
+                {
+                    next_server=$(printf '%s\n' "$lease" | sed -n "s/^[[:space:]]*Server Address:[[:space:]]*//p")
+                    [ -n "$next_server" ] && printf "new_next_server='%s'\n" "$next_server"
+                    # option 17 is the DHCP root-path; strip the leading "<code> <name> " columns
+                    root_path=$(printf '%s\n' "$lease" | sed -n "s/^[[:space:]]*17[[:space:]].*[[:space:]]//p")
+                    [ -n "$root_path" ] && printf "new_root_path='%s'\n" "$root_path"
+                } > "$dhcpopts_file" || :
+            fi
         fi
 
         source_hook initqueue/online "$ifname"


### PR DESCRIPTION
The internal lease is no longer saved to the private /run/ directory of networkd since v261, so it cannot be read from there. It was always clearly marked as private anyway.
Use the new 'dhcp-lease' networkctl verb to print it instead.

This fixes the various network boot tests in debci (60-nfs, 70-iscsi, 72-nbd).

### Checklist
- [x] I have tested it locally
- [x] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it
