### PR TITLE
ci: revert temporary remove Fedora Rawhide CI

### DIFF
--- a/.github/workflows/container-extra.yml
+++ b/.github/workflows/container-extra.yml
@@ -43,6 +43,7 @@ jobs:
                     - {dockerfile: 'Dockerfile-azurelinux', tag: 'azurelinux:3.0', registry: 'mcr.microsoft.com'}
                     - {dockerfile: 'Dockerfile-fedora', tag: 'centos:latest', registry: 'quay.io/centos'}
                     - {dockerfile: 'Dockerfile-debian', tag: 'debian:sid'}
+                    - {dockerfile: 'Dockerfile-fedora', tag: 'fedora:rawhide', registry: 'registry.fedoraproject.org'}
                     - {dockerfile: 'Dockerfile-gentoo', tag: 'gentoo:amd64-openrc', option: 'amd64-openrc'}
                     - {dockerfile: 'Dockerfile-gentoo', tag: 'gentoo:arm64-openrc', option: 'arm64-openrc'}
                     - {dockerfile: 'Dockerfile-gentoo', tag: 'gentoo:latest', option: 'systemd'}
@@ -91,6 +92,7 @@ jobs:
                     - {tag: 'azurelinux:3.0', platforms: ['amd', 'arm']}
                     - {tag: 'centos:latest', platforms: ['amd', 'arm']}
                     - {tag: 'debian:sid', platforms: ['amd', 'arm']}
+                    - {tag: 'fedora:rawhide', platforms: ['amd', 'arm']}
                     - {tag: 'gentoo:latest', platforms: ['amd', 'arm']}
                     - {tag: 'gentoo:amd64-openrc', platforms: ['amd']}
                     - {tag: 'gentoo:arm64-openrc', platforms: ['arm']}

--- a/.github/workflows/daily-basic.yml
+++ b/.github/workflows/daily-basic.yml
@@ -84,6 +84,7 @@ jobs:
                     - arch:latest
                     - azurelinux:3.0
                     - fedora:latest
+                    - fedora:rawhide
                     - centos:latest
                     - gentoo:amd64-openrc
                 test:

--- a/.github/workflows/daily-network.yml
+++ b/.github/workflows/daily-network.yml
@@ -33,6 +33,7 @@ jobs:
                     - debian:latest
                     - debian:sid
                     - fedora:latest
+                    - fedora:rawhide
                     - opensuse:latest
                     - ubuntu:devel
                     - ubuntu:rolling
@@ -43,6 +44,8 @@ jobs:
                     - container: arch:latest
                       architecture: {runner: 'ubuntu-24.04-arm', tag: 'arm'}
                     - container: fedora:latest
+                      architecture: {runner: 'ubuntu-24.04-arm', tag: 'arm'}
+                    - container: fedora:rawhide
                       architecture: {runner: 'ubuntu-24.04-arm', tag: 'arm'}
                     # https://github.com/dracut-ng/dracut/issues/1988
                     - container: debian:sid

--- a/.github/workflows/manualtest.yml
+++ b/.github/workflows/manualtest.yml
@@ -17,6 +17,7 @@ on:  # yamllint disable-line rule:truthy
                     - "azurelinux:3.0"
                     - "centos:latest"
                     - "fedora:latest"
+                    - "fedora:rawhide"
                     - "arch:latest"
                     - "debian:latest"
                     - "debian:sid"


### PR DESCRIPTION
This reverts commit 039f12146821c2279d0537364fbed8cc6e350757.

It seems rawhide is now fixed.

Fixes: https://github.com/dracut-ng/dracut/issues/2277

<!-- This pull request changes... -->

<!-- Fixes: https://github.com/dracut-ng/dracut/issues/<number> -->

### Checklist
- [ ] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it
