### PR TITLE
ci: update to systemd v257 and Azure Linux v4

### DIFF
--- a/.github/workflows/container-extra.yml
+++ b/.github/workflows/container-extra.yml
@@ -40,7 +40,7 @@ jobs:
                     - {platform: 'linux/amd64', runner: 'ubuntu-24.04', tag: 'amd'}
                     - {platform: 'linux/arm64', runner: 'ubuntu-24.04-arm', tag: 'arm'}
                 config:
-                    - {dockerfile: 'Dockerfile-azurelinux', tag: 'azurelinux:3.0', registry: 'mcr.microsoft.com'}
+                    - {dockerfile: 'Dockerfile-azurelinux', tag: 'azurelinux:latest', registry: 'mcr.microsoft.com'}
                     - {dockerfile: 'Dockerfile-fedora', tag: 'centos:latest', registry: 'quay.io/centos'}
                     - {dockerfile: 'Dockerfile-debian', tag: 'debian:sid'}
                     - {dockerfile: 'Dockerfile-gentoo', tag: 'gentoo:amd64-openrc', option: 'amd64-openrc'}
@@ -88,7 +88,7 @@ jobs:
         strategy:
             matrix:
                 config:
-                    - {tag: 'azurelinux:3.0', platforms: ['amd', 'arm']}
+                    - {tag: 'azurelinux:latest', platforms: ['amd', 'arm']}
                     - {tag: 'centos:latest', platforms: ['amd', 'arm']}
                     - {tag: 'debian:sid', platforms: ['amd', 'arm']}
                     - {tag: 'gentoo:latest', platforms: ['amd', 'arm']}

--- a/.github/workflows/daily-basic.yml
+++ b/.github/workflows/daily-basic.yml
@@ -82,7 +82,7 @@ jobs:
                 container:
                     - alpine:edge
                     - arch:latest
-                    - azurelinux:3.0
+                    - azurelinux:latest
                     - fedora:latest
                     - centos:latest
                     - gentoo:amd64-openrc

--- a/.github/workflows/daily-systemd.yml
+++ b/.github/workflows/daily-systemd.yml
@@ -30,7 +30,7 @@ jobs:
                     - {runner: 'ubuntu-24.04-arm', tag: 'arm'}
                 container:
                     - arch:latest
-                    - azurelinux:3.0
+                    - azurelinux:latest
                     - debian:latest
                     - debian:sid
                     - fedora:latest
@@ -51,7 +51,7 @@ jobs:
                 exclude:
                     - container: arch:latest
                       architecture: {runner: 'ubuntu-24.04-arm', tag: 'arm'}
-                    - container: azurelinux:3.0
+                    - container: azurelinux:latest
                       architecture: {runner: 'ubuntu-24.04-arm', tag: 'arm'}
                     - container: fedora:latest
                       architecture: {runner: 'ubuntu-24.04-arm', tag: 'arm'}

--- a/.github/workflows/manualtest.yml
+++ b/.github/workflows/manualtest.yml
@@ -14,7 +14,7 @@ on:  # yamllint disable-line rule:truthy
                 options:
                     - "all"
                     - "alpine:edge"
-                    - "azurelinux:3.0"
+                    - "azurelinux:latest"
                     - "centos:latest"
                     - "fedora:latest"
                     - "arch:latest"

--- a/doc_site/modules/ROOT/pages/developer/compatibility.adoc
+++ b/doc_site/modules/ROOT/pages/developer/compatibility.adoc
@@ -36,10 +36,10 @@ Dependencies for the generated initramfs:
 
 [cols="1,1"]
 |===
-|udev/systemd (Azure Linux 3.0) | 255
-|linux-kernel (Azure Linux 3.0) | 6.6
-|bash (Azure Linux 3.0)         | 5.2
-|qemu (Azure Linux 3.0)         | 8.2
+|udev/systemd (Debian 13)       | 257
+|linux-kernel (Debian 13)       | 6.12
+|bash (Debian 13)               | 5.2
+|qemu (Debian 13)               | 10.0
 |busybox (Alpine)               | 1.37
 |eudev (Alpine/Void)            | 3.2.14
 |===

--- a/test/container/Dockerfile-azurelinux
+++ b/test/container/Dockerfile-azurelinux
@@ -1,16 +1,17 @@
-FROM mcr.microsoft.com/azurelinux/base/core:3.0
+FROM mcr.microsoft.com/azurelinux-beta/base/core:4.0
 
 # export
 ARG TARGETARCH
 
 RUN \
 if [ "${TARGETARCH}" == "amd64" ]; then \
-    tdnf -y install --setopt=install_weak_deps=False \
+    dnf -y install --setopt=install_weak_deps=False \
         systemd-boot \
         systemd-ukify \
 ; fi
 
-RUN tdnf -y install --setopt=install_weak_deps=False \
+RUN dnf -y install --setopt=install_weak_deps=False \
+    asciidoc \
     bash-completion \
     bluez \
     btrfs-progs \
@@ -36,7 +37,6 @@ RUN tdnf -y install --setopt=install_weak_deps=False \
     lvm2 \
     make \
     mdadm \
-    nbd \
     ndctl \
     nfs-utils \
     nvme-cli \
@@ -45,7 +45,6 @@ RUN tdnf -y install --setopt=install_weak_deps=False \
     qemu \
     qemu-kvm \
     rng-tools \
-    rubygem-asciidoctor \
     rsyslog \
     squashfs-tools \
     swtpm \
@@ -56,7 +55,7 @@ RUN tdnf -y install --setopt=install_weak_deps=False \
     tpm2-tools \
     xfsprogs \
     xorriso \
-    && tdnf clean all
+    && dnf -y update && dnf clean all
 
 # disable systemd-portabled - it is optional and allows to pass the CI
 # disable multipath dracut module - it interferes with the CI on azurelinux


### PR DESCRIPTION
Azure Linux v3.0 is quite dated and a door has opened to upgrade to systemd v257 and Azure Linux v4.

<!-- This pull request changes... -->

<!-- Fixes: https://github.com/dracut-ng/dracut/issues/<number> -->

### Checklist
- [ ] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it
