### PR TITLE
fix(tpm2-tss): add missing 60-tpm2-id.rules

### DIFF
--- a/modules.d/73tpm2-tss/module-setup.sh
+++ b/modules.d/73tpm2-tss/module-setup.sh
@@ -42,6 +42,7 @@ install() {
 
     inst_multiple -o \
         "$tmpfilesdir"/tpm2-tss-fapi.conf \
+        "$udevrulesdir"/60-tpm2-id.rules \
         "$udevrulesdir"/60-tpm-udev.rules \
         "$udevrulesdir"/90-tpm.rules \
         "$systemdutildir"/systemd-tpm2-setup \


### PR DESCRIPTION
These rules containing hwdb quicks were added in systemd-v260 [1] to fix some TPM2 issues.

[1] https://github.com/systemd/systemd/pull/40931

### Checklist
- [ ] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it
