### PR TITLE
fix(dracut): install items after including modules

### DIFF
--- a/dracut.sh
+++ b/dracut.sh
@@ -2699,12 +2699,6 @@ if [[ $kernel_only != yes ]]; then
     mkdir -p "${initdir}/etc/cmdline.d"
     mkdir -m 0755 -p "${initdir}"/var/lib/dracut/hooks
 
-    # FIXME: handle legacy item split
-    # shellcheck disable=SC2068
-    ((${#install_items[@]} > 0)) && inst_multiple ${install_items[@]}
-    # shellcheck disable=SC2068
-    ((${#install_optional_items[@]} > 0)) && inst_multiple -o ${install_optional_items[@]}
-
     for _d in $hookdirs; do
         # shellcheck disable=SC2174
         mkdir -m 0755 -p "${initdir}/var/lib/dracut/hooks/$_d"
@@ -2860,6 +2854,12 @@ if [[ $kernel_only != yes ]]; then
             } > "${initdir}"/etc/conf.d/systemd.conf
         fi
     fi
+
+    # FIXME: handle legacy item split
+    # shellcheck disable=SC2068
+    ((${#install_items[@]} > 0)) && inst_multiple ${install_items[@]}
+    # shellcheck disable=SC2068
+    ((${#install_optional_items[@]} > 0)) && inst_multiple -o ${install_optional_items[@]}
 
     if [[ ${DRACUT_RESOLVE_LAZY-} ]] && [[ $DRACUT_INSTALL ]]; then
         dinfo "*** Resolving dependencies for executables and libraries ***"


### PR DESCRIPTION
Users or distributions might request installing additional binaries (like `cat` or `rm`) via `--install` or `--install-optional`. These binaries could be provided by different projects (like coreutils or busybox). Installing those files before including the modules will enforce specific implementations (e.g. use `cat` from coreutils instead of busybox).

Install those files after including the modules to allow the modules (like `busybox`) to pick an implementation. For example: If dracut is called with `--install cat` and busybox includes the `cat` applet, the `inst_multiple -o cat` will become a no-op.

<!-- This pull request changes... -->

<!-- Fixes: https://github.com/dracut-ng/dracut/issues/<number> -->

### Checklist
- [ ] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it
