### PR TITLE
feat(resume): add debug logs to check()

### DIFF
--- a/modules.d/74resume/module-setup.sh
+++ b/modules.d/74resume/module-setup.sh
@@ -13,22 +13,25 @@ check() {
     # If hostonly check if we want to include the resume module
     if [[ $hostonly ]] || [[ $mount_needs ]]; then
         # Resuming won't work if swap is on a netdevice
-        swap_on_netdevice && return 255
+        if swap_on_netdevice; then
+            ddebug "Module resume: swap is on a netdevice"
+            return 255
+        fi
         if grep -rqsE '(^| )resume=' /proc/cmdline /etc/kernel/cmdline /usr/lib/kernel/cmdline; then
-            # hibernation support requested on kernel command line
+            ddebug "Module resume: hibernation support requested on kernel command line"
             return 0
         else
             # resume= not set on kernel command line
             if [[ -f /sys/power/resume ]]; then
                 if [[ "$(< /sys/power/resume)" == "0:0" ]]; then
-                    # hibernation supported by the kernel, but not enabled
+                    ddebug "Module resume: hibernation supported by the kernel, but not enabled"
                     return 255
                 else
-                    # hibernation supported by the kernel and enabled
+                    ddebug "Module resume: hibernation supported by the kernel and enabled"
                     return 0
                 fi
             else
-                # resume file doesn't exist, hibernation not supported by kernel
+                ddebug "Module resume: resume file doesn't exist, hibernation not supported by kernel"
                 return 255
             fi
         fi


### PR DESCRIPTION
To ease debugging, add debug logs to the different cases in `check()`. Then the reason for not including the `resume` module can be seen in the output of:

```
dracut -L 5 --force
```

Related issue: https://github.com/dracut-ng/dracut/issues/1472

<!-- This pull request changes... -->

<!-- Fixes: https://github.com/dracut-ng/dracut/issues/<number> -->

### Checklist
- [x] I have tested it locally
- [x] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it
