### PR TITLE
fix(dracut): remove support for tmpfilesconfdir

### DIFF
--- a/dracut.sh
+++ b/dracut.sh
@@ -2218,7 +2218,6 @@ set_global_var "systemd" "systemduser" "${systemdutildir}/user"
 set_global_var "systemd" "sysusers" "/usr/lib/sysusers.d"
 [[ $hostonly ]] && set_global_var "systemd" "sysusersconfdir" "/etc/sysusers.d"
 set_global_var "systemd" "tmpfilesdir" "/lib/tmpfiles.d" "/usr/lib/tmpfiles.d"
-[[ $hostonly ]] && set_global_var "systemd" "tmpfilesconfdir" "/etc/tmpfiles.d"
 set_global_var "systemd" "modversion:systemdversion" "0"
 
 # libkmod global variables


### PR DESCRIPTION
tmpfilesconfdir variable was used only by the systemd-tmpfiles dracut module, but after 73e9b64 that variable is no no longer in use.

The motivation for this PR is to explicitly disallow the use of tmpfilesconfdir going forward as it is not recommended for a dracut module to pick up files from /etc/tmpfiles.d.

Follow-up to 73e9b64 .

<!-- This pull request changes... -->

<!-- Fixes: https://github.com/dracut-ng/dracut/issues/<number> -->

### Checklist
- [ ] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it
