### PR TITLE
fix(systemd-udevd): install systemd-udevd-varlink.socket

### DIFF
--- a/modules.d/11systemd-udevd/module-setup.sh
+++ b/modules.d/11systemd-udevd/module-setup.sh
@@ -50,8 +50,10 @@ install() {
         "$systemdsystemunitdir/systemd-udev-settle.service.d/*.conf" \
         "$systemdsystemunitdir"/systemd-udevd-control.socket \
         "$systemdsystemunitdir"/systemd-udevd-kernel.socket \
+        "$systemdsystemunitdir"/systemd-udevd-varlink.socket \
         "$systemdsystemunitdir"/sockets.target.wants/systemd-udevd-control.socket \
         "$systemdsystemunitdir"/sockets.target.wants/systemd-udevd-kernel.socket \
+        "$systemdsystemunitdir"/sockets.target.wants/systemd-udevd-varlink.socket \
         "$systemdsystemunitdir"/sysinit.target.wants/systemd-udevd.service \
         "$systemdsystemunitdir"/sysinit.target.wants/systemd-udev-trigger.service
 
@@ -68,8 +70,11 @@ install() {
             "$systemdsystemconfdir/systemd-udevd-control.socket.d/*.conf" \
             "$systemdsystemconfdir"/systemd-udevd-kernel.socket \
             "$systemdsystemconfdir/systemd-udevd-kernel.socket.d/*.conf" \
+            "$systemdsystemconfdir"/systemd-udevd-varlink.socket \
+            "$systemdsystemconfdir/systemd-udevd-varlink.socket.d/*.conf" \
             "$systemdsystemconfdir"/sockets.target.wants/systemd-udevd-control.socket \
             "$systemdsystemconfdir"/sockets.target.wants/systemd-udevd-kernel.socket \
+            "$systemdsystemconfdir"/sockets.target.wants/systemd-udevd-varlink.socket \
             "$systemdsystemconfdir"/sysinit.target.wants/systemd-udevd.service \
             "$systemdsystemconfdir"/sysinit.target.wants/systemd-udev-trigger.service
 


### PR DESCRIPTION
It was added in systemd-v258 [1], but it has become more important since systemd-udevd-control.socket was removed [2]. Although for now it remains as a symlink to systemd-udevd-varlink.socket for compatibility reasons, systemd-udevd.service and systemd-udev-trigger.service no longer reference it in "Sockets=" and "After=" respectively.

This is still working by accident. Thanks to the current symlink from systemd-udevd-control.socket to systemd-udevd-varlink.socket, dracut resolves it and also installs systemd-udevd-varlink.socket in the initrd. The symlink to sockets.target.wants is not created, but since systemd-udevd.service has `Sockets=... systemd-udevd-varlink.socket`, systemd creates automatic "Wants=" and "After=" dependencies (see systemd.service(5)), so the unit gets into the transaction.

[1] https://github.com/systemd/systemd/commit/2bc733d9b0e9c0b850ed523f5d1695cddb0c23d7
[2] https://github.com/systemd/systemd/commit/17e911ffc853c54f44edd11ead8b6edab72c1217

### Checklist
- [X] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it
