### PR TITLE
fix(network-legacy): sanitize DHCP values in dhclient-script.sh

### DIFF
--- a/modules.d/35network-legacy/dhclient-script.sh
+++ b/modules.d/35network-legacy/dhclient-script.sh
@@ -14,11 +14,11 @@ setup_interface() {
     mask=$new_subnet_mask
     bcast=$new_broadcast_address
     gw=${new_routers%%,*}
-    domain=$new_domain_name
     # get rid of control chars
+    domain=$(printf -- "%s" "$new_domain_name" | tr -d '[:cntrl:]')
     search=$(printf -- "%s" "$new_domain_search" | tr -d '[:cntrl:]')
     namesrv=$new_domain_name_servers
-    hostname=$new_host_name
+    hostname=$(printf '%s' "$new_host_name" | tr -d -c 'a-zA-Z0-9.-')
     [ -n "$new_dhcp_lease_time" ] && lease_time=$new_dhcp_lease_time
     [ -n "$new_max_life" ] && lease_time=$new_max_life
     preferred_lft=$lease_time
@@ -46,20 +46,32 @@ setup_interface() {
         ${preferred_lft:+preferred_lft ${preferred_lft}}
 
     if [ -n "$gw" ]; then
-        if [ "$mask" = "255.255.255.255" ]; then
-            # point-to-point connection => set explicit route to gateway
-            echo ip route add "$gw" dev "$netif" > /tmp/net."$netif".gw
-        fi
+        gw_check=0
+        for g in $gw; do
+            case "$g" in
+                *[!0-9.]*)
+                    gw_check=1
+                    break
+                    ;;
+            esac
+        done
 
-        echo "$gw" | {
-            IFS=' ' read -r main_gw other_gw
-            echo ip route replace default via "$main_gw" dev "$netif" >> /tmp/net."$netif".gw
-            if [ -n "$other_gw" ]; then
-                for g in $other_gw; do
-                    echo ip route add default via "$g" dev "$netif" >> /tmp/net."$netif".gw
-                done
+        if [ $gw_check -eq 0 ]; then
+            if [ "$mask" = "255.255.255.255" ]; then
+                # point-to-point connection => set explicit route to gateway
+                echo ip route add "$gw" dev "$netif" > /tmp/net."$netif".gw
             fi
-        }
+
+            echo "$gw" | {
+                IFS=' ' read -r main_gw other_gw
+                echo ip route replace default via "$main_gw" dev "$netif" >> /tmp/net."$netif".gw
+                if [ -n "$other_gw" ]; then
+                    for g in $other_gw; do
+                        echo ip route add default via "$g" dev "$netif" >> /tmp/net."$netif".gw
+                    done
+                fi
+            }
+        fi
     fi
 
     if getargbool 1 rd.peerdns; then
@@ -72,15 +84,15 @@ setup_interface() {
     fi
     # Note: hostname can be fqdn OR short hostname, so chop off any
     # trailing domain name and explicitly add any domain if set.
-    [ -n "$hostname" ] && echo "echo ${hostname%."$domain"}${domain:+.$domain} > /proc/sys/kernel/hostname" > /tmp/net."$netif".hostname
+    [ -n "$hostname" ] && echo "echo '${hostname%."$domain"}${domain:+.$domain}' > /proc/sys/kernel/hostname" > /tmp/net."$netif".hostname
 }
 
 setup_interface6() {
-    domain=$new_domain_name
     # get rid of control chars
+    domain=$(printf -- "%s" "$new_domain_name" | tr -d '[:cntrl:]')
     search=$(printf -- "%s" "$new_dhcp6_domain_search" | tr -d '[:cntrl:]')
     namesrv=$new_dhcp6_name_servers
-    hostname=$new_host_name
+    hostname=$(printf '%s' "$new_host_name" | tr -d -c 'a-zA-Z0-9.-')
     [ -n "$new_dhcp_lease_time" ] && lease_time=$new_dhcp_lease_time
     [ -n "$new_max_life" ] && lease_time=$new_max_life
     preferred_lft=$lease_time
@@ -105,7 +117,7 @@ setup_interface6() {
 
     # Note: hostname can be fqdn OR short hostname, so chop off any
     # trailing domain name and explicitly add any domain if set.
-    [ -n "$hostname" ] && echo "echo ${hostname%."$domain"}${domain:+.$domain} > /proc/sys/kernel/hostname" > /tmp/net."$netif".hostname
+    [ -n "$hostname" ] && echo "echo '${hostname%."$domain"}${domain:+.$domain}' > /proc/sys/kernel/hostname" > /tmp/net."$netif".hostname
 }
 
 parse_option_121() {
@@ -113,16 +125,18 @@ parse_option_121() {
     # Each route is: <mask_width> <dest_octets...> <gateway_4_octets>
     # mask_width determines how many destination octets follow (0-4)
     #
-    # This version validates arguments before operations to prevent
-    # "integer expression expected" and "shift count out of range" errors.
+    # Validate all arguments are numeric upfront to prevent
+    # shell injection via crafted octets in destination/gateway.
+    for _octet in "$@"; do
+        case "$_octet" in
+            '' | *[!0-9]*) return 0 ;;
+        esac
+    done
 
     while [ $# -ge 5 ]; do
         mask="$1"
 
         # Validate mask is a number between 0-32
-        case "$mask" in
-            '' | *[!0-9]*) return 0 ;;
-        esac
         if [ "$mask" -lt 0 ] 2> /dev/null || [ "$mask" -gt 32 ] 2> /dev/null; then
             return 0
         fi
@@ -150,9 +164,6 @@ parse_option_121() {
         # Check if destination is multicast (224.0.0.0 - 239.255.255.255)
         multicast=0
         if [ $need_dest -ge 1 ]; then
-            case "$1" in
-                '' | *[!0-9]*) return 0 ;;
-            esac
             if [ "$1" -ge 224 ] 2> /dev/null && [ "$1" -lt 240 ] 2> /dev/null; then
                 multicast=1
             fi


### PR DESCRIPTION
A rogue DHCP server can inject shell commands through `hostname`, `domain`, `gateway`, and classless static route values. These values are written to `/tmp` files that `setup_net()` later sources as shell.

- Sanitize hostname to RFC 952 chars (`a-zA-Z0-9.-`)
- Strip control chars from `domain` (like `search` already does)
- Validate gateway IPs contain only digits and dots
- Single-quote interpolated values in generated shell commands
- Validate all `parse_option_121` octets are numeric upfront; the existing inline checks only validated `mask` and the first destination octet, leaving dest octets 2-4 and all four gateway octets unchecked — those flow into shell commands written to the `initqueue/setup_net_"$netif".sh` hook script via `echo`

Fixes: CVE-2026-6893
Co-developed-by: Claude Opus 4.6 <noreply@anthropic.com>

### Checklist
- [ ] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it
