### PR TITLE
fix(dbus): restrict After/Requires removal patterns

### DIFF
--- a/modules.d/16dbus-broker/module-setup.sh
+++ b/modules.d/16dbus-broker/module-setup.sh
@@ -55,7 +55,8 @@ install() {
 
     # Remove After/Requires=sysinit.target for initramfs in the dbus socket unit.
     sed -i -e \
-        '/^\(After\|DefaultDependencies\|Requires\)=/d
+        '/^\(After\|Requires\)=.*sysinit\.target/d
+        /^DefaultDependencies=/d
         /^\[Unit\]/aDefaultDependencies=no\nConflicts=shutdown.target\nBefore=shutdown.target sockets.target
         /^\[Socket\]/aRemoveOnStop=yes' \
         "$initdir$systemdsystemunitdir/dbus.socket"

--- a/modules.d/16dbus-daemon/module-setup.sh
+++ b/modules.d/16dbus-daemon/module-setup.sh
@@ -52,13 +52,15 @@ install() {
 
     # Remove After/Requires=sysinit.target and After=basic.target for initramfs in the dbus service unit.
     sed -i -e \
-        '/^\(After\|DefaultDependencies\|Requires\)=/d
+        '/^\(After\|Requires\)=.*sysinit\.target/d
+        /^DefaultDependencies=/d
         /^\[Unit\]/aDefaultDependencies=no\nConflicts=shutdown.target\nBefore=shutdown.target' \
         "$initdir$systemdsystemunitdir/dbus.service"
 
     # Remove After/Requires=sysinit.target for initramfs in the dbus socket unit.
     sed -i -e \
-        '/^\(After\|DefaultDependencies\|Requires\)=/d
+        '/^\(After\|Requires\)=.*sysinit\.target/d
+        /^DefaultDependencies=/d
         /^\[Unit\]/aDefaultDependencies=no\nConflicts=shutdown.target\nBefore=shutdown.target sockets.target
         /^\[Socket\]/aRemoveOnStop=yes' \
         "$initdir$systemdsystemunitdir/dbus.socket"


### PR DESCRIPTION
While the intention for removing all After= and Requires= lines on dbus.service and dbus.socket is to remove the dependency on sysinit.target, this unintentionally removes the Requires=dbus.socket dependency for dbus.service as well, which is present in both upstream dbus and dbus-broker.

Restrict the pattern to only lines mentioning sysinit.target, to better match what Ubuntu has added downstream.

---

To be fully transparent, I'm not completely certain what this changes. I am submitting this because something broke [openRuyi](https://github.com/openRuyi-Project/openRuyi) between dracut 110 and 111.

This fixes or at least works around a problem where NetworkManager.service can fail to start in the openRuyi distribution. The symptom is:

- dbus.service is sometimes not stopped before switching root
- ... which causes units in the (non-initrd) system to not bring up dbus.service, since it is already active.
- Afterwards, dbus.service stops on its own, possibly because the initramfs is gone.
- Then, NetworkManager.service tries to start, but since it BindsTo=dbus.service, and dbus.service has already stopped, NetworkManager.service fails to start.

See journal at https://gist.github.com/dramforever/825a4e3f0f7a2dee29ed9d1e43047075, note in particular:

```
Jun 18 04:41:51 openruyi-d765-801c systemd[1]: NetworkManager.service: Bound to unit dbus.service, but unit isn't active.
Jun 18 04:41:51 openruyi-d765-801c systemd[1]: Dependency failed for Network Manager.
Jun 18 04:41:51 openruyi-d765-801c systemd[1]: NetworkManager.service: Job NetworkManager.service/start failed with result 'dependency'.
```

The cause *appears* to be the changes in #2273, but I have not been able to figure out the exact reason. The reason *seems* to be that having `dbus.service` `Requires=dbus.socket` causes `dbus.service` to be stopped when `dbus.socket` is stopped, and the latter is indeed stopped before switching root. I do not know why `dbus.service` is sometimes not stopped otherwise.

However, I think removing `Requires=dbus.socket` from `dbus.service` is more obviously a mistake, because nobody ever mentioned this being the goal for removing all `Requires=` lines.

<!-- This pull request changes... -->

<!-- Fixes: https://github.com/dracut-ng/dracut/issues/<number> -->

### Checklist
- [X] I have tested it locally
- [X] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it (Not sure how to test, since I haven't been able to properly diagnose this)

I also tried running the GitHub Actions network and nbd tests to make sure nothing regresssed. Interestingly, the opensuse arm test [times out](https://github.com/dramforever/dracut/actions/runs/28491315061/job/84450100979), but the same timeout is [already present on `main`](https://github.com/dramforever/dracut/actions/runs/28492054197/job/84450646557)

