### PR TITLE
fix(network-manager): prevent command injection while parsing DHCP options

### DIFF
--- a/modules.d/35network-manager/nm-run.sh
+++ b/modules.d/35network-manager/nm-run.sh
@@ -46,7 +46,7 @@ kf_unescape() {
 kf_parse() {
     v3="$(kf_get_string "$1")" || return 1
     v3="$(kf_unescape "$v3")"
-    printf '%s='%s'\n' "$2" "$(escape "$v3")"
+    printf "%s='%s'\n" "$2" "$(escape "$v3")"
 }
 
 dhcpopts_create() {


### PR DESCRIPTION
Replacing `printf '%q'` with the custom `escape` function introduced a flaw: if the whole format string is surrounded by single quotes (`'%s='%s'\n'`), the shell consumes those inner `'` characters as quoting delimiters instead of passing them to printf, so it receives just `%s=%s\n`, i.e., the surrounding quotes around the value are gone. Since nothing is quoted, now commands can be injected via dhcpopts files.

E.g.:

```
$ cat /tmp/test-rogue-dhcp
next-server=$(id > /tmp/pwned 2>&1)$
$ cat /tmp/pwned
cat: /tmp/pwned: No such file or directory
$ kf_parse next-server new_next_server < /tmp/test-rogue-dhcp > /tmp/test.dhcpopts
$ cat /tmp/test.dhcpopts
new_next_server=$(id > /tmp/pwned 2>&1)$
$ . /tmp/test.dhcpopts
$ cat /tmp/pwned
uid=0(root) gid=0(root) groups=0(root) context=unconfined_u:unconfined_r:unconfined_t:s0-s0:c0.c1023
```

Fixes 9c7459bde0e78dd2e1e14d35c5351ef627b1b1fc

### Checklist
- [X] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it
