### PR TITLE
fix(virtfs): Move mount hook to pre-mount

### DIFF
--- a/modules.d/74virtfs/module-setup.sh
+++ b/modules.d/74virtfs/module-setup.sh
@@ -24,5 +24,5 @@ installkernel() {
 # called by dracut
 install() {
     inst_hook cmdline 95 "$moddir/parse-virtfs.sh"
-    inst_hook mount 99 "$moddir/mount-virtfs.sh"
+    inst_hook pre-mount 99 "$moddir/mount-virtfs.sh"
 }


### PR DESCRIPTION
Mount hooks are executed after sysroot.mount when systemd is used. However, the systemd generated sysroot.mount from kernel cmdline will always fail when the given root= begins with virtfs:, making the system unable to start.

Moving the mount hook to pre-mount will mount the 9p virtfs directly onto /sysroot and the generated sysroot.mount will be ignored. This practice is similar to what is in virtiofs.

Fixes: #1397

<!-- This pull request changes... -->

<!-- Fixes: https://github.com/dracut-ng/dracut/issues/<number> -->

### Checklist
- [X] I have tested it locally
- [X] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it
