### PR TITLE
ci(alpine): remove duplicated packages

### DIFF
--- a/test/container/Dockerfile-alpine
+++ b/test/container/Dockerfile-alpine
@@ -25,13 +25,7 @@ ARG OPTION
 RUN apk add --no-cache \
     alpine-base \
     build-base \
-    cargo \
-    curl \
-    dnsmasq \
-    dracut-tests \
-    efistub \
-    tcpdump \
-    ukify
+    dracut-tests
 
 RUN \
 if [ "${TARGETARCH}" == "amd64" ]; then \


### PR DESCRIPTION
After a recent upstream change in the dracut-test package, we can remove most of the remaining downstream Alpine packages to improve readability and reduce maintenance.

See https://gitlab.alpinelinux.org/alpine/aports/-/merge_requests/103160/diffs .

<!-- This pull request changes... -->

<!-- Fixes: https://github.com/dracut-ng/dracut/issues/<number> -->

### Checklist
- [ ] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it
