### PR TITLE
test(run-qemu): use efi firmware when testing on loongarch64

### DIFF
--- a/test/run-qemu
+++ b/test/run-qemu
@@ -64,6 +64,13 @@ get_uefi_code() {
         arm | armhf | armv7l)
             paths=("/usr/share/AAVMF/AAVMF32_CODE.fd")
             ;;
+        loong64 | loongarch64)
+            paths=(
+                "/usr/share/qemu-efi-loongarch64/QEMU_EFI.fd"
+                "/usr/share/LA64VMF/QEMU_EFI.fd"
+                "/usr/share/edk2/loongarch64/QEMU_EFI.fd"
+            )
+            ;;
     esac
     for path in "${paths[@]}"; do
         if [[ -s $path ]]; then


### PR DESCRIPTION
When testing on loongarch64, we should use EFI firmware, since the UEFI runtime services and ACPI tables are required by the linux kernel for loongarch64.

<!-- This pull request changes... -->

<!-- Fixes: https://github.com/dracut-ng/dracut/issues/<number> -->

### Checklist
- [X] I have tested it locally
- [X] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it
