### PR TITLE
fix(nfs): rpc.statd binary is not required for NFSv4

### DIFF
--- a/modules.d/74nfs/module-setup.sh
+++ b/modules.d/74nfs/module-setup.sh
@@ -21,7 +21,11 @@ get_nfs_type() {
 check() {
     # If our prerequisites are not met, fail anyways.
     require_any_binary rpcbind portmap || return 1
-    require_binaries rpc.statd mount.nfs mount.nfs4 umount sed chmod chown || return 1
+    if [[ "$(get_nfs_type)" == "nfs4" ]]; then
+        require_binaries mount.nfs4 umount sed chmod chown || return 1
+    else
+        require_binaries rpc.statd mount.nfs umount sed chmod chown || return 1
+    fi
 
     [[ $hostonly ]] || [[ $mount_needs ]] && {
         [[ "$(get_nfs_type)" ]] && return 0


### PR DESCRIPTION
Dracut fails to create initramfs on nfs4-only host as the rpc.statd binary is not required for NFSv4 and yet dracut is checking for its existence and fails.

Fixes: https://bugzilla.redhat.com/show_bug.cgi?id=2483609
Fixes: https://github.com/dracut-ng/dracut/issues/2488

CC @pavelsimo

<!-- This pull request changes... -->

<!-- Fixes: https://github.com/dracut-ng/dracut/issues/<number> -->

### Checklist
- [ ] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it
