### PR TITLE
fix(crypt): do not call return to exit a systemd generator

### DIFF
--- a/modules.d/70crypt/crypt-generator.sh
+++ b/modules.d/70crypt/crypt-generator.sh
@@ -22,13 +22,13 @@ generator_set_device_timeout() {
 
 if ! getargbool 1 rd.luks; then
     # crypto LUKS detection is disabled
-    return 0
+    exit 0
 fi
 
-[ -e /etc/crypttab ] || return 0
+[ -e /etc/crypttab ] || exit 0
 
 GENERATOR_DIR="$1"
-[ -n "$GENERATOR_DIR" ] || return 1
+[ -n "$GENERATOR_DIR" ] || exit 1
 [ -d "$GENERATOR_DIR" ] || mkdir -p "$GENERATOR_DIR"
 
 timeout=$(getarg rd.timeout)


### PR DESCRIPTION
systemd generators implemented via shell scripts are not sourced by systemd, so calling `return` within them to exit is incorrect.

Fixes #2490

### Checklist
- [ ] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it
