### PR TITLE
fix(dracut): support chmod applet from busybox

### DIFF
--- a/dracut.sh
+++ b/dracut.sh
@@ -2902,7 +2902,7 @@ for ((i = 0; i < ${#include_src[@]}; i++)); do
                     if ! [[ -e $object_destdir ]]; then
                         # shellcheck disable=SC2174
                         mkdir -m 0755 -p "$object_destdir"
-                        chmod --reference="$objectname" "$object_destdir"
+                        chmod "$(stat -c '%a' "$objectname")" "$object_destdir"
                     fi
                     $DRACUT_CP -t "$object_destdir" "${dracutsysrootdir-}$objectname"/.
                 else


### PR DESCRIPTION
busybox's `chmod` applet does not support `--reference`. So replace it by using `stat` to query the mode.

**Note**: Found by debugging https://github.com/dracut-ng/dracut/issues/2512

### Checklist
- [ ] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it
