### PR TITLE
chore(Makefile): filter out chrony dracut module for non-systemd

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -279,7 +279,7 @@ endif
 	if ! [ -n "$(systemdsystemunitdir)" ]; then \
 		rm -rf $(DESTDIR)$(pkglibdir)/test/TEST-[0-9][0-9]-*SYSTEMD* ;\
 		rm -rf $(DESTDIR)$(pkglibdir)/modules.d/*systemd* $(DESTDIR)$(mandir)/man8/*.service.* ; \
-		for i in bluetooth connman dbus* fido2 lvmmerge lvmthinpool-monitor memstrack pcsc pkcs11 rngd squash* tpm2-tss; do \
+		for i in bluetooth chrony connman dbus* fido2 lvmmerge lvmthinpool-monitor memstrack pcsc pkcs11 rngd squash* tpm2-tss; do \
 			rm -r $(DESTDIR)$(pkglibdir)/modules.d/[0-9][0-9]$${i}; \
 		done \
 	fi


### PR DESCRIPTION
chrony dracut module in its current form depends on the systemd dracut module. Filter out chrony dracut module during build time for enviroments not supporting systemd to be consisent with othersystemd dependent dracut modules.

Follow-up to 4d64d0b .

<!-- This pull request changes... -->

<!-- Fixes: https://github.com/dracut-ng/dracut/issues/<number> -->

### Checklist
- [ ] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it
