### PR TITLE
fix(kernel-modules): include xhci-pci-prom21 for early USB

### DIFF
--- a/modules.d/70kernel-modules/module-setup.sh
+++ b/modules.d/70kernel-modules/module-setup.sh
@@ -39,15 +39,15 @@ installkernel() {
         hostonly='' instmods \
             hid_generic unix
 
-        # xhci-pci-renesas is needed for the USB to be available during
-        # initrd on platforms with such USB controllers since Linux
-        # 6.12-rc1 (commit 25f51b76f90f).
+        # Some xHCI PCI controllers are handled by sibling glue drivers
+        # instead of plain xhci-pci. Include them so USB is available
+        # during initrd when those drivers are built as modules.
         hostonly=$(optional_hostonly) instmods \
             ehci-hcd ehci-pci ehci-platform \
             ohci-hcd ohci-pci \
             uhci-hcd \
             usbhid \
-            xhci-hcd xhci-pci xhci-pci-renesas xhci-plat-hcd \
+            xhci-hcd xhci-pci xhci-pci-prom21 xhci-pci-renesas xhci-plat-hcd \
             "=drivers/hid" \
             "=drivers/tty/serial" \
             "=drivers/input/serio" \


### PR DESCRIPTION
Since Linux 7.2-rc1, AMD PROM21 xHCI controllers may be handled by the separate xhci-pci-prom21 PCI glue driver.

When CONFIG_USB_XHCI_PCI_PROM21=m, plain xhci-pci intentionally returns -ENODEV for the PROM21 PCI IDs so that xhci-pci-prom21 can bind them. However, xhci-pci-prom21 is not a dependency of xhci-pci, so an initramfs can include xhci-pci.ko while missing xhci-pci-prom21.ko.

On systems where USB keyboard or storage is attached through a PROM21 controller, this can make USB unavailable during initrd, for example at Plymouth/LUKS unlock.

This is the same class of issue as xhci-pci-renesas, which dracut already includes explicitly.

Link: https://bugzilla.kernel.org/show_bug.cgi?id=221721

<!-- This pull request changes... -->

<!-- Fixes: https://github.com/dracut-ng/dracut/issues/<number> -->

### Checklist
- [ ] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it