### PR TITLE
ci: install chrony to test the new chrony module

### DIFF
--- a/test/container/Dockerfile-debian
+++ b/test/container/Dockerfile-debian
@@ -37,6 +37,7 @@ RUN case $(dpkg --print-architecture) in \
     busybox \
     ca-certificates \
     cargo \
+    chrony \
     console-data \
     cryptsetup \
     curl \
@@ -96,7 +97,6 @@ RUN case $(dpkg --print-architecture) in \
     systemd-repart \
     systemd-resolved \
     systemd-sysv \
-    systemd-timesyncd \
     systemd-ukify \
     tcpdump \
     tgt \


### PR DESCRIPTION
Install chrony to test the new chrony module.

CC @bdrung 

<!-- This pull request changes... -->

<!-- Fixes: https://github.com/dracut-ng/dracut/issues/<number> -->

### Checklist
- [ ] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it
