### PR TITLE
feat: check shellcode to support busybox

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -330,8 +330,16 @@ else
 	find * -name '*.sh' -print0 | xargs -0 shellcheck
 endif
 
+.PHONY: shellcheck-busybox
+shellcheck-busybox:
+ifeq ($(HAVE_SHFMT),yes)
+	shellcheck -s busybox $$(shfmt -f * | test/filter-out-bash)
+else
+	find * -name '*.sh' | test/filter-out-bash | xargs shellcheck -s busybox
+endif
+
 .PHONY: syncheck
-syncheck: bashcheck $(if $(filter yes,$(HAVE_SHELLCHECK)),shellcheck)
+syncheck: bashcheck $(if $(filter yes,$(HAVE_SHELLCHECK)),shellcheck shellcheck-busybox)
 
 check: all
 	@$(MAKE) -C test check

--- a/test/filter-out-bash
+++ b/test/filter-out-bash
@@ -1,0 +1,9 @@
+#!/bin/sh
+set -eu
+
+while read -r script; do
+    if head -n 1 "$script" | grep -q bash; then
+        continue
+    fi
+    echo "$script"
+done


### PR DESCRIPTION
Explicitly check the shellcode to work with busybox to also catch cases like 'local' is only valid in functions (SC2168).

This PR needs https://github.com/dracut-ng/dracut/pull/2526 to make the shellcheck-busybox check succeed.

### Checklist
- [x] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it
