### PR TITLE
fix(systemd-networkd): use another name for the default .network file

### DIFF
--- a/modules.d/11systemd-networkd/module-setup.sh
+++ b/modules.d/11systemd-networkd/module-setup.sh
@@ -63,7 +63,7 @@ install() {
     inst_simple "$moddir"/99-wait-online-dracut.conf \
         "$systemdsystemunitdir"/systemd-networkd-wait-online.service.d/99-dracut.conf
 
-    inst_simple "$moddir"/dracut-default.network /usr/lib/dracut/dracut-default.network
+    inst_simple "$moddir"/dracut-default.network /usr/lib/dracut/default.network
 
     inst_hook cmdline 99 "$moddir"/networkd-config.sh
     inst_hook initqueue/settled 99 "$moddir"/networkd-run.sh

--- a/modules.d/11systemd-networkd/networkd-config.sh
+++ b/modules.d/11systemd-networkd/networkd-config.sh
@@ -27,7 +27,7 @@ done
 # Add the default network if none was generated
 if [ "$generated" -eq "0" ]; then
     mkdir -m 0755 -p /run/systemd/network
-    cp -a /usr/lib/dracut/dracut-default.network /run/systemd/network/zzzz-dracut-default.network
+    cp -a /usr/lib/dracut/default.network /run/systemd/network/zzzz-dracut-default.network
 fi
 
 # Just in case networkd was already running


### PR DESCRIPTION
Since da3353f022cc7b930dd532e2f1e06af4e86999d3, there is another file matching the pattern `dracut-*` used by lsinitrd to print the dracut version:

```
$ lsinitrd /boot/test.img | grep usr/lib/dracut/
-rw-r--r--   1 root     root           38 Jul 22 09:20 usr/lib/dracut/build-parameter.txt
-rw-r--r--   1 root     root           32 Jul 22 09:20 usr/lib/dracut/dracut-110+suse.45.geaec47e4-38
-rw-r--r--   1 root     root          131 Jul 22 08:10 usr/lib/dracut/dracut-default.network
-rw-r--r--   1 root     root          420 Jul 22 09:20 usr/lib/dracut/hostonly-files
-rw-r--r--   1 root     root          493 Jul 22 09:20 usr/lib/dracut/modules.txt
-rw-r--r--   1 root     root            0 Jul 22 09:20 usr/lib/dracut/need-initqueue
```

This is messing the output when the systemd-networkd module is included:

```
$ lsinitrd -m /boot/test.img
Image: /boot/test.img: 71M
========================================================================
Version: dracut-110+suse.45.geaec47e4-38
[Match]
Kind=!*
Type=!loopback

[Network]
DHCP=yes

[DHCPv4]
ClientIdentifier=mac
RequestOptions=17

[DHCPv6]
RequestOptions=59 60

dracut modules:
bash
systemd
systemd-ask-password
systemd-battery-check
systemd-initrd
systemd-journald
systemd-modules-load
systemd-networkd
...
```

There are already other files in /usr/lib/dracut, all of them avoiding the "dracut-" prefix, so use another name for this file.

Fixes da3353f022cc7b930dd532e2f1e06af4e86999d3

### Checklist
- [X] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it
