### PR TITLE
test(run-qemu): use -accel kvm instead of -enable-kvm

### DIFF
--- a/test/run-qemu
+++ b/test/run-qemu
@@ -141,7 +141,7 @@ if [[ -z ${NO_KVM-} && -c /dev/kvm && -r /dev/kvm && -w /dev/kvm ]]; then
     [[ -x /usr/bin/kvm ]] && BIN=/usr/bin/kvm && ARGS=(-cpu host)
     [[ -x /usr/bin/qemu-kvm ]] && BIN=/usr/bin/qemu-kvm && ARGS=(-cpu host)
     [[ -x /usr/libexec/qemu-kvm ]] && BIN=/usr/libexec/qemu-kvm && ARGS=(-cpu host)
-    [[ -x "/usr/bin/qemu-system-${ARCH}" ]] && BIN="/usr/bin/qemu-system-${ARCH}" && ARGS=(-enable-kvm -cpu host)
+    [[ -x "/usr/bin/qemu-system-${ARCH}" ]] && BIN="/usr/bin/qemu-system-${ARCH}" && ARGS=(-accel kvm -cpu host)
 fi
 
 [[ ${BIN-} ]] || {


### PR DESCRIPTION
-enable-kvm is believed to be deprecated and -accel kvm should be used instead.

<!-- This pull request changes... -->

<!-- Fixes: https://github.com/dracut-ng/dracut/issues/<number> -->

### Checklist
- [X] I have tested it locally
- [X] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it
