### PR TITLE
test(systemd): disable man page checks in verify test

### DIFF
--- a/test/TEST-40-SYSTEMD/systemd-analyze.sh
+++ b/test/TEST-40-SYSTEMD/systemd-analyze.sh
@@ -8,8 +8,8 @@ for i in \
     initrd-switch-root.target \
     emergency.target \
     shutdown.target; do
-    if ! systemd-analyze verify "$i"; then
-        warn "systemd-analyze verify $i failed"
+    if ! systemd-analyze --man=no verify "$i"; then
+        warn "systemd-analyze --man=no verify $i failed"
         poweroff
     fi
 done


### PR DESCRIPTION
TEST-40-SYSTEMD verifies initrd systemd targets, but systemd-analyze verify can also check referenced man pages. In the initrd test environment this may fail on man systemd.special, causing a false negative before the test reaches its success path.

Use --man=no so the test validates unit semantics without depending on man page availability.

Fixes: https://github.com/dracut-ng/dracut/issues/2492

<!-- This pull request changes... -->

<!-- Fixes: https://github.com/dracut-ng/dracut/issues/<number> -->

### Checklist
- [x] I have tested it locally
- [x] I have reviewed and updated any documentation if relevant
- [x] I am providing new code and test(s) for it
