### PR TITLE
ci(azurelinux): enable more test runs

### DIFF
--- a/test/container/Dockerfile-azurelinux
+++ b/test/container/Dockerfile-azurelinux
@@ -20,6 +20,7 @@ RUN dnf -y install --setopt=install_weak_deps=False \
     cifs-utils \
     cryptsetup \
     dhcpcd \
+    diffutils \
     dnsmasq \
     e2fsprogs \
     fuse3 \
@@ -51,6 +52,7 @@ RUN dnf -y install --setopt=install_weak_deps=False \
     swtpm \
     systemd-container \
     systemd-devel \
+    systemd-networkd \
     systemd-resolved \
     tar \
     tcpdump \


### PR DESCRIPTION
Install systemd-networkd package to enable networking tests for the Azure Linux test container.

Install diffutils package as TEST SKIPCPIO (81) needs diff command.

<!-- This pull request changes... -->

<!-- Fixes: https://github.com/dracut-ng/dracut/issues/<number> -->

### Checklist
- [ ] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it
