### PR TITLE
feat(resume): include in hostonly sloppy mode if supported by kernel

### DIFF
--- a/modules.d/74resume/module-setup.sh
+++ b/modules.d/74resume/module-setup.sh
@@ -22,7 +22,10 @@ check() {
             return 0
         # resume= not set on kernel command line
         elif [[ -f /sys/power/resume ]]; then
-            if [[ "$(< /sys/power/resume)" == "0:0" ]]; then
+            if [[ $hostonly_mode != "strict" ]]; then
+                ddebug "Module resume: hibernation supported by the kernel"
+                return 0
+            elif [[ "$(< /sys/power/resume)" == "0:0" ]]; then
                 ddebug "Module resume: hibernation supported by the kernel, but not enabled"
                 return 255
             else

--- a/modules.d/74resume/module-setup.sh
+++ b/modules.d/74resume/module-setup.sh
@@ -20,20 +20,18 @@ check() {
         if grep -rqsE '(^| )resume=' /proc/cmdline /etc/kernel/cmdline /usr/lib/kernel/cmdline; then
             ddebug "Module resume: hibernation support requested on kernel command line"
             return 0
-        else
-            # resume= not set on kernel command line
-            if [[ -f /sys/power/resume ]]; then
-                if [[ "$(< /sys/power/resume)" == "0:0" ]]; then
-                    ddebug "Module resume: hibernation supported by the kernel, but not enabled"
-                    return 255
-                else
-                    ddebug "Module resume: hibernation supported by the kernel and enabled"
-                    return 0
-                fi
-            else
-                ddebug "Module resume: resume file doesn't exist, hibernation not supported by kernel"
+        # resume= not set on kernel command line
+        elif [[ -f /sys/power/resume ]]; then
+            if [[ "$(< /sys/power/resume)" == "0:0" ]]; then
+                ddebug "Module resume: hibernation supported by the kernel, but not enabled"
                 return 255
+            else
+                ddebug "Module resume: hibernation supported by the kernel and enabled"
+                return 0
             fi
+        else
+            ddebug "Module resume: resume file doesn't exist, hibernation not supported by kernel"
+            return 255
         fi
     else
         return 0


### PR DESCRIPTION
Systems might support hibernation. They need the resume module to get a working hibernation. Users might configure their systems to enable hibernation, but the correct order of steps are crucial for it. Currently this workflow does not work:

1. Make sure system is supported the power state:
```
$ cat /sys/power/state
freeze mem disk
```
2. Configured swap partition
3. Populated the resume kernel boot parameter `resume=/dev/<swap partition>`
4. update grub
5. regenerate initrd

Regenerating the initrd will not include the resume module, because it hits the "hibernation supported by the kernel, but not enabled" code path (`/proc/cmdline` doesn not contain `resume=` yet and `/sys/power/resume` contains `0:0`). A user would need to reboot once before regenerating the initrd.

To make the system more predictable, include the `resume` module in hostonly `sloppy` mode if hibernation is supported by the kernel.

Bug-Ubuntu: https://launchpad.net/bugs/2158694