### PR TITLE
perf(systemd-tmpfiles): do not install systemd-tmpfiles-clean.service

### DIFF
--- a/modules.d/11systemd-tmpfiles/module-setup.sh
+++ b/modules.d/11systemd-tmpfiles/module-setup.sh
@@ -34,8 +34,6 @@ install() {
         "$tmpfilesdir/systemd.conf" \
         "$tmpfilesdir/20-systemd-stub.conf" \
         "$tmpfilesdir/var.conf" \
-        "$systemdsystemunitdir"/systemd-tmpfiles-clean.service \
-        "$systemdsystemunitdir/systemd-tmpfiles-clean.service.d/*.conf" \
         "$systemdsystemunitdir"/systemd-tmpfiles-setup.service \
         "$systemdsystemunitdir/systemd-tmpfiles-setup.service.d/*.conf" \
         "$systemdsystemunitdir"/systemd-tmpfiles-setup-dev.service \
@@ -50,8 +48,6 @@ install() {
     # Install the hosts local user configurations if enabled.
     if [[ $hostonly ]]; then
         inst_multiple -H -o \
-            "$systemdsystemconfdir"/systemd-tmpfiles-clean.service \
-            "$systemdsystemconfdir/systemd-tmpfiles-clean.service.d/*.conf" \
             "$systemdsystemconfdir"/systemd-tmpfiles-setup.service \
             "$systemdsystemconfdir/systemd-tmpfiles-setup.service.d/*.conf" \
             "$systemdsystemconfdir"/systemd-tmpfiles-setup-dev.service \


### PR DESCRIPTION
It does not have an "Install" section, nor is it manually installed, its only trigger systemd-tmpfiles-clean.timer is also not installed, and it cannot be run in the initrd [1].

[1] https://github.com/systemd/systemd/commit/fe7f113c1331e11af4e9f815d7305c8b1b332312

### Checklist
- [X] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it
