### PR TITLE
fix(devicetree-firmware): do not call inst_multiple if there are no fw files

### DIFF
--- a/modules.d/70devicetree-firmware/module-setup.sh
+++ b/modules.d/70devicetree-firmware/module-setup.sh
@@ -40,7 +40,7 @@ install_hostonly() {
             done
         done
     done
-    inst_multiple -o "${_fw_files[@]}"
+    ((${#_fw_files[@]} > 0)) && inst_multiple -o "${_fw_files[@]}"
 }
 
 # generic install (hostonly / generic use completely different approaches)
@@ -58,7 +58,7 @@ install_generic() {
             done
         done
     done
-    inst_multiple -o "${_fw_files[@]}"
+    ((${#_fw_files[@]} > 0)) && inst_multiple -o "${_fw_files[@]}"
 }
 
 # called by dracut


### PR DESCRIPTION
Otherwise `inst_multiple -o` is called without arguments.

### Checklist
- [X] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it
