### PR TITLE
style: remove unneeded function keyword

### DIFF
--- a/modules.d/68cms/cms-write-ifcfg.sh
+++ b/modules.d/68cms/cms-write-ifcfg.sh
@@ -7,7 +7,7 @@ umask 0022
 mkdir -p /run/initramfs/state/etc/sysconfig/network-scripts
 umask "$OLD_UMASK"
 
-function cms_write_config() {
+cms_write_config() {
     . /tmp/cms.conf
     SUBCHANNELS="$(echo "$SUBCHANNELS" | sed 'y/ABCDEF/abcdef/')"
     OLDIFS=$IFS

--- a/modules.d/68cms/cmssetup.sh
+++ b/modules.d/68cms/cmssetup.sh
@@ -3,7 +3,7 @@
 command -v getarg > /dev/null || . /lib/dracut-lib.sh
 command -v zdev_parse_dasd_list > /dev/null || . /lib/s390-tools/zdev-from-dasd_mod.dasd
 
-function dasd_settle() {
+dasd_settle() {
     local dasd_status
     dasd_status=$(lszdev dasd "$1" --columns ATTRPATH:status --no-headings --active)
     if [ ! -f "$dasd_status" ]; then
@@ -27,7 +27,7 @@ function dasd_settle() {
 }
 
 # read file from CMS and write it to /tmp
-function readcmsfile() { # $1=dasdport $2=filename
+readcmsfile() { # $1=dasdport $2=filename
     local dev
     local devname
     local ret=0

--- a/test/test-functions
+++ b/test/test-functions
@@ -279,13 +279,13 @@ determine_kernel_version() {
 }
 
 # terminal sequence to set color to a 'success' color (currently: green)
-function SETCOLOR_SUCCESS() { echo -en '\033[0;32m'; }
+SETCOLOR_SUCCESS() { echo -en '\033[0;32m'; }
 # terminal sequence to set color to a 'failure' color (currently: red)
-function SETCOLOR_FAILURE() { echo -en '\033[0;31m'; }
+SETCOLOR_FAILURE() { echo -en '\033[0;31m'; }
 # terminal sequence to set color to a 'warning' color (currently: yellow)
-function SETCOLOR_WARNING() { echo -en '\033[0;33m'; }
+SETCOLOR_WARNING() { echo -en '\033[0;33m'; }
 # terminal sequence to reset to the default color.
-function SETCOLOR_NORMAL() { echo -en '\033[0;39m'; }
+SETCOLOR_NORMAL() { echo -en '\033[0;39m'; }
 
 COLOR_SUCCESS='\033[0;32m'
 COLOR_FAILURE='\033[0;31m'


### PR DESCRIPTION
`function` is a non-standard keyword that can be used to declare functions in Bash and Ksh, but this would not work with POSIX shell. Remove it to make the code more consistent (and potential easier to port to POSIX).

<!-- This pull request changes... -->

<!-- Fixes: https://github.com/dracut-ng/dracut/issues/<number> -->

### Checklist
- [ ] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it
