### PR TITLE
perf(systemd-networkd): remove duplicate service from inst_multiple

### DIFF
--- a/modules.d/11systemd-networkd/module-setup.sh
+++ b/modules.d/11systemd-networkd/module-setup.sh
@@ -57,7 +57,6 @@ install() {
         "$systemdsystemunitdir"/systemd-network-generator.service \
         "$systemdsystemunitdir"/systemd-networkd-wait-online.service \
         "$systemdsystemunitdir"/systemd-networkd-wait-online@.service \
-        "$systemdsystemunitdir"/systemd-network-generator.service \
         ip sed grep networkctl tr
 
     inst_simple "$moddir"/99-wait-online-dracut.conf \


### PR DESCRIPTION
systemd-network-generator.service is listed twice.

https://github.com/dracut-ng/dracut/blob/5e133721eeb9c17135958389b2cf029bbf9a9f7c/modules.d/11systemd-networkd/module-setup.sh#L57

https://github.com/dracut-ng/dracut/blob/5e133721eeb9c17135958389b2cf029bbf9a9f7c/modules.d/11systemd-networkd/module-setup.sh#L60

### Checklist
- [ ] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it
