### PR TITLE
feat(network-manager): use escape to drop requiring bash

### DIFF
--- a/modules.d/35network-manager/module-setup.sh
+++ b/modules.d/35network-manager/module-setup.sh
@@ -10,7 +10,7 @@ check() {
 
 # called by dracut
 depends() {
-    echo bash net-lib kernel-network-modules initqueue
+    echo net-lib kernel-network-modules initqueue
     if dracut_module_included systemd; then
         echo dbus
     fi

--- a/modules.d/35network-manager/nm-run.sh
+++ b/modules.d/35network-manager/nm-run.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/sh
 
 command -v source_hook > /dev/null || . /lib/dracut-lib.sh
 
@@ -46,7 +46,7 @@ kf_unescape() {
 kf_parse() {
     v3="$(kf_get_string "$1")" || return 1
     v3="$(kf_unescape "$v3")"
-    printf '%s=%s\n' "$2" "$(printf '%q' "$v3")"
+    printf '%s='%s'\n' "$2" "$(escape "$v3")"
 }
 
 dhcpopts_create() {

--- a/modules.d/80base/dracut-lib.sh
+++ b/modules.d/80base/dracut-lib.sh
@@ -27,6 +27,12 @@ debug_on() {
     [ "$RD_DEBUG" = "yes" ] && set -x
 }
 
+# printf %q implementation for POSIX shell
+# Safe usage: printf "variable='%s'\n" "$(escape "$value")"
+escape() {
+    printf '%s' "$1" | sed -e "s/'/'\\\\''/g"
+}
+
 # returns OK if $1 contains literal string $2 (and isn't empty)
 strstr() {
     [ "${1##*"$2"*}" != "$1" ]


### PR DESCRIPTION
Use the new `escape` function to drop requiring bash in the network-manager module.

The output of `kf_parse` is written to `/tmp/dhclient."$ifname".dhcpopts` which is sourced by other dracut modules.

### Checklist
- [x] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it
