### PR TITLE
ci(debian:sid): install systemd-tpm package

### DIFF
--- a/test/container/Dockerfile-debian
+++ b/test/container/Dockerfile-debian
@@ -22,11 +22,15 @@ RUN case $(dpkg --print-architecture) in \
         arm64) arch_pkgs="qemu-efi-aarch64 qemu-system-arm" ;; \
     esac; \
     if [ "$DISTRIBUTION" != "debian:latest" ]; then cpio=3cpio; else cpio=cpio; fi; \
+    if [ "$DISTRIBUTION" = "debian:sid" ]; then \
+        systemd_pkgs="systemd-tpm"; \
+    fi; \
     apt-get update && DEBIAN_FRONTEND=noninteractive apt-get upgrade -y && \
     DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends -o Dpkg::Use-Pty=0 \
     $arch_pkgs \
     $cpio \
     $coreutils \
+    $systemd_pkgs \
     asciidoctor \
     bluez \
     btrfs-progs \


### PR DESCRIPTION
Debian:sid has split out systemd-pcrextend into systemd-tpm package.

See https://packages.debian.org/sid/systemd-tpm

This commit is required to resolve a regression for the kernel-install test - see https://github.com/dracut-ng/dracut/actions/workflows/daily-kernel-install-x64.yml

<!-- This pull request changes... -->

<!-- Fixes: https://github.com/dracut-ng/dracut/issues/<number> -->

### Checklist
- [ ] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it

CC @bdrung 
