### PR TITLE
ci(busybox): busybox blkid is not compatible with dracut

### DIFF
--- a/test/container/Dockerfile-alpine
+++ b/test/container/Dockerfile-alpine
@@ -45,6 +45,7 @@ RUN \
 
 # busybox container
 # replace GNU coreutils, util-linux, kmod binaries with busybox binaries
+# workaround for busybox blkid compatibility, see https://github.com/dracut-ng/dracut/issues/2512
 RUN \
 if [ "$OPTION" == "busybox" ] ; then \
   mkdir /busybox && cd /busybox && /bin/busybox --install -s /busybox ;\
@@ -53,4 +54,5 @@ if [ "$OPTION" == "busybox" ] ; then \
   cp -a /busybox/* /usr/bin/ ;\
   cp -a /busybox/* /usr/sbin/ ;\
   rm -f /bin/kmod ;\
+  apk fix --reinstall blkid ;\
 fi


### PR DESCRIPTION
Temporary use util-linux blkid as a workaround for busybox blkid compatibility issue, until the busybox blkid issue is fixed.

See https://github.com/dracut-ng/dracut/issues/2512

<!-- This pull request changes... -->

<!-- Fixes: https://github.com/dracut-ng/dracut/issues/<number> -->

### Checklist
- [ ] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it
