### PR TITLE
test(systemd): give more context in case of failure

### DIFF
--- a/test/TEST-40-SYSTEMD/systemd-analyze.sh
+++ b/test/TEST-40-SYSTEMD/systemd-analyze.sh
@@ -9,7 +9,7 @@ for i in \
     emergency.target \
     shutdown.target; do
     if ! systemd-analyze --man=no verify "$i"; then
-        warn "systemd-analyze --man=no verify $i failed"
+        warn "systemd-analyze.sh pre-pivot check 'systemd-analyze --man=no verify $i' failed. Failing test."
         poweroff
     fi
 done


### PR DESCRIPTION
To ease debugging, give more context in case of failure in the `systemd-analyze.sh` check.

<!-- This pull request changes... -->

<!-- Fixes: https://github.com/dracut-ng/dracut/issues/<number> -->

### Checklist
- [ ] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it
