### PR TITLE
fix(mdraid): escape slash in sed regular expression

### DIFF
--- a/modules.d/70mdraid/module-setup.sh
+++ b/modules.d/70mdraid/module-setup.sh
@@ -83,7 +83,7 @@ install() {
     # assembled
     # shellcheck disable=SC2016
     if [ -f "${initdir}${udevdir}/rules.d/64-md-raid-assembly.rules" ]; then
-        sed -i -r -e '/(RUN|IMPORT\{program\})\+?="[[:alpha:]/]*mdadm[[:blank:]]+(--incremental|-I)[[:blank:]]+(--export )?(\$env\{DEVNAME\}|\$devnode)/d' \
+        sed -i -r -e '/(RUN|IMPORT\{program\})\+?="[[:alpha:]\/]*mdadm[[:blank:]]+(--incremental|-I)[[:blank:]]+(--export )?(\$env\{DEVNAME\}|\$devnode)/d' \
             "${initdir}${udevdir}/rules.d/64-md-raid-assembly.rules"
     fi
 


### PR DESCRIPTION
`sed` from busybox treats the `/` from `[[:alpha:]/]` inside `/pattern/d` as the closing delimiter for the match pattern, rather than a character inside the bracket class:

```
sed: bad regex '(RUN|IMPORT\{program\})\+?="[[:alpha:]': Missing ']'
```

Escape the slash in sed regular expression.

**Note**: Found by debugging https://github.com/dracut-ng/dracut/issues/2512

<!-- This pull request changes... -->

<!-- Fixes: https://github.com/dracut-ng/dracut/issues/<number> -->

### Checklist
- [ ] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it
