### PR TITLE
fix(dracut): properly pass user-supplied SBAT to ukify

### DIFF
--- a/dracut.sh
+++ b/dracut.sh
@@ -3480,6 +3480,15 @@ if [[ $uefi == yes ]]; then
 
     if command -v ukify &> /dev/null && [[ $ukify != 'no' ]]; then
         dinfo "*** Using ukify to create UKI ***"
+        # ukify extracts SBAT from the stub and kernel PE files on its own,
+        # so only pass user-supplied SBAT entries here to avoid duplication.
+        ukify_sbat=""
+        if [[ -n $sbat ]]; then
+            ukify_sbat=$uefi_outdir/ukify_user.sbat
+            echo "$SBAT_DEFAULT" > "$ukify_sbat"
+            echo "$sbat" | sed "/${SBAT_DEFAULT//\//\\/}/d" >> "$ukify_sbat"
+        fi
+
         if ukify build \
             --linux "$kernel_image" \
             --initrd "${DRACUT_TMPDIR}/initramfs.img" \
@@ -3488,7 +3497,7 @@ if [[ $uefi == yes ]]; then
             ${uefi_osrelease:+--os-release @"$uefi_osrelease"} \
             ${uefi_splash_image:+--splash "$uefi_splash_image"} \
             --stub "$uefi_stub" \
-            --sbat "$sbat_out" \
+            ${ukify_sbat:+--sbat @"$ukify_sbat"} \
             ${uefi_secureboot_engine:+--signing-engine "$uefi_secureboot_engine"} \
             ${uefi_secureboot_key:+--secureboot-private-key "$uefi_secureboot_key"} \
             ${uefi_secureboot_cert:+--secureboot-certificate "$uefi_secureboot_cert"} \


### PR DESCRIPTION
ukify's --sbat option requires an @-prefixed argument if it's a path to a file. Without it it refuses the SBAT as invalid and moves on:
```
~# dracut -v --uefi --sbat "bar,666,Foo Corp,foo,1,https://example.com" test.efi
dracut[I]: Executing: /usr/bin/dracut -v --uefi --sbat "bar,666,Foo Corp,foo,1,https://example.com" test.efi ...
dracut[I]: *** Creating image file '/root/test.efi'***
dracut[I]: *** Hardlinking files ***
dracut[I]: *** Hardlinking files done ***
dracut[I]: Using auto-determined compression method 'zstd'
dracut[I]: ***Using ukify to create UKI ***
/var/tmp/dracut.dlTsVgm/uefi/uki.sbat does not contain a valid SBAT section, skipping. Wrote unsigned /var/tmp/dracut.dlTsVgm/uefi/linux.efi
dracut[I]: *** Creating UEFI image file '/root/test.efi' done ***

~# ukify inspect test.efi
.sbat:
  size: 342 bytes
  sha256: 1b071df03087b5f8186ec98c1915543c7c057c9e5b3adb333b0af61c0cfbac5a
  text:
    sbat,1,SBAT Version,sbat,1,https://github.com/rhboot/shim/blob/main/SBAT.md
    systemd-stub,1,The systemd Developers,systemd,261,https://systemd.io/
    systemd-stub.fedora,1,Fedora Linux,systemd,261.1-21.fc45,https://bugzilla.redhat.com/
    kernel.fedora,1,Red Hat,kernel-core,7.2.0-0.rc2.260711gdd3210c47e8d.24.fc45.x86_64,mailto:secalert@redhat.com
```
Also, pass only user-supplied SBAT to ukify, as ukify extracts the SBATs from the stub and kernel PEs on its own. Without this the final UKI contains duplicated SBATs for which there's not enough space:
```
dracut[I]: *** Using ukify to create UKI ***
Traceback (most recent call last):
  File "/usr/bin/ukify", line 2568, in <module>
    main()
    ~~~~^^
  File "/usr/bin/ukify", line 2557, in main
    make_uki(opts)
    ~~~~~~~~^^^^^^
  File "/usr/bin/ukify", line 1540, in make_uki
    pe_add_sections(opts, uki, unsigned_output)
    ~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/bin/ukify", line 1057, in pe_add_sections
    raise PEError(
    ...<2 lines>...
    )
PEError: Not enough space in existing section .sbat to append new data (need 5354, have 1024)
dracut[F]: *** Creating UEFI image file '/root/test.efi' failed ***
```

### Checklist
- [x] I have tested it locally

No supplied SBAT:

```
# dracut -f -v --uefi test.efi
...
dracut[I]: *** Using ukify to create UKI ***
Wrote unsigned /var/tmp/dracut.dD6eacK/uefi/linux.efi
dracut[I]: *** Creating UEFI image file '/root/test.efi.tmp' done ***
dracut[I]: *** Moving image file '/root/test.efi.tmp' to '/root/test.efi' ***
dracut[I]: *** Moving image file '/root/test.efi.tmp' to '/root/test.efi' done ***
# ukify inspect test.efi
.sbat:
  size: 424 bytes
  sha256: 71b34be59f843dd23843188e1930192762ce8e54ae09ed0c82bd668fafaed0de
  text:
    sbat,1,SBAT Version,sbat,1,https://github.com/rhboot/shim/blob/main/SBAT.md
    systemd-stub,1,The systemd Developers,systemd,261,https://systemd.io/
    systemd-stub.fedora,1,Fedora Linux,systemd,261.1-21.fc45,https://bugzilla.redhat.com/
    kernel.fedora,1,Red Hat,kernel-core,7.2.0-0.rc2.260711gdd3210c47e8d.24.fc45.x86_64,mailto:secalert@redhat.com
    uki,1,UKI,uki,1,https://uapi-group.org/specifications/specs/unified_kernel_image/
```

User-supplied SBAT:
```
# dracut -v --uefi --sbat "bar,666,Foo Corp,foo,1,https://example.com" test.efi
...
dracut[I]: *** Using ukify to create UKI ***
Wrote unsigned /var/tmp/dracut.dGLamLZ/uefi/linux.efi
dracut[I]: *** Creating UEFI image file '/root/test.efi.tmp' done ***
dracut[I]: *** Moving image file '/root/test.efi.tmp' to '/root/test.efi' ***
dracut[I]: *** Moving image file '/root/test.efi.tmp' to '/root/test.efi' done ***
# ukify inspect test.efi
.sbat:
  size: 385 bytes
  sha256: 60d3c4981bea8730411df63a0e4462adf6736768167c9f341d91739709166cfe
  text:
    sbat,1,SBAT Version,sbat,1,https://github.com/rhboot/shim/blob/main/SBAT.md
    systemd-stub,1,The systemd Developers,systemd,261,https://systemd.io/
    systemd-stub.fedora,1,Fedora Linux,systemd,261.1-21.fc45,https://bugzilla.redhat.com/
    kernel.fedora,1,Red Hat,kernel-core,7.2.0-0.rc2.260711gdd3210c47e8d.24.fc45.x86_64,mailto:secalert@redhat.com
    bar,666,Foo Corp,foo,1,https://example.com
...
```

- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it
