### PR TITLE
test(DRACUT-CPIO): fix specifying initrd name twice

### DIFF
--- a/test/TEST-82-DRACUT-CPIO/test.sh
+++ b/test/TEST-82-DRACUT-CPIO/test.sh
@@ -32,14 +32,13 @@ EOF
         --add-confdir "test" \
         "${dracut_cpio_params[@]}" \
         --include "$tdir/init.sh" /usr/lib/dracut/hooks/emergency/00-init.sh \
-        --install "poweroff" \
-        "$tdir/initramfs"
+        --install "poweroff"
 
     "$testdir"/run-qemu \
         -daemonize -pidfile "$tdir/vm.pid" \
         -serial "file:$tdir/console.out" \
         -append "panic=1 oops=panic softlockup_panic=1 rd.shell=1" \
-        -initrd "$tdir/initramfs"
+        -initrd "$TESTDIR"/initramfs.testing
 
     timeout=120
     while [[ -f $tdir/vm.pid ]] \
@@ -52,6 +51,7 @@ EOF
     cat "$tdir/console.out"
     grep -q "Image with ${dracut_cpio_params[*]} booted successfully" \
         "$tdir/console.out"
+    rm "$TESTDIR"/initramfs.testing
 }
 
 test_run() {


### PR DESCRIPTION
The initrd output file name parameter was moved to the `test_dracut`. Thus specifying the initrd name in the `test_dracut` would become the second parameter for dracut and interpreted as kernel name. This would lead to this `realpath` failure:

```
Calling dracut --confdir /var/tmp/dracut-test.NilYUr/dracut.conf.d --add-confdir test --tmpdir /var/tmp/dracut-test.NilYUr/initrd --no-kernel --drivers '' --add-confdir test --enhanced-cpio --no-compress --nostrip --include /var/tmp/dracut-test.NilYUr/cpio-test.Gg7wLrYrO7/simple/init.sh /usr/lib/dracut/hooks/emergency/00-init.sh --install poweroff /var/tmp/dracut-test.NilYUr/cpio-test.Gg7wLrYrO7/simple/initramfs /var/tmp/dracut-test.NilYUr/initramfs.testing
realpath: /lib/modules//var/tmp/dracut-test.NilYUr/initramfs.testing: No such file or directory
```

So use the common initrd output file name in the dracut-cpio test case as well.

Fixes: 4d55517094f6 ("ci: consolidate output filename for test runs")

<!-- This pull request changes... -->

<!-- Fixes: https://github.com/dracut-ng/dracut/issues/<number> -->

### Checklist
- [x] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it
