### PR TITLE
test(DRACUT-CPIO): run without set -x

### DIFF
--- a/test/TEST-82-DRACUT-CPIO/test.sh
+++ b/test/TEST-82-DRACUT-CPIO/test.sh
@@ -19,6 +19,7 @@ test_dracut_cpio() {
     shift
     # --enhanced-cpio tells dracut to use dracut-cpio instead of GNU cpio
     local dracut_cpio_params=("--enhanced-cpio" "$@")
+    echo "SUBTEST: ${dracut_cpio_params[*]}"
 
     mkdir -p "$tdir"
 
@@ -55,8 +56,6 @@ EOF
 }
 
 test_run() {
-    set -x
-
     # dracut-cpio is typically used with compression and strip disabled, to
     # increase the chance of (reflink) extent sharing.
     test_dracut_cpio "simple" "--no-compress" "--nostrip"


### PR DESCRIPTION
Running the test with `set -x` will be quite verbose and makes the logs harder to read.

<!-- This pull request changes... -->

<!-- Fixes: https://github.com/dracut-ng/dracut/issues/<number> -->

### Checklist
- [ ] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it
