### PR TITLE
fix(iscsi): normalize initiator and target names and validate iSCSI LUN parameters

### DIFF
--- a/modules.d/45net-lib/net-lib.sh
+++ b/modules.d/45net-lib/net-lib.sh
@@ -358,6 +358,13 @@ ibft_to_cmdline() {
     ) >> /etc/cmdline.d/20-ibft.conf
 }
 
+normalized_iscsi_name() {
+    # Normalize uppercase to lowercase. Instead of using the stringprep
+    # mapping table B.1 and B.2, just delete the not permitted characters.
+    # References: RFC 3720 Section 3.2.6.2 and RFC 3722
+    printf "%s" "$1" | tr '[:upper:]' '[:lower:]' | tr -cd 'a-z0-9.:-'
+}
+
 parse_iscsi_root() {
     local v
     v=${1#iscsi:}
@@ -464,6 +471,7 @@ parse_iscsi_root() {
 
     iscsi_target_name=$(printf "%s:" "$@")
     iscsi_target_name=${iscsi_target_name%:}
+    iscsi_target_name=$(normalized_iscsi_name "$iscsi_target_name")
 }
 
 ip_to_var() {

--- a/modules.d/45net-lib/net-lib.sh
+++ b/modules.d/45net-lib/net-lib.sh
@@ -365,6 +365,21 @@ normalized_iscsi_name() {
     printf "%s" "$1" | tr '[:upper:]' '[:lower:]' | tr -cd 'a-z0-9.:-'
 }
 
+_validate_iscsi_lun() {
+    local raw_lun="$1"
+
+    case "$raw_lun" in
+        *[!0-9]*)
+            warn "Given iSCSI LUN '$raw_lun' contains non-digits. Stripping non-digit characters."
+            printf "%s" "$raw_lun" | tr -cd '[:digit:]'
+            ;;
+        *)
+            # Purely decimal digits
+            echo "$raw_lun"
+            ;;
+    esac
+}
+
 parse_iscsi_root() {
     local v
     v=${1#iscsi:}
@@ -448,7 +463,7 @@ parse_iscsi_root() {
             iscsi_netdev_name=$1
             shift
         fi
-        iscsi_lun=$1
+        iscsi_lun=$(_validate_iscsi_lun "$1")
         shift
         if [ $# -ne 0 ]; then
             warn "Invalid parameter in iscsi: parameter!"
@@ -466,7 +481,7 @@ parse_iscsi_root() {
         fi
     fi
 
-    iscsi_lun=$1
+    iscsi_lun=$(_validate_iscsi_lun "$1")
     shift
 
     iscsi_target_name=$(printf "%s:" "$@")

--- a/modules.d/74iscsi/iscsiroot.sh
+++ b/modules.d/74iscsi/iscsiroot.sh
@@ -103,9 +103,9 @@ handle_netroot() {
 
     # override conf settings by command line options
     arg=$(getarg rd.iscsi.initiator -d iscsi_initiator=)
-    [ -n "$arg" ] && iscsi_initiator=$arg
+    [ -n "$arg" ] && iscsi_initiator=$(normalized_iscsi_name "$arg")
     arg=$(getarg rd.iscsi.target.group -d iscsi_target_group=)
-    [ -n "$arg" ] && iscsi_target_group=$arg
+    [ -n "$arg" ] && iscsi_target_group=$(normalized_iscsi_name "$arg")
     arg=$(getarg rd.iscsi.username -d iscsi_username=)
     [ -n "$arg" ] && iscsi_username=$arg
     arg=$(getarg rd.iscsi.password -d iscsi_password)
@@ -144,6 +144,7 @@ handle_netroot() {
 
     if [ -z "$iscsi_initiator" ] && [ -f /sys/firmware/ibft/initiator/initiator-name ] && ! [ -f /tmp/iscsi_set_initiator ]; then
         iscsi_initiator=$(while read -r line || [ -n "$line" ]; do echo "$line"; done < /sys/firmware/ibft/initiator/initiator-name)
+        iscsi_initiator=$(normalized_iscsi_name "$iscsi_initiator")
         echo "InitiatorName=$iscsi_initiator" > /run/initiatorname.iscsi
         rm -f /etc/iscsi/initiatorname.iscsi
         mkdir -p /etc/iscsi
@@ -160,11 +161,11 @@ handle_netroot() {
         [ -f /run/initiatorname.iscsi ] && . /run/initiatorname.iscsi
         [ -f /etc/initiatorname.iscsi ] && . /etc/initiatorname.iscsi
         [ -f /etc/iscsi/initiatorname.iscsi ] && . /etc/iscsi/initiatorname.iscsi
-        iscsi_initiator=$InitiatorName
+        iscsi_initiator=$(normalized_iscsi_name "$InitiatorName")
     fi
 
     if [ -z "$iscsi_initiator" ]; then
-        iscsi_initiator=$(iscsi-iname)
+        iscsi_initiator=$(normalized_iscsi_name "$(iscsi-iname)")
         echo "InitiatorName=$iscsi_initiator" > /run/initiatorname.iscsi
         rm -f /etc/iscsi/initiatorname.iscsi
         mkdir -p /etc/iscsi

--- a/modules.d/74iscsi/module-setup.sh
+++ b/modules.d/74iscsi/module-setup.sh
@@ -83,7 +83,8 @@ install_iscsiroot() {
         if [ "$is_boot" -eq 1 ]; then
             # qla4xxx flashnode session; skip iBFT discovery
             read -r iscsi_initiator < /sys/class/iscsi_host/"${iscsi_host}"/initiatorname
-            echo "rd.iscsi.initiator=${iscsi_initiator}"
+            command -v normalized_iscsi_name > /dev/null || . "$moddir/../45net-lib/net-lib.sh"
+            echo "rd.iscsi.initiator=$(normalized_iscsi_name "${iscsi_initiator}")"
             return
         fi
     done
@@ -125,7 +126,8 @@ install_iscsiroot() {
         esac
         # Must be two separate lines, so that "sort | uniq" commands later
         # can sort out rd.iscsi.initiator= duplicates
-        echo "rd.iscsi.initiator=${iscsi_initiator}"
+        command -v normalized_iscsi_name > /dev/null || . "$moddir/../45net-lib/net-lib.sh"
+        echo "rd.iscsi.initiator=$(normalized_iscsi_name "${iscsi_initiator}")"
         echo "netroot=iscsi:${iscsi_address}::${iscsi_port}:${iscsi_lun}:${iscsi_targetname}"
         echo "rd.neednet=1"
     fi

--- a/modules.d/74iscsi/parse-iscsiroot.sh
+++ b/modules.d/74iscsi/parse-iscsiroot.sh
@@ -32,6 +32,7 @@ fi
 
 [ -n "$iscsiroot" ] && [ -n "$iscsi_firmware" ] && die "Mixing iscsiroot and iscsi_firmware is dangerous"
 
+command -v normalized_iscsi_name > /dev/null || . /lib/net-lib.sh
 command -v write_fs_tab > /dev/null || . /lib/fs-lib.sh
 
 # Root takes precedence over netroot
@@ -110,7 +111,7 @@ if [ -n "$netroot" ] && [ "$root" != "/dev/root" ] && [ "$root" != "dhcp" ]; the
 fi
 
 if arg=$(getarg rd.iscsi.initiator -d iscsi_initiator=) && [ -n "$arg" ] && ! [ -f /run/initiatorname.iscsi ]; then
-    iscsi_initiator=$arg
+    iscsi_initiator=$(normalized_iscsi_name "$arg")
     echo "InitiatorName=$iscsi_initiator" > /run/initiatorname.iscsi
     ln -fs /run/initiatorname.iscsi /dev/.initiatorname.iscsi
     rm -f /etc/iscsi/initiatorname.iscsi
@@ -126,6 +127,7 @@ fi
 # If not given on the cmdline and initiator-name available via iBFT
 if [ -z "$iscsi_initiator" ] && [ -f /sys/firmware/ibft/initiator/initiator-name ] && ! [ -f /tmp/iscsi_set_initiator ]; then
     iscsi_initiator=$(while read -r line || [ -n "$line" ]; do echo "$line"; done < /sys/firmware/ibft/initiator/initiator-name)
+    iscsi_initiator=$(normalized_iscsi_name "$iscsi_initiator")
     if [ -n "$iscsi_initiator" ]; then
         echo "InitiatorName=$iscsi_initiator" > /run/initiatorname.iscsi
         rm -f /etc/iscsi/initiatorname.iscsi


### PR DESCRIPTION
According to RFC 3720 the iSCSI names must only use lowercase ASCII letters ('a'-'z'), digits ('0'-'9'), hyphen ('-'), period ('.'), and colon (':'). RFC 3720 also requires case-normalization from uppercase to lowercase.

To prevent injecting special characters into `initiatorname.iscsi` normalize the initiator and target names before writing them to `initiatorname.iscsi`.

The iscsi module writes the iSCSI LUN into `/etc/udev/rules.d/99-iscsi-root.rules` and into `$hookdir/mount/01-$$-iscsi.sh`. The iSCSI LUN is a number. Validate that given LUNs are numbers. This prevents invalid characters from propagating to those files.

### Checklist
- [ ] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it
