### PR TITLE
ci(azurelinux): install additional packages to pass CI

### DIFF
--- a/test/container/Dockerfile-azurelinux
+++ b/test/container/Dockerfile-azurelinux
@@ -40,6 +40,7 @@ RUN dnf -y install --setopt=install_weak_deps=False \
     ndctl \
     nfs-utils \
     nvme-cli \
+    openssl \
     parted \
     pcsc-lite \
     qemu \
@@ -48,6 +49,7 @@ RUN dnf -y install --setopt=install_weak_deps=False \
     rsyslog \
     squashfs-tools \
     swtpm \
+    systemd-container \
     systemd-devel \
     systemd-resolved \
     tar \


### PR DESCRIPTION
systemd-container is required to make importctl available for test SYSTEMD-IMPORT (45).

openssl is required for test SYSTEMD-SYSEXT (46).

<!-- This pull request changes... -->

<!-- Fixes: https://github.com/dracut-ng/dracut/issues/<number> -->

### Checklist
- [ ] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it
