### PR TITLE
fix(dracut-lib): sanitize variable assignments using eval

### DIFF
--- a/modules.d/80base/dracut-lib.sh
+++ b/modules.d/80base/dracut-lib.sh
@@ -342,12 +342,12 @@ splitsep() {
 
     while [ -n "$str" ] && [ "$#" -gt 1 ]; do
         tmp="${str%%"$sep"*}"
-        eval "$1='${tmp}'"
+        eval "$1=\${tmp}"
         str="${str#"$tmp"}"
         str="${str#"$sep"}"
         shift
     done
-    [ -n "$str" ] && [ -n "$1" ] && eval "$1='$str'"
+    [ -n "$str" ] && [ -n "$1" ] && eval "$1=\${str}"
     debug_on
     return 0
 }
@@ -952,7 +952,7 @@ export_n() {
     for var in "$@"; do
         eval "val=\$$var"
         unset "$var"
-        [ -n "$val" ] && eval "$var=\"$val\""
+        [ -n "$val" ] && eval "$var=\${val}"
     done
 }
 


### PR DESCRIPTION
`splitsep()` uses `eval "$1='${tmp}'"` and `eval "$1='$str'"` to assign values to caller-named variables. A single quote in the value breaks out of the assignment.

`export_n()` uses `eval "$var=\"$val\""` to re-assign an unexported variable. A double quote in the value breaks out of the assignment.

Similar to 584e95bea90cedd12d9190e9b09bb45e1aa26b08, but these are simply code quality issues, with virtually no underlying practical vulnerabilities.

### Checklist
- [X] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it
