### PR TITLE
ci: increase timeout for test 60-NFS from 10 to 15 min

### DIFF
--- a/.github/workflows/daily-network-legacy.yml
+++ b/.github/workflows/daily-network-legacy.yml
@@ -29,7 +29,7 @@ jobs:
             fail-fast: false
             matrix:
                 architecture:
-                    - {runner: 'ubuntu-24.04', tag: 'amd', timeout: 10}
+                    - {runner: 'ubuntu-24.04', tag: 'amd', timeout: 15}
                     - {runner: 'ubuntu-24.04-arm', tag: 'arm', timeout: 60}
                 network:
                     - network-legacy

--- a/.github/workflows/daily-network.yml
+++ b/.github/workflows/daily-network.yml
@@ -26,7 +26,7 @@ jobs:
             fail-fast: false
             matrix:
                 architecture:
-                    - {runner: 'ubuntu-24.04', tag: 'amd', timeout: 10}
+                    - {runner: 'ubuntu-24.04', tag: 'amd', timeout: 15}
                     - {runner: 'ubuntu-24.04-arm', tag: 'arm', timeout: 60}
                 container:
                     - arch:latest

--- a/.github/workflows/daily-omitsystemd.yml
+++ b/.github/workflows/daily-omitsystemd.yml
@@ -26,7 +26,7 @@ jobs:
             fail-fast: false
             matrix:
                 architecture:
-                    - {runner: 'ubuntu-24.04', tag: 'amd', timeout: 10}
+                    - {runner: 'ubuntu-24.04', tag: 'amd', timeout: 15}
                     - {runner: 'ubuntu-24.04-arm', tag: 'arm', timeout: 60}
                 container:
                     - ubuntu:rolling

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -173,7 +173,7 @@ jobs:
         # all nfs based on default networking
         name: ${{ matrix.test }} on ${{ matrix.container }}
         runs-on: ubuntu-24.04
-        timeout-minutes: 10
+        timeout-minutes: 15
         concurrency:
             group: >
                 network-${{ github.workflow }}-${{ github.ref }}


### PR DESCRIPTION
Test 60-NFS is the biggest test and 10 minutes was not enough for it on `fedora:rawhide` (network) and `gentoo:latest` (network-legacy).

So increase the timeout for test 60-NFS from 10 to 15 minutes.

See also: 4f6f4c47a5eb ("ci: unify timeout to 10 min by default")

<!-- This pull request changes... -->

<!-- Fixes: https://github.com/dracut-ng/dracut/issues/<number> -->

### Checklist
- [ ] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it
